### PR TITLE
badger backup system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,7 @@ require (
 	nhooyr.io/websocket v1.8.7 // indirect
 )
 
-replace github.com/dgraph-io/badger/v4 => github.com/VinGarcia/badger/v4 v4.0.0-20231207134132-548c3cee3e9c
+replace github.com/dgraph-io/badger/v4 => github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580
 
 replace github.com/dgraph-io/ristretto => github.com/anyproto/ristretto v0.1.2-0.20231209140254-b0fde22c72ec
 

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/gogo/status v1.1.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4
 	github.com/google/uuid v1.5.0
 	github.com/gosimple/slug v1.13.1
@@ -88,6 +89,7 @@ require (
 	golang.org/x/mobile v0.0.0-20231006135142-2b44d11868fe
 	golang.org/x/net v0.19.0
 	golang.org/x/oauth2 v0.15.0
+	golang.org/x/sys v0.15.0
 	golang.org/x/text v0.14.0
 	google.golang.org/grpc v1.60.1
 	gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20180125164251-1832d8546a9f
@@ -253,7 +255,6 @@ require (
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/sync v0.4.0 // indirect
-	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
@@ -266,6 +267,8 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace github.com/dgraph-io/badger/v4 => github.com/VinGarcia/badger/v4 v4.0.0-20231207134132-548c3cee3e9c
 
 replace github.com/dgraph-io/ristretto => github.com/anyproto/ristretto v0.1.2-0.20231209140254-b0fde22c72ec
 

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
+github.com/VinGarcia/badger/v4 v4.0.0-20231207134132-548c3cee3e9c h1:FKjUIW7DOhHB5jQa93+fveH1KwQMKdVyFwdm3f1ZD58=
+github.com/VinGarcia/badger/v4 v4.0.0-20231207134132-548c3cee3e9c/go.mod h1:T/uWAYxrXdaXw64ihI++9RMbKTCpKd/yE9+saARew7k=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -107,8 +109,6 @@ github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxB
 github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
-github.com/anyproto/any-sync v0.3.16 h1:6rukkZEM1U+I181xlTKkYxg8giqgUJ0Pc38zstIXnhs=
-github.com/anyproto/any-sync v0.3.16/go.mod h1:q4Wn0+1MbbV9PlZ3FRGOghEN+FeatlL5s/HlR9gkr+s=
 github.com/anyproto/any-sync v0.3.17 h1:SvMCOWPUKfYhok2rcdj78Sroe8g8RCrcPnojgSkWQ5M=
 github.com/anyproto/any-sync v0.3.17/go.mod h1:q4Wn0+1MbbV9PlZ3FRGOghEN+FeatlL5s/HlR9gkr+s=
 github.com/anyproto/go-chash v0.1.0 h1:I9meTPjXFRfXZHRJzjOHC/XF7Q5vzysKkiT/grsogXY=
@@ -294,8 +294,6 @@ github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzA
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
-github.com/dgraph-io/badger/v4 v4.2.0 h1:kJrlajbXXL9DFTNuhhu9yCx7JJa4qpYWxtE8BzuWsEs=
-github.com/dgraph-io/badger/v4 v4.2.0/go.mod h1:qfCqhPoWDFJRx1gp5QwwyGo8xk1lbHUxvK9nK0OGAak=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -398,7 +396,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -436,8 +433,6 @@ github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/gobwas/ws v1.2.1 h1:F2aeBZrm2NDsc7vbovKrWSogd4wvfAxg0FQ89/iqOTk=
-github.com/goccy/go-graphviz v0.1.1 h1:MGrsnzBxTyt7KG8FhHsFPDTGvF7UaQMmSa6A610DqPg=
-github.com/goccy/go-graphviz v0.1.1/go.mod h1:lpnwvVDjskayq84ZxG8tGCPeZX/WxP88W+OJajh+gFk=
 github.com/goccy/go-graphviz v0.1.2 h1:sWSJ6w13BCm/ZOUTHDVrdvbsxqN8yyzaFcHrH/hQ9Yg=
 github.com/goccy/go-graphviz v0.1.2/go.mod h1:pMYpbAqJT10V8dzV1JN/g/wUlG/0imKPzn3ZsrchGCI=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -476,6 +471,8 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
+github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -546,8 +543,6 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -1581,8 +1576,6 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
-golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
-golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1618,7 +1611,6 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mobile v0.0.0-20231006135142-2b44d11868fe h1:lrXv4yHeD9FA8PSJATWowP1QvexpyAPWmPia+Kbzql8=
@@ -1917,6 +1909,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
-github.com/VinGarcia/badger/v4 v4.0.0-20231207134132-548c3cee3e9c h1:FKjUIW7DOhHB5jQa93+fveH1KwQMKdVyFwdm3f1ZD58=
-github.com/VinGarcia/badger/v4 v4.0.0-20231207134132-548c3cee3e9c/go.mod h1:T/uWAYxrXdaXw64ihI++9RMbKTCpKd/yE9+saARew7k=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -111,6 +109,8 @@ github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsVi
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
 github.com/anyproto/any-sync v0.3.17 h1:SvMCOWPUKfYhok2rcdj78Sroe8g8RCrcPnojgSkWQ5M=
 github.com/anyproto/any-sync v0.3.17/go.mod h1:q4Wn0+1MbbV9PlZ3FRGOghEN+FeatlL5s/HlR9gkr+s=
+github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580 h1:Ba80IlCCxkZ9H1GF+7vFu/TSpPvbpDCxXJ5ogc4euYc=
+github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580/go.mod h1:T/uWAYxrXdaXw64ihI++9RMbKTCpKd/yE9+saARew7k=
 github.com/anyproto/go-chash v0.1.0 h1:I9meTPjXFRfXZHRJzjOHC/XF7Q5vzysKkiT/grsogXY=
 github.com/anyproto/go-chash v0.1.0/go.mod h1:0UjNQi3PDazP0fINpFYu6VKhuna+W/V+1vpXHAfNgLY=
 github.com/anyproto/go-gelf v0.0.0-20210418191311-774bd5b016e7 h1:SyEu5uxZ5nKHEJ6TPKQqjM+T00SYi0MW1VaLzqZtZ9E=

--- a/pkg/lib/datastore/clientds/backup.go
+++ b/pkg/lib/datastore/clientds/backup.go
@@ -146,6 +146,7 @@ func backupJob(db *badger.DB) error {
 		if err != nil {
 			return fmt.Errorf("failed to remove empty temp backup: %s", err)
 		}
+		return nil
 	}
 
 	err = os.Rename(path, getSpaceStoreFinishedBackupPath(backupPath, maxVersion))

--- a/pkg/lib/datastore/clientds/backup.go
+++ b/pkg/lib/datastore/clientds/backup.go
@@ -1,0 +1,259 @@
+package clientds
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// every FullBackupEvery incremental backups we do a full backup and remove all old backups
+	FullBackupEvery = 1000
+	BackupInterval  = time.Minute
+)
+
+// getAllBackupFiles returns all backup files in the repoPath sorted by timestamp suffix
+func getAllBackupFiles(repoPath string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(repoPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ".tmp" {
+			// means it is in not finished state - skip it
+			return nil
+		}
+
+		tsStr := filepath.Base(path)
+		ts, err := strconv.ParseInt(tsStr, 10, 64)
+		if err != nil {
+			return nil
+		}
+		if ts < 0 {
+			return nil
+		}
+
+		files = append(files, path)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i] < files[j]
+	})
+	return files, nil
+}
+
+func initBackupDir(dsPath string) error {
+	backupPath := getBackupPathFromDbPath(dsPath)
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		if err := os.Mkdir(backupPath, 0700); err != nil {
+			return fmt.Errorf("failed to create backup dir: %s", err)
+		}
+		// write text file with info about backup dir
+		if err := os.WriteFile(filepath.Join(backupPath, "README.txt"), []byte("This directory contains incremental backups of spacestore database. Do not modify or remove any files in this folder."), 0600); err != nil {
+			log.Errorf("failed to write README.txt: %s", err)
+		}
+	}
+	return nil
+}
+
+func (r *clientds) runBackup() error {
+	// create backup dir if not exists
+	if err := initBackupDir(r.spaceDS.Opts().Dir); err != nil {
+		return err
+	}
+	go func() {
+		for {
+			select {
+			case <-r.closed:
+				return
+			case <-time.After(BackupInterval):
+				err := backupJob(r.spaceDS)
+				if err != nil {
+					log.Errorf("failed to backup spacestore: %s", err)
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func backupJob(db *badger.DB) error {
+	if db == nil {
+		return fmt.Errorf("db is nil")
+	}
+	if db.IsClosed() {
+		return fmt.Errorf("db is closed")
+	}
+	var since uint64
+	backupPath := getBackupPathFromDbPath(db.Opts().Dir)
+	backups, err := getAllBackupFiles(backupPath)
+	if err != nil {
+		return fmt.Errorf("failed to get all backups: %s", err)
+	}
+
+	if len(backups) < FullBackupEvery && len(backups) > 0 {
+		lastTime, err := strconv.ParseUint(filepath.Base(backups[len(backups)-1]), 10, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse backup max version: %s", err)
+		} else {
+			since = lastTime
+		}
+	}
+	path := getSpaceStoreTempBackupPath(backupPath)
+	bak, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create spacestore backup file: %s", err)
+	}
+	maxVersion, err := db.Backup(bak, since)
+	if err != nil {
+		return fmt.Errorf("failed to backup spacestore: %s", err)
+	}
+
+	if maxVersion > 0 {
+		err = bak.Sync()
+		if err != nil {
+			// sync failed, lets log this info and continue
+			log.Errorf("db backup file failed to sync: %s", err)
+		}
+	}
+
+	info, _ := bak.Stat()
+	if maxVersion > 0 {
+		log.Debugf("spacestore backup since %d done, maxVersion: %d, size: %d", since, maxVersion, info.Size())
+	}
+
+	err = bak.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close backup file: %s", err)
+	}
+
+	if maxVersion == 0 {
+		err = os.Remove(path)
+		if err != nil {
+			return fmt.Errorf("failed to remove empty temp backup: %s", err)
+		}
+	}
+
+	err = os.Rename(path, getSpaceStoreFinishedBackupPath(backupPath, maxVersion))
+	if err != nil {
+		return fmt.Errorf("failed to rename temp backup: %s", err)
+	}
+
+	if len(backups) > FullBackupEvery {
+		for _, backup := range backups {
+			err = os.Remove(backup)
+			if err != nil {
+				name := filepath.Base(backup)
+				log.Errorf("failed to remove old backup %s: %s", name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func getSpaceStoreTempBackupPath(backupDir string) string {
+	return filepath.Join(backupDir, fmt.Sprintf("%d.tmp", time.Now().Unix()))
+}
+
+func getSpaceStoreFinishedBackupPath(backupDir string, ts uint64) string {
+	return filepath.Join(backupDir, fmt.Sprintf("%d", ts))
+}
+
+func getBackupPathFromDbPath(dbPath string) string {
+	return filepath.Join(filepath.Dir(dbPath), SpaceDSBackupsDir)
+}
+
+func restoreBadger(opts badger.Options, skipBackupRestore bool) (*badger.DB, error) {
+	base := filepath.Base(opts.Dir)
+	var (
+		backups []string
+		err     error
+	)
+	err = os.RemoveAll(filepath.Join(opts.Dir, lock))
+	if err != nil {
+		return nil, err
+	}
+	r, err := os.Open(opts.Dir)
+	if err != nil {
+		return nil, err
+	}
+	if err := unix.Flock(int(r.Fd()), unix.LOCK_UN); err != nil {
+		log.Fatal(err)
+	}
+	r.Close()
+
+	backups, err = getAllBackupFiles(getBackupPathFromDbPath(opts.Dir))
+	if err != nil {
+		if !skipBackupRestore {
+			return nil, err
+		}
+	}
+
+	if len(backups) == 0 && !skipBackupRestore {
+		return nil, fmt.Errorf("no backups found")
+	}
+
+	originalDir := opts.Dir
+	if len(backups) > 0 {
+		// lets start recovery in the separate dir in case it will be interrupted
+		recoveryDbDir := filepath.Join(filepath.Dir(opts.Dir), fmt.Sprintf(base+"_recovery_%d", time.Now().Unix()))
+		opts.Dir = recoveryDbDir
+	}
+
+	// at this
+	db, err := badger.Open(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(backups) == 0 {
+		return db, nil
+	}
+
+	// restore from incremental backup
+	// backup files are sorted
+	for _, backup := range backups {
+		f, err := os.Open(backup)
+		if err != nil {
+			return nil, err
+		}
+		err = db.Load(f, 16)
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = db.Sync()
+	if err != nil {
+		return nil, err
+	}
+	err = db.Close()
+	if err != nil {
+		return nil, err
+	}
+	err = os.Rename(originalDir, fmt.Sprintf("%s_corrupted_%d", originalDir, time.Now().Unix()))
+	if err != nil {
+		return nil, err
+	}
+	err = os.Rename(opts.Dir, originalDir)
+	if err != nil {
+		return nil, err
+	}
+	opts.Dir = originalDir
+	db, err = badger.Open(opts)
+	if err != nil {
+		log.Errorf("failed to open db after restore: %s", err)
+	} else {
+		log.Warn("badger db restored successfully after corruption")
+	}
+	return db, nil
+}

--- a/pkg/lib/datastore/clientds/backup_test.go
+++ b/pkg/lib/datastore/clientds/backup_test.go
@@ -1,0 +1,97 @@
+package clientds
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func generateRandString(n int) string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+// test for backupJob
+func TestBackupJob(t *testing.T) {
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anytypetestds*")
+	require.NoError(t, err)
+	fmt.Printf("tempDir: %s\n", tempDir)
+	dsDir := filepath.Join(tempDir, "ds")
+	opts := DefaultConfig.Spacestore
+	opts.Dir = dsDir
+	opts.ValueDir = dsDir
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	err = initBackupDir(opts.Dir)
+	require.NoError(t, err)
+
+	for i := 0; i < 10000; i++ {
+		rand.Seed(int64(i))
+		err = db.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(fmt.Sprintf("key/%d", i)), []byte("firstValue"))
+		})
+		require.NoError(t, err)
+	}
+	err = backupJob(db)
+	require.NoError(t, err)
+	for i := 0; i < 10000; i++ {
+		rand.Seed(int64(i))
+		err = db.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(fmt.Sprintf("key/%d", i)), []byte("secondValue"))
+		})
+		require.NoError(t, err)
+	}
+	err = backupJob(db)
+
+	err = db.Sync()
+	require.NoError(t, err)
+	err = db.Close()
+	require.NoError(t, err)
+
+	// corrupt db
+	nulloutBytesRangeInFile(t, filepath.Join(dsDir, "000001.sst"), 100000, 900000)
+
+	_, err = openBadgerWithRecover(opts)
+	require.NotNil(t, err)
+
+	db, err = restoreBadger(opts, false)
+	require.NoError(t, err)
+	for i := 0; i < 10000; i++ {
+		// iterate over all keys
+		err = db.View(func(txn *badger.Txn) error {
+			v, err := txn.Get([]byte(fmt.Sprintf("key/%d", i)))
+			require.NoError(t, err)
+			err = v.Value(func(val []byte) error {
+				require.Equal(t, []byte("secondValue"), val)
+				return nil
+			})
+			require.NoError(t, err)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+}
+
+func nulloutBytesRangeInFile(t *testing.T, path string, from, to int64) {
+	file, err := os.OpenFile(path, os.O_RDWR, 0644)
+	require.NoError(t, err)
+	defer file.Close()
+
+	_, err = file.Seek(from, 0)
+	require.NoError(t, err)
+
+	buf := make([]byte, to-from)
+	_, err = file.Write(buf)
+	require.NoError(t, err)
+	file.Sync()
+}

--- a/pkg/lib/datastore/clientds/backup_test.go
+++ b/pkg/lib/datastore/clientds/backup_test.go
@@ -2,7 +2,6 @@ package clientds
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,15 +9,6 @@ import (
 	"github.com/dgraph-io/badger/v4"
 	"github.com/stretchr/testify/require"
 )
-
-func generateRandString(n int) string {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
-}
 
 // test for backupJob
 func TestBackupJob(t *testing.T) {
@@ -35,7 +25,6 @@ func TestBackupJob(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 10000; i++ {
-		rand.Seed(int64(i))
 		err = db.Update(func(txn *badger.Txn) error {
 			return txn.Set([]byte(fmt.Sprintf("key/%d", i)), []byte("firstValue"))
 		})
@@ -44,7 +33,6 @@ func TestBackupJob(t *testing.T) {
 	err = backupJob(db)
 	require.NoError(t, err)
 	for i := 0; i < 10000; i++ {
-		rand.Seed(int64(i))
 		err = db.Update(func(txn *badger.Txn) error {
 			return txn.Set([]byte(fmt.Sprintf("key/%d", i)), []byte("secondValue"))
 		})
@@ -72,6 +60,65 @@ func TestBackupJob(t *testing.T) {
 			require.NoError(t, err)
 			err = v.Value(func(val []byte) error {
 				require.Equal(t, []byte("secondValue"), val)
+				return nil
+			})
+			require.NoError(t, err)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+}
+
+func TestBackupJob2(t *testing.T) {
+	tempDir, err := os.MkdirTemp(os.TempDir(), "anytypetestds*")
+	require.NoError(t, err)
+	fmt.Printf("tempDir: %s\n", tempDir)
+	dsDir := filepath.Join(tempDir, "ds")
+	opts := DefaultConfig.Spacestore
+	opts.Dir = dsDir
+	opts.ValueDir = dsDir
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	err = initBackupDir(opts.Dir)
+	require.NoError(t, err)
+
+	FullBackupEvery = 10
+	for j := 0; j <= 12; j++ {
+		for i := 0; i < 1000; i++ {
+			err = db.Update(func(txn *badger.Txn) error {
+				return txn.Set([]byte(fmt.Sprintf("key/%d", i)), []byte(fmt.Sprintf("Value-%d", j)))
+			})
+			require.NoError(t, err)
+		}
+		err = backupJob(db)
+		require.NoError(t, err)
+
+		backups, err := getAllBackupFiles(getBackupPathFromDbPath(opts.Dir))
+		require.NoError(t, err)
+		require.Equal(t, j%10+1, len(backups))
+	}
+
+	err = db.Sync()
+	require.NoError(t, err)
+	err = db.Close()
+	require.NoError(t, err)
+
+	// corrupt db
+	nulloutBytesRangeInFile(t, filepath.Join(dsDir, "000001.sst"), 100000, 900000)
+
+	_, err = openBadgerWithRecover(opts)
+	require.NotNil(t, err)
+
+	db, err = restoreBadger(opts, false)
+	require.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		// iterate over all keys
+		err = db.View(func(txn *badger.Txn) error {
+			v, err := txn.Get([]byte(fmt.Sprintf("key/%d", i)))
+			require.NoError(t, err)
+			err = v.Value(func(val []byte) error {
+				require.Equal(t, []byte("Value-12"), val)
 				return nil
 			})
 			require.NoError(t, err)

--- a/pkg/lib/datastore/clientds/clientds.go
+++ b/pkg/lib/datastore/clientds/clientds.go
@@ -31,6 +31,9 @@ const (
 
 var log = logging.Logger("anytype-clientds")
 
+// SyncDbAfterInactivity shows the minimum time after db was changed to call db.Sync
+// regular Db.Sync will help to decrease the chance of data loss in case of power loss/bsod
+// while this logic decrease the chance some db writer will need to wait for sync to finish
 var SyncDbAfterInactivity = time.Second * 60
 
 type clientds struct {

--- a/pkg/lib/datastore/clientds/clientds.go
+++ b/pkg/lib/datastore/clientds/clientds.go
@@ -98,8 +98,10 @@ func openBadgerWithRecover(opts badger.Options) (db *badger.DB, err error) {
 	defer func() {
 		// recover in case we have badger panic on open but not recovered by badger
 		if r := recover(); r != nil {
-			log.Errorf("badger panic: %v", r)
-			err = ErrBadgerPanicked
+			err = fmt.Errorf("badger panic: %v", r)
+			if db != nil {
+				db.Close()
+			}
 		}
 	}()
 	db, err = badger.Open(opts)

--- a/pkg/lib/datastore/clientds/clientds.go
+++ b/pkg/lib/datastore/clientds/clientds.go
@@ -94,8 +94,6 @@ func init() {
 
 }
 
-var ErrBadgerPanicked = fmt.Errorf("badger panicked")
-
 func openBadgerWithRecover(opts badger.Options) (db *badger.DB, err error) {
 	defer func() {
 		// recover in case we have badger panic on open but not recovered by badger


### PR DESCRIPTION
for spacestore
- run incremental backup every minute
- every 1000 backups(empty skipped) do the full backup and remove all others after
- do the os.Sync before renaming backups from *.tmp
- in case it was not able to open badger on start recover from backup
- only in case backup restore was successful the old corrupted dir got renamed and the restored one take it place
- because we never rewrite most of the keys' values in spacestore(only object heads), incremental backup works effective and doesn't consume a lot of space

for localstore
- in case of error on open just reinit the db without backup
- corrupted repo left for debugging

Also
Need to switch to this PR's branch https://github.com/dgraph-io/badger/pull/2033
The reason is that in the most cases the panic happens in the goroutine and it not possible to catch it in from the badger.Open caller


I think backuper may be used only on WIndows. Let's see how often this corruptions happen on UNIX