### PR TITLE
GO-2849 link challenge app not running case handle

### DIFF
--- a/core/account.go
+++ b/core/account.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"errors"
 
 	"github.com/anyproto/any-sync/net"
 	"google.golang.org/grpc/peer"
@@ -201,27 +200,16 @@ func (mw *Middleware) AccountLocalLinkNewChallenge(ctx context.Context, request 
 	info := getClientInfo(ctx)
 
 	challengeId, err := mw.applicationService.LinkLocalStartNewChallenge(&info)
-	if err != nil {
-		var code pb.RpcAccountLocalLinkNewChallengeResponseErrorCode
-		if errors.Is(err, session.ErrTooManyChallengeRequests) {
-			code = pb.RpcAccountLocalLinkNewChallengeResponseError_TOO_MANY_REQUESTS
-		} else {
-			code = pb.RpcAccountLocalLinkNewChallengeResponseError_UNKNOWN_ERROR
-		}
-		return &pb.RpcAccountLocalLinkNewChallengeResponse{
-			Error: &pb.RpcAccountLocalLinkNewChallengeResponseError{
-				Code:        code,
-				Description: err.Error(),
-			},
-		}
-	}
+	code := mapErrorCode(err,
+		errToCode(session.ErrTooManyChallengeRequests, pb.RpcAccountLocalLinkNewChallengeResponseError_TOO_MANY_REQUESTS),
+		errToCode(application.ErrApplicationIsNotRunning, pb.RpcAccountLocalLinkNewChallengeResponseError_ACCOUNT_IS_NOT_RUNNING),
+	)
 
-	// todo: implement errors
 	return &pb.RpcAccountLocalLinkNewChallengeResponse{
 		ChallengeId: challengeId,
 		Error: &pb.RpcAccountLocalLinkNewChallengeResponseError{
-			Code:        0,
-			Description: "",
+			Code:        code,
+			Description: getErrorDescription(err),
 		},
 	}
 }

--- a/core/application/sessions.go
+++ b/core/application/sessions.go
@@ -52,6 +52,10 @@ func (s *Service) ValidateSessionToken(token string) error {
 }
 
 func (s *Service) LinkLocalStartNewChallenge(clientInfo *pb.EventAccountLinkChallengeClientInfo) (id string, err error) {
+	if s.app == nil {
+		return "", ErrApplicationIsNotRunning
+	}
+
 	id, value, err := s.sessions.StartNewChallenge(clientInfo)
 	if err != nil {
 		return "", err
@@ -72,6 +76,9 @@ func (s *Service) LinkLocalStartNewChallenge(clientInfo *pb.EventAccountLinkChal
 }
 
 func (s *Service) LinkLocalSolveChallenge(req *pb.RpcAccountLocalLinkSolveChallengeRequest) (token string, appKey string, err error) {
+	if s.app == nil {
+		return "", "", ErrApplicationIsNotRunning
+	}
 	clientInfo, token, err := s.sessions.SolveChallenge(req.ChallengeId, req.Answer, s.sessionSigningKey)
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
handle the case when app(account) was not started and return the error