### PR TITLE
GO-2726 Fix memory allocation when pasting huge amount of blocks

### DIFF
--- a/core/block/editor/state/normalize.go
+++ b/core/block/editor/state/normalize.go
@@ -247,9 +247,11 @@ func (s *State) divBalance(d1, d2 *model.Block) (overflow bool) {
 		div = maxChildrenThreshold / 2
 	}
 
-	d2.ChildrenIds = make([]string, len(d1.ChildrenIds[div:]))
-	copy(d2.ChildrenIds, d1.ChildrenIds[div:])
-	d1.ChildrenIds = d1.ChildrenIds[:div]
+	d1ChildrenIds := make([]string, div)
+	copy(d1ChildrenIds, d1.ChildrenIds[:div])
+
+	d2.ChildrenIds = d1.ChildrenIds[div:]
+	d1.ChildrenIds = d1ChildrenIds
 	return len(d2.ChildrenIds) > maxChildrenThreshold
 }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
