### PR TITLE
GO-2345 migrate subobjects in realtime changes

### DIFF
--- a/core/block/editor/workspaces.go
+++ b/core/block/editor/workspaces.go
@@ -106,6 +106,14 @@ func (w *Workspaces) StateMigrations() migration.Migrations {
 
 func (w *Workspaces) onApply(info smartblock.ApplyInfo) error {
 	w.onWorkspaceChanged(info.State)
+	if !info.ReceivedFromRemote {
+		return nil
+	}
+	// only in case we got this changes from remote we need to try to migrate subobjects
+	subObjectMigration := subObjectsMigration{
+		workspace: w,
+	}
+	subObjectMigration.migrateSubObjects(info.State)
 	return nil
 }
 


### PR DESCRIPTION
In case we got some realtime changes from the old pre-migration client they still may reference the subobjects. We need to migrate the state in this case as well. 