### PR TITLE
Fix output of `make install-dev-js`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ endif
 	@cp pkg/lib/bundle/internal*.json ../anytype-ts/dist/lib/json/generated
 
 build-js: setup-go build-server protos-js
-	@echo "Run 'make install-dev-js' instead if you want to build&install into ../anytype-ts"
+	@echo "Run 'make install-dev-js' instead if you want to build & install into ../anytype-ts"
 
 install-linter:
 	@go install github.com/daixiang0/gci@latest

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ install-dev-js-addon: setup build-lib build-js-addon protos-js
 	@cp -r clientlibrary/jsaddon/build ../anytype-ts/
 	@cp -r dist/js/pb/* ../anytype-ts/dist/lib
 
-install-dev-js: build-js
+install-dev-js: setup-go build-server protos-js
 	@echo 'Installing JS-server (dev-mode)...'
 	@rm -f ../anytype-ts/dist/anytypeHelper
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description
I noticed misleading output when executing `make install-dev-js`. In the second-to-last line, it currently displays: "Run 'make install-dev-js' instead if you want to build&install into ../anytype-ts". This appears to be inaccurate because it's asking to run the exact command that was just executed.

I checked the Makefile for the echo statement. I traced it back to the install-dev-js target, which indirectly calls `build-js`, leading to `setup-go build-server protos-js`, and finally the echoing of the mentioned line. The line should not appear though, when running `make install-dev-js` directly.

To address this, I modified the install-dev-js target to directly call the three preceding targets: setup-go, build-server, and protos-js. This maintains the same functionality, while correcting the output.

**Before:**
```
$ make install-dev-js
Using the default production Any Sync Network
Setting up go modules...
make: govvv: Command not found
Building anytype-heart server...
go build -v -o dist/server -ldflags "" --tags "nosigar nowatchdog" github.com/anyproto/anytype-heart/cmd/grpcserver
Generating protobuf packages (JS)...
Run 'make install-dev-js' instead if you want to build&install into ../anytype-ts
Installing JS-server (dev-mode)...
```

**After:**
```
$ make install-dev-js
Using the default production Any Sync Network
Setting up go modules...
make: govvv: Command not found
Building anytype-heart server...
go build -v -o dist/server -ldflags "" --tags "nosigar nowatchdog" github.com/anyproto/anytype-heart/cmd/grpcserver
Generating protobuf packages (JS)...
Installing JS-server (dev-mode)...
```
 
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
