### PR TITLE
GO-2335 Create blank template in case it is archived

### DIFF
--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -123,6 +123,10 @@ func (s *service) createCustomTemplateState(templateId string) (targetState *sta
 		}
 		targetState = sb.NewState().Copy()
 
+		if pbtypes.GetBool(targetState.LocalDetails(), bundle.RelationKeyIsArchived.String()) {
+			return spacestorage.ErrTreeStorageAlreadyDeleted
+		}
+
 		innerErr = s.updateTypeKey(targetState)
 		if innerErr != nil {
 			return

--- a/core/block/template/service_test.go
+++ b/core/block/template/service_test.go
@@ -24,30 +24,33 @@ import (
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
-const deletedTemplateId = "iamdeleted"
+const (
+	deletedTemplateId  = "iamdeleted"
+	archivedTemplateId = "iamarchived"
+)
 
 type testPicker struct {
 	sb smartblock.SmartBlock
 }
 
-func (t *testPicker) GetObject(ctx context.Context, id string) (sb smartblock.SmartBlock, err error) {
+func (t *testPicker) GetObject(_ context.Context, id string) (sb smartblock.SmartBlock, err error) {
 	if id == deletedTemplateId {
 		return nil, spacestorage.ErrTreeStorageAlreadyDeleted
 	}
 	return t.sb, nil
 }
 
-func (t *testPicker) GetObjectByFullID(ctx context.Context, id domain.FullID) (sb smartblock.SmartBlock, err error) {
+func (t *testPicker) GetObjectByFullID(_ context.Context, id domain.FullID) (sb smartblock.SmartBlock, err error) {
 	return t.sb, nil
 }
 
-func (t *testPicker) Init(a *app.App) error { return nil }
+func (t *testPicker) Init(_ *app.App) error { return nil }
 
 func (t *testPicker) Name() string { return "" }
 
 func NewTemplateTest(templateName, typeKey string) smartblock.SmartBlock {
 	sb := smarttest.New(templateName)
-	_ = sb.SetDetails(nil, []*pb.RpcObjectSetDetailsDetail{
+	details := []*pb.RpcObjectSetDetailsDetail{
 		{
 			Key:   bundle.RelationKeyName.String(),
 			Value: pbtypes.String(templateName),
@@ -56,7 +59,14 @@ func NewTemplateTest(templateName, typeKey string) smartblock.SmartBlock {
 			Key:   bundle.RelationKeyDescription.String(),
 			Value: pbtypes.String(templateName),
 		},
-	}, false)
+	}
+	if templateName == archivedTemplateId {
+		details = append(details, &pb.RpcObjectSetDetailsDetail{
+			Key:   bundle.RelationKeyIsArchived.String(),
+			Value: pbtypes.Bool(true),
+		})
+	}
+	_ = sb.SetDetails(nil, details, false)
 	sb.Doc.(*state.State).SetObjectTypeKeys([]domain.TypeKey{bundle.TypeKeyTemplate, domain.TypeKey(typeKey)})
 	sb.AddBlock(simple.New(&model.Block{Id: templateName, ChildrenIds: []string{template.TitleBlockId, template.DescriptionBlockId}}))
 	sb.AddBlock(text.NewDetails(&model.Block{
@@ -137,44 +147,25 @@ func TestService_StateFromTemplate(t *testing.T) {
 		}
 	}
 
-	t.Run("empty templateId", func(t *testing.T) {
-		// given
-		tmpl := NewTemplateTest(templateName, "")
-		s := service{picker: &testPicker{sb: tmpl}}
+	for _, testCase := range [][]string{
+		{"templateId is empty", ""},
+		{"templateId is blank", BlankTemplateId},
+		{"target template is deleted", deletedTemplateId},
+		{"target template is archived", archivedTemplateId},
+	} {
+		t.Run("create blank template in case "+testCase[0], func(t *testing.T) {
+			// given
+			tmpl := NewTemplateTest(testCase[1], "")
+			s := service{picker: &testPicker{sb: tmpl}}
 
-		// when
-		st, err := s.CreateTemplateStateWithDetails("", nil)
+			// when
+			st, err := s.CreateTemplateStateWithDetails(testCase[1], nil)
 
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, st.RootId(), BlankTemplateId)
-	})
-
-	t.Run("blank templateId", func(t *testing.T) {
-		// given
-		tmpl := NewTemplateTest(templateName, "")
-		s := service{picker: &testPicker{sb: tmpl}}
-
-		// when
-		st, err := s.CreateTemplateStateWithDetails(BlankTemplateId, nil)
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, st.RootId(), BlankTemplateId)
-	})
-
-	t.Run("create blank template in case template object is deleted", func(t *testing.T) {
-		// given
-		s := service{picker: &testPicker{}}
-
-		// when
-		st, err := s.CreateTemplateStateWithDetails(deletedTemplateId, nil)
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, st.RootId(), BlankTemplateId)
-
-	})
+			// then
+			assert.NoError(t, err)
+			assert.Equal(t, BlankTemplateId, st.RootId())
+		})
+	}
 
 	t.Run("requested smartblock is not a template", func(t *testing.T) {
 		// given
@@ -199,6 +190,6 @@ func TestService_StateFromTemplate(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, st.ObjectTypeKey(), bundle.TypeKeyWeeklyPlan)
+		assert.Equal(t, bundle.TypeKeyWeeklyPlan, st.ObjectTypeKey())
 	})
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2335/use-blank-template-in-case-template-is-archived

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
