### PR TITLE
Go-2064 memory leak starts at about 12gb and grows to 24gb hotfix

### DIFF
--- a/core/files/debug.go
+++ b/core/files/debug.go
@@ -68,27 +68,36 @@ func (s *service) printTree(w io.Writer, req *http.Request) error {
 	if err != nil {
 		return fmt.Errorf("parse cid %s: %w", rawID, err)
 	}
-	return s.printNode(req.Context(), w, id, 0)
+	_, err = s.printNode(req.Context(), w, id, 0)
+	return err
 }
 
-func (s *service) printNode(ctx context.Context, w io.Writer, id cid.Cid, level int) error {
+func (s *service) printNode(ctx context.Context, w io.Writer, id cid.Cid, level int) (uint64, error) {
 	node, err := s.dagService.Get(ctx, id)
 	if err != nil {
-		return fmt.Errorf("get dag node %s: %w", id.String(), err)
+		return 0, fmt.Errorf("get dag node %s: %w", id.String(), err)
 	}
 	size, err := node.Size()
 	if err != nil {
-		return fmt.Errorf("get size for node %s: %w", id.String(), err)
+		return 0, fmt.Errorf("get size for node %s: %w", id.String(), err)
 	}
-	_, err = fmt.Fprintln(w, strings.Repeat("  ", level), id.String(), size)
+
+	prefix := strings.Repeat("|   ", level)
+	_, err = fmt.Fprintf(w, "%s%s  totalSize=%d\n", prefix, id.String(), size)
 	if err != nil {
-		return fmt.Errorf("print node %s: %w", id.String(), err)
+		return 0, fmt.Errorf("print node %s: %w", id.String(), err)
 	}
+	var childrenSize uint64
 	for _, link := range node.Links() {
-		err = s.printNode(ctx, w, link.Cid, level+1)
+		childSize, err := s.printNode(ctx, w, link.Cid, level+1)
 		if err != nil {
-			return err
+			return 0, err
 		}
+		childrenSize += childSize
 	}
-	return nil
+	_, err = fmt.Fprintf(w, "%s%s %d\n", prefix, "node size", size-childrenSize)
+	if err != nil {
+		return 0, fmt.Errorf("print node %s: %w", id.String(), err)
+	}
+	return size, nil
 }

--- a/core/files/files.go
+++ b/core/files/files.go
@@ -199,6 +199,22 @@ func (s *service) fileRestoreKeys(ctx context.Context, hash string) (map[string]
 	return fileKeys, nil
 }
 
+// fileAddNodeFromDirs has structure:
+/*
+- dir (outer)
+	- dir (dir1)
+		- dir (file1)
+			- meta
+			- content
+		- dir (file2)
+			- meta
+			- content
+	- dir (dir2)
+		- dir (file3)
+			- meta
+			- content
+	...
+*/
 func (s *service) fileAddNodeFromDirs(ctx context.Context, dirs *storage.DirectoryList) (ipld.Node, *storage.FileKeys, error) {
 	keys := &storage.FileKeys{KeysByPath: make(map[string]string)}
 	outer := uio.NewDirectory(s.dagService)
@@ -222,7 +238,6 @@ func (s *service) fileAddNodeFromDirs(ctx context.Context, dirs *storage.Directo
 		if err != nil {
 			return nil, nil, err
 		}
-		// todo: pin?
 		err = s.dagService.Add(ctx, node)
 		if err != nil {
 			return nil, nil, err
@@ -239,7 +254,6 @@ func (s *service) fileAddNodeFromDirs(ctx context.Context, dirs *storage.Directo
 	if err != nil {
 		return nil, nil, err
 	}
-	// todo: pin?
 	err = s.dagService.Add(ctx, node)
 	if err != nil {
 		return nil, nil, err
@@ -247,6 +261,17 @@ func (s *service) fileAddNodeFromDirs(ctx context.Context, dirs *storage.Directo
 	return node, keys, nil
 }
 
+// fileAddNodeFromFiles has structure:
+/*
+- dir (outer)
+	- dir (file1)
+		- meta
+		- content
+	- dir (file2)
+		- meta
+		- content
+	...
+*/
 func (s *service) fileAddNodeFromFiles(ctx context.Context, files []*storage.FileInfo) (ipld.Node, *storage.FileKeys, error) {
 	keys := &storage.FileKeys{KeysByPath: make(map[string]string)}
 	outer := uio.NewDirectory(s.dagService)
@@ -611,7 +636,14 @@ func (s *service) fileAddWithConfig(ctx context.Context, mill m.Mill, conf AddOp
 	return fileInfo, nil
 }
 
-func (s *service) fileNode(ctx context.Context, file *storage.FileInfo, dir uio.Directory, link string) error {
+// fileNode has structure:
+/*
+- dir (outer)
+  	- dir
+  		- meta
+  		- content
+*/
+func (s *service) fileNode(ctx context.Context, file *storage.FileInfo, outerDir uio.Directory, link string) error {
 	file, err := s.fileStore.GetByHash(file.Hash)
 	if err != nil {
 		return err
@@ -639,7 +671,7 @@ func (s *service) fileNode(ctx context.Context, file *storage.FileInfo, dir uio.
 		return err
 	}
 
-	return helpers.AddLinkToDirectory(ctx, s.dagService, dir, link, node.Cid().String())
+	return helpers.AddLinkToDirectory(ctx, s.dagService, outerDir, link, node.Cid().String())
 }
 
 func (s *service) fileBuildDirectory(ctx context.Context, reader io.ReadSeeker, filename string, plaintext bool, sch *storage.Node) (*storage.Directory, error) {

--- a/core/files/files.go
+++ b/core/files/files.go
@@ -376,6 +376,7 @@ func (s *service) fileIndexNode(ctx context.Context, inode ipld.Node, fileID str
 		if err != nil {
 			return fmt.Errorf("add file %s to sync queue: %w", fileID, err)
 		}
+		return nil
 	}
 
 	links := inode.Links()

--- a/core/filestorage/filesync/upload.go
+++ b/core/filestorage/filesync/upload.go
@@ -252,6 +252,13 @@ func (f *fileSync) prepareToUpload(ctx context.Context, spaceId string, fileId s
 
 // estimateFileSize use heuristic to estimate file size. It's pretty accurate for ordinary files,
 // But getting worse for images because they have a different structure.
+// Samples of estimation errors in bytes (the bigger the file, the bigger the error):
+/*
+	Estimation error: 968 — 10Mb jpeg file
+	Estimation error: 1401 — 30Mb png file
+	Estimation error: 810 — 50Mb ordinary file
+	Estimation error: 3576 — 250Mb ordinary file
+*/
 // Ordinary file structure:
 /*
 - dir (root)

--- a/pkg/lib/localstore/filestore/debug.go
+++ b/pkg/lib/localstore/filestore/debug.go
@@ -1,0 +1,44 @@
+package filestore
+
+import (
+	"net/http"
+	"path/filepath"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/storage"
+	"github.com/anyproto/anytype-heart/util/debug"
+)
+
+func (s *dsFileStore) DebugRouter(r chi.Router) {
+	r.Get("/list", debug.JSONHandler(s.debugList))
+	r.Get("/list_by_target/{targetID}", debug.JSONHandler(s.debugListByTarget))
+}
+
+func (s *dsFileStore) debugList(_ *http.Request) ([]*storage.FileInfo, error) {
+	return sanitizeFileInfos(s.List())
+}
+
+func (s *dsFileStore) debugListByTarget(req *http.Request) ([]*storage.FileInfo, error) {
+	id := chi.URLParam(req, "targetID")
+	return sanitizeFileInfos(s.ListByTarget(id))
+}
+
+func sanitizeFileInfos(infos []*storage.FileInfo, err error) ([]*storage.FileInfo, error) {
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*storage.FileInfo, len(infos))
+	for i, info := range infos {
+		out[i] = sanitizeFileInfoForDebug(info)
+	}
+	return out, nil
+}
+
+func sanitizeFileInfoForDebug(info *storage.FileInfo) *storage.FileInfo {
+	out := proto.Clone(info).(*storage.FileInfo)
+	out.Key = "<ENCRYPTION KEY>"
+	out.Name = "<SENSITIVE DATA>" + filepath.Ext(out.Name)
+	return out
+}


### PR DESCRIPTION
We want to release hotfix for the 0.28.5 release
This PR cherry-picks #435 on top of version/0.28.5 branch