### PR TITLE
GO-2664 anymark: introduce TextBlockLengthSoftLimit

### DIFF
--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -1,6 +1,7 @@
 package clipboard
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -316,8 +317,6 @@ func (cb *clipboard) pasteText(ctx session.Context, req *pb.RpcBlockPasteRequest
 		return blockIds, uploadArr, caretPosition, isSameBlockCaret, nil
 	}
 
-	textArr := strings.Split(req.TextSlot, "\n")
-
 	if len(req.FocusedBlockId) > 0 {
 		block := cb.Pick(req.FocusedBlockId)
 		if block != nil {
@@ -328,10 +327,12 @@ func (cb *clipboard) pasteText(ctx session.Context, req *pb.RpcBlockPasteRequest
 	}
 
 	mdText := whitespace.WhitespaceNormalizeString(req.TextSlot)
-
 	blocks, _, err := anymark.MarkdownToBlocks([]byte(mdText), "", []string{})
 	if err != nil {
-		return cb.pasteRawText(ctx, req, textArr, groupId)
+		// in case we've failed to parse the text as a valid markdown,
+		// split it into text paragraphs with the same logic like in anymark and paste it as a plain text
+		paragraphs := splitStringIntoParagraphs(req.TextSlot, anymark.TextBlockLengthSoftLimit)
+		return cb.pasteRawText(ctx, req, paragraphs, groupId)
 	}
 	req.AnySlot = append(req.AnySlot, blocks...)
 
@@ -640,4 +641,46 @@ func extractTextWithStyleAndTabs(block *model.Block, texts []string, level int, 
 		}
 	}
 	return texts, numberedCount
+}
+
+// splitStringIntoParagraphs splits text into pararagraphs
+// - when text has a double line break, it is considered as a paragraph separator
+// - when text has a single line break, it is considered as a soft line break, not a paragraph separator
+// - when text has a single line break and the current block is longer than the soft limit, it is considered as a paragraph separator
+// - func consider line with whitespaces as a paragraph separator (e.g. "\n   \n")
+func splitStringIntoParagraphs(s string, lineBreakSoftLimit int) []string {
+	var blocks []string
+	var currentBlock strings.Builder
+
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.TrimSpace(line) == "" { // This is a simple proxy for a double line break.
+			if currentBlock.Len() > 0 {
+				blocks = append(blocks, currentBlock.String())
+				currentBlock.Reset()
+			}
+			continue
+		}
+
+		// Add line to current block with space handling for the soft limit.
+		if lineBreakSoftLimit > 0 && currentBlock.Len()+len(line) > lineBreakSoftLimit && currentBlock.Len() > 0 {
+			// Append the current block and start a new one
+			blocks = append(blocks, currentBlock.String())
+			currentBlock.Reset()
+		}
+
+		if currentBlock.Len() > 0 {
+			currentBlock.WriteString("\n")
+		}
+		currentBlock.WriteString(line)
+	}
+
+	// Don't forget to add the last block if it exists.
+	if currentBlock.Len() > 0 {
+		blocks = append(blocks, currentBlock.String())
+	}
+
+	return blocks
 }

--- a/core/block/import/markdown/anymark/blocks_renderer.go
+++ b/core/block/import/markdown/anymark/blocks_renderer.go
@@ -199,6 +199,15 @@ func (r *blocksRenderer) AddTextToBuffer(text string) {
 	r.textBuffer += text
 }
 
+func (r *blocksRenderer) TextBufferLen() int {
+	if len(r.openedTextBlocks) > 0 {
+		return len(r.openedTextBlocks[len(r.openedTextBlocks)-1].textBuffer)
+
+	}
+
+	return len(r.textBuffer)
+}
+
 func (r *blocksRenderer) AddImageBlock(source string) {
 	sourceUnescaped, err := url.PathUnescape(source)
 	if err != nil {

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -20,9 +20,9 @@ import (
 
 var log = logging.Logger("anytype-anymark")
 
-// BlockLengthSoftLimit is the soft limit for the length of a block.
-// In case block length exceeds this limit and the soft line break found(e.g. single \n) the new text block will be started.
-const BlockLengthSoftLimit = 1024
+// BlockLengthSoftLimit is the soft limit for the length of a text block.
+// In case text block length exceeds this limit and the soft line break found(e.g. single \n) the new text block will be started.
+const TextBlockLengthSoftLimit = 1024
 
 type Renderer struct {
 	*blocksRenderer
@@ -397,7 +397,7 @@ func (r *Renderer) renderText(_ util.BufWriter,
 	segment := n.Segment
 
 	r.AddTextToBuffer(string(segment.Value(source)))
-	if n.HardLineBreak() || n.SoftLineBreak() && r.TextBufferLen() > BlockLengthSoftLimit {
+	if n.HardLineBreak() || n.SoftLineBreak() && r.TextBufferLen() > TextBlockLengthSoftLimit {
 		r.openTextBlockWithStyle(false, model.BlockContentText_Paragraph, nil)
 
 	} else if n.SoftLineBreak() {

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -20,6 +20,10 @@ import (
 
 var log = logging.Logger("anytype-anymark")
 
+// BlockLengthSoftLimit is the soft limit for the length of a block.
+// In case block length exceeds this limit and the soft line break found(e.g. single \n) the new text block will be started.
+const BlockLengthSoftLimit = 1024
+
 type Renderer struct {
 	*blocksRenderer
 }
@@ -393,7 +397,7 @@ func (r *Renderer) renderText(_ util.BufWriter,
 	segment := n.Segment
 
 	r.AddTextToBuffer(string(segment.Value(source)))
-	if n.HardLineBreak() {
+	if n.HardLineBreak() || n.SoftLineBreak() && r.TextBufferLen() > BlockLengthSoftLimit {
 		r.openTextBlockWithStyle(false, model.BlockContentText_Paragraph, nil)
 
 	} else if n.SoftLineBreak() {


### PR DESCRIPTION
In case user paste the text with a hugge amount of text without double line breaks(\n\n) it will results in huge text blocks created. It is very bad from multiple sides.
- every change to text block contains the full text of block
- large text block is hard to render on client (per-block virtualisation is not possible)
- full-text is also indexing per-block, making it consume a lot of memory during the indexing

This PR introduces the soft limit the breaks block on a single line ending in case it exceeded the soft limit.

Currently I set the limit to 1024 symbols. 

Also, in case markdown parsing was failing(e.g. in case text has invalid markdown sequences), text was splitting by a single line break. I've changed the logic to be consistent with anymark behaviour