### PR TITLE
GO-2012 Allow set and collection as defaultType on collection convert

### DIFF
--- a/core/block/collection/service.go
+++ b/core/block/collection/service.go
@@ -254,5 +254,5 @@ func setDefaultObjectTypeToViews(st *state.State) {
 }
 
 func isNotCreatableType(key bundle.TypeKey) bool {
-	return lo.Contains(append(bundle.InternalTypes, bundle.TypeKeyObjectType, bundle.TypeKeySet, bundle.TypeKeyCollection), key)
+	return lo.Contains(append(bundle.InternalTypes, bundle.TypeKeyObjectType), key)
 }

--- a/core/block/collection/service_test.go
+++ b/core/block/collection/service_test.go
@@ -189,7 +189,7 @@ func TestSetObjectTypeToViews(t *testing.T) {
 
 	t.Run("object is a set by not creatable type", func(t *testing.T) {
 		// given
-		st := generateState(bundle.TypeKeySet.URL(), bundle.TypeKeyCollection.URL())
+		st := generateState(bundle.TypeKeySet.URL(), bundle.TypeKeyObjectType.URL())
 
 		// when
 		setDefaultObjectTypeToViews(st)


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR allows Collections and Sets be defaultObjectTypeID value for collection views converted from set

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2012/convert-set-into-collection

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
