### PR TITLE
Go-2131 optimize badger memory consumption

### DIFF
--- a/pkg/lib/datastore/clientds/clientds.go
+++ b/pkg/lib/datastore/clientds/clientds.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v3/options"
 	"github.com/hashicorp/go-multierror"
 	ds "github.com/ipfs/go-datastore"
 	dsbadgerv3 "github.com/textileio/go-ds-badger3"
@@ -70,18 +71,19 @@ func init() {
 	DefaultConfig.Spacestore.ValueThreshold = 1024 * 128 // Object details should be small enough, e.g. under 10KB. 512KB here is just a precaution.
 	DefaultConfig.Spacestore.Logger = logging.LWrapper{logging.Logger("store.spacestore")}
 	DefaultConfig.Spacestore.SyncWrites = false
-	DefaultConfig.Spacestore.WithCompression(0) // disable compression
+	DefaultConfig.Spacestore.BlockCacheSize = 0
+	DefaultConfig.Spacestore.Compression = options.None
 
 	// used to store objects localstore + threads logs info
-	DefaultConfig.Localstore.MemTableSize = 64 * 1024 * 1024
+	DefaultConfig.Localstore.MemTableSize = 32 * 1024 * 1024
 	DefaultConfig.Localstore.ValueLogFileSize = 16 * 1024 * 1024 // Vlog has all values more than value threshold, actual file uses 2x the amount, the size is preallocated
 	DefaultConfig.Localstore.GcInterval = 0                      // we don't need to have value GC here, because all the values should fit in the ValueThreshold. So GC will be done by the live LSM compactions
 	DefaultConfig.Localstore.GcSleep = 0
 	DefaultConfig.Localstore.ValueThreshold = 1024 * 1024 // Object details should be small enough, e.g. under 10KB. 512KB here is just a precaution.
 	DefaultConfig.Localstore.Logger = logging.LWrapper{logging.Logger("store.localstore")}
 	DefaultConfig.Localstore.SyncWrites = false
-	DefaultConfig.Localstore.WithCompression(0) // disable compression
-
+	DefaultConfig.Localstore.BlockCacheSize = 0
+	DefaultConfig.Localstore.Compression = options.None
 }
 
 func (r *clientds) Init(a *app.App) (err error) {

--- a/pkg/lib/localstore/objectstore/queries.go
+++ b/pkg/lib/localstore/objectstore/queries.go
@@ -31,6 +31,7 @@ func (s *dsObjectStore) QueryRaw(filters *database.Filters, limit int, offset in
 	var records []database.Record
 	err := s.db.View(func(txn *badger.Txn) error {
 		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
 		opts.Prefix = pagesDetailsBase.Bytes()
 		iterator := txn.NewIterator(opts)
 		defer iterator.Close()


### PR DESCRIPTION
I did all the benchmark in this way:
- Run desktop anytype app with 3700 objects in the objectstore (so it do the objectSearch under the hood and warm-up the cache)
- Run 1000 iterations of ObjectSearch with a filter that matches nothing

1. Main branch
  disk = SSD
  blockCache = 256mb
  valuethreshold = 1024*1024
  iterator.valuePrefetch=true
  compression = snappy
  **Result:
  4518ms for 1000 iterations**

2. Main branch + disabled valuePrefetch for iterator
  disk = SSD
  blockCache = 256mb
  valuethreshold = 1024*1024
  iterator.valuePrefetch=false
  compression = snappy
  **Result:
  1948ms for 1000 iterations**

3. all badger options tunes(this branch)
  disk = SSD
  blockCache = 0mb
  valuethreshold = 1024*1024
  iterator.valuePrefetch=false
  compression = none
  **Result:
  1761ms for 1000 iterations**

4. This branch on HDD
  disk = HDD (to check that disabled cache doesn't affect the speed)
  cache = 0mb
  valuethreshold = 1024*1024
  iterator.valuePrefetch=false
  compression = none
  **Result:
  1254ms for 1000 iterations (probably db files were fully cached by OS)**

Allocs test:
- Start desktop app (hot or cold account start)
1. This branch
  disk = SSD
  blockCache = 0mb
  valuethreshold = 1024*1024
  iterator.valuePrefetch=false
  compression = none
  **Result:
  Cold start(fetch from remote): 959MB
  Hot start: 313MB**
 
2. Main branch
  disk = SSD
  blockCache = 256mb
  valuethreshold = 1024*1024
  iterator.valuePrefetch=true
  compression = snappy
  **Result:
  Cold start(fetch from remote): 1906MB
  Hot start: 352MB**