### PR TITLE
GO-1748 Do not inherit background color when splitting Code block

### DIFF
--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -1,14 +1,15 @@
 package stext
 
 import (
-	"github.com/anyproto/anytype-heart/core/session"
 	"testing"
 	"time"
 
+	"github.com/anyproto/anytype-heart/core/session"
+
 	"github.com/gogo/protobuf/types"
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
@@ -32,6 +33,20 @@ func newTextBlock(id, contentText string, childrenIds ...string) simple.Block {
 			},
 		},
 		ChildrenIds: childrenIds,
+	})
+}
+
+func newCodeBlock(id, contentText string, childrenIds ...string) simple.Block {
+	return text.NewText(&model.Block{
+		Id: id,
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  contentText,
+				Style: model.BlockContentText_Code,
+			},
+		},
+		ChildrenIds:     childrenIds,
+		BackgroundColor: "grey",
 	})
 }
 
@@ -130,6 +145,37 @@ func TestTextImpl_Split(t *testing.T) {
 		assert.Equal(t, []string{newId, "inner2"}, r.Pick("1").Model().ChildrenIds)
 		assert.Equal(t, "one", r.Pick("1").Model().GetText().Text)
 		assert.Equal(t, "two", r.Pick(newId).Model().GetText().Text)
+	})
+	t.Run("split - when code block", func(t *testing.T) {
+		//given
+		sb := smarttest.New("test")
+		sb.AddBlock(
+			simple.New(
+				&model.Block{
+					Id:          "test",
+					ChildrenIds: []string{"1"},
+				},
+			),
+		).AddBlock(newCodeBlock("1", "onetwo"))
+		tb := NewText(sb, nil)
+
+		//when
+		newId, err := tb.Split(nil, pb.RpcBlockSplitRequest{
+			BlockId: "1",
+			Range:   &model.Range{From: 3, To: 3},
+			Style:   model.BlockContentText_Checkbox,
+			Mode:    pb.RpcBlockSplitRequest_BOTTOM,
+		})
+
+		//then
+		require.NoError(t, err)
+		require.NotEmpty(t, newId)
+		r := sb.NewState()
+		assert.Equal(t, []string{"1", newId}, r.Pick(r.RootId()).Model().ChildrenIds)
+		assert.Equal(t, "one", r.Pick("1").Model().GetText().Text)
+		assert.Equal(t, "two", r.Pick(newId).Model().GetText().Text)
+		assert.Equal(t, "", r.Pick(newId).Model().BackgroundColor)
+		assert.Equal(t, model.BlockContentText_Checkbox, r.Pick(newId).Model().GetText().Style)
 	})
 }
 

--- a/core/block/simple/text/text.go
+++ b/core/block/simple/text/text.go
@@ -2,18 +2,16 @@ package text
 
 import (
 	"fmt"
-	textutil "github.com/anyproto/anytype-heart/util/text"
 	"sort"
-
-	"github.com/anyproto/anytype-heart/util/uri"
-
-	"github.com/anyproto/anytype-heart/pkg/lib/logging"
-	"github.com/anyproto/anytype-heart/util/pbtypes"
 
 	"github.com/anyproto/anytype-heart/core/block/simple"
 	"github.com/anyproto/anytype-heart/core/block/simple/base"
 	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+	textutil "github.com/anyproto/anytype-heart/util/text"
+	"github.com/anyproto/anytype-heart/util/uri"
 )
 
 var (
@@ -410,6 +408,10 @@ func (t *Text) RangeSplit(from int32, to int32, top bool) (newBlock simple.Block
 		m.Range.To = m.Range.To - r.From
 	}
 
+	tBackgroundColor := t.BackgroundColor
+	if t.content.Style == model.BlockContentText_Code {
+		tBackgroundColor = ""
+	}
 	if top {
 		newBlock = simple.New(&model.Block{
 			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
@@ -418,7 +420,7 @@ func (t *Text) RangeSplit(from int32, to int32, top bool) (newBlock simple.Block
 				Marks: oldMarks,
 				Color: t.content.Color,
 			}},
-			BackgroundColor: t.BackgroundColor,
+			BackgroundColor: tBackgroundColor,
 			Align:           t.Align,
 		})
 
@@ -434,7 +436,7 @@ func (t *Text) RangeSplit(from int32, to int32, top bool) (newBlock simple.Block
 				Checked: false,
 				Color:   t.content.Color,
 			}},
-			BackgroundColor: t.BackgroundColor,
+			BackgroundColor: tBackgroundColor,
 			Align:           t.Align,
 		})
 		t.content.Text = textutil.UTF16ToStr(runes[:from])


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
