### PR TITLE
GO-2968: add addPageContent flag

### DIFF
--- a/core/block/service.go
+++ b/core/block/service.go
@@ -798,7 +798,7 @@ func (s *Service) CreateObjectFromUrl(ctx context.Context, req *pb.RpcObjectCrea
 		return "", nil, err
 	}
 
-	res := s.bookmark.FetchBookmarkContent(req.SpaceId, url, true)
+	res := s.bookmark.FetchBookmarkContent(req.SpaceId, url, req.AddPageContent)
 	content := res()
 	shouldUpdateDetails := s.updateBookmarkContentWithUserDetails(req.Details, objectDetails, content)
 	if shouldUpdateDetails {

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -11591,6 +11591,7 @@ Get the info for page alongside with info for all inbound and outbound links fro
 | objectTypeUniqueKey | [string](#string) |  |  |
 | url | [string](#string) |  |  |
 | details | [google.protobuf.Struct](#google-protobuf-Struct) |  |  |
+| addPageContent | [bool](#bool) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -1490,6 +1490,7 @@ message Rpc {
                 string objectTypeUniqueKey = 2;
                 string url = 3;
                 google.protobuf.Struct details = 4;
+                bool addPageContent = 5;
             }
 
             message Response {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2968/

In weblclipper we don't add parsed blocks from web page to Anytype object if the `addPageContent` flag is not set in `ObjectCreateFromUrl` request