### PR TITLE
GO-2012 Set defaultObjectTypeID to views of coverted collection

### DIFF
--- a/core/block/collection/service_test.go
+++ b/core/block/collection/service_test.go
@@ -2,6 +2,11 @@ package collection
 
 import (
 	"context"
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/simple/dataview"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 	"sync"
 	"testing"
 
@@ -108,4 +113,66 @@ func TestBroadcast(t *testing.T) {
 		{"1", "2", "3", "4"},
 		{"1", "4"},
 	}, sub2Results)
+}
+
+func TestSetObjectTypeToViews(t *testing.T) {
+	var (
+		viewID1 = "view1"
+		viewID2 = "view2"
+
+		generateState = func(objectType, setOf string) *state.State {
+			parent := state.NewDoc("root", nil).(*state.State)
+			parent.SetObjectType(objectType)
+			parent.Set(dataview.NewDataview(&model.Block{
+				Id: state.DataviewBlockID,
+				Content: &model.BlockContentOfDataview{Dataview: &model.BlockContentDataview{
+					Views: []*model.BlockContentDataviewView{{Id: viewID1}, {Id: viewID2}},
+				}},
+			}))
+			parent.SetDetail(bundle.RelationKeySetOf.String(), pbtypes.StringList([]string{setOf}))
+			return parent.NewState()
+		}
+
+		assertViews = func(st *state.State, defaultObjectType string) {
+			block := st.Get(state.DataviewBlockID)
+			dataviewBlock, _ := block.(dataview.Block)
+			view1, _ := dataviewBlock.GetView(viewID1)
+			view2, _ := dataviewBlock.GetView(viewID2)
+			assert.Equal(t, defaultObjectType, view1.DefaultObjectTypeId)
+			assert.Equal(t, defaultObjectType, view2.DefaultObjectTypeId)
+		}
+	)
+
+	t.Run("object is not a set", func(t *testing.T) {
+		// given
+		st := generateState(bundle.TypeKeyPage.URL(), bundle.TypeKeySet.URL())
+
+		// when
+		setDefaultObjectTypeToViews(st)
+
+		// then
+		assertViews(st, "")
+	})
+
+	t.Run("object is a set by relation", func(t *testing.T) {
+		// given
+		st := generateState(bundle.TypeKeySet.URL(), bundle.RelationKeyDescription.URL())
+
+		// when
+		setDefaultObjectTypeToViews(st)
+
+		// then
+		assertViews(st, "")
+	})
+
+	t.Run("object is a set by object type", func(t *testing.T) {
+		// given
+		st := generateState(bundle.TypeKeySet.URL(), bundle.TypeKeyBook.URL())
+
+		// when
+		setDefaultObjectTypeToViews(st)
+
+		// then
+		assertViews(st, bundle.TypeKeyBook.URL())
+	})
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR add logic to setting defaultObjectTypeID to views of collection converted from set by type.
SetOf value is set to defaultObjectTypeID of each view

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2012/convert-set-into-collection

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
