### PR TITLE
makefile: add ANYTYPE_NO_LOCAL_AUTH env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,10 @@ build-server: setup-network-config
 ifdef ANY_SYNC_NETWORK
 	@$(eval TAGS := $(TAGS) envnetworkcustom)
 endif
+
+ifdef ANYTYPE_NO_LOCAL_AUTH
+	@$(eval TAGS := $(TAGS) noauth)
+endif
 	go build -v -o dist/server -ldflags "$(FLAGS)" --tags "$(TAGS)" github.com/anyproto/anytype-heart/cmd/grpcserver
 
 run-server: build-server

--- a/cmd/grpcserver/grpc.go
+++ b/cmd/grpcserver/grpc.go
@@ -46,6 +46,7 @@ const grpcWebStartedMessagePrefix = "gRPC Web proxy started at: "
 
 var log = logging.Logger("anytype-grpc-server")
 var commonOSSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGINT}
+var localAPIAuthDisabled = false
 
 func main() {
 	var addr string
@@ -234,6 +235,9 @@ func main() {
 	}()
 	fmt.Println("gRPC server started at: " + addr)
 
+	if localAPIAuthDisabled {
+		fmt.Println("⚠️WARNING: local API auth is disabled. It should be used only for the testing purposes.")
+	}
 	go func() {
 		if err := proxy.Serve(webLis); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("proxy error: %v", err)

--- a/cmd/grpcserver/grpc_debug.go
+++ b/cmd/grpcserver/grpc_debug.go
@@ -1,0 +1,13 @@
+//go:build !nogrpcserver && noauth
+// +build !nogrpcserver,noauth
+
+package main
+
+import (
+	//nolint: gosec
+	_ "net/http/pprof"
+)
+
+func init() {
+	localAPIAuthDisabled = true
+}


### PR DESCRIPTION
### Description

This PR add an easy ability to pass the noauth build flag. It is used to test the local grpc API without the need to auth. 
⚠️ should be used only for testing purposes. In case auth is disabled anyone can access the local API and read the account's data

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [v] 🤖 Build
- [ ] 🔁 CI

### Added tests?

- [ ] 👍 yes
- [v] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [v] 🙅 no documentation needed