### PR TITLE
GO-2734 Add globalName directly

### DIFF
--- a/core/identity/identity.go
+++ b/core/identity/identity.go
@@ -42,7 +42,7 @@ var (
 type Service interface {
 	GetMyProfileDetails() (identity string, metadataKey crypto.SymKey, details *types.Struct)
 
-	UpdateGlobalNames()
+	UpdateGlobalNames(myIdentityGlobalName string)
 
 	RegisterIdentity(spaceId string, identity string, encryptionKey crypto.SymKey, observer func(identity string, profile *model.IdentityProfile)) error
 
@@ -238,7 +238,9 @@ func (s *service) GetMyProfileDetails() (identity string, metadataKey crypto.Sym
 	return s.myIdentity, s.spaceService.AccountMetadataSymKey(), s.currentProfileDetails
 }
 
-func (s *service) UpdateGlobalNames() {
+func (s *service) UpdateGlobalNames(myIdentityGlobalName string) {
+	// we update globalName of local identity directly because Naming Node is not registering new name immediately
+	s.updateMyIdentityGlobalName(myIdentityGlobalName)
 	select {
 	case s.globalNamesForceUpdate <- struct{}{}:
 	default:
@@ -551,16 +553,20 @@ func (s *service) fetchGlobalNames(identities []string, forceUpdate bool) error 
 	for i, anyID := range identities {
 		s.identityGlobalNames[anyID] = response.Results[i]
 		if anyID == s.myIdentity && response.Results[i].Found {
-			s.currentProfileDetailsLock.RLock()
-			details := pbtypes.CopyStruct(s.currentProfileDetails, true)
-			s.currentProfileDetailsLock.RUnlock()
-			details.Fields[bundle.RelationKeyGlobalName.String()] = pbtypes.String(response.Results[i].Name)
-			if err = s.objectStore.UpdateObjectDetails(pbtypes.GetString(details, bundle.RelationKeyId.String()), details); err != nil {
-				return err
-			}
+			s.updateMyIdentityGlobalName(response.Results[i].Name)
 		}
 	}
 	return nil
+}
+
+func (s *service) updateMyIdentityGlobalName(name string) {
+	s.currentProfileDetailsLock.RLock()
+	details := pbtypes.CopyStruct(s.currentProfileDetails, true)
+	s.currentProfileDetailsLock.RUnlock()
+	details.Fields[bundle.RelationKeyGlobalName.String()] = pbtypes.String(name)
+	if err := s.objectStore.UpdateObjectDetails(pbtypes.GetString(details, bundle.RelationKeyId.String()), details); err != nil {
+		log.Error("failed to update global name of my identity in store", zap.Error(err))
+	}
 }
 
 func (s *service) cacheIdentityProfile(rawProfile []byte, profile *model.IdentityProfile) error {

--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -42,7 +42,7 @@ var (
 )
 
 type globalNamesUpdater interface {
-	UpdateGlobalNames()
+	UpdateGlobalNames(myIdentityGlobalName string)
 }
 
 /*
@@ -273,7 +273,7 @@ func (s *service) GetSubscriptionStatus(ctx context.Context, req *pb.RpcMembersh
 
 	// 5 - if requested any name has changed, then we need to update details of local identity
 	if isDiffRequestedName {
-		s.profileUpdater.UpdateGlobalNames()
+		s.profileUpdater.UpdateGlobalNames(status.RequestedAnyName)
 	}
 
 	return &out, nil

--- a/core/payments/payments_test.go
+++ b/core/payments/payments_test.go
@@ -38,7 +38,7 @@ var cacheExpireTime time.Time = time.Unix(int64(subsExpire.Unix()), 0)
 
 type mockGlobalNamesUpdater struct{}
 
-func (u *mockGlobalNamesUpdater) UpdateGlobalNames() {}
+func (u *mockGlobalNamesUpdater) UpdateGlobalNames(string) {}
 
 func (u *mockGlobalNamesUpdater) Init(*app.App) (err error) {
 	return nil


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2734/add-cache-for-client-to-resolve-id-name

Save globalName of myIdentity directly, as NS need some time to process newly registered name