### PR TITLE
GO-2886: change ico to vnd.microsoft.icon format

### DIFF
--- a/pkg/lib/mill/image_resize.go
+++ b/pkg/lib/mill/image_resize.go
@@ -28,14 +28,14 @@ import (
 type Format string
 
 func init() {
-	image.RegisterFormat("ico", string([]byte{0x00, 0x00, 0x01, 0x00}), ico.Decode, ico.DecodeConfig)
+	image.RegisterFormat("vnd.microsoft.icon", string([]byte{0x00, 0x00, 0x01, 0x00}), ico.Decode, ico.DecodeConfig)
 }
 
 const (
 	JPEG Format = "jpeg"
 	PNG  Format = "png"
 	GIF  Format = "gif"
-	ICO  Format = "ico"
+	ICO  Format = "vnd.microsoft.icon"
 	WEBP Format = "webp"
 	HEIC Format = "heic"
 )


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2866/icons-of-bookmarks-are-missed

Problem:
We can't load icons in bookmarks with format .ico. That's because we assume that mime type of .ico image is `ico`, but actually it is `vnd.microsoft.icon`
https://github.com/anyproto/anytype-heart/blob/ad227be334f762df0b3581a0ad8345110862887d/pkg/lib/mill/image_resize.go#L43

Solution
Change format `vnd.microsoft.icon`, so now we can load such files as images and show in bookmark