### PR TITLE
Go 2643 fix tz on android and ios

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
           go install github.com/vektra/mockery/v2@v2.35.3
           go install go.uber.org/mock/mockgen@v0.3.0
           make test-deps
-          gomobile bind -tags "envproduction nogrpcserver gomobile nowatchdog nosigar nomutexdeadlockdetector" -ldflags "$FLAGS" -v -target=ios -o Lib.xcframework github.com/anyproto/anytype-heart/clientlibrary/service github.com/anyproto/anytype-heart/core || true
+          gomobile bind -tags "envproduction nogrpcserver gomobile nowatchdog nosigar nomutexdeadlockdetector timetzdata" -ldflags "$FLAGS" -v -target=ios -o Lib.xcframework github.com/anyproto/anytype-heart/clientlibrary/service github.com/anyproto/anytype-heart/core || true
           gtar --exclude ".*" -czvf ios_framework.tar.gz Lib.xcframework protobuf json
           gradle publish
           mv ios_framework.tar.gz .release/ios_framework_${VERSION}.tar.gz
@@ -209,7 +209,7 @@ jobs:
           cp pkg/lib/bundle/internalTypes.json ./json
       - name: Compile android lib
         run: |
-          gomobile bind -tags "envproduction nogrpcserver gomobile nowatchdog nosigar nomutexdeadlockdetector" -ldflags "$FLAGS" -v -target=android -androidapi 19 -o lib.aar github.com/anyproto/anytype-heart/clientlibrary/service github.com/anyproto/anytype-heart/core || true
+          gomobile bind -tags "envproduction nogrpcserver gomobile nowatchdog nosigar nomutexdeadlockdetector timetzdata" -ldflags "$FLAGS" -v -target=android -androidapi 19 -o lib.aar github.com/anyproto/anytype-heart/clientlibrary/service github.com/anyproto/anytype-heart/core || true
           gtar --exclude ".*" -czvf android_lib_${VERSION}.tar.gz lib.aar protobuf json
           mv android_lib_${VERSION}.tar.gz .release/
       - name: Publish android lib to maven

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ build-ios: setup-go setup-gomobile
 	@rm -rf ./dist/ios/Lib.xcframework
 	@echo 'Building library for iOS...'
 	@$(eval FLAGS := $$(shell govvv -flags | sed 's/main/github.com\/anyproto\/anytype-heart\/util\/vcs/g'))
-	@$(eval TAGS := nogrpcserver gomobile nowatchdog nosigar)
+	@$(eval TAGS := nogrpcserver gomobile nowatchdog nosigar timetzdata)
 ifdef ANY_SYNC_NETWORK
 	@$(eval TAGS := $(TAGS) envnetworkcustom)
 endif
@@ -128,7 +128,7 @@ build-android: setup-go setup-gomobile
 	$(DEPS_PATH)/gomobile init
 	@echo 'Building library for Android...'
 	@$(eval FLAGS := $$(shell govvv -flags | sed 's/main/github.com\/anyproto\/anytype-heart\/util\/vcs/g'))
-	@$(eval TAGS := nogrpcserver gomobile nowatchdog nosigar)
+	@$(eval TAGS := nogrpcserver gomobile nowatchdog nosigar timetzdata)
 ifdef ANY_SYNC_NETWORK
 	@$(eval TAGS := $(TAGS) envnetworkcustom)
 endif

--- a/clientlibrary/service/fixtz_android.go
+++ b/clientlibrary/service/fixtz_android.go
@@ -7,12 +7,15 @@ import (
 )
 
 func fixTZ() {
-	out, err := exec.Command("/system/bin/getprop", "persist.sys.timezone").Output()
+	tzName, err := exec.Command("/system/bin/getprop", "persist.sys.timezone").Output()
 	if err != nil {
+		fmt.Printf("failed to get system timezone: %s\n", err.Error())
 		return
 	}
-	z, err := time.LoadLocation(strings.TrimSpace(string(out)))
+	tzName = strings.TrimSpace(string(tzName))
+	z, err := time.LoadLocation(tzName)
 	if err != nil {
+		fmt.Printf("failed to load tz %s: %s\n", tzName, err.Error())
 		return
 	}
 	time.Local = z

--- a/clientlibrary/service/fixtz_android.go
+++ b/clientlibrary/service/fixtz_android.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func fixTZ() {
+	out, err := exec.Command("/system/bin/getprop", "persist.sys.timezone").Output()
+	if err != nil {
+		return
+	}
+	z, err := time.LoadLocation(strings.TrimSpace(string(out)))
+	if err != nil {
+		return
+	}
+	time.Local = z
+}

--- a/clientlibrary/service/fixtz_ios.go
+++ b/clientlibrary/service/fixtz_ios.go
@@ -1,0 +1,31 @@
+//go:build cgo && ios
+
+package service
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+#import <Foundation/Foundation.h>
+
+const char* getSystemTimeZone() {
+    NSTimeZone *timeZone = [NSTimeZone systemTimeZone];
+    NSString *timeZoneName = [timeZone description];
+    return [timeZoneName UTF8String];
+}
+*/
+import "C"
+
+import (
+	"strings"
+	"time"
+)
+
+func getSystemTimeZone() string {
+	tz := C.getSystemTimeZone()
+	return C.GoString(tz)
+}
+
+func fixTZ() {
+	z, _ := time.LoadLocation(strings.Split(getSystemTimeZone(), " ")[0])
+	time.Local = z
+}

--- a/clientlibrary/service/fixtz_ios.go
+++ b/clientlibrary/service/fixtz_ios.go
@@ -16,6 +16,7 @@ const char* getSystemTimeZone() {
 import "C"
 
 import (
+	"fmt"
 	"strings"
 	"time"
 )
@@ -26,6 +27,16 @@ func getSystemTimeZone() string {
 }
 
 func fixTZ() {
-	z, _ := time.LoadLocation(strings.Split(getSystemTimeZone(), " ")[0])
+	tzDesc := getSystemTimeZone()
+	if len(tzDesc) == 0 {
+		fmt.Printf("failed to get system timezone\n")
+		return
+	}
+	tzName := strings.Split(tzDesc, " ")[0]
+	z, err := time.LoadLocation(tzName)
+	if err != nil {
+		fmt.Printf("failed to load tz %s: %s\n", tzName, err.Error())
+		return
+	}
 	time.Local = z
 }

--- a/clientlibrary/service/fixtz_skip.go
+++ b/clientlibrary/service/fixtz_skip.go
@@ -1,0 +1,7 @@
+//go:build !android && !ios
+
+package service
+
+func fixTZ() {
+
+}

--- a/clientlibrary/service/lib.go
+++ b/clientlibrary/service/lib.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	"github.com/anyproto/any-sync/app"
@@ -13,8 +14,6 @@ import (
 	"github.com/anyproto/anytype-heart/metrics"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
-
-	_ "net/http/pprof"
 )
 
 var log = logging.Logger("anytype-mw")
@@ -22,6 +21,8 @@ var log = logging.Logger("anytype-mw")
 var mw = core.New()
 
 func init() {
+	fixTZ()
+
 	fmt.Printf("mw jsaddon: %s\n", app.GitSummary)
 	registerClientCommandsHandler(mw)
 	PanicHandler = mw.OnPanic

--- a/clientlibrary/service/lib.go
+++ b/clientlibrary/service/lib.go
@@ -6,7 +6,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 
-	"github.com/anyproto/any-sync/app"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/anyproto/anytype-heart/core"
@@ -14,6 +13,7 @@ import (
 	"github.com/anyproto/anytype-heart/metrics"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
+	"github.com/anyproto/anytype-heart/util/vcs"
 )
 
 var log = logging.Logger("anytype-mw")
@@ -22,8 +22,8 @@ var mw = core.New()
 
 func init() {
 	fixTZ()
+	fmt.Printf("mw lib: %s\n", vcs.GetVCSInfo().Description())
 
-	fmt.Printf("mw jsaddon: %s\n", app.GitSummary)
 	registerClientCommandsHandler(mw)
 	PanicHandler = mw.OnPanic
 	metrics.SharedClient.InitWithKey(metrics.DefaultAmplitudeKey)

--- a/cmd/grpcserver/grpc.go
+++ b/cmd/grpcserver/grpc.go
@@ -35,6 +35,7 @@ import (
 	"github.com/anyproto/anytype-heart/pb/service"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/util/debug"
+	"github.com/anyproto/anytype-heart/util/vcs"
 )
 
 const defaultAddr = "127.0.0.1:31007"
@@ -51,7 +52,7 @@ func main() {
 	var addr string
 	var webaddr string
 	app.StartWarningAfter = time.Second * 5
-	fmt.Printf("mw grpc: %s\n", app.VersionDescription())
+	fmt.Printf("mw grpc: %s\n", vcs.GetVCSInfo().Description())
 	if len(os.Args) > 1 {
 		addr = os.Args[1]
 		if len(os.Args) > 2 {

--- a/util/vcs/vcs.go
+++ b/util/vcs/vcs.go
@@ -51,7 +51,7 @@ func (v VCSInfo) Description() string {
 	if !v.CGO {
 		desc += " (no-cgo)"
 	}
-	return fmt.Sprintf("build on %s from %s at #%s(%s)", v.BuildDate, v.Branch, v.Revision, v.Summary)
+	return desc
 }
 
 // GetVCSInfo returns git build info


### PR DESCRIPTION
https://github.com/golang/go/issues/20455
https://github.com/golang/go/issues/20797

Tested on both iOS and Android. Fixes problems with relative filters, e.g. Today

Android seems to have tzdata on some devices and I was not able to fine a way to read it on iOS. I have embed [tzdata](https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/time/tzdata/tzdata.go) on both of them and it should add 450kb to the binary/heap size