### PR TITLE
GO-2781 Notification on internet loss on ImportExperience

### DIFF
--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -234,7 +234,9 @@ func (b *builtinObjects) CreateObjectsForExperience(ctx context.Context, spaceID
 		path = url
 	} else {
 		if path, err = b.downloadZipToFile(url, progress); err != nil {
-			_ = progress.Cancel()
+			if pErr := progress.Cancel(); pErr != nil {
+				log.Errorf("failed to cancel progress %s: %v", progress.Id(), pErr)
+			}
 			sendNotification(model.Import_INTERNAL_ERROR)
 			if errors.Is(err, uri.ErrFilepathNotSupported) {
 				return fmt.Errorf("invalid path to file: '%s'", url)

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -209,13 +209,33 @@ func (b *builtinObjects) CreateObjectsForExperience(ctx context.Context, spaceID
 		return err
 	}
 
-	var path string
-	removeFunc := func() {}
+	var (
+		path             string
+		removeFunc       = func() {}
+		sendNotification = func(code model.ImportErrorCode) {
+			nErr := b.notifications.CreateAndSendLocal(&model.Notification{
+				Status:  model.Notification_Created,
+				IsLocal: true,
+				Space:   spaceID,
+				Payload: &model.NotificationPayloadOfGalleryImport{GalleryImport: &model.NotificationGalleryImport{
+					ProcessId: progress.Id(),
+					ErrorCode: code,
+					SpaceId:   spaceID,
+					Name:      title,
+				}},
+			})
+			if nErr != nil {
+				log.Errorf("failed to send notification: %v", nErr)
+			}
+		}
+	)
 
 	if _, err = os.Stat(url); err == nil {
 		path = url
 	} else {
 		if path, err = b.downloadZipToFile(url, progress); err != nil {
+			_ = progress.Cancel()
+			sendNotification(model.Import_INTERNAL_ERROR)
 			if errors.Is(err, uri.ErrFilepathNotSupported) {
 				return fmt.Errorf("invalid path to file: '%s'", url)
 			}
@@ -229,21 +249,7 @@ func (b *builtinObjects) CreateObjectsForExperience(ctx context.Context, spaceID
 	}
 
 	importErr := b.importArchive(ctx, spaceID, path, title, pb.RpcObjectImportRequestPbParams_EXPERIENCE, progress, isNewSpace)
-
-	err = b.notifications.CreateAndSendLocal(&model.Notification{
-		Status:  model.Notification_Created,
-		IsLocal: true,
-		Space:   spaceID,
-		Payload: &model.NotificationPayloadOfGalleryImport{GalleryImport: &model.NotificationGalleryImport{
-			ProcessId: progress.Id(),
-			ErrorCode: common.GetImportErrorCode(importErr),
-			SpaceId:   spaceID,
-			Name:      title,
-		}},
-	})
-	if err != nil {
-		log.Errorf("failed to send notification: %v", err)
-	}
+	sendNotification(common.GetImportErrorCode(importErr))
 
 	if isNewSpace {
 		// TODO: GO-2627 Home page handling should be moved to importer
@@ -532,8 +538,9 @@ func (b *builtinObjects) setupProgress() (process.Progress, error) {
 }
 
 func getArchiveReaderAndSize(url string) (reader io.ReadCloser, size int64, err error) {
+	client := http.Client{Timeout: 15 * time.Second}
 	// nolint: gosec
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2781/no-notification-on-internet-loss-on-objectimportexperience

On internet loss during import of experience from gallery we:

1. Cancel progress bar
2. Send notification