### PR TITLE
GO-2313 add restrictions to profile, identity

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -98,6 +98,7 @@ var (
 	}
 
 	objectRestrictionsBySBType = map[smartblock.SmartBlockType]ObjectRestrictions{
+		smartblock.SmartBlockTypeIdentity: objRestrictAll,
 		smartblock.SmartBlockTypeProfilePage: {
 			model.Restrictions_LayoutChange,
 			model.Restrictions_TypeChange,
@@ -224,10 +225,9 @@ func GetRestrictionsForUniqueKey(uk domain.UniqueKey) (r ObjectRestrictions) {
 		if lo.Contains(bundle.SystemRelations, domain.RelationKey(key)) {
 			return sysRelationsRestrictions
 		}
-	case smartblock.SmartBlockTypeBundledObjectType:
-		return objRestrictAll
-	case smartblock.SmartBlockTypeBundledRelation:
-		return objRestrictAll
+	default:
+		// we assume that all sb types are exists in objectRestrictionsBySBType
+		return objectRestrictionsBySBType[uk.SmartblockType()]
 	}
 	return
 }

--- a/space/objectprovider/objectprovider.go
+++ b/space/objectprovider/objectprovider.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 
 	"github.com/anyproto/any-sync/app/logger"
+	"github.com/anyproto/any-sync/util/slice"
+	"github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
@@ -105,9 +107,11 @@ func (o *objectProvider) DeriveObjectIDs(ctx context.Context) (objIDs threads.De
 
 func (o *objectProvider) LoadObjects(ctx context.Context, objIDs []string) (err error) {
 	for _, id := range objIDs {
-		_, err = o.cache.GetObject(ctx, id)
-		if err != nil {
-			return err
+		_, errObject := o.cache.GetObject(ctx, id)
+		if errObject != nil {
+			predefinedIdPosition := slice.FindPos(o.derivedObjectIds.IDs(), id)
+			log.Error("loadObject failed", zap.Error(errObject), zap.String("objectID", id), zap.Int("predefinedIDPosition", predefinedIdPosition))
+			err = multierror.Append(err, errObject)
 		}
 	}
 	return

--- a/space/space.go
+++ b/space/space.go
@@ -2,12 +2,14 @@ package space
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/anyproto/any-sync/commonspace"
 	"github.com/anyproto/any-sync/commonspace/headsync"
 	"github.com/anyproto/any-sync/commonspace/objecttreebuilder"
 	"github.com/anyproto/any-sync/commonspace/spacestorage"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/object/objectcache"
@@ -86,6 +88,20 @@ func (s *space) mandatoryObjectsLoad(ctx context.Context) {
 	}
 	s.loadMandatoryObjectsErr = s.LoadObjects(ctx, s.derivedIDs.IDs())
 	if s.loadMandatoryObjectsErr != nil {
+		// we had a bug that allowed some users to remove their profile
+		// this workaround is to allow these users to load their accounts without errors and export their anytype data
+		// todo: remove this after we don't have msgs in graylog or find a better way to fix this type of problems
+		if mErr, ok := s.loadMandatoryObjectsErr.(*multierror.Error); ok {
+			var shouldReturnError bool
+			for _, err := range mErr.Errors {
+				if !errors.Is(err, spacestorage.ErrTreeStorageAlreadyDeleted) {
+					shouldReturnError = true
+				}
+			}
+			if !shouldReturnError {
+				s.loadMandatoryObjectsErr = nil
+			}
+		}
 		return
 	}
 	s.loadMandatoryObjectsErr = s.InstallBundledObjects(ctx)


### PR DESCRIPTION
- fallback to objectRestrictionsBySBType to have the single source of truth
- add restrictions to static Identity object
- add workaround to tolerate the existing error if Profile object has been removed