### PR TITLE
GO-2390 fix subobject migration

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -347,6 +347,9 @@ func (sb *smartBlock) Init(ctx *InitContext) (err error) {
 		}
 	}
 	ctx.State.AddBundledRelations(relKeys...)
+	if ctx.IsNewObject && ctx.State != nil {
+		source.NewSubObjectsAndProfileLinksMigration(sb.space, sb.currentProfileId, sb.objectStore).Migrate(ctx.State)
+	}
 
 	if err = sb.injectLocalDetails(ctx.State); err != nil {
 		return
@@ -825,6 +828,7 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 }
 
 func (sb *smartBlock) ResetToVersion(s *state.State) (err error) {
+	source.NewSubObjectsAndProfileLinksMigration(sb.space, sb.currentProfileId, sb.objectStore).Migrate(s)
 	s.SetParent(sb.Doc.(*state.State))
 	sb.storeFileKeys(s)
 	sb.injectLocalDetails(s)

--- a/core/block/editor/state/change_test.go
+++ b/core/block/editor/state/change_test.go
@@ -764,3 +764,47 @@ func buildStateFromAST(root *Block) *State {
 	ApplyState(st, true)
 	return st.NewState()
 }
+
+func Test_migrateObjectTypeIDToKey(t *testing.T) {
+	type args struct {
+		old string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantNew      string
+		wantMigrated bool
+	}{
+		{
+			name: "type url to key",
+			args: args{
+				old: "ot-task",
+			},
+			wantNew:      "task",
+			wantMigrated: true,
+		},
+		{
+			name: "type bundled url to key",
+			args: args{
+				old: "_ottask",
+			},
+			wantNew:      "task",
+			wantMigrated: true,
+		},
+		{
+			name: "no migration",
+			args: args{
+				old: "task",
+			},
+			wantNew:      "task",
+			wantMigrated: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNew, gotMigrated := migrateObjectTypeIDToKey(tt.args.old)
+			assert.Equalf(t, tt.wantNew, gotNew, "migrateObjectTypeIDToKey(%v)", tt.args.old)
+			assert.Equalf(t, tt.wantMigrated, gotMigrated, "migrateObjectTypeIDToKey(%v)", tt.args.old)
+		})
+	}
+}

--- a/core/block/source/source.go
+++ b/core/block/source/source.go
@@ -280,8 +280,8 @@ func (s *source) buildState() (doc state.Doc, err error) {
 	// temporary, though the applying change to this Dataview block will persist this migration, breaking backward
 	// compatibility. But in many cases we expect that users update object not so often as they just view them.
 	// TODO: we can skip migration for non-personal spaces
-	migration := newSubObjectsAndProfileLinksMigration(s.space, s.accountService.IdentityObjectId(), s.objectStore)
-	migration.migrate(st)
+	migration := NewSubObjectsAndProfileLinksMigration(s.space, s.accountService.IdentityObjectId(), s.objectStore)
+	migration.Migrate(st)
 
 	s.changesSinceSnapshot = changesAppliedSinceSnapshot
 	// TODO: check if we can leave only removeDuplicates instead of Normalize

--- a/core/block/source/sub_object_links_migration.go
+++ b/core/block/source/sub_object_links_migration.go
@@ -122,6 +122,12 @@ func subObjectIdToUniqueKey(id string) (uniqueKey domain.UniqueKey, valid bool) 
 	if bson.IsObjectIdHex(id) {
 		return domain.MustUniqueKey(smartblock.SmartBlockTypeRelationOption, id), true
 	}
+	// special case: we don't support bundled relations/types in uniqueKeys (GO-2394). So in case we got it, we need to replace the prefix
+	if strings.HasPrefix(id, addr.BundledObjectTypeURLPrefix) {
+		id = addr.ObjectTypeKeyToIdPrefix + strings.TrimPrefix(id, addr.BundledObjectTypeURLPrefix)
+	} else if strings.HasPrefix(id, addr.BundledRelationURLPrefix) {
+		id = addr.RelationKeyToIdPrefix + strings.TrimPrefix(id, addr.BundledRelationURLPrefix)
+	}
 	uniqueKey, err := domain.UnmarshalUniqueKey(id)
 	if err != nil {
 		return nil, false

--- a/core/block/source/sub_object_links_migration.go
+++ b/core/block/source/sub_object_links_migration.go
@@ -3,6 +3,7 @@ package source
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/gogo/protobuf/types"
@@ -12,6 +13,7 @@ import (
 	dataview2 "github.com/anyproto/anytype-heart/core/block/simple/dataview"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
@@ -26,7 +28,7 @@ type subObjectsAndProfileLinksMigration struct {
 	objectStore      objectstore.ObjectStore
 }
 
-func newSubObjectsAndProfileLinksMigration(space Space, identityObjectID string, objectStore objectstore.ObjectStore) *subObjectsAndProfileLinksMigration {
+func NewSubObjectsAndProfileLinksMigration(space Space, identityObjectID string, objectStore objectstore.ObjectStore) *subObjectsAndProfileLinksMigration {
 	return &subObjectsAndProfileLinksMigration{
 		space:            space,
 		identityObjectID: identityObjectID,
@@ -62,7 +64,7 @@ func (m *subObjectsAndProfileLinksMigration) replaceLinksInDetails(s *state.Stat
 	}
 }
 
-func (m *subObjectsAndProfileLinksMigration) migrate(s *state.State) {
+func (m *subObjectsAndProfileLinksMigration) Migrate(s *state.State) {
 	uk, err := domain.NewUniqueKey(smartblock.SmartBlockTypeProfilePage, "")
 	if err != nil {
 		log.Errorf("migration: failed to create unique key for profile: %s", err)

--- a/core/domain/uniquekey.go
+++ b/core/domain/uniquekey.go
@@ -11,17 +11,15 @@ import (
 const uniqueKeySeparator = "-"
 
 var smartBlockTypeToKey = map[smartblock.SmartBlockType]string{
-	smartblock.SmartBlockTypeObjectType:        "ot",
-	smartblock.SmartBlockTypeBundledRelation:   "_br",
-	smartblock.SmartBlockTypeBundledObjectType: "_ot",
-	smartblock.SmartBlockTypeRelation:          "rel",
-	smartblock.SmartBlockTypeRelationOption:    "opt",
-	smartblock.SmartBlockTypeWorkspace:         "ws",
-	smartblock.SmartBlockTypeHome:              "home",
-	smartblock.SmartBlockTypeArchive:           "archive",
-	smartblock.SmartBlockTypeProfilePage:       "profile",
-	smartblock.SmartBlockTypeWidget:            "widget",
-	smartblock.SmartBlockTypeSpaceView:         "spaceview",
+	smartblock.SmartBlockTypeObjectType:     "ot",
+	smartblock.SmartBlockTypeRelation:       "rel",
+	smartblock.SmartBlockTypeRelationOption: "opt",
+	smartblock.SmartBlockTypeWorkspace:      "ws",
+	smartblock.SmartBlockTypeHome:           "home",
+	smartblock.SmartBlockTypeArchive:        "archive",
+	smartblock.SmartBlockTypeProfilePage:    "profile",
+	smartblock.SmartBlockTypeWidget:         "widget",
+	smartblock.SmartBlockTypeSpaceView:      "spaceview",
 }
 
 // UniqueKey is unique key composed of two parts: smartblock type and internal key.

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// ForceObjectsReindexCounter reindex thread-based objects
-	ForceObjectsReindexCounter int32 = 9
+	ForceObjectsReindexCounter int32 = 10
 
 	// ForceFilesReindexCounter reindex ipfs-file-based objects
 	ForceFilesReindexCounter int32 = 11 //


### PR DESCRIPTION
- handle wrong bundled objectTypes
- migrate state on Init so it will handle object creation
- migrate state on ResetToVersion so it will handle history version revert operation