### PR TITLE
GO-2271: when importing MD, the first block is deleted

### DIFF
--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -408,7 +408,7 @@ func (r *Renderer) renderText(_ util.BufWriter,
 
 	r.AddTextToBuffer(string(segment.Value(source)))
 	if n.HardLineBreak() {
-		r.ForceCloseTextBlock()
+		r.CloseTextBlock(model.BlockContentText_Paragraph)
 
 	} else if n.SoftLineBreak() {
 		r.AddTextToBuffer("\n")


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
`ForceCloseTextBlock` for some reasons deletes text block from `openedTextBlocks`, so it can't be created. That's why I change it to simple `CloseTextBlock`, where text block is not deleted
### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2271/when-importing-md-the-first-block-is-deleted
### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
