### PR TITLE
GO-2668 Add details of objects in dataview filters

### DIFF
--- a/core/block/simple/dataview/dataview.go
+++ b/core/block/simple/dataview/dataview.go
@@ -221,6 +221,33 @@ func (l *Dataview) FillSmartIds(ids []string) []string {
 		if view.DefaultTemplateId != "" {
 			ids = append(ids, view.DefaultTemplateId)
 		}
+		ids = append(ids, getIdsFromFilters(view.Filters)...)
+	}
+
+	return ids
+}
+
+func getIdsFromFilters(filters []*model.BlockContentDataviewFilter) (ids []string) {
+	for _, filter := range filters {
+		if filter.Format != model.RelationFormat_object &&
+			filter.Format != model.RelationFormat_status &&
+			filter.Format != model.RelationFormat_tag {
+			continue
+		}
+
+		id := filter.Value.GetStringValue()
+		if id != "" {
+			ids = append(ids, id)
+			continue
+		}
+
+		list := filter.Value.GetListValue()
+		if list == nil {
+			continue
+		}
+		for _, value := range list.Values {
+			ids = append(ids, value.GetStringValue())
+		}
 	}
 
 	return ids

--- a/core/block/simple/dataview/dataview_test.go
+++ b/core/block/simple/dataview/dataview_test.go
@@ -1,0 +1,47 @@
+package dataview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+func TestDataview_FillSmartIds(t *testing.T) {
+	obj1 := "obj1"
+	obj2 := "obj2"
+	obj3 := "obj3"
+
+	t.Run("object ids should be added from filter", func(t *testing.T) {
+		// given
+		var ids []string
+		d := Dataview{content: &model.BlockContentDataview{
+			Views: []*model.BlockContentDataviewView{{
+				Filters: []*model.BlockContentDataviewFilter{{
+					Format: model.RelationFormat_object,
+					Value:  pbtypes.StringList([]string{obj1, obj2}),
+				}, {
+					Format: model.RelationFormat_tag,
+					Value:  pbtypes.String(obj3),
+				}, {
+					Format: model.RelationFormat_number,
+					Value:  pbtypes.Int64(555),
+				}, {
+					Format: model.RelationFormat_longtext,
+					Value:  pbtypes.String("hello"),
+				}},
+			}},
+		}}
+
+		// when
+		ids = d.FillSmartIds(ids)
+
+		// then
+		assert.Contains(t, ids, obj1)
+		assert.Contains(t, ids, obj2)
+		assert.Contains(t, ids, obj3)
+		assert.Len(t, ids, 3)
+	})
+}

--- a/core/block/simple/dataview/views.go
+++ b/core/block/simple/dataview/views.go
@@ -18,6 +18,7 @@ func (l *Dataview) AddFilter(viewID string, filter *model.BlockContentDataviewFi
 	if filter.Id == "" {
 		filter.Id = bson.NewObjectId().Hex()
 	}
+	l.setRelationFormat(filter)
 	view.Filters = append(view.Filters, filter)
 	return nil
 }
@@ -52,6 +53,7 @@ func (l *Dataview) ReplaceFilter(viewID string, filterID string, filter *model.B
 	}
 
 	filter.Id = filterID
+	l.setRelationFormat(filter)
 	view.Filters[idx] = filter
 
 	return nil
@@ -206,4 +208,12 @@ func (l *Dataview) ReorderViewRelations(viewID string, relationKeys []string) er
 		}
 	}
 	return nil
+}
+
+func (l *Dataview) setRelationFormat(filter *model.BlockContentDataviewFilter) {
+	for _, relLink := range l.content.RelationLinks {
+		if relLink.Key == filter.RelationKey {
+			filter.Format = relLink.Format
+		}
+	}
 }

--- a/core/subscription/collection.go
+++ b/core/subscription/collection.go
@@ -161,7 +161,9 @@ func (c *collectionSub) close() {
 	c.sortedSub.close()
 }
 
-func (s *service) newCollectionSub(id string, collectionID string, keys []string, flt database.Filter, order database.Order, limit, offset int, disableDepSub bool) (*collectionSub, error) {
+func (s *service) newCollectionSub(
+	id, collectionID string, keys, filterDepIds []string, flt database.Filter, order database.Order, limit, offset int, disableDepSub bool,
+) (*collectionSub, error) {
 	obs, err := s.newCollectionObserver(collectionID, id)
 	if err != nil {
 		return nil, err
@@ -174,6 +176,10 @@ func (s *service) newCollectionSub(id string, collectionID string, keys []string
 
 	ssub := s.newSortedSub(id, keys, flt, order, limit, offset)
 	ssub.disableDep = disableDepSub
+	if !ssub.disableDep {
+		ssub.forceSubIds = filterDepIds
+	}
+
 	sub := &collectionSub{
 		id:           id,
 		collectionID: collectionID,

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -241,12 +241,9 @@ func queryEntries(objectStore objectstore.ObjectStore, f *database.Filters) ([]*
 }
 
 func (s *service) subscribeForCollection(req pb.RpcObjectSearchSubscribeRequest, f *database.Filters, filterDepIds []string) (*pb.RpcObjectSearchSubscribeResponse, error) {
-	sub, err := s.newCollectionSub(req.SubId, req.CollectionId, req.Keys, f.FilterObj, f.Order, int(req.Limit), int(req.Offset), req.NoDepSubscription)
+	sub, err := s.newCollectionSub(req.SubId, req.CollectionId, req.Keys, filterDepIds, f.FilterObj, f.Order, int(req.Limit), int(req.Offset), req.NoDepSubscription)
 	if err != nil {
 		return nil, err
-	}
-	if !sub.sortedSub.disableDep {
-		sub.sortedSub.forceSubIds = filterDepIds
 	}
 	if err := sub.init(nil); err != nil {
 		return nil, fmt.Errorf("subscription init error: %w", err)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2668/collections-filters-are-not-working

Objects set in filters of Collection views were not shown up, because desktop client did not recieve their details on ObjectSearchSubscribe.

This PR contains two fixes: 

1. For desktop, that takes details from dependencies in ObjecSearchSubscribe response. Collection subscription was not taking filterObjectIds into account, while initialising dependency subscription.
2. For mobile clients, that take details from smartblock view on ObjectOpen. We did not analyze filters on collecting dependent ids from dataview block.