### PR TITLE
GO-1786: create separate collection for CSV transposed option

### DIFF
--- a/core/block/import/csv/collectionstrategy.go
+++ b/core/block/import/csv/collectionstrategy.go
@@ -31,6 +31,8 @@ var logger = logging.Logger("import-csv")
 const (
 	defaultRelationName = "Field"
 	rowSourceName       = "row"
+	transposeSource     = "transpose"
+	transposeName       = "Transpose"
 )
 
 type CollectionStrategy struct {
@@ -41,17 +43,18 @@ func NewCollectionStrategy(collectionService *collection.Service) *CollectionStr
 	return &CollectionStrategy{collectionService: collectionService}
 }
 
-func (c *CollectionStrategy) CreateObjects(path string, csvTable [][]string, useFirstRowForRelations bool, progress process.Progress) (string, []*converter.Snapshot, error) {
+func (c *CollectionStrategy) CreateObjects(path string, csvTable [][]string, params *pb.RpcObjectImportRequestCsvParams, progress process.Progress) (string, []*converter.Snapshot, error) {
 	snapshots := make([]*converter.Snapshot, 0)
 	allObjectsIDs := make([]string, 0)
 	details := converter.GetCommonDetails(path, "", "")
 	details.GetFields()[bundle.RelationKeyLayout.String()] = pbtypes.Float64(float64(model.ObjectType_collection))
+	updateDetailsForTransposeCollection(details, params.TransposeRowsAndColumns)
 	_, _, st, err := c.collectionService.CreateCollection(details, nil)
 	if err != nil {
 		return "", nil, err
 	}
-	relations, relationsSnapshots, errRelationLimit := getDetailsFromCSVTable(csvTable, useFirstRowForRelations)
-	objectsSnapshots, errRowLimit := getObjectsFromCSVRows(path, csvTable, relations, useFirstRowForRelations)
+	relations, relationsSnapshots, errRelationLimit := getDetailsFromCSVTable(csvTable, params.UseFirstRowForRelations)
+	objectsSnapshots, errRowLimit := getObjectsFromCSVRows(path, csvTable, relations, params)
 	targetIDs := make([]string, 0, len(objectsSnapshots))
 	for _, objectsSnapshot := range objectsSnapshots {
 		targetIDs = append(targetIDs, objectsSnapshot.Id)
@@ -69,6 +72,17 @@ func (c *CollectionStrategy) CreateObjects(path string, csvTable [][]string, use
 		return "", nil, converter.ErrLimitExceeded
 	}
 	return snapshot.Id, snapshots, nil
+}
+
+func updateDetailsForTransposeCollection(details *types.Struct, transpose bool) {
+	if transpose {
+		source := pbtypes.GetString(details, bundle.RelationKeySourceFilePath.String())
+		source = source + string(filepath.Separator) + transposeSource
+		details.Fields[bundle.RelationKeySourceFilePath.String()] = pbtypes.String(source)
+		name := pbtypes.GetString(details, bundle.RelationKeyName.String())
+		name = name + " " + transposeName
+		details.Fields[bundle.RelationKeyName.String()] = pbtypes.String(name)
+	}
 }
 
 func getDetailsFromCSVTable(csvTable [][]string, useFirstRowForRelations bool) ([]*model.Relation, []*converter.Snapshot, error) {
@@ -167,20 +181,20 @@ func getRelationDetails(name, key string, format float64) *types.Struct {
 	return details
 }
 
-func getObjectsFromCSVRows(path string, csvTable [][]string, relations []*model.Relation, useFirstRowForRelations bool) ([]*converter.Snapshot, error) {
+func getObjectsFromCSVRows(path string, csvTable [][]string, relations []*model.Relation, params *pb.RpcObjectImportRequestCsvParams) ([]*converter.Snapshot, error) {
 	snapshots := make([]*converter.Snapshot, 0, len(csvTable))
 	numberOfObjectsLimit := len(csvTable)
 	var err error
 	if numberOfObjectsLimit > limitForRows {
 		err = converter.ErrLimitExceeded
 		numberOfObjectsLimit = limitForRows
-		if useFirstRowForRelations {
+		if params.UseFirstRowForRelations {
 			numberOfObjectsLimit++ // because first row is relations, so we need to add plus 1 row
 		}
 	}
 	for i := 0; i < numberOfObjectsLimit; i++ {
 		// skip first row if option is turned on
-		if i == 0 && useFirstRowForRelations {
+		if i == 0 && params.UseFirstRowForRelations {
 			continue
 		}
 		st := state.NewDoc("root", map[string]simple.Block{
@@ -190,7 +204,7 @@ func getObjectsFromCSVRows(path string, csvTable [][]string, relations []*model.
 				},
 			}),
 		}).NewState()
-		details, relationLinks := getDetailsForObject(csvTable[i], relations, path, i)
+		details, relationLinks := getDetailsForObject(csvTable[i], relations, path, i, params.TransposeRowsAndColumns)
 		st.SetDetails(details)
 		st.AddRelationLinks(relationLinks...)
 		template.InitTemplate(st, template.WithTitle)
@@ -200,15 +214,21 @@ func getObjectsFromCSVRows(path string, csvTable [][]string, relations []*model.
 	return snapshots, err
 }
 
-func buildSourcePath(path string, i int) string {
+func buildSourcePath(path string, i int, transpose bool) string {
+	var transposePart string
+	if transpose {
+		transposePart = string(filepath.Separator) + transposeSource
+	}
 	return path +
 		string(filepath.Separator) +
 		rowSourceName +
 		string(filepath.Separator) +
-		strconv.FormatInt(int64(i), 10)
+		strconv.FormatInt(int64(i), 10) +
+		string(filepath.Separator) +
+		transposePart
 }
 
-func getDetailsForObject(relationsValues []string, relations []*model.Relation, path string, objectOrderIndex int) (*types.Struct, []*model.RelationLink) {
+func getDetailsForObject(relationsValues []string, relations []*model.Relation, path string, objectOrderIndex int, transpose bool) (*types.Struct, []*model.RelationLink) {
 	details := &types.Struct{Fields: map[string]*types.Value{}}
 	relationLinks := make([]*model.RelationLink, 0)
 	for j, value := range relationsValues {
@@ -222,7 +242,7 @@ func getDetailsForObject(relationsValues []string, relations []*model.Relation, 
 			Format: relation.Format,
 		})
 	}
-	details.Fields[bundle.RelationKeySourceFilePath.String()] = pbtypes.String(buildSourcePath(path, objectOrderIndex))
+	details.Fields[bundle.RelationKeySourceFilePath.String()] = pbtypes.String(buildSourcePath(path, objectOrderIndex, transpose))
 	return details, relationLinks
 }
 

--- a/core/block/import/csv/converter.go
+++ b/core/block/import/csv/converter.go
@@ -157,7 +157,7 @@ func (c *CSV) getSnapshots(mode pb.RpcObjectImportRequestMode,
 		if params.TransposeRowsAndColumns && len(csvTable) != 0 {
 			csvTable = transpose(csvTable)
 		}
-		collectionID, snapshots, err := str.CreateObjects(filePath, csvTable, params.UseFirstRowForRelations, progress)
+		collectionID, snapshots, err := str.CreateObjects(filePath, csvTable, params, progress)
 		if err != nil {
 			cErr.Add(err)
 			if errors.Is(err, converter.ErrLimitExceeded) {

--- a/core/block/import/csv/converter_test.go
+++ b/core/block/import/csv/converter_test.go
@@ -192,6 +192,18 @@ func TestCsv_GetSnapshotsTranspose(t *testing.T) {
 			assert.True(t, name == "name" || name == "price")
 		}
 	}
+
+	var collection *converter.Snapshot
+	for _, snapshot := range sn.Snapshots {
+		// only objects created from rows
+		if snapshot.SbType != sb.SmartBlockTypeSubObject &&
+			lo.Contains(snapshot.Snapshot.Data.ObjectTypes, bundle.TypeKeyCollection.URL()) &&
+			pbtypes.GetString(snapshot.Snapshot.Data.Details, bundle.RelationKeyName.String()) == "transpose Transpose" {
+			collection = snapshot
+		}
+	}
+
+	assert.NotNil(t, collection)
 }
 
 func TestCsv_GetSnapshotsTransposeUseFirstRowForRelationsOff(t *testing.T) {

--- a/core/block/import/csv/strategy.go
+++ b/core/block/import/csv/strategy.go
@@ -3,8 +3,9 @@ package csv
 import (
 	"github.com/anyproto/anytype-heart/core/block/import/converter"
 	"github.com/anyproto/anytype-heart/core/block/process"
+	"github.com/anyproto/anytype-heart/pb"
 )
 
 type Strategy interface {
-	CreateObjects(path string, csvTable [][]string, useFirstRowForRelations bool, progress process.Progress) (string, []*converter.Snapshot, error)
+	CreateObjects(path string, csvTable [][]string, params *pb.RpcObjectImportRequestCsvParams, progress process.Progress) (string, []*converter.Snapshot, error)
 }

--- a/core/block/import/csv/tablestrategy.go
+++ b/core/block/import/csv/tablestrategy.go
@@ -22,7 +22,7 @@ func NewTableStrategy(tableEditor te.TableEditor) *TableStrategy {
 	return &TableStrategy{tableEditor: tableEditor}
 }
 
-func (c *TableStrategy) CreateObjects(path string, csvTable [][]string, useFirstRowForHeader bool, progress process.Progress) (string, []*converter.Snapshot, error) {
+func (c *TableStrategy) CreateObjects(path string, csvTable [][]string, params *pb.RpcObjectImportRequestCsvParams, progress process.Progress) (string, []*converter.Snapshot, error) {
 	st := state.NewDoc("root", map[string]simple.Block{
 		"root": simple.New(&model.Block{
 			Content: &model.BlockContentOfSmartblock{
@@ -32,7 +32,7 @@ func (c *TableStrategy) CreateObjects(path string, csvTable [][]string, useFirst
 	}).NewState()
 
 	if len(csvTable) != 0 {
-		err := c.createTable(st, csvTable, useFirstRowForHeader)
+		err := c.createTable(st, csvTable, params.UseFirstRowForRelations)
 		if err != nil {
 			return "", nil, err
 		}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

We agreed to create separate collection for CSV import in case of "transpose rows and columns" option is turned on. It's needed to avoid messing transposed and original objects in 1 collection. Now tranposed file collection has different name <filename Transpose> and contains new created objects

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://linear.app/anytype/issue/GO-1786/re-importing-the-same-file-adds-objects-to-it

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
