### PR TITLE
GO-2908: fix import from files directory

### DIFF
--- a/core/block/import/pb/converter.go
+++ b/core/block/import/pb/converter.go
@@ -36,6 +36,7 @@ const (
 	Name               = "Pb"
 	rootCollectionName = "Protobuf Import"
 	configFile         = "config.json"
+	fileDir            = "files"
 )
 
 var ErrNotAnyBlockExtension = errors.New("not JSON or PB extension")
@@ -225,6 +226,10 @@ func (p *Pb) getSnapshotsFromProvidedFiles(
 	workspaceSnapshot *common.Snapshot,
 ) {
 	if iterateErr := pbFiles.Iterate(func(fileName string, fileReader io.ReadCloser) (isContinue bool) {
+		// skip files from "files" directory
+		if filepath.Dir(fileName) == fileDir {
+			return true
+		}
 		snapshot, err := p.makeSnapshot(fileName, profileID, path, fileReader, isMigration, pbFiles)
 		if err != nil {
 			allErrors.Add(err)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2908/the-import-of-the-space-passed-with-an-error

If we have Json or Pb `files` in files directory from export, we try to import them too. So I decided to skip `files` directory during import. 
I decided that, because we have task to implement export structure https://linear.app/anytype/issue/GO-2746/export-structure. So we will import from relations/relationsOptions/objects/types directories and skip `files` any way. So it is not a hack.