### PR TITLE
GO-1966 Change widgets' order in Strategic usecase

### DIFF
--- a/core/block/editor/widget.go
+++ b/core/block/editor/widget.go
@@ -60,7 +60,6 @@ func (w *WidgetObject) CreationStateMigration(ctx *smartblock.InitContext) migra
 				template.WithEmpty,
 				template.WithObjectTypesAndLayout([]string{bundle.TypeKeyDashboard.URL()}, model.ObjectType_dashboard),
 				template.WithDetail(bundle.RelationKeyIsHidden, pbtypes.Bool(true)),
-				w.withDefaultWidgets,
 			)
 		},
 	}

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -70,7 +70,7 @@ var (
 		pb.RpcObjectImportUseCaseRequest_STRATEGIC_WRITING: strategicWritingZip,
 	}
 
-	//TODO: GO-2009 Now we need to create widgets by hands, widget import is not implemented yet
+	// TODO: GO-2009 Now we need to create widgets by hands, widget import is not implemented yet
 	widgetParams = map[pb.RpcObjectImportUseCaseRequestUseCase][]widgetParameters{
 		pb.RpcObjectImportUseCaseRequest_SKIP: {
 			{model.BlockContentWidget_Link, "bafyreiag57kbhehecmhe4xks5nv7p5x5flr3xoc6gm7y4i7uznp2f2spum", "", true},
@@ -185,16 +185,16 @@ func (b *builtinObjects) inject(ctx *session.Context, useCase pb.RpcObjectImport
 	}
 
 	// TODO: GO-1387 Need to use profile.pb to handle dashboard injection during migration
-	oldId := migrationDashboardName
+	oldID := migrationDashboardName
 	if useCase != migrationUseCase {
-		oldId, err = b.getOldSpaceDashboardId(archive)
+		oldID, err = b.getOldSpaceDashboardId(archive)
 		if err != nil {
 			log.Errorf("Failed to get old id of space dashboard object: %s", err.Error())
 			return nil
 		}
 	}
 
-	newID, err := b.getNewObjectID(oldId)
+	newID, err := b.getNewObjectID(oldID)
 	if err != nil {
 		log.Errorf("Failed to get new id of space dashboard object: %s", err.Error())
 		return nil
@@ -263,13 +263,13 @@ func (b *builtinObjects) getOldSpaceDashboardId(archive []byte) (id string, err 
 	return profile.SpaceDashboardId, nil
 }
 
-func (b *builtinObjects) getNewObjectID(oldId string) (id string, err error) {
+func (b *builtinObjects) getNewObjectID(oldID string) (id string, err error) {
 	ids, _, err := b.store.QueryObjectIDs(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				Condition:   model.BlockContentDataviewFilter_Equal,
 				RelationKey: bundle.RelationKeyOldAnytypeID.String(),
-				Value:       pbtypes.String(oldId),
+				Value:       pbtypes.String(oldID),
 			},
 		},
 	}, nil)

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -3,7 +3,6 @@ package builtinobjects
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	_ "embed"
 	"fmt"
 	"io"
@@ -14,13 +13,13 @@ import (
 	"github.com/anyproto/any-sync/app"
 
 	"github.com/anyproto/anytype-heart/core/block"
+	"github.com/anyproto/anytype-heart/core/block/editor/widget"
 	importer "github.com/anyproto/anytype-heart/core/block/import"
 	"github.com/anyproto/anytype-heart/core/session"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
-	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -35,6 +34,12 @@ const (
 	migrationUseCase       = -1
 	migrationDashboardName = "bafyreiha2hjbrzmwo7rpiiechv45vv37d6g5aezyr5wihj3agwawu6zi3u"
 )
+
+type widgetParameters struct {
+	layout            model.BlockContentWidgetLayout
+	objectID, viewID  string
+	isObjectIDChanged bool
+}
 
 //go:embed data/skip.zip
 var skipZip []byte
@@ -63,6 +68,48 @@ var (
 		pb.RpcObjectImportUseCaseRequest_KNOWLEDGE_BASE:    knowledgeBaseZip,
 		pb.RpcObjectImportUseCaseRequest_NOTES_DIARY:       notesDiaryZip,
 		pb.RpcObjectImportUseCaseRequest_STRATEGIC_WRITING: strategicWritingZip,
+	}
+
+	//TODO: GO-2009 Now we need to create widgets by hands, widget import is not implemented yet
+	widgetParams = map[pb.RpcObjectImportUseCaseRequestUseCase][]widgetParameters{
+		pb.RpcObjectImportUseCaseRequest_SKIP: {
+			{model.BlockContentWidget_Link, "bafyreiag57kbhehecmhe4xks5nv7p5x5flr3xoc6gm7y4i7uznp2f2spum", "", true},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetFavorite, "", false},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetSet, "", false},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetRecent, "", false},
+		},
+		pb.RpcObjectImportUseCaseRequest_PERSONAL_PROJECTS: {
+			{model.BlockContentWidget_Link, "bafyreier6tne4keezldgkfj5qmix4a64gehznuu4vbpqq3edl53qjoswk4", "", true},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetFavorite, "", false},
+			{model.BlockContentWidget_CompactList, "bafyreicigdupziu7vg56l7chnd6shof3e53tkcqqya33ub2v67fmclbjki", "", true}, // Task tracker
+			{model.BlockContentWidget_CompactList, "bafyreigtcovw3g3kaowacqzty7t6wcnp2u2365zjzytvgezb7rqjzokbwe", "", true}, // My Notes
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetSet, "", false},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetRecent, "", false},
+		},
+		pb.RpcObjectImportUseCaseRequest_KNOWLEDGE_BASE: {
+			{model.BlockContentWidget_Link, "bafyreiaszkibjyfls2og3ztgxfllqlom422y5ic64z7w3k3oio6f3pc2ia", "", true},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetFavorite, "", false},
+			{model.BlockContentWidget_CompactList, "bafyreiatdyctn5noworljilcvmhhanzyiszrtch6njw3ekz4eichw6g4eu", "", true}, // Task tracker
+			{model.BlockContentWidget_CompactList, "bafyreidjcztbyyee3qcxbkk3gp6nbkwjc5zftguubhznwvjej6q5jflp5q", "", true}, // My Notes
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetSet, "", false},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetRecent, "", false},
+		},
+		pb.RpcObjectImportUseCaseRequest_NOTES_DIARY: {
+			{model.BlockContentWidget_Link, "bafyreiexkrata5ofvswxyisuumukmkyerdwv3xa34qkxpgx6jtl7waah34", "", true},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetFavorite, "", false},
+			{model.BlockContentWidget_CompactList, "bafyreighzavahzdk3ewvlcftwfid6uebirl4asymohgikhpanwbzmfdaq4", "", true}, // Task tracker
+			{model.BlockContentWidget_CompactList, "bafyreignt4iidebdxh5ydjohhp75yrffebcqhgo4wjonzc3thobitdari4", "", true}, // My Notes
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetSet, "", false},
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetRecent, "", false},
+		},
+		pb.RpcObjectImportUseCaseRequest_STRATEGIC_WRITING: {
+			{model.BlockContentWidget_List, "bafyreido5lhh4vntmlxh2hwn4b3xfmz53yw5rrfmcl22cdb4phywhjlcdu", "f984ddde-eb13-497e-809a-2b9a96fd3503", true}, // Task tracker
+			{model.BlockContentWidget_List, widget.DefaultWidgetFavorite, "", false},
+			{model.BlockContentWidget_Tree, "bafyreicblsgojhhlfduz7ek4g4jh6ejy24fle2q5xjbue5kkcd7ifbc4ki", "", true}, // My Home
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetRecent, "", false},
+			{model.BlockContentWidget_Link, "bafyreiaoeaxv4dkw4xgdcgubetieyuqlf24q2kg5pdysz4prun6qg5v2ru", "", true}, // About Anytype
+			{model.BlockContentWidget_CompactList, widget.DefaultWidgetSet, "", false},
+		},
 	}
 )
 
@@ -147,17 +194,14 @@ func (b *builtinObjects) inject(ctx *session.Context, useCase pb.RpcObjectImport
 		}
 	}
 
-	newId, err := b.getNewSpaceDashboardId(oldId)
+	newId, err := b.getNewObjectId(oldId)
 	if err != nil {
 		log.Errorf("Failed to get new id of space dashboard object: %s", err.Error())
 		return nil
 	}
 
 	b.handleSpaceDashboard(newId)
-
-	if useCase != pb.RpcObjectImportUseCaseRequest_SKIP {
-		b.createNotesAndTaskTrackerWidgets()
-	}
+	b.createWidgets(useCase)
 	return
 }
 
@@ -219,7 +263,7 @@ func (b *builtinObjects) getOldSpaceDashboardId(archive []byte) (id string, err 
 	return profile.SpaceDashboardId, nil
 }
 
-func (b *builtinObjects) getNewSpaceDashboardId(oldId string) (id string, err error) {
+func (b *builtinObjects) getNewObjectId(oldId string) (id string, err error) {
 	ids, _, err := b.store.QueryObjectIDs(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
@@ -247,62 +291,28 @@ func (b *builtinObjects) handleSpaceDashboard(id string) {
 	}); err != nil {
 		log.Errorf("Failed to set SpaceDashboardId relation to Account object: %s", err.Error())
 	}
-	b.createSpaceDashboardWidget(id)
 }
 
-func (b *builtinObjects) createSpaceDashboardWidget(id string) {
-	targetID, err := b.getWidgetBlockIdByNumber(0)
-	if err != nil {
-		log.Errorf(err.Error())
-		return
-	}
+func (b *builtinObjects) createWidgets(useCase pb.RpcObjectImportUseCaseRequestUseCase) {
+	var err error
 
-	if _, err = b.service.CreateWidgetBlock(nil, &pb.RpcBlockCreateWidgetRequest{
-		ContextId:    b.coreService.PredefinedBlocks().Widgets,
-		TargetId:     targetID,
-		Position:     model.Block_Top,
-		WidgetLayout: model.BlockContentWidget_Link,
-		Block: &model.Block{
-			Id:          "",
-			ChildrenIds: nil,
-			Content: &model.BlockContentOfLink{
-				Link: &model.BlockContentLink{
-					TargetBlockId: id,
-					Style:         model.BlockContentLink_Page,
-					IconSize:      model.BlockContentLink_SizeNone,
-					CardStyle:     model.BlockContentLink_Inline,
-					Description:   model.BlockContentLink_None,
-				},
-			},
-		},
-	}); err != nil {
-		log.Errorf("Failed to link SpaceDashboard to Widget object: %s", err.Error())
-	}
-}
-
-func (b *builtinObjects) createNotesAndTaskTrackerWidgets() {
-	targetID, err := b.getWidgetBlockIdByNumber(1)
-	if err != nil {
-		log.Errorf("Failed to get id of second widget block: %s", err.Error())
-		return
-	}
-	for _, setOf := range []string{bundle.TypeKeyNote.String(), bundle.TypeKeyTask.String()} {
-		id, err := b.getObjectIdBySetOfValue(setOf)
-		if err != nil {
-			log.Errorf("Failed to get id of set by '%s' to create widget object: %s", setOf, err.Error())
-			continue
+	widgetObjectID := b.coreService.PredefinedBlocks().Widgets
+	for _, param := range widgetParams[useCase] {
+		objectID := param.objectID
+		if param.isObjectIDChanged {
+			objectID, err = b.getNewObjectId(objectID)
+			if err != nil {
+				log.Errorf("Failed to get new id with old id: '%s'", objectID)
+			}
 		}
-		if _, err = b.service.CreateWidgetBlock(nil, &pb.RpcBlockCreateWidgetRequest{
-			ContextId:    b.coreService.PredefinedBlocks().Widgets,
-			TargetId:     targetID,
+		request := &pb.RpcBlockCreateWidgetRequest{
+			ContextId:    widgetObjectID,
 			Position:     model.Block_Bottom,
-			WidgetLayout: model.BlockContentWidget_CompactList,
+			WidgetLayout: param.layout,
 			Block: &model.Block{
-				Id:          "",
-				ChildrenIds: nil,
 				Content: &model.BlockContentOfLink{
 					Link: &model.BlockContentLink{
-						TargetBlockId: id,
+						TargetBlockId: objectID,
 						Style:         model.BlockContentLink_Page,
 						IconSize:      model.BlockContentLink_SizeNone,
 						CardStyle:     model.BlockContentLink_Inline,
@@ -310,46 +320,12 @@ func (b *builtinObjects) createNotesAndTaskTrackerWidgets() {
 					},
 				},
 			},
-		}); err != nil {
-			log.Errorf("Failed to make Widget block for set by '%s': %s", setOf, err.Error())
+		}
+		if param.viewID != "" {
+			request.ViewId = param.viewID
+		}
+		if _, err := b.service.CreateWidgetBlock(nil, request); err != nil {
+			log.Errorf("Failed to make Widget block for object '%s': %s", objectID, err.Error())
 		}
 	}
-}
-
-func (b *builtinObjects) getObjectIdBySetOfValue(setOfValue string) (string, error) {
-	ids, _, err := b.store.QueryObjectIDs(database.Query{
-		Filters: []*model.BlockContentDataviewFilter{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeySetOf.String(),
-				Value:       pbtypes.StringList([]string{addr.ObjectTypeKeyToIdPrefix + setOfValue}),
-			},
-		},
-	}, nil)
-	if err == nil && len(ids) > 0 {
-		return ids[0], nil
-	}
-	if len(ids) == 0 {
-		err = fmt.Errorf("no object found")
-	}
-	return "", err
-}
-
-func (b *builtinObjects) getWidgetBlockIdByNumber(index int) (string, error) {
-	w, err := b.service.GetObject(context.Background(), b.coreService.PredefinedBlocks().Account, b.coreService.PredefinedBlocks().Widgets)
-	if err != nil {
-		return "", fmt.Errorf("failed to get Widget object: %s", err.Error())
-	}
-	root := w.Pick(w.RootId())
-	if root == nil {
-		return "", fmt.Errorf("failed to pick root block of Widget object: %s", err.Error())
-	}
-	if len(root.Model().ChildrenIds) < index+1 {
-		return "", fmt.Errorf("failed to get %d block of Widget object as there olny %d of them", index+1, len(root.Model().ChildrenIds))
-	}
-	target := w.Pick(root.Model().ChildrenIds[index])
-	if target == nil {
-		return "", fmt.Errorf("failed to get id of first block of Widget object: %s", err.Error())
-	}
-	return target.Model().Id, nil
 }

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -194,13 +194,13 @@ func (b *builtinObjects) inject(ctx *session.Context, useCase pb.RpcObjectImport
 		}
 	}
 
-	newId, err := b.getNewObjectId(oldId)
+	newID, err := b.getNewObjectID(oldId)
 	if err != nil {
 		log.Errorf("Failed to get new id of space dashboard object: %s", err.Error())
 		return nil
 	}
 
-	b.handleSpaceDashboard(newId)
+	b.handleSpaceDashboard(newID)
 	b.createWidgets(useCase)
 	return
 }
@@ -263,7 +263,7 @@ func (b *builtinObjects) getOldSpaceDashboardId(archive []byte) (id string, err 
 	return profile.SpaceDashboardId, nil
 }
 
-func (b *builtinObjects) getNewObjectId(oldId string) (id string, err error) {
+func (b *builtinObjects) getNewObjectID(oldId string) (id string, err error) {
 	ids, _, err := b.store.QueryObjectIDs(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
@@ -300,7 +300,7 @@ func (b *builtinObjects) createWidgets(useCase pb.RpcObjectImportUseCaseRequestU
 	for _, param := range widgetParams[useCase] {
 		objectID := param.objectID
 		if param.isObjectIDChanged {
-			objectID, err = b.getNewObjectId(objectID)
+			objectID, err = b.getNewObjectID(objectID)
 			if err != nil {
 				log.Errorf("Failed to get new id with old id: '%s'", objectID)
 			}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR presents changes to Widget object creation flow.
As import does not support Widget right now (GO-2009 was created to fix that), all blocks in Widget are created manually according to specific usecase.
Skip and Strategic usecases share widget blocks order that differs from other usecases, so that situation was a push to that temporary solution
### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-1966/widgets-appearance-and-order

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
