### PR TITLE
GO-2343: add import start and import finish events to amplitude

### DIFF
--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -33,6 +33,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/object/objectcreator"
 	"github.com/anyproto/anytype-heart/core/block/process"
 	"github.com/anyproto/anytype-heart/core/filestorage/filesync"
+	"github.com/anyproto/anytype-heart/metrics"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core"
@@ -109,10 +110,12 @@ func (i *Import) Import(ctx context.Context, req *pb.RpcObjectImportRequest, ori
 	defer func() {
 		i.finishImportProcess(returnedErr, progress)
 		i.sendFileEvents(returnedErr)
+		i.recordEvent(&metrics.ImportFinishedEvent{ID: progress.Id(), ImportType: req.Type.String()})
 	}()
 	if i.s != nil && !req.GetNoProgress() {
 		i.s.ProcessAdd(progress)
 	}
+	i.recordEvent(&metrics.ImportStartedEvent{ID: progress.Id(), ImportType: req.Type.String()})
 	var rootCollectionID string
 	if c, ok := i.converters[req.Type.String()]; ok {
 		rootCollectionID, returnedErr = i.importFromBuiltinConverter(ctx, req, c, progress, origin)
@@ -402,6 +405,10 @@ func (i *Import) readResultFromPool(pool *workerpool.WorkerPool,
 		details[res.NewID] = res.Details
 	}
 	return details
+}
+
+func (i *Import) recordEvent(event metrics.EventRepresentable) {
+	metrics.SharedClient.RecordEvent(event)
 }
 
 func convertType(cType string) pb.RpcObjectImportListImportResponseType {

--- a/metrics/events.go
+++ b/metrics/events.go
@@ -300,3 +300,33 @@ func (c OpenBlockEvent) ToEvent() *Event {
 		},
 	}
 }
+
+type ImportStartedEvent struct {
+	ID         string
+	ImportType string
+}
+
+func (i ImportStartedEvent) ToEvent() *Event {
+	return &Event{
+		EventType: "import_started",
+		EventData: map[string]interface{}{
+			"import_id":   i.ID,
+			"import_type": i.ImportType,
+		},
+	}
+}
+
+type ImportFinishedEvent struct {
+	ID         string
+	ImportType string
+}
+
+func (i ImportFinishedEvent) ToEvent() *Event {
+	return &Event{
+		EventType: "import_finished",
+		EventData: map[string]interface{}{
+			"import_id":   i.ID,
+			"import_type": i.ImportType,
+		},
+	}
+}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Add events for amplitude to track metrics when user start import, but not finish it (close application or turned off device and etc)
### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2343/import-notion-timeout-check-graylog-how-many-notion-imported-started
### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
