### PR TITLE
GO-2811: Importing from Notion ends with an error

### DIFF
--- a/core/block/import/common/common.go
+++ b/core/block/import/common/common.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
+	"github.com/ipfs/go-cid"
 	"github.com/samber/lo"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
@@ -196,11 +197,14 @@ func isBundledObjects(targetObjectID string) bool {
 
 func handleTextBlock(oldIDtoNew map[string]string, block simple.Block, st *state.State, filesIDs []string) {
 	if iconImage := block.Model().GetText().GetIconImage(); iconImage != "" {
-		newTarget := oldIDtoNew[iconImage]
-		if newTarget == "" {
-			newTarget = addr.MissingObject
+		_, err := cid.Decode(iconImage)
+		if err == nil { // this can be url, because for notion import we store url to picture
+			newTarget := oldIDtoNew[iconImage]
+			if newTarget == "" {
+				newTarget = addr.MissingObject
+			}
+			block.Model().GetText().IconImage = newTarget
 		}
-		block.Model().GetText().IconImage = newTarget
 	}
 	marks := block.Model().GetText().GetMarks().GetMarks()
 	for i, mark := range marks {

--- a/util/os/error.go
+++ b/util/os/error.go
@@ -1,6 +1,7 @@
 package os
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,16 +11,28 @@ import (
 
 func TransformError(err error) error {
 	if pathErr, ok := err.(*os.PathError); ok {
-		filePathParts := strings.Split(pathErr.Path, string(filepath.Separator))
-		anonymizedFilePathParts := lo.Map(filePathParts, func(item string, index int) string {
-			if item == "" {
-				return ""
-			}
-			return strings.ReplaceAll(item, item, "***")
-		})
-		newPath := strings.Join(anonymizedFilePathParts, string(filepath.Separator))
-		pathErr.Path = newPath
-		return pathErr
+		return anonymizePathError(pathErr)
+	}
+	if urlErr, ok := err.(*url.Error); ok {
+		return anonymizeUrlError(urlErr)
 	}
 	return err
+}
+
+func anonymizePathError(pathErr *os.PathError) error {
+	filePathParts := strings.Split(pathErr.Path, string(filepath.Separator))
+	anonymizedFilePathParts := lo.Map(filePathParts, func(item string, index int) string {
+		if item == "" {
+			return ""
+		}
+		return strings.ReplaceAll(item, item, "***")
+	})
+	newPath := strings.Join(anonymizedFilePathParts, string(filepath.Separator))
+	pathErr.Path = newPath
+	return pathErr
+}
+
+func anonymizeUrlError(urlErr *url.Error) error {
+	urlErr.URL = "<masked url>"
+	return urlErr
 }

--- a/util/os/error_test.go
+++ b/util/os/error_test.go
@@ -2,6 +2,7 @@ package os
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,28 +12,42 @@ import (
 
 func TestTransformError(t *testing.T) {
 	sep := string(filepath.Separator)
-	pathError := &os.PathError{
-		Op:   "read",
-		Path: sep + "test" + sep + "file" + sep + "path" + sep,
-		Err:  fmt.Errorf("test"),
-	}
 
-	resultErrorMessage := "read /***/***/***/: test"
-	assert.NotNil(t, TransformError(pathError))
-	assert.Equal(t, resultErrorMessage, TransformError(pathError).Error())
+	t.Run("absolute path", func(t *testing.T) {
+		pathError := &os.PathError{
+			Op:   "read",
+			Path: sep + "test" + sep + "file" + sep + "path" + sep,
+			Err:  fmt.Errorf("test"),
+		}
 
-	pathError = &os.PathError{
-		Op:   "read",
-		Path: "test" + sep + "file",
-		Err:  fmt.Errorf("test"),
-	}
+		resultErrorMessage := "read /***/***/***/: test"
+		assert.NotNil(t, TransformError(pathError))
+		assert.Equal(t, resultErrorMessage, TransformError(pathError).Error())
+	})
 
-	resultErrorMessage = "read ***/***: test"
-	assert.NotNil(t, TransformError(pathError))
-	assert.Equal(t, resultErrorMessage, TransformError(pathError).Error())
+	t.Run("relative path", func(t *testing.T) {
+		pathError := &os.PathError{
+			Op:   "read",
+			Path: "test" + sep + "file",
+			Err:  fmt.Errorf("test"),
+		}
 
-	err := fmt.Errorf("test")
-	resultErrorMessage = "test"
-	assert.NotNil(t, TransformError(err))
-	assert.Equal(t, resultErrorMessage, TransformError(err).Error())
+		resultErrorMessage := "read ***/***: test"
+		assert.NotNil(t, TransformError(pathError))
+		assert.Equal(t, resultErrorMessage, TransformError(pathError).Error())
+	})
+
+	t.Run("not os path error", func(t *testing.T) {
+		err := fmt.Errorf("test")
+		resultErrorMessage := "test"
+		assert.NotNil(t, TransformError(err))
+		assert.Equal(t, resultErrorMessage, TransformError(err).Error())
+	})
+
+	t.Run("url error", func(t *testing.T) {
+		err := &url.Error{URL: "http://test.test", Op: "Test", Err: fmt.Errorf("test")}
+		resultErrorMessage := "Test \"<masked url>\": test"
+		assert.NotNil(t, TransformError(err))
+		assert.Equal(t, resultErrorMessage, TransformError(err).Error())
+	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2811/importing-from-notion-ends-with-an-error
1. Anonymize returned error in ObjectImport response by masking url
2. Fix import of notion icons. We didn't take into account that originally iconImage field in text block contained url to Notion icon. So Notion icons weren't imported, because they were considered as missing objects