### PR TITLE
GO-2213 bookmark change user agent

### DIFF
--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -550,13 +550,7 @@ func (s *Service) Redo(
 
 func (s *Service) BookmarkFetch(ctx session.Context, req pb.RpcBlockBookmarkFetchRequest) (err error) {
 	return Do(s, req.ContextId, func(b bookmark.Bookmark) error {
-		return b.Fetch(ctx, req.BlockId, req.Url, false)
-	})
-}
-
-func (s *Service) BookmarkFetchSync(ctx session.Context, req pb.RpcBlockBookmarkFetchRequest) (err error) {
-	return Do(s, req.ContextId, func(b bookmark.Bookmark) error {
-		return b.Fetch(ctx, req.BlockId, req.Url, true)
+		return b.Fetch(ctx, req.BlockId, req.Url)
 	})
 }
 

--- a/core/block/simple/bookmark/bookmark.go
+++ b/core/block/simple/bookmark/bookmark.go
@@ -67,7 +67,6 @@ var _ Block = &Bookmark{}
 type FetchParams struct {
 	Url     string
 	Updater Updater
-	Sync    bool
 }
 
 type Updater func(blockID string, apply func(b Block) error) (err error)

--- a/util/linkpreview/linkpreview.go
+++ b/util/linkpreview/linkpreview.go
@@ -144,7 +144,7 @@ type proxyRoundTripper struct {
 }
 
 func (p *proxyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)")
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; AnytypeBot/1.0; +https://anytype.io/bot)")
 	resp, err := p.RoundTripper.RoundTrip(req)
 	if err == nil {
 		p.lastResponse = resp

--- a/util/linkpreview/linkpreview.go
+++ b/util/linkpreview/linkpreview.go
@@ -3,6 +3,7 @@ package linkpreview
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -62,6 +63,10 @@ func (l *linkPreview) Fetch(ctx context.Context, fetchUrl string) (model.LinkPre
 			return l.makeNonHtml(fetchUrl, resp)
 		}
 		return model.LinkPreview{}, err
+	}
+
+	if resp := rt.lastResponse; resp != nil && resp.StatusCode != http.StatusOK {
+		return model.LinkPreview{}, fmt.Errorf("invalid http code %d", resp.StatusCode)
 	}
 	res := l.convertOGToInfo(fetchUrl, og)
 	if len(res.Description) == 0 {


### PR DESCRIPTION
- change userAgent used for preview from `Googlebot/2.1` to `AnytypeBot`. Looks like GoogleBot ug got abused and strictly checked with IP ranges of google services by popular services like cloudflare
- check http status code. If code != 200 then do not fill the web preview
- do not set error code for the block. It still creates the underlying bookmark object but block looks ugly

Later we will add the background bookmark refetcher for the offline/ratelimited cases