### PR TITLE
fix iterateKeysByPrefixBatchedTx

### DIFF
--- a/pkg/lib/localstore/objectstore/badger_helpers.go
+++ b/pkg/lib/localstore/objectstore/badger_helpers.go
@@ -77,7 +77,7 @@ func iterateKeysByPrefixTx(txn *badger.Txn, prefix []byte, processKeyFn func(key
 	defer iter.Close()
 
 	for iter.Rewind(); iter.Valid(); iter.Next() {
-		key := iter.Item().Key()
+		key := iter.Item().KeyCopy(nil)
 		processKeyFn(key)
 	}
 	return nil

--- a/pkg/lib/localstore/objectstore/badger_helpers.go
+++ b/pkg/lib/localstore/objectstore/badger_helpers.go
@@ -45,7 +45,7 @@ func iterateKeysByPrefixBatchedTx(
 	count := 0
 
 	for iter.Rewind(); iter.Valid(); iter.Next() {
-		key := iter.Item().Key()
+		key := iter.Item().KeyCopy(nil)
 		batch = append(batch, key)
 		count++
 


### PR DESCRIPTION
iterator key can't be sed outside of iterator without copy