### PR TITLE
GO-2455 | GO-2570 | GO-2575 - Save template details

### DIFF
--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -39,7 +39,15 @@ const (
 	BlankTemplateId = "blank"
 )
 
-var log = logging.Logger("template")
+var (
+	log = logging.Logger("template")
+
+	templateIsPreferableRelationKeys = []domain.RelationKey{
+		bundle.RelationKeyFeaturedRelations, bundle.RelationKeyLayout,
+		bundle.RelationKeyIconEmoji, bundle.RelationKeyCoverId,
+		bundle.RelationKeySourceObject,
+	}
+)
 
 type Service interface {
 	CreateTemplateStateWithDetails(templateId string, details *types.Struct) (st *state.State, err error)
@@ -105,19 +113,22 @@ func (s *service) CreateTemplateStateWithDetails(
 	return targetState, nil
 }
 
-func extractTargetDetails(addedDetails *types.Struct, templateDetails *types.Struct) *types.Struct {
-	templateIsPreferableRelationKeys := []domain.RelationKey{bundle.RelationKeyFeaturedRelations, bundle.RelationKeyLayout}
-	targetDetails := pbtypes.CopyStruct(addedDetails)
+func extractTargetDetails(originDetails *types.Struct, templateDetails *types.Struct) *types.Struct {
+	targetDetails := pbtypes.CopyStruct(originDetails)
 	if templateDetails == nil {
 		return targetDetails
 	}
-	for key := range addedDetails.GetFields() {
+	for key := range originDetails.GetFields() {
 		_, exists := templateDetails.Fields[key]
 		if exists {
 			inTemplateEmpty := pbtypes.IsEmptyValueOrAbsent(templateDetails, key)
-			inAddedEmpty := pbtypes.IsEmptyValueOrAbsent(addedDetails, key)
+			if key == bundle.RelationKeyLayout.String() {
+				// layout = 0 is actually basic layout, so it counts
+				inTemplateEmpty = false
+			}
+			inOriginEmpty := pbtypes.IsEmptyValueOrAbsent(originDetails, key)
 			templateValueShouldBePreferred := lo.Contains(templateIsPreferableRelationKeys, domain.RelationKey(key))
-			if !inTemplateEmpty && (inAddedEmpty || templateValueShouldBePreferred) {
+			if !inTemplateEmpty && (inOriginEmpty || templateValueShouldBePreferred) {
 				delete(targetDetails.Fields, key)
 			}
 		}

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -146,13 +146,8 @@ func (s *service) createCustomTemplateState(templateId string) (targetState *sta
 		targetState.SetLocalDetails(nil)
 		return
 	})
-	if err != nil {
-		if errors.Is(err, spacestorage.ErrTreeStorageAlreadyDeleted) {
-			targetState = s.createBlankTemplateState(model.ObjectType_basic)
-			err = nil
-		} else {
-			err = fmt.Errorf("can't apply template: %w", err)
-		}
+	if errors.Is(err, spacestorage.ErrTreeStorageAlreadyDeleted) {
+		return s.createBlankTemplateState(model.ObjectType_basic), nil
 	}
 	return
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR makes sourceObject and layout values of template state more prioritized than in origin state

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2455/template-dont-change-layout
https://linear.app/anytype/issue/GO-2570/relation-source-object-does-not-update-the-linked-template-when
https://linear.app/anytype/issue/GO-2575/template-selector-not-working-correctly

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
