### PR TITLE
GO-2031 Add view fields to smartblock dependent ids

### DIFF
--- a/core/block/simple/dataview/dataview.go
+++ b/core/block/simple/dataview/dataview.go
@@ -214,10 +214,25 @@ func (l *Dataview) FillSmartIds(ids []string) []string {
 	if l.content.TargetObjectId != "" {
 		ids = append(ids, l.content.TargetObjectId)
 	}
+
+	for _, view := range l.content.Views {
+		if view.DefaultObjectTypeId != "" {
+			ids = append(ids, view.DefaultObjectTypeId)
+		}
+		if view.DefaultTemplateId != "" {
+			ids = append(ids, view.DefaultTemplateId)
+		}
+	}
+
 	return ids
 }
 
 func (l *Dataview) HasSmartIds() bool {
+	for _, view := range l.content.Views {
+		if view.DefaultObjectTypeId != "" || view.DefaultTemplateId != "" {
+			return true
+		}
+	}
 	return len(l.content.RelationLinks) > 0 || l.content.TargetObjectId != ""
 }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes the behavior on ObjectOpen of dataview smartblocks. Now dependent objects include objects mentioned in defaultObjectTypeId and defaultTemplateId fields of all views of collections and sets by relation.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2031/add-defaulttypeid-and-defaulttemplateid-value-to-dependencies

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
