### PR TITLE
GO-2012 Fix set to collection convertion

### DIFF
--- a/core/block/collection/service.go
+++ b/core/block/collection/service.go
@@ -2,7 +2,6 @@ package collection
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/anyproto/any-sync/app"
@@ -19,7 +18,6 @@ import (
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
-	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -216,7 +214,7 @@ func (s *Service) ObjectToCollection(id string) error {
 			return fmt.Errorf("set layout: %w", err)
 		}
 		st.SetObjectTypeKey(bundle.TypeKeyCollection)
-		setDefaultObjectTypeToViews(st)
+		s.setDefaultObjectTypeToViews(st)
 		flags := internalflag.NewFromState(st)
 		flags.Remove(model.InternalFlag_editorSelectType)
 		flags.Remove(model.InternalFlag_editorDeleteEmpty)
@@ -229,17 +227,17 @@ func (s *Service) ObjectToCollection(id string) error {
 	return nil
 }
 
-func setDefaultObjectTypeToViews(st *state.State) {
-	if !lo.Contains(st.ObjectTypeKeys(), bundle.TypeKeySet) {
+func (s *Service) setDefaultObjectTypeToViews(st *state.State) {
+	if !lo.Contains(st.ParentState().ObjectTypeKeys(), bundle.TypeKeySet) {
 		return
 	}
 
 	setOfValue := pbtypes.GetStringList(st.ParentState().Details(), bundle.RelationKeySetOf.String())
-	if len(setOfValue) == 0 || !strings.HasPrefix(setOfValue[0], addr.ObjectTypeKeyToIdPrefix) {
+	if len(setOfValue) == 0 {
 		return
 	}
 
-	if isNotCreatableType(domain.TypeKey(strings.TrimPrefix(setOfValue[0], addr.ObjectTypeKeyToIdPrefix))) {
+	if s.isNotCreatableType(setOfValue[0]) {
 		return
 	}
 
@@ -257,6 +255,13 @@ func setDefaultObjectTypeToViews(st *state.State) {
 	}
 }
 
-func isNotCreatableType(key domain.TypeKey) bool {
-	return lo.Contains(append(bundle.InternalTypes, bundle.TypeKeyObjectType), key)
+func (s *Service) isNotCreatableType(id string) bool {
+	uk, err := s.objectStore.GetUniqueKeyById(id)
+	if err != nil {
+		return true
+	}
+	if uk.SmartblockType() != coresb.SmartBlockTypeObjectType {
+		return true
+	}
+	return lo.Contains(append(bundle.InternalTypes, bundle.TypeKeyObjectType), domain.TypeKey(uk.InternalKey()))
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes setting defaultObjectTypeId to views during conversion from set to collection.
Now all object types has its own local-space id, so the mechanism was broken

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2012/convert-set-into-collection

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
