### PR TITLE
GO-2284 No error on deleted template

### DIFF
--- a/core/block/editor/template.go
+++ b/core/block/editor/template.go
@@ -66,7 +66,7 @@ func (t *Template) GetNewPageState(name string) (st *state.State, err error) {
 	}
 
 	st.RemoveDetail(bundle.RelationKeyTargetObjectType.String(), bundle.RelationKeyTemplateIsBundled.String())
-	st.SetDetail(bundle.RelationKeySourceObject.String(), pbtypes.String(t.Id()))
+	st.SetDetailAndBundledRelation(bundle.RelationKeySourceObject, pbtypes.String(t.Id()))
 	// clean-up local details from the template state
 	st.SetLocalDetails(nil)
 

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -2,10 +2,12 @@ package objectcreator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/commonspace/spacestorage"
 	"github.com/globalsign/mgo/bson"
 	"github.com/gogo/protobuf/types"
 	"golang.org/x/exp/slices"
@@ -88,7 +90,10 @@ func (s *service) createSmartBlockFromTemplate(ctx context.Context, space space.
 	var createState *state.State
 	if templateID != "" {
 		if createState, err = s.blockService.StateFromTemplate(templateID, pbtypes.GetString(details, bundle.RelationKeyName.String())); err != nil {
-			return
+			if !errors.Is(err, spacestorage.ErrTreeStorageAlreadyDeleted) {
+				return
+			}
+			createState = state.NewDoc("", nil).NewState()
 		}
 	} else {
 		createState = state.NewDoc("", nil).NewState()


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR cancels error return in case template provided in object creation commands is deleted

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2284/use-blank-template-in-case-provided-template-is-deleted

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
