### PR TITLE
GO-2151 Enable snappy encoding

### DIFF
--- a/core/block/source/source.go
+++ b/core/block/source/source.go
@@ -338,10 +338,7 @@ func (s *source) PushChange(params PushChangeParams) (id string, err error) {
 	}
 	change := s.buildChange(params)
 
-	// TODO: GO-2151 Need to enable snappy compression when all clients will be able to decode snappy
-	// data, dataType, err := MarshalChange(change)
-	dataType := ""
-	data, err := change.Marshal()
+	data, dataType, err := MarshalChange(change)
 
 	if err != nil {
 		return


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2151/enable-snappy-encoding

Snappy decoding was enabled along with Multispaces in 0.29.0:

MW: https://github.com/anyproto/anytype-heart/releases/tag/v0.29.0
TS: https://github.com/anyproto/anytype-ts/releases/tag/v0.35.15-beta
iOS: https://github.com/anyproto/anytype-swift/releases/tag/release%2F0.26.0%2F43
Android: https://github.com/anyproto/anytype-kotlin/releases/tag/0.26.20

Enable snappy encoding for changes exceeding 64 bytes