### PR TITLE
GO-2047 Remove DeleteEmpty on SetText

### DIFF
--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -569,7 +569,7 @@ func TestTextImpl_TurnInto(t *testing.T) {
 	})
 }
 
-func TestTextImpl_shouldKeepInternalFlags(t *testing.T) {
+func TestTextImpl_removeInternalFlags(t *testing.T) {
 	text := "text"
 	rootID := "root"
 	blockID := "block"
@@ -664,6 +664,8 @@ func TestTextImpl_shouldKeepInternalFlags(t *testing.T) {
 		// then
 		assert.NoError(t, err1)
 		assert.NoError(t, err2)
-		assert.Len(t, pbtypes.GetIntList(sb.Details(), bundle.RelationKeyInternalFlags.String()), 3)
+		flags := pbtypes.GetIntList(sb.Details(), bundle.RelationKeyInternalFlags.String())
+		assert.Len(t, flags, 2)
+		assert.NotContains(t, flags, model.InternalFlag_editorDeleteEmpty)
 	})
 }

--- a/util/internalflag/flag.go
+++ b/util/internalflag/flag.go
@@ -57,6 +57,10 @@ func (s Set) AddToState(st *state.State) {
 	st.SetDetailAndBundledRelation(relationKey, pbtypes.IntList(s.flags...))
 }
 
+func (s Set) IsEmpty() bool {
+	return len(s.flags) == 0
+}
+
 func PutToDetails(details *types.Struct, flags []*model.InternalFlag) *types.Struct {
 	ints := make([]int, 0, len(flags))
 	for _, f := range flags {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR provides logic for deletion DeleteEmpty flag if we change Title or Description.
Sets and Collections do not have any other text blocks except title and description, so they were deleted on Close

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2047/do-not-create-object-without-context-for-sets-collections-and-notes

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
