### PR TITLE
GO-2950 Change relations order

### DIFF
--- a/core/block/editor/participant.go
+++ b/core/block/editor/participant.go
@@ -39,8 +39,8 @@ func (p *participant) Init(ctx *smartblock.InitContext) (err error) {
 		template.WithDescription,
 		template.WithFeaturedRelations,
 		template.WithAddedFeaturedRelation(bundle.RelationKeyType),
-		template.WithAddedFeaturedRelation(bundle.RelationKeyBacklinks),
 		template.WithAddedFeaturedRelation(bundle.RelationKeyIdentity),
+		template.WithAddedFeaturedRelation(bundle.RelationKeyBacklinks),
 	)
 	return nil
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2950/make-anytype-identity-relation-as-featured-for-space-member-objects

Change featured relations order:
type -> AnyID -> backlinks

![image](https://github.com/anyproto/anytype-heart/assets/40611691/d74e408e-dad1-4ae1-9bd8-dada3ae7ae49)
