### PR TITLE
GO-3177: Fix removing spaces

### DIFF
--- a/space/internal/shareablespace/shareable.go
+++ b/space/internal/shareablespace/shareable.go
@@ -104,7 +104,7 @@ func (s *spaceController) SetInfo(ctx context.Context, info spaceinfo.SpacePersi
 
 func (s *spaceController) UpdateInfo(ctx context.Context, info spaceinfo.SpacePersistentInfo) error {
 	s.status.Lock()
-	if s.lastUpdatedStatus == info.AccountStatus || (s.lastUpdatedStatus == spaceinfo.AccountStatusDeleted && info.AccountStatus == spaceinfo.AccountStatusRemoving) {
+	if s.lastUpdatedStatus == info.AccountStatus {
 		s.status.Unlock()
 		return nil
 	}

--- a/space/service.go
+++ b/space/service.go
@@ -265,12 +265,11 @@ func (s *service) UpdateRemoteStatus(ctx context.Context, status spaceinfo.Space
 		accountStatus := ctrl.GetStatus()
 		if accountStatus != spaceinfo.AccountStatusDeleted && accountStatus != spaceinfo.AccountStatusRemoving {
 			s.sendNotification(status.SpaceId)
+			return ctrl.SetInfo(ctx, spaceinfo.SpacePersistentInfo{
+				SpaceID:       status.SpaceId,
+				AccountStatus: spaceinfo.AccountStatusRemoving,
+			})
 		}
-		return ctrl.SetInfo(ctx, spaceinfo.SpacePersistentInfo{
-			SpaceID:       status.SpaceId,
-			AccountStatus: spaceinfo.AccountStatusRemoving,
-		})
-
 	}
 	return nil
 }

--- a/space/service_test.go
+++ b/space/service_test.go
@@ -67,10 +67,6 @@ func TestService_UpdateRemoteStatus(t *testing.T) {
 		}
 		controller.EXPECT().UpdateRemoteStatus(context.Background(), statusInfo).Return(nil)
 		controller.EXPECT().GetStatus().Return(spaceinfo.AccountStatusDeleted)
-		controller.EXPECT().SetInfo(context.Background(), spaceinfo.SpacePersistentInfo{
-			SpaceID:       spaceID,
-			AccountStatus: spaceinfo.AccountStatusRemoving,
-		}).Return(nil)
 		notifications := mock_notifications.NewMockNotifications(t)
 		s := service{
 			spaceControllers:    map[string]spacecontroller.SpaceController{spaceID: controller},
@@ -93,10 +89,6 @@ func TestService_UpdateRemoteStatus(t *testing.T) {
 		}
 		controller.EXPECT().UpdateRemoteStatus(context.Background(), statusInfo).Return(nil)
 		controller.EXPECT().GetStatus().Return(spaceinfo.AccountStatusRemoving)
-		controller.EXPECT().SetInfo(context.Background(), spaceinfo.SpacePersistentInfo{
-			SpaceID:       spaceID,
-			AccountStatus: spaceinfo.AccountStatusRemoving,
-		}).Return(nil)
 		notifications := mock_notifications.NewMockNotifications(t)
 		s := service{
 			spaceControllers:    map[string]spacecontroller.SpaceController{spaceID: controller},
@@ -177,7 +169,7 @@ func TestService_UpdateRemoteStatus(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 	})
-	t.Run("send notification, because space status - deleted, but we get space name with name Test", func(t *testing.T) {
+	t.Run("send notification, because space remote status - deleted, but we get space name with name Test", func(t *testing.T) {
 		// given
 		controller := mock_spacecontroller.NewMockSpaceController(t)
 		statusInfo := spaceinfo.SpaceRemoteStatusInfo{


### PR DESCRIPTION
Fix a bug when we could change status to removing for the spaces that were previously deleted by the space member