### PR TITLE
GO-2636: Add responsible peers to space loader

### DIFF
--- a/space/internal/components/spaceloader/spaceloader.go
+++ b/space/internal/components/spaceloader/spaceloader.go
@@ -67,7 +67,7 @@ func (s *spaceLoader) Close(ctx context.Context) (err error) {
 		s.status.Unlock()
 		return nil
 	}
-	s.status.Lock()
+	s.status.Unlock()
 	s.cancel()
 	sp, err := s.WaitLoad(ctx)
 	if err != nil {

--- a/space/internal/components/spaceloader/spaceloader.go
+++ b/space/internal/components/spaceloader/spaceloader.go
@@ -62,6 +62,12 @@ func (s *spaceLoader) Run(ctx context.Context) (err error) {
 }
 
 func (s *spaceLoader) Close(ctx context.Context) (err error) {
+	s.status.Lock()
+	if s.loading == nil {
+		s.status.Unlock()
+		return nil
+	}
+	s.status.Lock()
 	s.cancel()
 	sp, err := s.WaitLoad(ctx)
 	if err != nil {

--- a/space/internal/techspace/techspace.go
+++ b/space/internal/techspace/techspace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/app/logger"
 	"github.com/anyproto/any-sync/commonspace"
+	"github.com/anyproto/any-sync/net/peer"
 	"github.com/gogo/protobuf/types"
 	"go.uber.org/zap"
 
@@ -142,6 +143,7 @@ func (s *techSpace) SpaceViewExists(ctx context.Context, spaceId string) (exists
 	if err != nil {
 		return
 	}
+	ctx = peer.CtxWithPeerId(ctx, peer.CtxResponsiblePeers)
 	_, getErr := s.objectCache.GetObject(ctx, viewId)
 	return getErr == nil, nil
 }

--- a/space/internal/techspace/techspace_test.go
+++ b/space/internal/techspace/techspace_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
 	"github.com/anyproto/any-sync/commonspace/object/tree/treestorage"
 	"github.com/anyproto/any-sync/commonspace/object/treesyncer/mock_treesyncer"
+	"github.com/anyproto/any-sync/net/peer"
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -89,12 +90,13 @@ func TestTechSpace_SpaceViewExists(t *testing.T) {
 		spaceId = "space.id"
 		viewId  = "viewId"
 		view    = newSpaceViewStub(viewId)
+		respCtx = peer.CtxWithPeerId(context.Background(), peer.CtxResponsiblePeers)
 	)
 	t.Run("exists", func(t *testing.T) {
 		fx := newFixture(t, nil)
 		defer fx.finish(t)
 		fx.expectDeriveTreePayload(viewId)
-		fx.objectCache.EXPECT().GetObject(ctx, viewId).Return(view, nil)
+		fx.objectCache.EXPECT().GetObject(respCtx, viewId).Return(view, nil)
 		exists, err := fx.SpaceViewExists(ctx, spaceId)
 		require.NoError(t, err)
 		assert.True(t, exists)
@@ -103,7 +105,7 @@ func TestTechSpace_SpaceViewExists(t *testing.T) {
 		fx := newFixture(t, nil)
 		defer fx.finish(t)
 		fx.expectDeriveTreePayload(viewId)
-		fx.objectCache.EXPECT().GetObject(ctx, viewId).Return(nil, fmt.Errorf("not found"))
+		fx.objectCache.EXPECT().GetObject(respCtx, viewId).Return(nil, fmt.Errorf("not found"))
 		exists, err := fx.SpaceViewExists(ctx, spaceId)
 		require.NoError(t, err)
 		assert.False(t, exists)


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
