### PR TITLE
GO-2556: experience creates an empty widget collection

### DIFF
--- a/core/block/import/pb/gallery.go
+++ b/core/block/import/pb/gallery.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
@@ -96,6 +97,9 @@ func (g *GalleryImport) getObjectsFromWidgets(widgetSnapshot *common.Snapshot) [
 	err := widgetState.Iterate(func(b simple.Block) (isContinue bool) {
 		if link := b.Model().GetLink(); link != nil && link.TargetBlockId != "" {
 			if widgets.IsPredefinedWidgetTargetId(link.TargetBlockId) {
+				return true
+			}
+			if link.TargetBlockId == addr.MissingObject {
 				return true
 			}
 			objectsInWidget = append(objectsInWidget, link.TargetBlockId)

--- a/core/block/import/pb/gallery_test.go
+++ b/core/block/import/pb/gallery_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
@@ -312,5 +313,39 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.Nil(t, collection)
+	})
+
+	t.Run("widget has only deleted objects - not create widget collection", func(t *testing.T) {
+		// given
+		p := GalleryImport{}
+		params := &pb.RpcObjectImportRequestPbParams{NoCollection: false}
+
+		// object with widget
+		widgetSnapshot := &common.Snapshot{
+			Id:     "widgetID",
+			SbType: smartblock.SmartBlockTypeWidget,
+			Snapshot: &pb.ChangeSnapshot{
+				Data: &model.SmartBlockSnapshotBase{
+					Blocks: []*model.Block{
+						{
+							Id: "widgetID",
+							Content: &model.BlockContentOfLink{
+								Link: &model.BlockContentLink{
+									TargetBlockId: addr.MissingObject,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// when
+		collection, err := p.ProvideCollection(nil, widgetSnapshot, nil, params, nil, false)
+
+		// then
+		assert.Nil(t, err)
+		assert.Len(t, collection, 1)
+		assert.NotContains(t, widgetCollectionPattern, collection[0].FileName)
 	})
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Currently widgets are not updated, when user delete object, which was linked to widget objects. So that leads to a situation, when widget object contains not existing objects in links blocks. During import such objects don't exist in archive. So we skip such objects during gallery import and not add them to widget collection 

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
