### PR TITLE
GO-1770: fix panic in html import

### DIFF
--- a/core/block/import/markdown/anymark/testdata/html_cases.json
+++ b/core/block/import/markdown/anymark/testdata/html_cases.json
@@ -162,6 +162,11 @@
     "blocks": [{"id":"1","Content":{"text":{"text":"UnderlineBoldItalic","marks":{"marks":[{"range":{"to":9},"type":4},{"range":{"from":9, "to":13},"type":3},{"range":{"from":13, "to":19},"type":2}]}}}}]
   },
   {
+    "desc": "Underline text, unescaped class",
+    "html": "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">\n<html>\n<head>\n<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\n<meta http-equiv=\"Content-Style-Type\" content=\"text/css\">\n<title></title>\n<meta name=\"Generator\" content=\"Cocoa HTML Writer\">\n<meta name=\"CocoaVersion\" content=\"2113.4\">\n<style type=\"text/css\">\np.p1 {margin: 0.0px 0.0px 0.0px 0.0px; font: 12.0px Helvetica}\nspan.s(1 {text-decoration: underline}\n</style>\n</head>\n<body>\n<p class=\"p1\"><span class=\"s(1\">Underline</span><b>Bold</b><i>Italic</i></p>\n</body>\n</html>\n",
+    "blocks": [{"id":"1","Content":{"text":{"text":"UnderlineBoldItalic","marks":{"marks":[{"range":{"to":9},"type":4},{"range":{"from":9, "to":13},"type":3},{"range":{"from":13, "to":19},"type":2}]}}}}]
+  },
+  {
     "desc": "a tag with no href",
     "html": "<a class=\"jump-link video-time\" data-video-part=\"-1\" data-video-time=\"660\">11:00</a>",
     "blocks": [{"id":"1","Content":{"text":{"text":"11:00","marks":{}}}}]

--- a/core/block/import/markdown/anymark/underscore.go
+++ b/core/block/import/markdown/anymark/underscore.go
@@ -35,10 +35,20 @@ func transformCSSUnderscore(source string) string {
 		}
 
 	}
-	for _, class := range underscoreCSS {
-		underscore := regexp.MustCompile(`<span class=\"` + class + `\"[\s\S]*?>([\s\S]*?)</span>`)
-		source = underscore.ReplaceAllString(source, "<u>"+`$1`+"</u>")
 
+	for _, class := range underscoreCSS {
+		class = escapeRegexSpecialChars(class)
+		expr := `<span class=\"` + class + `\"[\s\S]*?>([\s\S]*?)</span>`
+		underscore := regexp.MustCompile(expr)
+		source = underscore.ReplaceAllString(source, "<u>"+`$1`+"</u>")
 	}
 	return source
+}
+
+func escapeRegexSpecialChars(input string) string {
+	specialChars := []string{`\`, `.`, `+`, `*`, `?`, `|`, `(`, `)`, `[`, `]`, `{`, `}`, `^`, `$`, `-`}
+	for _, char := range specialChars {
+		input = regexp.MustCompile(`\`+char).ReplaceAllString(input, "\\"+char)
+	}
+	return input
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
When we replace "underline" CSS classes to "\<u\>" tag, there is a probability, that class name may contain special characters, so we escape them

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
https://linear.app/anytype/issue/GO-1770/research-root-cause-of-panic-during-objectimport

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
