### PR TITLE
GO-2574 SetAppDeviceState improvements

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -37,7 +37,8 @@ func New() *Middleware {
 }
 
 func (mw *Middleware) AppShutdown(cctx context.Context, request *pb.RpcAppShutdownRequest) *pb.RpcAppShutdownResponse {
-	mw.applicationService.Stop()
+	// no need to handle error here, it's already logged inside
+	_ = mw.applicationService.Stop()
 	return &pb.RpcAppShutdownResponse{
 		Error: &pb.RpcAppShutdownResponseError{
 			Code: pb.RpcAppShutdownResponseError_NULL,
@@ -46,6 +47,16 @@ func (mw *Middleware) AppShutdown(cctx context.Context, request *pb.RpcAppShutdo
 }
 
 func (mw *Middleware) AppSetDeviceState(cctx context.Context, req *pb.RpcAppSetDeviceStateRequest) *pb.RpcAppSetDeviceStateResponse {
+	if req.DeviceState == pb.RpcAppSetDeviceStateRequest_TERMINATING {
+		// no need to handle error here, it's already logged inside
+		_ = mw.applicationService.Stop()
+
+		return &pb.RpcAppSetDeviceStateResponse{
+			Error: &pb.RpcAppSetDeviceStateResponseError{
+				Code: pb.RpcAppSetDeviceStateResponseError_NULL,
+			},
+		}
+	}
 	mw.applicationService.GetApp().SetDeviceState(int(req.DeviceState))
 
 	return &pb.RpcAppSetDeviceStateResponse{

--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
@@ -66,12 +67,14 @@ type indexer struct {
 	quit       chan struct{}
 	btHash     Hasher
 	newAccount bool
-	forceFt    chan struct{}
 
 	indexedFiles     *sync.Map
 	reindexLogFields []zap.Field
 
 	flags reindexFlags
+
+	forceFt  chan struct{}
+	ftPaused atomic.Bool
 }
 
 func (i *indexer) Init(a *app.App) (err error) {

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -16335,8 +16335,11 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| BACKGROUND | 0 |  |
-| FOREGROUND | 1 |  |
+| FOREGROUND | 0 | default mode; app should work normally onResume on Android, didBecomeActiveNotification on iOS |
+| RESUMED | 1 | app is starting; onStart on Android, didBecomeActiveNotification on iOS |
+| PAUSING | 2 | app is no longer focused and active; onPause on Android, applicationWillResignActive on iOS |
+| BACKGROUND | 3 | app is no longer visible; onStop on Android, didEnterBackgroundNotification on iOS |
+| TERMINATING | 4 | app is about to be destroyed, same as AppShutdown; onDestroy on Android, willTerminateNotification on iOS |
 
 
 

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -16335,7 +16335,7 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| FOREGROUND | 0 | default mode; app should work normally onResume on Android, didBecomeActiveNotification on iOS |
+| FOREGROUND | 0 | default mode – app should work normally; onResume on Android, applicationWillEnterForeground on iOS |
 | RESUMED | 1 | app is starting; onStart on Android, didBecomeActiveNotification on iOS |
 | PAUSING | 2 | app is no longer focused and active; onPause on Android, applicationWillResignActive on iOS |
 | BACKGROUND | 3 | app is no longer visible; onStop on Android, didEnterBackgroundNotification on iOS |

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -49,7 +49,7 @@ message Rpc {
                 DeviceState deviceState = 1;
 
                 enum DeviceState {
-                    FOREGROUND = 0; // default mode; app should work normally onResume on Android, didBecomeActiveNotification on iOS
+                    FOREGROUND = 0; // default mode – app should work normally; onResume on Android, applicationWillEnterForeground on iOS
                     RESUMED = 1; // app is starting; onStart on Android, didBecomeActiveNotification on iOS
                     PAUSING = 2; // app is no longer focused and active; onPause on Android, applicationWillResignActive on iOS
                     BACKGROUND = 3; // app is no longer visible; onStop on Android, didEnterBackgroundNotification on iOS

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -49,8 +49,11 @@ message Rpc {
                 DeviceState deviceState = 1;
 
                 enum DeviceState {
-                    BACKGROUND = 0;
-                    FOREGROUND = 1;
+                    FOREGROUND = 0; // default mode; app should work normally onResume on Android, didBecomeActiveNotification on iOS
+                    RESUMED = 1; // app is starting; onStart on Android, didBecomeActiveNotification on iOS
+                    PAUSING = 2; // app is no longer focused and active; onPause on Android, applicationWillResignActive on iOS
+                    BACKGROUND = 3; // app is no longer visible; onStop on Android, didEnterBackgroundNotification on iOS
+                    TERMINATING = 4; // app is about to be destroyed, same as AppShutdown; onDestroy on Android, willTerminateNotification on iOS
                 }
             }
 


### PR DESCRIPTION
Possible DeviceStates:
```
FOREGROUND = 0; // default mode - app should work normally; onResume on Android, didBecomeActiveNotification on iOS
RESUMED = 1; // app is starting; onStart on Android, didBecomeActiveNotification on iOS
PAUSING = 2; // app is no longer focused and active; onPause on Android, applicationWillResignActive on iOS
BACKGROUND = 3; // app is no longer visible; onStop on Android, didEnterBackgroundNotification on iOS
TERMINATING = 4; // app is about to be destroyed, same as AppShutdown; onDestroy on Android, 
```

- sync db when going background
- disable ft indexing when pausing/background