### PR TITLE
use crypto safe prng for session seed

### DIFF
--- a/core/session/service.go
+++ b/core/session/service.go
@@ -1,9 +1,10 @@
 package session
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"github.com/golang-jwt/jwt"
-	"math/rand"
 	"sync"
 
 	"github.com/anyproto/any-sync/app"
@@ -79,21 +80,21 @@ func (s *service) CloseSession(token string) error {
 func generateToken(privKey []byte) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		// "expiresAt": time.Now().Add(10 * time.Minute).Unix(),
-		"seed": randStringRunes(8),
+		"seed": randBytesInHex(8),
 	})
 
 	// Sign and get the complete encoded token as a string using the secret
 	return token.SignedString(privKey)
 }
 
-var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-func randStringRunes(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+// Return hexlify representation of a random byte[n]
+func randBytesInHex(n int) string {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
 	}
-	return string(b)
+	return hex.EncodeToString(b)
 }
 
 func validateToken(privKey []byte, rawToken string) error {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR replaces `math/rand` with `crypto/rand` when generating seed. The `math/rand` is using LFG without cryptography guarantee. Seed format is changed by adding 8 more bytes, but should be safe since it's not used yet.

Risk of `panic()` seems acceptable, because it only happens under these scenarios, and those would almost crash other parts of the application first:

* *nix: Raise error if open or read `/dev/urandom` read failed.
* Windows: Call to RtlGenRandom failed. Discussed in golang/go#33542 and seems only fail if "a size addition overflows", which seems hard in this case.
* Javascript: Never fail

So I think it won't panic under most cases.


### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

N/A

### Mobile & Desktop Screenshots/Recordings

N/A
### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed


