### PR TITLE
GO-2883 Ignore origin in custom templates

### DIFF
--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -152,7 +152,7 @@ func (s *service) createCustomTemplateState(templateId string) (targetState *sta
 			return
 		}
 
-		targetState.RemoveDetail(bundle.RelationKeyTargetObjectType.String(), bundle.RelationKeyTemplateIsBundled.String())
+		targetState.RemoveDetail(bundle.RelationKeyTargetObjectType.String(), bundle.RelationKeyTemplateIsBundled.String(), bundle.RelationKeyOrigin.String())
 		targetState.SetDetailAndBundledRelation(bundle.RelationKeySourceObject, pbtypes.String(sb.Id()))
 		targetState.SetLocalDetails(nil)
 		return


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2883/lastuseddate-is-not-updated-when-creating-an-object-using-a-template

We should ignore Origin value of template object when creating new object