### PR TITLE
GO-1948 Add Empty usecase

### DIFF
--- a/docs/proto.md
+++ b/docs/proto.md
@@ -17122,9 +17122,9 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 | UNKNOWN_ERROR | 1 |  |
 | BAD_INPUT | 2 |  |
 | INTERNAL_ERROR | 3 |  |
-| NO_OBJECTS_TO_IMPORT | 4 |  |
-| IMPORT_IS_CANCELED | 5 |  |
-| LIMIT_OF_ROWS_OR_RELATIONS_EXCEEDED | 6 |  |
+| NO_OBJECTS_TO_IMPORT | 5 |  |
+| IMPORT_IS_CANCELED | 6 |  |
+| LIMIT_OF_ROWS_OR_RELATIONS_EXCEEDED | 7 |  |
 
 
 
@@ -17163,11 +17163,12 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| SKIP | 0 |  |
-| PERSONAL_PROJECTS | 1 |  |
-| KNOWLEDGE_BASE | 2 |  |
-| NOTES_DIARY | 3 |  |
-| STRATEGIC_WRITING | 4 |  |
+| EMPTY | 0 |  |
+| SKIP | 1 |  |
+| PERSONAL_PROJECTS | 2 |  |
+| KNOWLEDGE_BASE | 3 |  |
+| NOTES_DIARY | 4 |  |
+| STRATEGIC_WRITING | 5 |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -1988,11 +1988,12 @@ message Rpc {
                 UseCase useCase = 1;
 
                 enum UseCase {
-                    SKIP = 0;
-                    PERSONAL_PROJECTS = 1;
-                    KNOWLEDGE_BASE = 2;
-                    NOTES_DIARY = 3;
-                    STRATEGIC_WRITING = 4;
+                    EMPTY = 0;
+                    SKIP = 1;
+                    PERSONAL_PROJECTS = 2;
+                    KNOWLEDGE_BASE = 3;
+                    NOTES_DIARY = 4;
+                    STRATEGIC_WRITING = 5;
                 }
             }
 

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -101,6 +101,10 @@ func (b *builtinObjects) Name() (name string) {
 func (b *builtinObjects) CreateObjectsForUseCase(
 	ctx *session.Context, useCase pb.RpcObjectImportUseCaseRequestUseCase,
 ) (code pb.RpcObjectImportUseCaseResponseErrorCode, err error) {
+	if useCase == pb.RpcObjectImportUseCaseRequest_EMPTY {
+		return pb.RpcObjectImportUseCaseResponseError_NULL, err
+	}
+
 	start := time.Now()
 
 	archive, found := archives[useCase]


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR presents new option for ObjectImportUseCase request - EMPTY. If this one is provided, no additional objects except predefined ones are created:
- profile
- account
- widget
- home (favorited objects holder)

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-1948/add-empty-option-for-usecase-selection-to-add-opportunity-to-create
### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
