### PR TITLE
GO-2585: add root block in response

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -1128,6 +1128,6 @@ func (mw *Middleware) BlockPreview(cctx context.Context, req *pb.RpcBlockPreview
 	if err != nil {
 		return response(pb.RpcBlockPreviewResponseError_UNKNOWN_ERROR, nil, err)
 	}
-
+	blocks = anymark.AddRootBlock(blocks, "preview")
 	return response(pb.RpcBlockPreviewResponseError_NULL, blocks, nil)
 }

--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/history"
 	"github.com/anyproto/anytype-heart/core/block/import/common"
 	"github.com/anyproto/anytype-heart/core/block/import/common/syncer"
+	"github.com/anyproto/anytype-heart/core/block/import/markdown/anymark"
 	"github.com/anyproto/anytype-heart/core/block/object/objectcreator"
 	"github.com/anyproto/anytype-heart/core/block/simple"
 	"github.com/anyproto/anytype-heart/core/domain"
@@ -273,36 +274,8 @@ func (oc *ObjectCreator) setRootBlock(snapshot *model.SmartBlockSnapshotBase, ne
 		}
 	}
 	if !found {
-		oc.addRootBlock(snapshot, newID)
+		snapshot.Blocks = anymark.AddRootBlock(snapshot.Blocks, newID)
 	}
-}
-
-func (oc *ObjectCreator) addRootBlock(snapshot *model.SmartBlockSnapshotBase, pageID string) {
-	for i, b := range snapshot.Blocks {
-		if _, ok := b.Content.(*model.BlockContentOfSmartblock); ok {
-			snapshot.Blocks[i].Id = pageID
-			return
-		}
-	}
-	notRootBlockChild := make(map[string]bool, 0)
-	for _, b := range snapshot.Blocks {
-		for _, id := range b.ChildrenIds {
-			notRootBlockChild[id] = true
-		}
-	}
-	childrenIds := make([]string, 0)
-	for _, b := range snapshot.Blocks {
-		if _, ok := notRootBlockChild[b.Id]; !ok {
-			childrenIds = append(childrenIds, b.Id)
-		}
-	}
-	snapshot.Blocks = append(snapshot.Blocks, &model.Block{
-		Id: pageID,
-		Content: &model.BlockContentOfSmartblock{
-			Smartblock: &model.BlockContentSmartblock{},
-		},
-		ChildrenIds: childrenIds,
-	})
 }
 
 func (oc *ObjectCreator) onFinish(err error, st *state.State, filesToDelete []string) {

--- a/core/block/import/markdown/anymark/anyblocks.go
+++ b/core/block/import/markdown/anymark/anyblocks.go
@@ -141,3 +141,32 @@ func ConvertTextToFile(block *model.Block) {
 		}
 	}
 }
+
+func AddRootBlock(blocks []*model.Block, rootBlockID string) []*model.Block {
+	for i, b := range blocks {
+		if _, ok := b.Content.(*model.BlockContentOfSmartblock); ok {
+			blocks[i].Id = rootBlockID
+			return nil
+		}
+	}
+	notRootBlockChild := make(map[string]bool, 0)
+	for _, b := range blocks {
+		for _, id := range b.ChildrenIds {
+			notRootBlockChild[id] = true
+		}
+	}
+	childrenIds := make([]string, 0)
+	for _, b := range blocks {
+		if _, ok := notRootBlockChild[b.Id]; !ok {
+			childrenIds = append(childrenIds, b.Id)
+		}
+	}
+	blocks = append(blocks, &model.Block{
+		Id: rootBlockID,
+		Content: &model.BlockContentOfSmartblock{
+			Smartblock: &model.BlockContentSmartblock{},
+		},
+		ChildrenIds: childrenIds,
+	})
+	return blocks
+}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Add root block to response to preserve structure of blocks

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://linear.app/anytype/issue/GO-2585/implement-command-which-shows-preview-of-generated-blocks
### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
