### PR TITLE
subscriptions: add IsFullDetailsSent

### DIFF
--- a/core/subscription/cache_test.go
+++ b/core/subscription/cache_test.go
@@ -8,14 +8,22 @@ import (
 
 func TestEntry_SubIds(t *testing.T) {
 	e := &entry{}
-	e.SetSub("1", true)
+	e.SetSub("1", true, false)
 	assert.Len(t, e.SubIds(), 1)
-	e.SetSub("2", false)
+	e.SetSub("2", false, false)
 	assert.Len(t, e.SubIds(), 2)
-	e.SetSub("2", false)
+	e.SetSub("2", false, false)
 	assert.Len(t, e.SubIds(), 2)
 	assert.True(t, e.IsActive("1"))
 	assert.False(t, e.IsActive("1", "2"))
 	e.RemoveSubId("1")
 	assert.Len(t, e.SubIds(), 1)
+
+	e.SetSub("2", true, true)
+	e.SetSub("3", true, false)
+	assert.False(t, e.IsFullDetailsSent("2", "3"))
+	assert.True(t, e.IsFullDetailsSent("2"))
+	e.SetSub("3", true, true)
+	assert.True(t, e.IsFullDetailsSent("2", "3"))
+
 }

--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -64,13 +64,16 @@ func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, depIds []string) (d
 			if e = ds.s.cache.Get(id); e != nil {
 				newSubIds := make([]string, len(e.subIds))
 				newSubIsActive := make([]bool, len(e.subIsActive))
+				newSubFullDetailsSent := make([]bool, len(e.subFullDetailsSent))
 				copy(newSubIds, e.subIds)
 				copy(newSubIsActive, e.subIsActive)
+				copy(newSubFullDetailsSent, e.subFullDetailsSent)
 				e = &entry{
-					id:          id,
-					data:        e.data,
-					subIds:      newSubIds,
-					subIsActive: newSubIsActive,
+					id:                 id,
+					data:               e.data,
+					subIds:             newSubIds,
+					subIsActive:        newSubIsActive,
+					subFullDetailsSent: newSubFullDetailsSent,
 				}
 			} else {
 				missIds = append(missIds, id)

--- a/core/subscription/group.go
+++ b/core/subscription/group.go
@@ -38,7 +38,7 @@ type groupSub struct {
 func (gs *groupSub) init(entries []*entry) (err error) {
 	for _, e := range entries {
 		e = gs.cache.GetOrSet(e)
-		e.SetSub(gs.id, true)
+		e.SetSub(gs.id, true, false)
 		gs.set[e.id] = struct{}{}
 	}
 	return
@@ -64,7 +64,8 @@ func (gs *groupSub) onChange(ctx *opCtx) {
 				delete(gs.set, ctxEntry.id)
 				checkGroups = true
 			}
-		} else if inFilter { // if not in cache but has been added new tags
+		} else if inFilter {
+			// if not in cache but has been added new tags
 			gs.cache.Set(ctxEntry)
 			gs.set[ctxEntry.id] = struct{}{}
 			checkGroups = true

--- a/core/subscription/simple.go
+++ b/core/subscription/simple.go
@@ -36,7 +36,7 @@ func (s *simpleSub) init(entries []*entry) (err error) {
 	for _, e := range entries {
 		e = s.cache.GetOrSet(e)
 		s.set[e.id] = struct{}{}
-		e.SetSub(s.id, true)
+		e.SetSub(s.id, true, false)
 	}
 	if s.ds != nil {
 		s.depKeys = s.ds.depKeys(s.keys)
@@ -77,7 +77,7 @@ func (s *simpleSub) refill(ctx *opCtx, entries []*entry) {
 			})
 		}
 		newSet[e.id] = struct{}{}
-		e.SetSub(s.id, true)
+		e.SetSub(s.id, true, false)
 	}
 	for oldId := range s.set {
 		if _, inSet := newSet[oldId]; !inSet {
@@ -105,7 +105,7 @@ func (s *simpleSub) onChange(ctx *opCtx) {
 				keys:  s.keys,
 			})
 			changed = true
-			e.SetSub(s.id, true)
+			e.SetSub(s.id, true, false)
 		}
 	}
 	if changed && s.depSub != nil {

--- a/core/subscription/sorted.go
+++ b/core/subscription/sorted.go
@@ -68,7 +68,7 @@ func (s *sortedSub) init(entries []*entry) (err error) {
 	for i, e := range entries {
 		e = s.cache.GetOrSet(e)
 		entries[i] = e
-		e.SetSub(s.id, false)
+		e.SetSub(s.id, false, false)
 		s.skl.Set(e, nil)
 	}
 	if s.afterId != "" {
@@ -114,7 +114,7 @@ func (s *sortedSub) init(entries []*entry) (err error) {
 	activeEntries := s.getActiveEntries()
 	var activeIds = make([]string, len(activeEntries))
 	for i, ae := range activeEntries {
-		ae.SetSub(s.id, true)
+		ae.SetSub(s.id, true, false)
 		activeIds[i] = ae.id
 	}
 	s.diff = newListDiff(activeIds)
@@ -167,7 +167,7 @@ func (s *sortedSub) onChange(ctx *opCtx) {
 	hasChanges := false
 	for _, e := range ctx.entries {
 		if _, ok := s.diff.afterIdsM[e.id]; ok {
-			e.SetSub(s.id, true)
+			e.SetSub(s.id, true, false)
 			ctx.change = append(ctx.change, opChange{
 				id:    e.id,
 				subId: s.id,
@@ -203,14 +203,14 @@ func (s *sortedSub) onEntryChange(ctx *opCtx, e *entry) (noChange bool) {
 	// add
 	if !curInSet && newInSet {
 		s.skl.Set(e, nil)
-		e.SetSub(s.id, false)
+		e.SetSub(s.id, false, false)
 		return
 	}
 	// change
 	if curInSet && newInSet {
 		s.skl.Remove(curr)
 		s.skl.Set(e, nil)
-		e.SetSub(s.id, false)
+		e.SetSub(s.id, false, false)
 		return
 	}
 	panic("subscription: check algo")


### PR DESCRIPTION
This PR fixes the issue when groups subscriptions breaks the logic of full/incremental updates condition.

The logic was relying on the existence of the object in the cache + checking the list of active subscriptions. But group subscriptions broke this logic by setting the cache before the details event. 

I've added the explicit slice to store whatever the full details have been sent for the object in the context of specific subscription ID