### PR TITLE
Fix reindex deadlock

### DIFF
--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -89,7 +89,7 @@ func (p *Page) Init(ctx *smartblock.InitContext) (err error) {
 		go func() {
 			err = p.deleteRelationOptions(p.SpaceID(), pbtypes.GetString(p.Details(), bundle.RelationKeyRelationKey.String()))
 			if err != nil {
-				log.With("err", err)
+				log.With("err", err).Error("failed to delete relation options")
 			}
 		}()
 	}

--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -85,10 +85,13 @@ func (p *Page) Init(ctx *smartblock.InitContext) (err error) {
 	}
 
 	if p.isRelationDeleted(ctx) {
-		err = p.deleteRelationOptions(ctx)
-		if err != nil {
-			return err
-		}
+		// todo: move this to separate component
+		go func() {
+			err = p.deleteRelationOptions(p.SpaceID(), pbtypes.GetString(p.Details(), bundle.RelationKeyRelationKey.String()))
+			if err != nil {
+				log.With("err", err)
+			}
+		}()
 	}
 	return nil
 }
@@ -98,8 +101,7 @@ func (p *Page) isRelationDeleted(ctx *smartblock.InitContext) bool {
 		pbtypes.GetBool(ctx.State.Details(), bundle.RelationKeyIsUninstalled.String())
 }
 
-func (p *Page) deleteRelationOptions(ctx *smartblock.InitContext) error {
-	relationKey := pbtypes.GetString(ctx.State.Details(), bundle.RelationKeyRelationKey.String())
+func (p *Page) deleteRelationOptions(spaceID string, relationKey string) error {
 	relationOptions, _, err := p.objectStore.QueryObjectIDs(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
@@ -117,7 +119,7 @@ func (p *Page) deleteRelationOptions(ctx *smartblock.InitContext) error {
 	if err != nil {
 		return err
 	}
-	spaceID := p.Space().Id()
+
 	for _, id := range relationOptions {
 		err := p.objectDeleter.DeleteObjectByFullID(domain.FullID{SpaceID: spaceID, ObjectID: id})
 		if err != nil {

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -36,7 +36,7 @@ const (
 
 	// ForceIdxRebuildCounter erases localstore indexes and reindex all type of objects
 	// (no need to increase ForceObjectsReindexCounter & ForceFilesReindexCounter)
-	ForceIdxRebuildCounter int32 = 63
+	ForceIdxRebuildCounter int32 = 62
 
 	// ForceFulltextIndexCounter  performs fulltext indexing for all type of objects (useful when we change fulltext config)
 	ForceFulltextIndexCounter int32 = 6


### PR DESCRIPTION
- move deleteRelationOptions to separate goroutine cause it can cause deadlocks on account reindex
- downgrade ForceIdxRebuildCounter counter. No need to increase it from the last production release https://github.com/anyproto/anytype-heart/releases/tag/v0.30.15