### PR TITLE
GO-3023 Add billingID to response

### DIFF
--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -441,8 +441,10 @@ func (s *service) GetPaymentURL(ctx context.Context, req *pb.RpcMembershipGetPay
 		return nil, err
 	}
 
-	var out pb.RpcMembershipGetPaymentUrlResponse
-	out.PaymentUrl = bsRet.PaymentUrl
+	out := pb.RpcMembershipGetPaymentUrlResponse{
+		PaymentUrl: bsRet.PaymentUrl,
+		BillingId:  bsRet.BillingID,
+	}
 
 	// 2 - disable cache for 30 minutes
 	log.Debug("disabling cache for 30 minutes after payment URL was received")
@@ -715,9 +717,9 @@ func (s *service) getAllTiers(ctx context.Context, req *pb.RpcMembershipTiersGet
 			Id:          tier.Id,
 			Name:        tier.Name,
 			Description: tier.Description,
-			//IsActive:              tier.IsActive,
+			// IsActive:              tier.IsActive,
 			IsTest: tier.IsTest,
-			//IsHiddenTier:          tier.IsHiddenTier,
+			// IsHiddenTier:          tier.IsHiddenTier,
 			PeriodType:          model.MembershipTierDataPeriodType(tier.PeriodType),
 			PeriodValue:         tier.PeriodValue,
 			PriceStripeUsdCents: tier.PriceStripeUsdCents,

--- a/core/payments/payments_test.go
+++ b/core/payments/payments_test.go
@@ -516,6 +516,7 @@ func TestGetPaymentURL(t *testing.T) {
 		fx.ppclient.EXPECT().BuySubscription(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx interface{}, in interface{}) (*psp.BuySubscriptionResponse, error) {
 			var out psp.BuySubscriptionResponse
 			out.PaymentUrl = "https://xxxx.com"
+			out.BillingID = "killbillingid"
 
 			return &out, nil
 		}).MinTimes(1)
@@ -533,6 +534,7 @@ func TestGetPaymentURL(t *testing.T) {
 		resp, err := fx.GetPaymentURL(ctx, req)
 		assert.NoError(t, err)
 		assert.Equal(t, "https://xxxx.com", resp.PaymentUrl)
+		assert.Equal(t, "killbillingid", resp.BillingId)
 	})
 }
 

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -11192,6 +11192,7 @@ where user can pay for the membership
 | ----- | ---- | ----- | ----------- |
 | error | [Rpc.Membership.GetPaymentUrl.Response.Error](#anytype-Rpc-Membership-GetPaymentUrl-Response-Error) |  |  |
 | paymentUrl | [string](#string) |  | will feature current billing ID stripe.com/?client_reference_id=1234 |
+| billingId | [string](#string) |  | raw billing ID |
 
 
 

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -11192,7 +11192,7 @@ where user can pay for the membership
 | ----- | ---- | ----- | ----------- |
 | error | [Rpc.Membership.GetPaymentUrl.Response.Error](#anytype-Rpc-Membership-GetPaymentUrl-Response-Error) |  |  |
 | paymentUrl | [string](#string) |  | will feature current billing ID stripe.com/?client_reference_id=1234 |
-| billingId | [string](#string) |  | raw billing ID |
+| billingId | [string](#string) |  | billingID is only needed for mobile clients |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -6490,6 +6490,8 @@ message Rpc {
                 // will feature current billing ID
                 // stripe.com/?client_reference_id=1234
                 string paymentUrl = 2;
+                // raw billing ID
+                string billingId = 3;
 
                 message Error {
                     Code code = 1;

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -6490,7 +6490,7 @@ message Rpc {
                 // will feature current billing ID
                 // stripe.com/?client_reference_id=1234
                 string paymentUrl = 2;
-                // raw billing ID
+                // billingID is only needed for mobile clients
                 string billingId = 3;
 
                 message Error {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3023/implement-payments-support-on-android

Add billingID to response of GetPaymentURL, as this value is the universal identifier of payment request, so it should be propagated by mobile clients