### PR TITLE
GO-1845 localdiscovery: fix stop in case not enabled

### DIFF
--- a/space/localdiscovery/localdiscovery.go
+++ b/space/localdiscovery/localdiscovery.go
@@ -75,6 +75,9 @@ func (l *localDiscovery) Start() (err error) {
 	}
 	l.m.Lock()
 	defer l.m.Unlock()
+	if l.started {
+		return
+	}
 	l.started = true
 
 	l.port = l.drpcServer.Port()


### PR DESCRIPTION
We had deadlock in the periodicCheck in case Close() called without the prior Run()