### PR TITLE
GO-2848 Fix panic on html render

### DIFF
--- a/core/converter/html/html.go
+++ b/core/converter/html/html.go
@@ -457,12 +457,11 @@ func (h *HTML) writeTextToBuf(text *model.BlockContentText) {
 			// iterate marks forwards to put closing tags
 			for _, m := range text.Marks.Marks {
 				if int(m.Range.To) == i {
-					// TODO: check lastOpenedTags on zero length ?
-					if lastOpenedTags[0] != m.Type {
-						h.closeTagsUntil(text, &lastOpenedTags, m.Type, i)
-					}
+					h.closeTagsUntil(text, &lastOpenedTags, m.Type, i)
 					h.writeTag(m, false)
-					lastOpenedTags = lastOpenedTags[1:]
+					if len(lastOpenedTags) != 0 {
+						lastOpenedTags = lastOpenedTags[1:]
+					}
 				}
 			}
 			// iterate marks backwards to put opening tags


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2848/check-lastopenedtags-length-on-blockcut

Check of first value in lastOpenedTags is redundant, as we do this check in closeTagsUntil, so we should check array emptiness only on lastOpenedTags shortening to avoid panic