### PR TITLE
GO-2964 Unset maxCount for restrictions

### DIFF
--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "621cf86429879ad8a5713e819e2280ef1f5522ec9dcd8d0f813966bfa8723b0b"
+const RelationChecksum = "ae2464df23c777d39a4285deac06430672ca6d5b41698101834847a1f2258311"
 const (
 	RelationKeyTag                       domain.RelationKey = "tag"
 	RelationKeyCamera                    domain.RelationKey = "camera"
@@ -1808,7 +1808,6 @@ var (
 			Hidden:           true,
 			Id:               "_brrestrictions",
 			Key:              "restrictions",
-			MaxCount:         1,
 			Name:             "Object restrictions",
 			ReadOnly:         true,
 			ReadOnlyRelation: true,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -141,7 +141,7 @@
     "format": "number",
     "hidden": true,
     "key": "restrictions",
-    "maxCount": 1,
+    "maxCount": 0,
     "name": "Object restrictions",
     "readonly": true,
     "source": "derived"


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2964/remove-maxcount=1-from-restrictions-relation

We should remove maxCount=1 from Restrictions relation, as it is []int