### PR TITLE
fix reindex deadlock

### DIFF
--- a/space/space.go
+++ b/space/space.go
@@ -98,7 +98,6 @@ func (s *space) mandatoryObjectsLoad(ctx context.Context) {
 }
 
 func (s *space) DerivedIDs() threads.DerivedSmartblockIds {
-	<-s.loadMandatoryObjectsCh
 	return s.derivedIDs
 }
 


### PR DESCRIPTION
because we calculate all derived ids on the space init there is no need to wait for load