### PR TITLE
GO-1684 fix ObjectApplyTemplate: fix name setting

### DIFF
--- a/core/block/service.go
+++ b/core/block/service.go
@@ -1033,9 +1033,6 @@ func (s *Service) ObjectApplyTemplate(contextId, templateId string) error {
 			return err
 		}
 		ts.SetRootId(contextId)
-		if name == "" {
-			orig.SetDetail(bundle.RelationKeyName.String(), ts.Details().Fields[bundle.RelationKeyName.String()])
-		}
 		ts.SetParent(orig)
 
 		fromLayout, _ := orig.Layout()
@@ -1045,7 +1042,7 @@ func (s *Service) ObjectApplyTemplate(contextId, templateId string) error {
 			}
 		}
 
-		ts.BlocksInit(orig)
+		ts.BlocksInit(ts)
 		objType := ts.ObjectType()
 		// StateFromTemplate returns state without the localdetails, so they will be taken from the orig state
 		ts.SetObjectType(objType)


### PR DESCRIPTION
- blockInit was using the wrong state(parent)
- name was setting to the both parent and the head state, make the diff between them not produce detail change