### PR TITLE
add ctx to file load, do not reindex files when reindexing objects

### DIFF
--- a/core/files/files.go
+++ b/core/files/files.go
@@ -274,7 +274,7 @@ func (s *service) fileAddNodeFromFiles(ctx context.Context, files []*storage.Fil
 	return node, keys, nil
 }
 
-func (s *service) fileGetInfoForPath(pth string) (*storage.FileInfo, error) {
+func (s *service) fileGetInfoForPath(ctx context.Context, pth string) (*storage.FileInfo, error) {
 	if !strings.HasPrefix(pth, "/ipfs/") {
 		return nil, fmt.Errorf("path should starts with '/dagService/...'")
 	}
@@ -290,7 +290,7 @@ func (s *service) fileGetInfoForPath(pth string) (*storage.FileInfo, error) {
 	}
 
 	if key, exists := keys.Keys["/"+strings.Join(pthParts[3:], "/")+"/"]; exists {
-		return s.fileInfoFromPath("", pth, key)
+		return s.fileInfoFromPath(ctx, "", pth, key)
 	}
 
 	return nil, fmt.Errorf("key not found")
@@ -378,8 +378,8 @@ func (s *service) fileIndexLink(ctx context.Context, inode ipld.Node, fileID str
 	return nil
 }
 
-func (s *service) fileInfoFromPath(target string, path string, key string) (*storage.FileInfo, error) {
-	cid, r, err := helpers.DataAtPath(context.TODO(), s.commonFile, path+"/"+MetaLinkName)
+func (s *service) fileInfoFromPath(ctx context.Context, target string, path string, key string) (*storage.FileInfo, error) {
+	cid, r, err := helpers.DataAtPath(ctx, s.commonFile, path+"/"+MetaLinkName)
 	if err != nil {
 		return nil, err
 	}
@@ -755,7 +755,7 @@ func (s *service) fileIndexInfo(ctx context.Context, hash string, updateIfExists
 				key = keys["/"+index.Name+"/"]
 			}
 
-			fileIndex, err := s.fileInfoFromPath(hash, hash+"/"+index.Name, key)
+			fileIndex, err := s.fileInfoFromPath(ctx, hash, hash+"/"+index.Name, key)
 			if err != nil {
 				return nil, fmt.Errorf("fileInfoFromPath error: %s", err.Error())
 			}
@@ -767,7 +767,7 @@ func (s *service) fileIndexInfo(ctx context.Context, hash string, updateIfExists
 					key = keys["/"+index.Name+"/"+link.Name+"/"]
 				}
 
-				fileIndex, err := s.fileInfoFromPath(hash, hash+"/"+index.Name+"/"+link.Name, key)
+				fileIndex, err := s.fileInfoFromPath(ctx, hash, hash+"/"+index.Name+"/"+link.Name, key)
 				if err != nil {
 					return nil, fmt.Errorf("fileInfoFromPath error: %s", err.Error())
 				}

--- a/core/files/image.go
+++ b/core/files/image.go
@@ -43,7 +43,7 @@ func (i *image) GetFileForWidth(ctx context.Context, wantWidth int) (File, error
 	}
 
 	if wantWidth > 1920 {
-		fileIndex, err := i.service.fileGetInfoForPath("/ipfs/" + i.hash + "/0/original")
+		fileIndex, err := i.service.fileGetInfoForPath(ctx, "/ipfs/"+i.hash+"/0/original")
 		if err == nil {
 			return &file{
 				hash: fileIndex.Hash,
@@ -54,7 +54,7 @@ func (i *image) GetFileForWidth(ctx context.Context, wantWidth int) (File, error
 	}
 
 	sizeName := getSizeForWidth(wantWidth)
-	fileIndex, err := i.service.fileGetInfoForPath("/ipfs/" + i.hash + "/0/" + sizeName)
+	fileIndex, err := i.service.fileGetInfoForPath(ctx, "/ipfs/"+i.hash+"/0/"+sizeName)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (i *image) GetFileForWidth(ctx context.Context, wantWidth int) (File, error
 // GetOriginalFile doesn't contains Meta
 func (i *image) GetOriginalFile(ctx context.Context) (File, error) {
 	sizeName := "original"
-	fileIndex, err := i.service.fileGetInfoForPath("/ipfs/" + i.hash + "/0/" + sizeName)
+	fileIndex, err := i.service.fileGetInfoForPath(ctx, "/ipfs/"+i.hash+"/0/"+sizeName)
 	if err == nil {
 		return &file{
 			hash: fileIndex.Hash,
@@ -89,7 +89,7 @@ func (i *image) GetFileForLargestWidth(ctx context.Context) (File, error) {
 
 	// fallback to large size, because older image nodes don't have an original
 	sizeName := "large"
-	fileIndex, err := i.service.fileGetInfoForPath("/ipfs/" + i.hash + "/0/" + sizeName)
+	fileIndex, err := i.service.fileGetInfoForPath(ctx, "/ipfs/"+i.hash+"/0/"+sizeName)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (i *image) Hash() string {
 }
 
 func (i *image) Exif(ctx context.Context) (*mill.ImageExifSchema, error) {
-	fileIndex, err := i.service.fileGetInfoForPath("/ipfs/" + i.hash + "/0/exif")
+	fileIndex, err := i.service.fileGetInfoForPath(ctx, "/ipfs/"+i.hash+"/0/exif")
 	if err != nil {
 		return nil, err
 	}

--- a/core/files/offload.go
+++ b/core/files/offload.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/anyproto/any-sync/commonspace/syncstatus"
+	"github.com/anyproto/anytype-heart/core/filestorage"
 	"github.com/ipfs/go-cid"
 
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore"
@@ -137,6 +138,7 @@ func (s *service) getAllExistingFileBlocksCids(hash string) (totalSize uint64, c
 
 		// here we can be sure that the block is loaded to the blockstore, so 1s should be more than enough
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx = context.WithValue(ctx, filestorage.CtxKeyRemoteLoadDisabled, true)
 		n, err := s.commonFile.DAGService().Get(ctx, c)
 		if err != nil {
 			log.Errorf("GetAllExistingFileBlocksCids: failed to get links: %s", err.Error())

--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -381,6 +381,15 @@ func (i *indexer) reindex(ctx context.Context, flags reindexFlags) (err error) {
 		log.Infof("start store reindex (%s)", flags.String())
 	}
 
+	ctx = block.CacheOptsWithRemoteLoadDisabled(ctx)
+	if flags.threadObjects && flags.fileObjects {
+		// files will be indexed within object indexing (see indexLinkedFiles)
+		// because we need to do it in the background.
+		// otherwise it will lead to the situation when files loading called from the reindex with DisableRemoteFlag
+		// will be waiting for the linkedFiles background indexing without this flag
+		flags.fileObjects = false
+	}
+
 	if flags.fileKeys {
 		err = i.fileStore.RemoveEmptyFileKeys()
 		if err != nil {


### PR DESCRIPTION
- pass the ctx when loading files
- add flag to ctx to disable remote loading when doing Reindex
- do not reindex files when reindexing tree-based objects, because this code is already handled in the indexLinkedFiles