### PR TITLE
GO-2805 Restrict moving types and relations to bin

### DIFF
--- a/core/block/service.go
+++ b/core/block/service.go
@@ -570,6 +570,9 @@ func (s *Service) checkArchivedRestriction(isArchived bool, spaceID string, obje
 		return nil
 	}
 	return Do(s, objectId, func(sb smartblock.SmartBlock) error {
+		if sb.Type() == coresb.SmartBlockTypeRelation || sb.Type() == coresb.SmartBlockTypeObjectType {
+			return restriction.ErrRestricted
+		}
 		return s.restriction.CheckRestrictions(sb, model.Restrictions_Delete)
 	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2805/i-cant-add-an-anytype-library-project

We need to restrict moving types and relations to bin