### PR TITLE
GO-1892: not allowed to import files without extension in PB import

### DIFF
--- a/core/block/import/csv/converter.go
+++ b/core/block/import/csv/converter.go
@@ -117,7 +117,7 @@ func (c *CSV) getSnapshotsFromFiles(req *pb.RpcObjectImportRequest, p string, cE
 		cErr.Add(fmt.Errorf("failed to identify source: %s", p))
 		return nil
 	}
-	readers, err := s.GetFileReaders(p, []string{".csv"})
+	readers, err := s.GetFileReaders(p, []string{".csv"}, nil)
 	if err != nil {
 		cErr.Add(fmt.Errorf("failed to get readers: %s", err.Error()))
 		if req.GetMode() == pb.RpcObjectImportRequest_ALL_OR_NOTHING {

--- a/core/block/import/html/converter.go
+++ b/core/block/import/html/converter.go
@@ -110,7 +110,7 @@ func (h *HTML) handleImportPath(p string, mode pb.RpcObjectImportRequestMode) ([
 		return nil, nil, fmt.Errorf("failed to identify source: %s", p)
 	}
 
-	readers, err := s.GetFileReaders(p, []string{".html"})
+	readers, err := s.GetFileReaders(p, []string{".html"}, nil)
 	if err != nil {
 		if mode == pb.RpcObjectImportRequest_ALL_OR_NOTHING {
 			return nil, nil, err

--- a/core/block/import/markdown/blockconverter.go
+++ b/core/block/import/markdown/blockconverter.go
@@ -60,7 +60,7 @@ func (m *mdConverter) processFiles(importPath string, mode string, allErrors *ce
 	supportedExtensions = append(supportedExtensions, videoFormats...)
 	supportedExtensions = append(supportedExtensions, imageFormats...)
 	supportedExtensions = append(supportedExtensions, audioFormats...)
-	readers, err := s.GetFileReaders(importPath, supportedExtensions)
+	readers, err := s.GetFileReaders(importPath, supportedExtensions, nil)
 	if err != nil {
 		allErrors.Add(err)
 		if mode == pb.RpcObjectImportRequest_ALL_OR_NOTHING.String() {

--- a/core/block/import/pb/converter.go
+++ b/core/block/import/pb/converter.go
@@ -116,12 +116,9 @@ func (p *Pb) handlePath(req *pb.RpcObjectImportRequest,
 	files, err := p.readFile(path)
 	if err != nil {
 		allErrors.Add(err)
-		if req.Mode == pb.RpcObjectImportRequest_ALL_OR_NOTHING {
+		if req.Mode == pb.RpcObjectImportRequest_ALL_OR_NOTHING || errors.Is(err, converter.ErrNoObjectsToImport) {
 			return nil, nil
 		}
-	}
-	if len(files) == 0 {
-		return nil, nil
 	}
 	var (
 		needToImportWidgets bool

--- a/core/block/import/pb/converter.go
+++ b/core/block/import/pb/converter.go
@@ -293,7 +293,7 @@ func (p *Pb) readFile(importPath string) (map[string]io.ReadCloser, error) {
 	if s == nil {
 		return nil, fmt.Errorf("failed to identify source")
 	}
-	readers, err := s.GetFileReaders(importPath, []string{".pb", ".json", ""})
+	readers, err := s.GetFileReaders(importPath, []string{".pb", ".json"}, []string{constant.ProfileFile, configFile})
 	if err != nil {
 		return nil, err
 	}

--- a/core/block/import/pb/converter_test.go
+++ b/core/block/import/pb/converter_test.go
@@ -148,6 +148,45 @@ func Test_GetSnapshotsWithoutRootCollection(t *testing.T) {
 	assert.Len(t, res.Snapshots, 1)
 }
 
+func Test_GetSnapshotsSkipFileWithoutExtension(t *testing.T) {
+	path, err := ioutil.TempDir("", "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(path)
+	wr, err := newZipWriter(path)
+	assert.NoError(t, err)
+
+	f, err := os.Open("testdata/bafyreig5sd7mlmhindapjuvzc4gnetdbszztb755sa7nflojkljmu56mmi.pb")
+	assert.NoError(t, err)
+	reader := bufio.NewReader(f)
+
+	assert.NoError(t, wr.WriteFile("bafyreig5sd7mlmhindapjuvzc4gnetdbszztb755sa7nflojkljmu56mmi.pb", reader))
+
+	f, err = os.Open("testdata/test")
+	assert.NoError(t, err)
+	reader = bufio.NewReader(f)
+
+	assert.NoError(t, wr.WriteFile("test", reader))
+	assert.NoError(t, wr.Close())
+	p := &Pb{}
+
+	zipPath := wr.Path()
+	res, ce := p.GetSnapshots(&pb.RpcObjectImportRequest{
+		Params: &pb.RpcObjectImportRequestParamsOfPbParams{PbParams: &pb.RpcObjectImportRequestPbParams{
+			Path: []string{zipPath},
+		}},
+		UpdateExistingObjects: false,
+		Type:                  0,
+		Mode:                  0,
+	}, process.NewProgress(pb.ModelProcess_Import))
+
+	assert.Nil(t, ce)
+	assert.NotNil(t, res.Snapshots)
+	assert.Len(t, res.Snapshots, 2)
+
+	assert.Equal(t, res.Snapshots[0].FileName, "bafyreig5sd7mlmhindapjuvzc4gnetdbszztb755sa7nflojkljmu56mmi.pb")
+	assert.Equal(t, res.Snapshots[1].FileName, rootCollectionName)
+}
+
 func newZipWriter(path string) (*zipWriter, error) {
 	filename := filepath.Join(path, "Anytype"+strconv.FormatInt(rand.Int63(), 10)+".zip")
 	f, err := os.Create(filename)

--- a/core/block/import/source/directory.go
+++ b/core/block/import/source/directory.go
@@ -12,7 +12,7 @@ func NewDirectory() *Directory {
 	return &Directory{}
 }
 
-func (d *Directory) GetFileReaders(importPath string, expectedExt []string) (map[string]io.ReadCloser, error) {
+func (d *Directory) GetFileReaders(importPath string, expectedExt []string, includeFiles []string) (map[string]io.ReadCloser, error) {
 	files := make(map[string]io.ReadCloser)
 	err := filepath.Walk(importPath,
 		func(path string, info os.FileInfo, err error) error {
@@ -22,7 +22,7 @@ func (d *Directory) GetFileReaders(importPath string, expectedExt []string) (map
 					log.Errorf("failed to get relative path %s", err)
 					return nil
 				}
-				if !isSupportedExtension(filepath.Ext(path), expectedExt) {
+				if !isFileAllowedToImport(shortPath, filepath.Ext(path), expectedExt, includeFiles) {
 					log.Errorf("not supported extensions")
 					return nil
 				}

--- a/core/block/import/source/file.go
+++ b/core/block/import/source/file.go
@@ -12,9 +12,9 @@ func NewFile() *File {
 	return &File{}
 }
 
-func (f *File) GetFileReaders(importPath string, expectedExt []string) (map[string]io.ReadCloser, error) {
+func (f *File) GetFileReaders(importPath string, expectedExt []string, includeFiles []string) (map[string]io.ReadCloser, error) {
 	shortPath := filepath.Clean(importPath)
-	if !isSupportedExtension(filepath.Ext(importPath), expectedExt) {
+	if !isFileAllowedToImport(shortPath, filepath.Ext(importPath), expectedExt, includeFiles) {
 		log.Errorf("not expected extension")
 		return nil, nil
 	}

--- a/core/block/import/source/source.go
+++ b/core/block/import/source/source.go
@@ -15,7 +15,7 @@ var log = logging.Logger("import-source")
 var extensions = []string{".md", ".csv", ".txt", ".pb", ".json", ".html"}
 
 type Source interface {
-	GetFileReaders(importPath string, ext []string) (map[string]io.ReadCloser, error)
+	GetFileReaders(importPath string, ext []string, includeFiles []string) (map[string]io.ReadCloser, error)
 }
 
 func GetSource(importPath string) Source {
@@ -32,4 +32,8 @@ func GetSource(importPath string) Source {
 
 func isSupportedExtension(ext string, expectedExt []string) bool {
 	return lo.Contains(expectedExt, ext)
+}
+
+func isFileAllowedToImport(fileName, ext string, expectedExt, includeFiles []string) bool {
+	return isSupportedExtension(ext, expectedExt) || lo.Contains(includeFiles, filepath.Base(fileName))
 }

--- a/core/block/import/source/zip.go
+++ b/core/block/import/source/zip.go
@@ -15,7 +15,7 @@ func NewZip() *Zip {
 	return &Zip{}
 }
 
-func (d *Zip) GetFileReaders(importPath string, expectedExt []string) (map[string]io.ReadCloser, error) {
+func (d *Zip) GetFileReaders(importPath string, expectedExt []string, includeFiles []string) (map[string]io.ReadCloser, error) {
 	r, err := zip.OpenReader(importPath)
 	if err != nil {
 		return nil, err
@@ -28,15 +28,14 @@ func (d *Zip) GetFileReaders(importPath string, expectedExt []string) (map[strin
 		}
 		if f.FileInfo() != nil && f.FileInfo().IsDir() {
 			dir := NewDirectory()
-			fr, e := dir.GetFileReaders(f.Name, expectedExt)
+			fr, e := dir.GetFileReaders(f.Name, expectedExt, nil)
 			if e != nil {
 				log.Errorf("failed to get files from directory, %s", e)
 			}
 			files = lo.Assign(files, fr)
 			continue
 		}
-		ext := filepath.Ext(f.Name)
-		if !isSupportedExtension(ext, expectedExt) {
+		if !isFileAllowedToImport(f.Name, filepath.Ext(f.Name), expectedExt, includeFiles) {
 			log.Errorf("not expected extension")
 			continue
 		}

--- a/core/block/import/txt/converter.go
+++ b/core/block/import/txt/converter.go
@@ -107,7 +107,7 @@ func (t *TXT) handleImportPath(p string, mode pb.RpcObjectImportRequestMode) ([]
 		return nil, nil, fmt.Errorf("failed to identify source: %s", p)
 	}
 
-	readers, err := s.GetFileReaders(p, []string{".txt"})
+	readers, err := s.GetFileReaders(p, []string{".txt"}, nil)
 	if err != nil {
 		if mode == pb.RpcObjectImportRequest_ALL_OR_NOTHING {
 			return nil, nil, err


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

We allow to import files without extension in PB import to support `profile` file. It was used during migration process. But it also allowed to import other not supported files, which are without extension. 
So I remove importing of files without extension in PB import and extend `GetFileReaders` method with `includeFiles` slice. `includeFiles` contains files-exceptions, which are allowed to be imported. For Pb import it is `profile` and `config` files.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

https://linear.app/anytype/issue/GO-1892/importing-protobuf-to-zip-ends-with-an-error

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
