### PR TITLE
GO-1774: remove mutex from request

### DIFF
--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
@@ -53,6 +54,7 @@ type Import struct {
 	objectIDGetter  IDGetter
 	tempDirProvider core.TempDirProvider
 	sbtProvider     typeprovider.SmartBlockTypeProvider
+	sync.Mutex
 }
 
 func New() Importer {
@@ -92,6 +94,8 @@ func (i *Import) Init(a *app.App) (err error) {
 
 // Import get snapshots from converter or external api and create smartblocks from them
 func (i *Import) Import(ctx *session.Context, req *pb.RpcObjectImportRequest) error {
+	i.Lock()
+	defer i.Unlock()
 	progress := i.setupProgressBar(req)
 	var returnedErr error
 	defer func() {

--- a/core/object.go
+++ b/core/object.go
@@ -821,12 +821,7 @@ func (mw *Middleware) ObjectImport(cctx context.Context, req *pb.RpcObjectImport
 		return m
 	}
 
-	if mw.app == nil {
-		return response(pb.RpcObjectImportResponseError_ACCOUNT_IS_NOT_RUNNING, fmt.Errorf("user didn't log in"))
-	}
-
-	importer := mw.app.MustComponent(importer.CName).(importer.Importer)
-	err := importer.Import(ctx, req)
+	err := getService[importer.Importer](mw).Import(ctx, req)
 
 	if err == nil {
 		return response(pb.RpcObjectImportResponseError_NULL, nil)

--- a/core/object.go
+++ b/core/object.go
@@ -821,9 +821,6 @@ func (mw *Middleware) ObjectImport(cctx context.Context, req *pb.RpcObjectImport
 		return m
 	}
 
-	mw.m.RLock()
-	defer mw.m.RUnlock()
-
 	if mw.app == nil {
 		return response(pb.RpcObjectImportResponseError_ACCOUNT_IS_NOT_RUNNING, fmt.Errorf("user didn't log in"))
 	}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

When computer wakes up after sleep mode, desktop do requests to restore tcp connections, but ObjectImport acquire mutex for whole application and block other requests. So we remove this mutex to allow other request execution. This solution helps to avoid stuck Logging screen, which is mentioned in the task.

It doesn't stop import, so it continue execution

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

https://linear.app/anytype/issue/GO-1774/there-is-an-exit-from-the-account-during-import-when-switching-to

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
