### PR TITLE
GO-1911 Check account subobjects status first

### DIFF
--- a/core/syncstatus/update_receiver.go
+++ b/core/syncstatus/update_receiver.go
@@ -49,16 +49,16 @@ func (r *updateReceiver) UpdateTree(ctx context.Context, objId string, status sy
 	filesSummary := r.linkedFilesWatcher.GetLinkedFilesSummary(objId)
 	objStatus := r.getObjectStatus(status)
 
-	if !r.isStatusUpdated(objId, objStatus, filesSummary) {
-		return nil
-	}
-	r.notify(objId, objStatus, filesSummary.pinStatus)
-
 	if objId == r.coreService.PredefinedBlocks().Account {
 		r.subObjectsWatcher.ForEach(func(subObjectID string) {
 			r.notify(subObjectID, objStatus, filesSummary.pinStatus)
 		})
 	}
+
+	if !r.isStatusUpdated(objId, objStatus, filesSummary) {
+		return nil
+	}
+	r.notify(objId, objStatus, filesSummary.pinStatus)
 	return nil
 }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes status update for object types and relations. They are linked to Account object, so the bug was connected with incorrect order of instructions: firstly status of acc object was checked than statuses of subobjects were updated

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-1911/sync-status-remains-preparing-for-types-relations-and-custom-objects

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
