### PR TITLE
GO-2041 | JS-2979 Sync widget update on account creation - spaces

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 STAGED_GO_FILES=$(git diff --cached --name-only | grep ".go$")
 
@@ -9,7 +9,7 @@ fi
 for FILE in $STAGED_GO_FILES
 do
   echo $FILE
-  gci write $FILE -s "standard,default,prefix(github.com/anyproto/anytype-heart),blank,dot"
+  gci write $FILE -s standard -s default -s "prefix(github.com/anyproto/anytype-heart)" -s blank -s dot
 done
 
 exit 0

--- a/core/block/create.go
+++ b/core/block/create.go
@@ -194,7 +194,7 @@ func (s *Service) CreateWorkspace(ctx context.Context, req *pb.RpcWorkspaceCreat
 		return "", fmt.Errorf("set details for space %s: %w", spc.Id(), err)
 	}
 
-	_, err = s.builtinObjectService.CreateObjectsForUseCase(ctx, spc.Id(), req.UseCase)
+	_, err = s.builtinObjectService.CreateObjectsForUseCase(nil, spc.Id(), req.UseCase)
 	if err != nil {
 		return "", fmt.Errorf("import use-case: %w", err)
 	}

--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -864,14 +864,6 @@ func (s *Service) CreateWidgetBlock(ctx session.Context, req *pb.RpcBlockCreateW
 	return id, err
 }
 
-func (s *Service) CreateWidgetBlocks(ctx session.Context, reqs []*pb.RpcBlockCreateWidgetRequest) (string, error) {
-	var id string
-	err := DoStateCtx(s, ctx, reqs[0].ContextId, func(st *state.State, w widget.Widget) error {
-		return w.CreateBlocks(st, reqs)
-	})
-	return id, err
-}
-
 func (s *Service) CopyDataviewToBlock(
 	ctx session.Context,
 	req *pb.RpcBlockDataviewCreateFromExistingObjectRequest,

--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -864,6 +864,14 @@ func (s *Service) CreateWidgetBlock(ctx session.Context, req *pb.RpcBlockCreateW
 	return id, err
 }
 
+func (s *Service) CreateWidgetBlocks(ctx session.Context, reqs []*pb.RpcBlockCreateWidgetRequest) (string, error) {
+	var id string
+	err := DoStateCtx(s, ctx, reqs[0].ContextId, func(st *state.State, w widget.Widget) error {
+		return w.CreateBlocks(st, reqs)
+	})
+	return id, err
+}
+
 func (s *Service) CopyDataviewToBlock(
 	ctx session.Context,
 	req *pb.RpcBlockDataviewCreateFromExistingObjectRequest,

--- a/core/block/editor/widget/widget.go
+++ b/core/block/editor/widget/widget.go
@@ -19,7 +19,6 @@ const (
 
 type Widget interface {
 	CreateBlock(s *state.State, req *pb.RpcBlockCreateWidgetRequest) (string, error)
-	CreateBlocks(s *state.State, reqs []*pb.RpcBlockCreateWidgetRequest) error
 }
 
 type widget struct {
@@ -106,13 +105,4 @@ func (w *widget) CreateBlock(s *state.State, req *pb.RpcBlockCreateWidgetRequest
 	}
 
 	return wrapper.Model().Id, nil
-}
-
-func (w *widget) CreateBlocks(s *state.State, reqs []*pb.RpcBlockCreateWidgetRequest) error {
-	for _, req := range reqs {
-		if _, err := w.CreateBlock(s, req); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/core/block/editor/widget/widget.go
+++ b/core/block/editor/widget/widget.go
@@ -19,6 +19,7 @@ const (
 
 type Widget interface {
 	CreateBlock(s *state.State, req *pb.RpcBlockCreateWidgetRequest) (string, error)
+	CreateBlocks(s *state.State, reqs []*pb.RpcBlockCreateWidgetRequest) error
 }
 
 type widget struct {
@@ -105,4 +106,13 @@ func (w *widget) CreateBlock(s *state.State, req *pb.RpcBlockCreateWidgetRequest
 	}
 
 	return wrapper.Model().Id, nil
+}
+
+func (w *widget) CreateBlocks(s *state.State, reqs []*pb.RpcBlockCreateWidgetRequest) error {
+	for _, req := range reqs {
+		if _, err := w.CreateBlock(s, req); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -118,7 +118,7 @@ type indexer interface {
 }
 
 type builtinObjects interface {
-	CreateObjectsForUseCase(ctx context.Context, spaceID string, req pb.RpcObjectImportUseCaseRequestUseCase) (code pb.RpcObjectImportUseCaseResponseErrorCode, err error)
+	CreateObjectsForUseCase(ctx session.Context, spaceID string, req pb.RpcObjectImportUseCaseRequestUseCase) (code pb.RpcObjectImportUseCaseResponseErrorCode, err error)
 }
 
 type Service struct {

--- a/core/object.go
+++ b/core/object.go
@@ -871,6 +871,8 @@ func (mw *Middleware) ObjectImportNotionValidateToken(ctx context.Context,
 }
 
 func (mw *Middleware) ObjectImportUseCase(cctx context.Context, req *pb.RpcObjectImportUseCaseRequest) *pb.RpcObjectImportUseCaseResponse {
+	ctx := mw.newContext(cctx)
+
 	response := func(code pb.RpcObjectImportUseCaseResponseErrorCode, err error) *pb.RpcObjectImportUseCaseResponse {
 		resp := &pb.RpcObjectImportUseCaseResponse{
 			Error: &pb.RpcObjectImportUseCaseResponseError{
@@ -879,12 +881,14 @@ func (mw *Middleware) ObjectImportUseCase(cctx context.Context, req *pb.RpcObjec
 		}
 		if err != nil {
 			resp.Error.Description = err.Error()
+		} else {
+
 		}
 		return resp
 	}
 
 	objCreator := getService[builtinobjects.BuiltinObjects](mw)
-	return response(objCreator.CreateObjectsForUseCase(cctx, req.SpaceId, req.UseCase))
+	return response(objCreator.CreateObjectsForUseCase(ctx, req.SpaceId, req.UseCase))
 }
 
 func (mw *Middleware) ObjectImportExperience(ctx context.Context, req *pb.RpcObjectImportExperienceRequest) *pb.RpcObjectImportExperienceResponse {

--- a/core/object.go
+++ b/core/object.go
@@ -882,7 +882,7 @@ func (mw *Middleware) ObjectImportUseCase(cctx context.Context, req *pb.RpcObjec
 		if err != nil {
 			resp.Error.Description = err.Error()
 		} else {
-
+			resp.Event = ctx.GetResponseEvent()
 		}
 		return resp
 	}

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -11251,6 +11251,7 @@ DEPRECATED, GO-1926 |
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | error | [Rpc.Object.ImportUseCase.Response.Error](#anytype-Rpc-Object-ImportUseCase-Response-Error) |  |  |
+| event | [ResponseEvent](#anytype-ResponseEvent) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -2035,6 +2035,7 @@ message Rpc {
 
             message Response {
                 Error error = 1;
+                ResponseEvent event = 2;
 
                 message Error {
                     Code code = 1;

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -16,6 +16,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block"
 	"github.com/anyproto/anytype-heart/core/block/editor/widget"
 	importer "github.com/anyproto/anytype-heart/core/block/import"
+	"github.com/anyproto/anytype-heart/core/session"
 	"github.com/anyproto/anytype-heart/core/system_object"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -120,7 +121,7 @@ var (
 type BuiltinObjects interface {
 	app.Component
 
-	CreateObjectsForUseCase(ctx context.Context, spaceID string, req pb.RpcObjectImportUseCaseRequestUseCase) (code pb.RpcObjectImportUseCaseResponseErrorCode, err error)
+	CreateObjectsForUseCase(ctx session.Context, spaceID string, req pb.RpcObjectImportUseCaseRequestUseCase) (code pb.RpcObjectImportUseCaseResponseErrorCode, err error)
 	CreateObjectsForExperience(ctx context.Context, spaceID, source string, isLocal bool) (err error)
 	InjectMigrationDashboard(spaceID string) error
 }
@@ -153,7 +154,7 @@ func (b *builtinObjects) Name() (name string) {
 }
 
 func (b *builtinObjects) CreateObjectsForUseCase(
-	ctx context.Context,
+	ctx session.Context,
 	spaceID string,
 	useCase pb.RpcObjectImportUseCaseRequestUseCase,
 ) (code pb.RpcObjectImportUseCaseResponseErrorCode, err error) {
@@ -229,10 +230,10 @@ func (b *builtinObjects) CreateObjectsForExperience(ctx context.Context, spaceID
 }
 
 func (b *builtinObjects) InjectMigrationDashboard(spaceID string) error {
-	return b.inject(context.Background(), spaceID, migrationUseCase, migrationDashboardZip)
+	return b.inject(nil, spaceID, migrationUseCase, migrationDashboardZip)
 }
 
-func (b *builtinObjects) inject(ctx context.Context, spaceID string, useCase pb.RpcObjectImportUseCaseRequestUseCase, archive []byte) (err error) {
+func (b *builtinObjects) inject(ctx session.Context, spaceID string, useCase pb.RpcObjectImportUseCaseRequestUseCase, archive []byte) (err error) {
 	path := filepath.Join(b.tempDirService.TempDir(), time.Now().Format("tmp.20060102.150405.99")+".zip")
 	if err = os.WriteFile(path, archive, 0644); err != nil {
 		return fmt.Errorf("failed to save use case archive to temporary file: %s", err.Error())
@@ -243,7 +244,7 @@ func (b *builtinObjects) inject(ctx context.Context, spaceID string, useCase pb.
 		}
 	}()
 
-	if err = b.importArchive(ctx, spaceID, path); err != nil {
+	if err = b.importArchive(context.Background(), spaceID, path); err != nil {
 		return err
 	}
 
@@ -263,8 +264,8 @@ func (b *builtinObjects) inject(ctx context.Context, spaceID string, useCase pb.
 		return nil
 	}
 
-	b.handleSpaceDashboard(ctx, spaceID, newID)
-	b.createWidgets(spaceID, useCase)
+	b.handleSpaceDashboard(spaceID, newID)
+	b.createWidgets(ctx, spaceID, useCase)
 	return
 }
 
@@ -340,7 +341,7 @@ func (b *builtinObjects) getNewSpaceDashboardId(spaceID string, oldID string) (i
 	return "", err
 }
 
-func (b *builtinObjects) handleSpaceDashboard(ctx context.Context, spaceID string, id string) {
+func (b *builtinObjects) handleSpaceDashboard(spaceID string, id string) {
 	if err := b.service.SetDetails(nil, pb.RpcObjectSetDetailsRequest{
 		ContextId: b.coreService.PredefinedObjects(spaceID).Workspace,
 		Details: []*pb.RpcObjectSetDetailsDetail{
@@ -354,8 +355,9 @@ func (b *builtinObjects) handleSpaceDashboard(ctx context.Context, spaceID strin
 	}
 }
 
-func (b *builtinObjects) createWidgets(spaceID string, useCase pb.RpcObjectImportUseCaseRequestUseCase) {
+func (b *builtinObjects) createWidgets(ctx session.Context, spaceID string, useCase pb.RpcObjectImportUseCaseRequestUseCase) {
 	var err error
+	reqs := make([]*pb.RpcBlockCreateWidgetRequest, 0)
 
 	widgetObjectID := b.coreService.PredefinedObjects(spaceID).Widgets
 	for _, param := range widgetParams[useCase] {
@@ -385,9 +387,10 @@ func (b *builtinObjects) createWidgets(spaceID string, useCase pb.RpcObjectImpor
 		if param.viewID != "" {
 			request.ViewId = param.viewID
 		}
-		if _, err := b.service.CreateWidgetBlock(nil, request); err != nil {
-			log.Errorf("Failed to make Widget block for object '%s': %s", objectID, err.Error())
-		}
+		reqs = append(reqs, request)
+	}
+	if _, err = b.service.CreateWidgetBlocks(ctx, reqs); err != nil {
+		log.Errorf("Failed to make Widget blocks: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes built-in usecases addition flow by sending events on widget blocks creation synchronously.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/JS-2979/the-first-block-with-space-info-in-the-sidebar-is-absent

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
