### PR TITLE
GO-2673 Exclude deleted objects

### DIFF
--- a/cmd/usecasevalidator/main.go
+++ b/cmd/usecasevalidator/main.go
@@ -75,7 +75,7 @@ const anytypeProfileFilename = addr.AnytypeProfileId + ".pb"
 var (
 	errIncorrectFileFound = fmt.Errorf("incorrect protobuf file was found")
 	errValidationFailed   = fmt.Errorf("validation failed")
-	errSkipObject         = fmt.Errorf("validation failed, but object can be skipped")
+	errSkipObject         = fmt.Errorf("object is invalid, skip it")
 )
 
 func main() {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2673/implement-validator-on-usecase-addition-in-gallery

- exclude deleted object from archive
- exclude templates with no target type presented in the archive
- delete recommendedRelations of type objects in case these relations are not in the archive