### PR TITLE
GO-1811: replace also "tags" property with relation Tag

### DIFF
--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -65,6 +65,7 @@ func (i *Import) Init(a *app.App) (err error) {
 	i.s = a.MustComponent(block.CName).(*block.Service)
 	coreService := a.MustComponent(core.CName).(core.Service)
 	col := app.MustComponent[*collection.Service](a)
+	i.tempDirProvider = app.MustComponent[core.TempDirProvider](a)
 	converters := []converter.Converter{
 		markdown.New(i.tempDirProvider, col),
 		notion.New(col),
@@ -85,7 +86,6 @@ func (i *Import) Init(a *app.App) (err error) {
 	fileStore := app.MustComponent[filestore.FileStore](a)
 	relationSyncer := syncer.NewFileRelationSyncer(i.s, fileStore)
 	i.oc = NewCreator(i.s, objCreator, coreService, factory, store, relationSyncer, fileStore)
-	i.tempDirProvider = app.MustComponent[core.TempDirProvider](a)
 	i.sbtProvider = app.MustComponent[typeprovider.SmartBlockTypeProvider](a)
 	return nil
 }

--- a/core/block/import/notion/api/database/database.go
+++ b/core/block/import/notion/api/database/database.go
@@ -142,14 +142,16 @@ func (ds *Service) makeRelationsSnapshots(d Database, st *state.State, relations
 		}
 	}
 	hasTag := isDbContainsTagProperty(d.Properties)
+	var tagAlreadyExist bool
 	for name, databaseProperty := range d.Properties {
 		if _, ok := databaseProperty.(*property.DatabaseTitle); ok {
 			continue
 		}
 		relationKey := bson.NewObjectId().Hex()
-		if tagName, tagRelationKey := ds.getNameAndRelationKeyForTagProperty(databaseProperty, hasTag); tagName != "" && tagRelationKey != "" {
+		if tagName, tagRelationKey := ds.getNameAndRelationKeyForTagProperty(databaseProperty, hasTag); tagName != "" && tagRelationKey != "" && !tagAlreadyExist {
 			name = tagName
 			relationKey = tagRelationKey
+			tagAlreadyExist = true
 		}
 		if snapshot := ds.makeRelationSnapshotFromDatabaseProperty(relations, databaseProperty, name, relationKey, st); snapshot != nil {
 			snapshots = append(snapshots, snapshot)

--- a/core/block/import/notion/api/database/database_test.go
+++ b/core/block/import/notion/api/database/database_test.go
@@ -496,4 +496,64 @@ func Test_makeDatabaseSnapshot(t *testing.T) {
 		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
+
+	t.Run("Page has MultiSelect property with tags name and Select property with Tags name - tags is mapped to Tag relation", func(t *testing.T) {
+		p := property.DatabaseMultiSelect{
+			Property: property.Property{
+				ID:   "id",
+				Name: "tags",
+			},
+		}
+		ps := property.DatabaseSelect{
+			Property: property.Property{
+				ID:   "id1",
+				Name: "Tags",
+			},
+		}
+		pr := property.DatabaseProperties{"tags": &p, "Tags": &ps}
+		dbService := New(nil)
+		req := &property.PropertiesStore{
+			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
+			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
+		}
+		db := Database{Properties: pr}
+
+		// when
+		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
+
+		// then
+		assert.Len(t, req.PropertyIdsToSnapshots, 2)
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+	})
+
+	t.Run("Page has MultiSelect property with Tag name and Select property with tags name - MultiSelect is mapped to Tag relation", func(t *testing.T) {
+		p := property.DatabaseMultiSelect{
+			Property: property.Property{
+				ID:   "id",
+				Name: "Tag",
+			},
+		}
+		ps := property.DatabaseSelect{
+			Property: property.Property{
+				ID:   "id1",
+				Name: "tags",
+			},
+		}
+		pr := property.DatabaseProperties{"Tag": &p, "tags": &ps}
+		dbService := New(nil)
+		req := &property.PropertiesStore{
+			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
+			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
+		}
+		db := Database{Properties: pr}
+
+		// when
+		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
+
+		// then
+		assert.Len(t, req.PropertyIdsToSnapshots, 2)
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+	})
 }

--- a/core/block/import/notion/api/database/database_test.go
+++ b/core/block/import/notion/api/database/database_test.go
@@ -497,36 +497,6 @@ func Test_makeDatabaseSnapshot(t *testing.T) {
 		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
-	t.Run("Page has MultiSelect property with tags name and Select property with Tags name - tags is mapped to Tag relation", func(t *testing.T) {
-		p := property.DatabaseMultiSelect{
-			Property: property.Property{
-				ID:   "id",
-				Name: "tags",
-			},
-		}
-		ps := property.DatabaseSelect{
-			Property: property.Property{
-				ID:   "id1",
-				Name: "Tags",
-			},
-		}
-		pr := property.DatabaseProperties{"tags": &p, "Tags": &ps}
-		dbService := New(nil)
-		req := &property.PropertiesStore{
-			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
-			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
-		}
-		db := Database{Properties: pr}
-
-		// when
-		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
-
-		// then
-		assert.Len(t, req.PropertyIdsToSnapshots, 2)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-	})
-
 	t.Run("Page has MultiSelect property with Tag name and Select property with tags name - MultiSelect is mapped to Tag relation", func(t *testing.T) {
 		p := property.DatabaseMultiSelect{
 			Property: property.Property{

--- a/core/block/import/notion/api/database/database_test.go
+++ b/core/block/import/notion/api/database/database_test.go
@@ -399,131 +399,131 @@ func Test_makeDatabaseSnapshot(t *testing.T) {
 
 	t.Run("Database has Select property with Tags name", func(t *testing.T) {
 		// given
-		p := property.DatabaseSelect{
+		selectProperty := property.DatabaseSelect{
 			Property: property.Property{
 				ID:   "id",
 				Name: "Tags",
 			},
 		}
-		pr := property.DatabaseProperties{"Tags": &p}
+		properties := property.DatabaseProperties{"Tags": &selectProperty}
 		dbService := New(nil)
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
 			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
 		}
-		db := Database{Properties: pr}
+		db := Database{Properties: properties}
 
 		// when
 		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
 
 		// then
 		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tags name", func(t *testing.T) {
-		p := property.DatabaseMultiSelect{
+		multiSelectProperty := property.DatabaseMultiSelect{
 			Property: property.Property{
 				ID:   "id",
 				Name: "Tags",
 			},
 		}
-		pr := property.DatabaseProperties{"Tags": &p}
+		selectProperty := property.DatabaseProperties{"Tags": &multiSelectProperty}
 		dbService := New(nil)
-		req := &property.PropertiesStore{
+		properties := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
 			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
 		}
-		db := Database{Properties: pr}
+		db := Database{Properties: selectProperty}
 
 		// when
-		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
+		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), properties)
 
 		// then
-		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Len(t, properties.PropertyIdsToSnapshots, 1)
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(properties.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tag name", func(t *testing.T) {
-		p := property.DatabaseMultiSelect{
+		multiSelectProperty := property.DatabaseMultiSelect{
 			Property: property.Property{
 				ID:   "id",
 				Name: "Tag",
 			},
 		}
-		pr := property.DatabaseProperties{"Tag": &p}
+		selectProperty := property.DatabaseProperties{"Tag": &multiSelectProperty}
 		dbService := New(nil)
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
 			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
 		}
-		db := Database{Properties: pr}
+		db := Database{Properties: selectProperty}
 
 		// when
 		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
 
 		// then
 		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tag name and Select property with Tags name - MultiSelect is mapped to Tag relation", func(t *testing.T) {
-		p := property.DatabaseMultiSelect{
+		multiSelectProperty := property.DatabaseMultiSelect{
 			Property: property.Property{
 				ID:   "id",
 				Name: "Tag",
 			},
 		}
-		ps := property.DatabaseSelect{
+		selectProperty := property.DatabaseSelect{
 			Property: property.Property{
 				ID:   "id1",
 				Name: "Tags",
 			},
 		}
-		pr := property.DatabaseProperties{"Tag": &p, "Tags": &ps}
+		pr := property.DatabaseProperties{"Tag": &multiSelectProperty, "Tags": &selectProperty}
 		dbService := New(nil)
-		req := &property.PropertiesStore{
+		properties := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
 			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
 		}
 		db := Database{Properties: pr}
 
 		// when
-		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
+		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), properties)
 
 		// then
-		assert.Len(t, req.PropertyIdsToSnapshots, 2)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Len(t, properties.PropertyIdsToSnapshots, 2)
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(properties.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(properties.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tag name and Select property with tags name - MultiSelect is mapped to Tag relation", func(t *testing.T) {
-		p := property.DatabaseMultiSelect{
+		multiSelectProperty := property.DatabaseMultiSelect{
 			Property: property.Property{
 				ID:   "id",
 				Name: "Tag",
 			},
 		}
-		ps := property.DatabaseSelect{
+		selectProperty := property.DatabaseSelect{
 			Property: property.Property{
 				ID:   "id1",
 				Name: "tags",
 			},
 		}
-		pr := property.DatabaseProperties{"Tag": &p, "tags": &ps}
+		properties := property.DatabaseProperties{"Tag": &multiSelectProperty, "tags": &selectProperty}
 		dbService := New(nil)
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
 			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
 		}
-		db := Database{Properties: pr}
+		db := Database{Properties: properties}
 
 		// when
 		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
 
 		// then
 		assert.Len(t, req.PropertyIdsToSnapshots, 2)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[ps.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 }

--- a/core/block/import/notion/api/database/database_test.go
+++ b/core/block/import/notion/api/database/database_test.go
@@ -480,21 +480,21 @@ func Test_makeDatabaseSnapshot(t *testing.T) {
 				Name: "Tags",
 			},
 		}
-		pr := property.DatabaseProperties{"Tag": &multiSelectProperty, "Tags": &selectProperty}
+		properties := property.DatabaseProperties{"Tag": &multiSelectProperty, "Tags": &selectProperty}
 		dbService := New(nil)
-		properties := &property.PropertiesStore{
+		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
 			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
 		}
-		db := Database{Properties: pr}
+		db := Database{Properties: properties}
 
 		// when
-		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), properties)
+		dbService.makeDatabaseSnapshot(db, block.NewNotionImportContext(), req)
 
 		// then
-		assert.Len(t, properties.PropertyIdsToSnapshots, 2)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(properties.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(properties.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Len(t, req.PropertyIdsToSnapshots, 2)
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tag name and Select property with tags name - MultiSelect is mapped to Tag relation", func(t *testing.T) {

--- a/core/block/import/notion/api/page/page_test.go
+++ b/core/block/import/notion/api/page/page_test.go
@@ -22,7 +22,7 @@ import (
 func Test_handlePagePropertiesSelect(t *testing.T) {
 	details := make(map[string]*types.Value, 0)
 	c := client.NewClient()
-	p := property.SelectItem{
+	selectProperty := property.SelectItem{
 		Object: "",
 		ID:     "id",
 		Type:   string(property.PropertyConfigTypeSelect),
@@ -32,12 +32,12 @@ func Test_handlePagePropertiesSelect(t *testing.T) {
 			Color: api.Blue,
 		},
 	}
-	pr := property.Properties{"Select": &p}
-	ps := Task{
+	properties := property.Properties{"Select": &selectProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -47,7 +47,7 @@ func Test_handlePagePropertiesSelect(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 2) // 1 relation + 1 option
 	assert.Len(t, req.RelationsIdsToOptions, 1)
@@ -59,7 +59,7 @@ func Test_handlePagePropertiesSelect(t *testing.T) {
 	}
 
 	//Relation already exist
-	p = property.SelectItem{
+	selectProperty = property.SelectItem{
 		Object: "",
 		ID:     "id",
 		Type:   string(property.PropertyConfigTypeSelect),
@@ -69,7 +69,7 @@ func Test_handlePagePropertiesSelect(t *testing.T) {
 			Color: api.Pink,
 		},
 	}
-	snapshots, _ = ps.handlePageProperties(do, details)
+	snapshots, _ = pageTask.handlePageProperties(do, details)
 
 	assert.NotEmpty(t, req)
 	assert.Len(t, snapshots, 1) // 1 option
@@ -90,17 +90,17 @@ func Test_handlePagePropertiesLastEditedTime(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p := property.LastEditedTimeItem{
+	lastEditedTimeProperty := property.LastEditedTimeItem{
 		ID:             "id",
 		Type:           string(property.PropertyConfigLastEditedTime),
 		LastEditedTime: "2022-10-24T22:56:00.000Z",
 	}
-	pr := property.Properties{"LastEditedTime": &p}
-	ps := Task{
+	properties := property.Properties{"LastEditedTime": &lastEditedTimeProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -110,7 +110,7 @@ func Test_handlePagePropertiesLastEditedTime(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
 	assert.NotEmpty(t, req.PropertyIdsToSnapshots["id"])
@@ -127,13 +127,13 @@ func Test_handlePagePropertiesRichText(t *testing.T) {
 	c.BasePath = s.URL
 	details := make(map[string]*types.Value, 0)
 
-	p := property.RichTextItem{ID: "id", Type: string(property.PropertyConfigTypeRichText)}
-	pr := property.Properties{"RichText": &p}
-	ps := Task{
+	richTextProperty := property.RichTextItem{ID: "id", Type: string(property.PropertyConfigTypeRichText)}
+	properties := property.Properties{"RichText": &richTextProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -144,7 +144,7 @@ func Test_handlePagePropertiesRichText(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
@@ -157,7 +157,7 @@ func Test_handlePagePropertiesStatus(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p := property.StatusItem{
+	statusProperty := property.StatusItem{
 		ID:   "id",
 		Type: property.PropertyConfigStatus,
 		Status: &property.Status{
@@ -166,12 +166,12 @@ func Test_handlePagePropertiesStatus(t *testing.T) {
 			Color: api.Pink,
 		},
 	}
-	pr := property.Properties{"Status": &p}
-	ps := Task{
+	properties := property.Properties{"Status": &statusProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -181,7 +181,7 @@ func Test_handlePagePropertiesStatus(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 2) // 1 relation + 1 option
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
@@ -198,7 +198,7 @@ func Test_handlePagePropertiesStatus(t *testing.T) {
 	}
 
 	//Relation already exist
-	p = property.StatusItem{
+	statusProperty = property.StatusItem{
 		ID:   "id",
 		Type: property.PropertyConfigStatus,
 		Status: &property.Status{
@@ -207,7 +207,7 @@ func Test_handlePagePropertiesStatus(t *testing.T) {
 			Color: api.Gray,
 		},
 	}
-	snapshots, _ = ps.handlePageProperties(do, details)
+	snapshots, _ = pageTask.handlePageProperties(do, details)
 
 	assert.NotEmpty(t, req)
 	assert.Len(t, snapshots, 1) // 1 option
@@ -229,17 +229,17 @@ func Test_handlePagePropertiesNumber(t *testing.T) {
 	details := make(map[string]*types.Value, 0)
 
 	num := float64(12)
-	p := property.NumberItem{
+	numberProperty := property.NumberItem{
 		ID:     "id",
 		Type:   string(property.PropertyConfigTypeNumber),
 		Number: &num,
 	}
-	pr := property.Properties{"Number": &p}
-	ps := Task{
+	properties := property.Properties{"Number": &numberProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -249,7 +249,7 @@ func Test_handlePagePropertiesNumber(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
@@ -262,7 +262,7 @@ func Test_handlePagePropertiesMultiSelect(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p := property.MultiSelectItem{
+	multiSelectProperty := property.MultiSelectItem{
 		ID:   "id",
 		Type: string(property.PropertyConfigTypeMultiSelect),
 		MultiSelect: []*property.SelectOption{
@@ -273,12 +273,12 @@ func Test_handlePagePropertiesMultiSelect(t *testing.T) {
 			},
 		},
 	}
-	pr := property.Properties{"MultiSelect": &p}
-	ps := Task{
+	properties := property.Properties{"MultiSelect": &multiSelectProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -288,7 +288,7 @@ func Test_handlePagePropertiesMultiSelect(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 2) // 1 relation + 1 option
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
@@ -305,7 +305,7 @@ func Test_handlePagePropertiesMultiSelect(t *testing.T) {
 	}
 
 	//Relation already exist
-	p = property.MultiSelectItem{
+	multiSelectProperty = property.MultiSelectItem{
 		ID:   "id",
 		Type: string(property.PropertyConfigTypeMultiSelect),
 		MultiSelect: []*property.SelectOption{
@@ -316,7 +316,7 @@ func Test_handlePagePropertiesMultiSelect(t *testing.T) {
 			},
 		},
 	}
-	snapshots, _ = ps.handlePageProperties(do, details)
+	snapshots, _ = pageTask.handlePageProperties(do, details)
 
 	assert.NotEmpty(t, req)
 	assert.Len(t, snapshots, 1) // 1 option
@@ -337,17 +337,17 @@ func Test_handlePagePropertiesCheckbox(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p := property.CheckboxItem{
+	checkboxProperty := property.CheckboxItem{
 		ID:       "id",
 		Type:     string(property.PropertyConfigTypeCheckbox),
 		Checkbox: true,
 	}
-	pr := property.Properties{"Checkbox": &p}
-	ps := Task{
+	properties := property.Properties{"Checkbox": &checkboxProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -357,7 +357,7 @@ func Test_handlePagePropertiesCheckbox(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
@@ -371,17 +371,17 @@ func Test_handlePagePropertiesEmail(t *testing.T) {
 	details := make(map[string]*types.Value, 0)
 
 	email := "a@mail.com"
-	p := property.EmailItem{
+	emailProperty := property.EmailItem{
 		ID:    "id",
 		Type:  string(property.PropertyConfigTypeEmail),
 		Email: &email,
 	}
-	pr := property.Properties{"Email": &p}
-	ps := Task{
+	properties := property.Properties{"Email": &emailProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	req := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -391,7 +391,7 @@ func Test_handlePagePropertiesEmail(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: req,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, req.PropertyIdsToSnapshots, 1)
@@ -410,19 +410,19 @@ func Test_handlePagePropertiesRelation(t *testing.T) {
 
 	details := make(map[string]*types.Value, 0)
 
-	p := property.RelationItem{ID: "id", Type: string(property.PropertyConfigTypeRelation), HasMore: true, Relation: []*property.Relation{{ID: "id"}}}
-	pr := property.Properties{"Relation": &p}
+	relationProperty := property.RelationItem{ID: "id", Type: string(property.PropertyConfigTypeRelation), HasMore: true, Relation: []*property.Relation{{ID: "id"}}}
+	properties := property.Properties{"Relation": &relationProperty}
 	notionPageIdsToAnytype := map[string]string{"id": "anytypeID"}
 	notionDatabaseIdsToAnytype := map[string]string{"id": "anytypeID"}
 	req := &block.NotionImportContext{
 		NotionPageIdsToAnytype:     notionPageIdsToAnytype,
 		NotionDatabaseIdsToAnytype: notionDatabaseIdsToAnytype,
 	}
-	ps := Task{
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	store := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -433,7 +433,7 @@ func Test_handlePagePropertiesRelation(t *testing.T) {
 		request:   req,
 		relations: store,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, store.PropertyIdsToSnapshots, 1)
@@ -452,17 +452,17 @@ func Test_handlePagePropertiesPeople(t *testing.T) {
 	c.BasePath = s.URL
 	details := make(map[string]*types.Value, 0)
 
-	p := property.PeopleItem{
+	peopleProperty := property.PeopleItem{
 		Object: "",
 		ID:     "id",
 		Type:   string(property.PropertyConfigTypePeople),
 	}
-	pr := property.Properties{"People": &p}
-	ps := Task{
+	properties := property.Properties{"People": &peopleProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	store := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -473,7 +473,7 @@ func Test_handlePagePropertiesPeople(t *testing.T) {
 		relations: store,
 		ctx:       context.Background(),
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 3) // 1 relation + 1 option
 	assert.Len(t, store.PropertyIdsToSnapshots, 1)
@@ -495,17 +495,17 @@ func Test_handlePagePropertiesFormula(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p := property.FormulaItem{
+	formulaProperty := property.FormulaItem{
 		ID:      "id",
 		Type:    string(property.PropertyConfigTypeFormula),
 		Formula: map[string]interface{}{"type": property.NumberFormula, "number": float64(1)},
 	}
-	pr := property.Properties{"Formula": &p}
-	ps := Task{
+	properties := property.Properties{"Formula": &formulaProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	store := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -515,7 +515,7 @@ func Test_handlePagePropertiesFormula(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: store,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 1) // 1 relation
 	assert.Len(t, store.PropertyIdsToSnapshots, 1)
@@ -528,17 +528,17 @@ func Test_handlePagePropertiesTitle(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p := property.TitleItem{
+	titleProperty := property.TitleItem{
 		ID:    "id",
 		Type:  string(property.PropertyConfigTypeTitle),
 		Title: []*api.RichText{{PlainText: "Title"}},
 	}
-	pr := property.Properties{"Title": &p}
-	ps := Task{
+	properties := property.Properties{"Title": &titleProperty}
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	store := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -548,7 +548,7 @@ func Test_handlePagePropertiesTitle(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: store,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 	assert.Len(t, snapshots, 0) // not create snapshot for existing anytype relation name
 }
 
@@ -556,7 +556,7 @@ func Test_handleRollupProperties(t *testing.T) {
 	c := client.NewClient()
 	details := make(map[string]*types.Value, 0)
 
-	p1 := property.RollupItem{
+	rollupPropertyNumber := property.RollupItem{
 		ID:   "id1",
 		Type: string(property.PropertyConfigTypeRollup),
 		Rollup: property.RollupObject{
@@ -565,7 +565,7 @@ func Test_handleRollupProperties(t *testing.T) {
 		},
 	}
 
-	p2 := property.RollupItem{
+	rollupPropertyDate := property.RollupItem{
 		ID:   "id2",
 		Type: string(property.PropertyConfigTypeRollup),
 		Rollup: property.RollupObject{
@@ -576,7 +576,7 @@ func Test_handleRollupProperties(t *testing.T) {
 		},
 	}
 
-	p3 := property.RollupItem{
+	rollupPropertyArray := property.RollupItem{
 		ID:   "id3",
 		Type: string(property.PropertyConfigTypeRollup),
 		Rollup: property.RollupObject{
@@ -587,13 +587,13 @@ func Test_handleRollupProperties(t *testing.T) {
 		},
 	}
 
-	pr := property.Properties{"Rollup1": &p1, "Rollup2": &p2, "Rollup3": &p3}
+	properties := property.Properties{"Rollup1": &rollupPropertyNumber, "Rollup2": &rollupPropertyDate, "Rollup3": &rollupPropertyArray}
 
-	ps := Task{
+	pageTask := Task{
 		propertyService:        property.New(c),
 		relationOptCreateMutex: &sync.Mutex{},
 		relationCreateMutex:    &sync.Mutex{},
-		p:                      Page{Properties: pr},
+		p:                      Page{Properties: properties},
 	}
 	store := &property.PropertiesStore{
 		PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -603,7 +603,7 @@ func Test_handleRollupProperties(t *testing.T) {
 		request:   &block.NotionImportContext{},
 		relations: store,
 	}
-	snapshots, _ := ps.handlePageProperties(do, details)
+	snapshots, _ := pageTask.handlePageProperties(do, details)
 
 	assert.Len(t, snapshots, 3) // 3 relations
 	assert.Len(t, store.PropertyIdsToSnapshots, 3)
@@ -628,19 +628,19 @@ func Test_handlePagePropertiesUniqueID(t *testing.T) {
 		c := client.NewClient()
 		details := make(map[string]*types.Value, 0)
 
-		p := property.UniqueIDItem{
+		uniqueIDProperty := property.UniqueIDItem{
 			ID:   "id",
 			Type: "unique_id",
 			UniqueID: property.UniqueID{
 				Number: 1,
 			},
 		}
-		pr := property.Properties{"ID": &p}
-		ps := Task{
+		properties := property.Properties{"ID": &uniqueIDProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		store := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -652,7 +652,7 @@ func Test_handlePagePropertiesUniqueID(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 1)
@@ -668,7 +668,7 @@ func Test_handlePagePropertiesUniqueID(t *testing.T) {
 		c := client.NewClient()
 		details := make(map[string]*types.Value, 0)
 
-		p := property.UniqueIDItem{
+		uniqueIDProperty := property.UniqueIDItem{
 			ID:   "id",
 			Type: "unique_id",
 			UniqueID: property.UniqueID{
@@ -676,12 +676,12 @@ func Test_handlePagePropertiesUniqueID(t *testing.T) {
 				Prefix: "PR",
 			},
 		}
-		pr := property.Properties{"ID": &p}
-		ps := Task{
+		properties := property.Properties{"ID": &uniqueIDProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		store := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -693,7 +693,7 @@ func Test_handlePagePropertiesUniqueID(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 1)
@@ -710,7 +710,7 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)
 		c := client.NewClient()
-		p := property.SelectItem{
+		selectProperty := property.SelectItem{
 			Object: "",
 			ID:     "id",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -720,12 +720,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 				Color: api.Blue,
 			},
 		}
-		pr := property.Properties{"Tag": &p}
-		ps := Task{
+		properties := property.Properties{"Tag": &selectProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -737,19 +737,19 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 2) // 1 relation + 1 option
 		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has Select property with Tags name", func(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)
 		c := client.NewClient()
-		p := property.SelectItem{
+		selectProperty := property.SelectItem{
 			Object: "",
 			ID:     "id",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -759,12 +759,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 				Color: api.Blue,
 			},
 		}
-		pr := property.Properties{"Tags": &p}
-		ps := Task{
+		properties := property.Properties{"Tags": &selectProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -776,19 +776,19 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 2) // 1 relation + 1 option
 		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tags name", func(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)
 		c := client.NewClient()
-		p := property.MultiSelectItem{
+		multiSelectProperty := property.MultiSelectItem{
 			Object: "",
 			ID:     "id",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -799,12 +799,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 			},
 			},
 		}
-		pr := property.Properties{"Tags": &p}
-		ps := Task{
+		properties := property.Properties{"Tags": &multiSelectProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -816,19 +816,19 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 2) // 1 relation + 1 option
 		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tag name", func(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)
 		c := client.NewClient()
-		p := property.MultiSelectItem{
+		multiSelectProperty := property.MultiSelectItem{
 			Object: "",
 			ID:     "id",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -839,12 +839,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 			},
 			},
 		}
-		pr := property.Properties{"Tags": &p}
-		ps := Task{
+		properties := property.Properties{"Tags": &multiSelectProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -856,19 +856,19 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 2) // 1 relation + 1 option
 		assert.Len(t, req.PropertyIdsToSnapshots, 1)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with Tag name and Select property with Tags name - MultiSelect is mapped to Tag relation", func(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)
 		c := client.NewClient()
-		p := property.MultiSelectItem{
+		multiSelectProperty := property.MultiSelectItem{
 			Object: "",
 			ID:     "id",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -879,7 +879,7 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 			},
 			},
 		}
-		prs := property.SelectItem{
+		selectProperty := property.SelectItem{
 			Object: "",
 			ID:     "id1",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -889,12 +889,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 				Color: api.Blue,
 			},
 		}
-		pr := property.Properties{"Tag": &p, "Tags": &prs}
-		ps := Task{
+		properties := property.Properties{"Tag": &multiSelectProperty, "Tags": &selectProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -906,20 +906,20 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 4) // 2 relation + 2 option
 		assert.Len(t, req.PropertyIdsToSnapshots, 2)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
 	t.Run("Page has MultiSelect property with tags name and Select property with Tag name - Tag property is mapped to Tag relation, tags is a new relation", func(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)
 		c := client.NewClient()
-		p := property.MultiSelectItem{
+		multiSelectProperty := property.MultiSelectItem{
 			Object: "",
 			ID:     "id",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -930,7 +930,7 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 			},
 			},
 		}
-		prs := property.SelectItem{
+		selectProperty := property.SelectItem{
 			Object: "",
 			ID:     "id1",
 			Type:   string(property.PropertyConfigTypeSelect),
@@ -940,12 +940,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 				Color: api.Blue,
 			},
 		}
-		pr := property.Properties{"tags": &p, "Tag": &prs}
-		ps := Task{
+		properties := property.Properties{"tags": &multiSelectProperty, "Tag": &selectProperty}
+		pageTask := Task{
 			propertyService:        property.New(c),
 			relationOptCreateMutex: &sync.Mutex{},
 			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
+			p:                      Page{Properties: properties},
 		}
 		req := &property.PropertiesStore{
 			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
@@ -957,12 +957,12 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		}
 
 		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
+		snapshots, _ := pageTask.handlePageProperties(do, details)
 
 		// then
 		assert.Len(t, snapshots, 4) // 2 relation + 2 option
 		assert.Len(t, req.PropertyIdsToSnapshots, 2)
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[multiSelectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[selectProperty.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 }

--- a/core/block/import/notion/api/page/page_test.go
+++ b/core/block/import/notion/api/page/page_test.go
@@ -915,57 +915,6 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
 
-	t.Run("Page has MultiSelect property with tags name and Select property with Tags name - MultiSelect is mapped to Tag relation, Tags is a new relation", func(t *testing.T) {
-		// given
-		details := make(map[string]*types.Value, 0)
-		c := client.NewClient()
-		p := property.MultiSelectItem{
-			Object: "",
-			ID:     "id",
-			Type:   string(property.PropertyConfigTypeSelect),
-			MultiSelect: []*property.SelectOption{{
-				ID:    "id",
-				Name:  "Name",
-				Color: api.Blue,
-			},
-			},
-		}
-		prs := property.SelectItem{
-			Object: "",
-			ID:     "id1",
-			Type:   string(property.PropertyConfigTypeSelect),
-			Select: property.SelectOption{
-				ID:    "id1",
-				Name:  "Name",
-				Color: api.Blue,
-			},
-		}
-		pr := property.Properties{"tags": &p, "Tags": &prs}
-		ps := Task{
-			propertyService:        property.New(c),
-			relationOptCreateMutex: &sync.Mutex{},
-			relationCreateMutex:    &sync.Mutex{},
-			p:                      Page{Properties: pr},
-		}
-		req := &property.PropertiesStore{
-			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
-			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
-		}
-		do := &DataObject{
-			request:   &block.NotionImportContext{},
-			relations: req,
-		}
-
-		// when
-		snapshots, _ := ps.handlePageProperties(do, details)
-
-		// then
-		assert.Len(t, snapshots, 4) // 2 relation + 2 option
-		assert.Len(t, req.PropertyIdsToSnapshots, 2)
-		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
-	})
-
 	t.Run("Page has MultiSelect property with tags name and Select property with Tag name - Tag property is mapped to Tag relation, tags is a new relation", func(t *testing.T) {
 		// given
 		details := make(map[string]*types.Value, 0)

--- a/core/block/import/notion/api/page/page_test.go
+++ b/core/block/import/notion/api/page/page_test.go
@@ -914,4 +914,106 @@ func Test_handlePagePropertiesSelectWithTagName(t *testing.T) {
 		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
 	})
+
+	t.Run("Page has MultiSelect property with tags name and Select property with Tags name - MultiSelect is mapped to Tag relation, Tags is a new relation", func(t *testing.T) {
+		// given
+		details := make(map[string]*types.Value, 0)
+		c := client.NewClient()
+		p := property.MultiSelectItem{
+			Object: "",
+			ID:     "id",
+			Type:   string(property.PropertyConfigTypeSelect),
+			MultiSelect: []*property.SelectOption{{
+				ID:    "id",
+				Name:  "Name",
+				Color: api.Blue,
+			},
+			},
+		}
+		prs := property.SelectItem{
+			Object: "",
+			ID:     "id1",
+			Type:   string(property.PropertyConfigTypeSelect),
+			Select: property.SelectOption{
+				ID:    "id1",
+				Name:  "Name",
+				Color: api.Blue,
+			},
+		}
+		pr := property.Properties{"tags": &p, "Tags": &prs}
+		ps := Task{
+			propertyService:        property.New(c),
+			relationOptCreateMutex: &sync.Mutex{},
+			relationCreateMutex:    &sync.Mutex{},
+			p:                      Page{Properties: pr},
+		}
+		req := &property.PropertiesStore{
+			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
+			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
+		}
+		do := &DataObject{
+			request:   &block.NotionImportContext{},
+			relations: req,
+		}
+
+		// when
+		snapshots, _ := ps.handlePageProperties(do, details)
+
+		// then
+		assert.Len(t, snapshots, 4) // 2 relation + 2 option
+		assert.Len(t, req.PropertyIdsToSnapshots, 2)
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+	})
+
+	t.Run("Page has MultiSelect property with tags name and Select property with Tag name - Tag property is mapped to Tag relation, tags is a new relation", func(t *testing.T) {
+		// given
+		details := make(map[string]*types.Value, 0)
+		c := client.NewClient()
+		p := property.MultiSelectItem{
+			Object: "",
+			ID:     "id",
+			Type:   string(property.PropertyConfigTypeSelect),
+			MultiSelect: []*property.SelectOption{{
+				ID:    "id",
+				Name:  "Name",
+				Color: api.Blue,
+			},
+			},
+		}
+		prs := property.SelectItem{
+			Object: "",
+			ID:     "id1",
+			Type:   string(property.PropertyConfigTypeSelect),
+			Select: property.SelectOption{
+				ID:    "id1",
+				Name:  "Name",
+				Color: api.Blue,
+			},
+		}
+		pr := property.Properties{"tags": &p, "Tag": &prs}
+		ps := Task{
+			propertyService:        property.New(c),
+			relationOptCreateMutex: &sync.Mutex{},
+			relationCreateMutex:    &sync.Mutex{},
+			p:                      Page{Properties: pr},
+		}
+		req := &property.PropertiesStore{
+			PropertyIdsToSnapshots: map[string]*model.SmartBlockSnapshotBase{},
+			RelationsIdsToOptions:  map[string][]*model.SmartBlockSnapshotBase{},
+		}
+		do := &DataObject{
+			request:   &block.NotionImportContext{},
+			relations: req,
+		}
+
+		// when
+		snapshots, _ := ps.handlePageProperties(do, details)
+
+		// then
+		assert.Len(t, snapshots, 4) // 2 relation + 2 option
+		assert.Len(t, req.PropertyIdsToSnapshots, 2)
+		assert.NotEqual(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[p.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(req.PropertyIdsToSnapshots[prs.ID].GetDetails(), bundle.RelationKeyRelationKey.String()))
+	})
 }

--- a/core/block/import/notion/api/page/task.go
+++ b/core/block/import/notion/api/page/task.go
@@ -133,31 +133,35 @@ func (pt *Task) handlePageProperties(object *DataObject, details map[string]*typ
 	relationsSnapshots := make([]*model.SmartBlockSnapshotBase, 0)
 	relationsLinks := make([]*model.RelationLink, 0)
 	hasTag := isPageContainsTagProperty(pt.p.Properties)
-	for k, v := range pt.p.Properties {
-		relation, relationLink, err := pt.retrieveRelation(object, k, v, details, hasTag)
+	var tagExist bool
+	for name, prop := range pt.p.Properties {
+		relation, relationLink, err := pt.retrieveRelation(object, name, prop, details, hasTag, tagExist)
 		if err != nil {
 			logger.With("method", "handlePageProperties").Error(err)
 			continue
 		}
 		relationsSnapshots = append(relationsSnapshots, relation...)
 		relationsLinks = append(relationsLinks, relationLink)
+		if shouldApplyTagPropertyToTagRelation(name, prop, hasTag, tagExist) {
+			tagExist = true
+		}
 	}
 	return relationsSnapshots, relationsLinks
 }
 
-func (pt *Task) retrieveRelation(object *DataObject, key string, propObject property.Object, details map[string]*types.Value, hasTag bool) ([]*model.SmartBlockSnapshotBase, *model.RelationLink, error) {
+func (pt *Task) retrieveRelation(object *DataObject, key string, propObject property.Object, details map[string]*types.Value, hasTag bool, tagExist bool) ([]*model.SmartBlockSnapshotBase, *model.RelationLink, error) {
 	if err := pt.handlePagination(object.ctx, object.apiKey, propObject); err != nil {
 		return nil, nil, err
 	}
 	pt.handleLinkRelationsIDWithAnytypeID(propObject, object.request)
-	return pt.makeRelationFromProperty(object.relations, propObject, details, key, hasTag)
+	return pt.makeRelationFromProperty(object.relations, propObject, details, key, hasTag, tagExist)
 }
 
 func (pt *Task) makeRelationFromProperty(relation *property.PropertiesStore,
 	propObject property.Object,
 	details map[string]*types.Value,
 	name string,
-	hasTag bool) ([]*model.SmartBlockSnapshotBase, *model.RelationLink, error) {
+	hasTag, tagExist bool) ([]*model.SmartBlockSnapshotBase, *model.RelationLink, error) {
 	pt.relationCreateMutex.Lock()
 	defer pt.relationCreateMutex.Unlock()
 	var (
@@ -166,7 +170,7 @@ func (pt *Task) makeRelationFromProperty(relation *property.PropertiesStore,
 		subObjectsSnapshots []*model.SmartBlockSnapshotBase
 	)
 	if snapshot = relation.ReadRelationsMap(propObject.GetID()); snapshot == nil {
-		snapshot, key = pt.getRelationSnapshot(name, propObject, hasTag)
+		snapshot, key = pt.getRelationSnapshot(name, propObject, hasTag, tagExist)
 		if snapshot != nil {
 			relation.WriteToRelationsMap(propObject.GetID(), snapshot)
 			subObjectsSnapshots = append(subObjectsSnapshots, snapshot)
@@ -186,15 +190,12 @@ func (pt *Task) makeRelationFromProperty(relation *property.PropertiesStore,
 	return subObjectsSnapshots, relationLink, nil
 }
 
-func (pt *Task) getRelationSnapshot(name string, propObject property.Object, hasTag bool) (*model.SmartBlockSnapshotBase, string) {
+func (pt *Task) getRelationSnapshot(name string, propObject property.Object, hasTag bool, tagExist bool) (*model.SmartBlockSnapshotBase, string) {
 	key := bson.NewObjectId().Hex()
 	if propObject.GetPropertyType() == property.PropertyConfigTypeTitle {
 		return nil, bundle.RelationKeyName.String()
 	}
-	if propObject.GetPropertyType() == property.PropertyConfigTypeMultiSelect && property.IsPropertyMatchTagRelation(name, hasTag) {
-		key = bundle.RelationKeyTag.String()
-	}
-	if propObject.GetPropertyType() == property.PropertyConfigTypeSelect && property.IsPropertyMatchTagRelation(name, hasTag) {
+	if shouldApplyTagPropertyToTagRelation(name, propObject, hasTag, tagExist) {
 		key = bundle.RelationKeyTag.String()
 	}
 	details := pt.getRelationDetails(key, name, propObject)
@@ -478,4 +479,9 @@ func isPageContainsTagProperty(properties property.Properties) bool {
 		}
 	}
 	return false
+}
+
+func shouldApplyTagPropertyToTagRelation(name string, prop property.Object, hasTag, tagExist bool) bool {
+	return (prop.GetPropertyType() == property.PropertyConfigTypeMultiSelect || prop.GetPropertyType() == property.PropertyConfigTypeSelect) &&
+		property.IsPropertyMatchTagRelation(name, hasTag) && !tagExist
 }

--- a/core/block/import/notion/api/property/common.go
+++ b/core/block/import/notion/api/property/common.go
@@ -5,10 +5,13 @@ import (
 )
 
 const (
-	TagNameProperty          = "Tag"
-	TagNamePropertyToReplace = "Tags"
+	TagNameProperty               = "Tag"
+	TagNamePropertyLower          = "tag"
+	TagNamePropertyToReplace      = "Tags"
+	TagNamePropertyToReplaceLower = "tags"
 )
 
 func IsPropertyMatchTagRelation(tags string, hasTag bool) bool {
-	return (tags == TagNamePropertyToReplace && !hasTag) || strings.TrimSpace(tags) == TagNameProperty
+	return ((tags == TagNamePropertyToReplace || strings.TrimSpace(tags) == TagNamePropertyToReplaceLower) && !hasTag) ||
+		(strings.TrimSpace(tags) == TagNameProperty || strings.TrimSpace(tags) == TagNamePropertyLower)
 }

--- a/core/block/import/notion/api/property/common.go
+++ b/core/block/import/notion/api/property/common.go
@@ -6,12 +6,11 @@ import (
 
 const (
 	TagNameProperty               = "Tag"
-	TagNamePropertyLower          = "tag"
 	TagNamePropertyToReplace      = "Tags"
 	TagNamePropertyToReplaceLower = "tags"
 )
 
 func IsPropertyMatchTagRelation(tags string, hasTag bool) bool {
 	return ((tags == TagNamePropertyToReplace || strings.TrimSpace(tags) == TagNamePropertyToReplaceLower) && !hasTag) ||
-		(strings.TrimSpace(tags) == TagNameProperty || strings.TrimSpace(tags) == TagNamePropertyLower)
+		(strings.TrimSpace(tags) == TagNameProperty)
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Now we replace property `Tags` with relation `Tag`. But we also want to replace `tags` property

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
