### PR TITLE
GO-1936 grpc auth: return proper grpc code

### DIFF
--- a/core/auth.go
+++ b/core/auth.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/gogo/status"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/anyproto/anytype-heart/pb"
@@ -29,13 +31,13 @@ func (mw *Middleware) Authorize(ctx context.Context, req interface{}, info *grpc
 	}
 	v := md.Get("token")
 	if len(v) == 0 {
-		return nil, fmt.Errorf("missing token")
+		return nil, status.Error(codes.Unauthenticated, "missing token")
 	}
 	tok := v[0]
 
 	err = mw.applicationService.ValidateSessionToken(tok)
 	if err != nil {
-		return
+		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
 	resp, err = handler(ctx, req)


### PR DESCRIPTION
return proper grpc code [UNAUTHENTICATED](https://grpc.github.io/grpc/core/md_doc_statuscodes.html)