### PR TITLE
GO-1884: adjust progress bar

### DIFF
--- a/core/block/import/notion/converter.go
+++ b/core/block/import/notion/converter.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/samber/lo"
+
 	"github.com/anyproto/anytype-heart/core/block/collection"
 	"github.com/anyproto/anytype-heart/core/block/import/converter"
 	"github.com/anyproto/anytype-heart/core/block/import/notion/api/block"
 	"github.com/anyproto/anytype-heart/core/block/import/notion/api/client"
 	"github.com/anyproto/anytype-heart/core/block/import/notion/api/database"
 	"github.com/anyproto/anytype-heart/core/block/import/notion/api/page"
+	"github.com/anyproto/anytype-heart/core/block/import/notion/api/property"
 	"github.com/anyproto/anytype-heart/core/block/import/notion/api/search"
 	"github.com/anyproto/anytype-heart/core/block/process"
 	"github.com/anyproto/anytype-heart/pb"
@@ -65,7 +69,8 @@ func (n *Notion) GetSnapshots(req *pb.RpcObjectImportRequest, progress process.P
 		return nil, ce
 	}
 	logger.With("pages", len(pages)).With("dbs", len(db)).Warnf("import from notion started")
-	progress.SetTotal(int64(len(db)*numberOfStepsForDatabases+len(pages)*numberOfStepsForPages) + stepForSearch)
+	allProperties := n.getUniqueProperties(db, pages)
+	progress.SetTotal(int64(len(db)*numberOfStepsForDatabases+len(pages)*numberOfStepsForPages+len(allProperties)) + stepForSearch)
 
 	if err = progress.TryStep(1); err != nil {
 		return nil, converter.NewFromError(converter.ErrCancel)
@@ -137,6 +142,22 @@ func (n *Notion) GetSnapshots(req *pb.RpcObjectImportRequest, progress process.P
 	}
 
 	return &converter.Response{Snapshots: allSnapshots}, nil
+}
+
+func (n *Notion) getUniqueProperties(db []database.Database, pages []page.Page) []string {
+	var allProperties []string
+	for _, d := range db {
+		keys := lo.MapToSlice(d.Properties, func(key string, value property.DatabasePropertyHandler) string { return key })
+		uniqueKeys := lo.Filter(keys, func(item string, index int) bool { return !lo.Contains(allProperties, item) })
+		allProperties = append(allProperties, uniqueKeys...)
+	}
+
+	for _, pg := range pages {
+		keys := lo.MapToSlice(pg.Properties, func(key string, value property.Object) string { return key })
+		uniqueKeys := lo.Filter(keys, func(item string, index int) bool { return !lo.Contains(allProperties, item) })
+		allProperties = append(allProperties, uniqueKeys...)
+	}
+	return allProperties
 }
 
 func (n *Notion) getParams(param *pb.RpcObjectImportRequest) string {

--- a/core/block/import/notion/converter_test.go
+++ b/core/block/import/notion/converter_test.go
@@ -1,0 +1,89 @@
+package notion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/import/notion/api/database"
+	"github.com/anyproto/anytype-heart/core/block/import/notion/api/page"
+	"github.com/anyproto/anytype-heart/core/block/import/notion/api/property"
+)
+
+func TestNotion_getUniqueProperties(t *testing.T) {
+	t.Run("Page and Database have the same property - 1 unique item", func(t *testing.T) {
+		// given
+		converter := &Notion{}
+
+		databases := []database.Database{
+			{
+				Properties: map[string]property.DatabasePropertyHandler{
+					"Name": &property.DatabaseTitle{},
+				},
+			},
+		}
+		pages := []page.Page{
+			{
+				Properties: map[string]property.Object{
+					"Name": &property.TitleItem{},
+				},
+			},
+		}
+
+		// when
+		properties := converter.getUniqueProperties(databases, pages)
+
+		// then
+		assert.Len(t, properties, 1)
+	})
+	t.Run("Page and Database have the different properties - 2 unique item", func(t *testing.T) {
+		// given
+		converter := &Notion{}
+		db := []database.Database{
+			{
+				Properties: map[string]property.DatabasePropertyHandler{
+					"Name": &property.DatabaseTitle{},
+				},
+			},
+		}
+		pages := []page.Page{
+			{
+				Properties: map[string]property.Object{
+					"Name1": &property.TitleItem{},
+				},
+			},
+		}
+
+		// when
+		properties := converter.getUniqueProperties(db, pages)
+
+		// then
+		assert.Len(t, properties, 2)
+	})
+	t.Run("Page and Database have the 2 different properties and 1 same property - 3 unique item", func(t *testing.T) {
+		// given
+		converter := &Notion{}
+		databases := []database.Database{
+			{
+				Properties: map[string]property.DatabasePropertyHandler{
+					"Name":   &property.DatabaseTitle{},
+					"Name 1": &property.DatabaseTitle{},
+				},
+			},
+		}
+		pages := []page.Page{
+			{
+				Properties: map[string]property.Object{
+					"Name":   &property.TitleItem{},
+					"Name 2": &property.TitleItem{},
+				},
+			},
+		}
+
+		// when
+		properties := converter.getUniqueProperties(databases, pages)
+
+		// then
+		assert.Len(t, properties, 3)
+	})
+}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
Notion progress bar doesn't take into account creation of subobjects. So progress bar window can disappear earlier than import finishes.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://linear.app/anytype/issue/GO-1884/the-bar-process-is-running-with-a-delay

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
