### PR TITLE
GO-3210 | GO-3211 Make globalName derived

### DIFF
--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gogo/protobuf/types"
+	"golang.org/x/exp/maps"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/basic"
 	"github.com/anyproto/anytype-heart/core/block/editor/bookmark"
@@ -624,7 +625,14 @@ func (s *Service) ModifyDetails(objectId string, modifier func(current *types.St
 			return err
 		}
 
-		return b.Apply(b.NewState().SetDetails(dets))
+		rels, err := s.objectStore.FetchRelationByKeys(b.SpaceID(), maps.Keys(dets.Fields)...)
+		if err != nil {
+			return err
+		}
+
+		st := b.NewState().SetDetails(dets)
+		st.AddRelationLinks(rels.RelationLinks()...)
+		return b.Apply(st)
 	})
 }
 

--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/globalsign/mgo/bson"
+	"github.com/gogo/protobuf/types"
 	"github.com/samber/lo"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/converter"
@@ -40,6 +41,7 @@ type AllOperations interface {
 
 type CommonOperations interface {
 	DetailsSettable
+	DetailsUpdatable
 
 	SetFields(ctx session.Context, fields ...*pb.RpcBlockListSetFieldsRequestBlockField) (err error)
 	SetDivStyle(ctx session.Context, style model.BlockContentDivStyle, ids ...string) (err error)
@@ -62,6 +64,10 @@ type CommonOperations interface {
 
 type DetailsSettable interface {
 	SetDetails(ctx session.Context, details []*pb.RpcObjectSetDetailsDetail, showEvent bool) (err error)
+}
+
+type DetailsUpdatable interface {
+	UpdateDetails(update func(current *types.Struct) (*types.Struct, error)) (err error)
 }
 
 type Restrictionable interface {
@@ -402,7 +408,7 @@ func (bs *basic) FeaturedRelationAdd(ctx session.Context, relations ...string) (
 			}
 			frc = append(frc, r)
 			if !bs.HasRelation(s, r) {
-				err = bs.addRelationLink(r, s)
+				err = bs.addRelationLink(s, r)
 				if err != nil {
 					return fmt.Errorf("failed to add relation link on adding featured relation '%s': %w", r, err)
 				}

--- a/core/block/editor/participant.go
+++ b/core/block/editor/participant.go
@@ -3,6 +3,7 @@ package editor
 import (
 	"time"
 
+	"github.com/anyproto/anytype-heart/core/block/editor/basic"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -12,11 +13,14 @@ import (
 
 type participant struct {
 	smartblock.SmartBlock
+	basic.DetailsUpdatable
 }
 
 func (f *ObjectFactory) newParticipant(sb smartblock.SmartBlock) *participant {
+	basicComponent := basic.NewBasic(sb, f.objectStore, f.layoutConverter)
 	return &participant{
-		SmartBlock: sb,
+		SmartBlock:       sb,
+		DetailsUpdatable: basicComponent,
 	}
 }
 

--- a/core/block/editor_test.go
+++ b/core/block/editor_test.go
@@ -1,0 +1,155 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/block/object/idresolver/mock_idresolver"
+	"github.com/anyproto/anytype-heart/core/relationutils"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/mock_objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/space/mock_space"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+type fixture struct {
+	blockService *Service
+	store        *mock_objectstore.MockObjectStore
+
+	sb  *smarttest.SmartTest
+	spc *mock_clientspace.MockSpace
+}
+
+var (
+	objectId = "id"
+	spaceId  = "spaceId"
+)
+
+func newFixture(t *testing.T) *fixture {
+	blockService := New()
+
+	sb := smarttest.New(objectId)
+	sb.SetDetails(nil, nil, false)
+	sb.SetSpaceId(spaceId)
+
+	spc := mock_clientspace.NewMockSpace(t)
+	spc.EXPECT().GetObject(mock.Anything, objectId).Return(sb, nil).Times(1)
+
+	spaceService := mock_space.NewMockService(t)
+	spaceService.EXPECT().Get(mock.Anything, spaceId).Return(spc, nil).Times(1)
+
+	resolver := mock_idresolver.NewMockResolver(t)
+	resolver.EXPECT().ResolveSpaceID(objectId).Return(spaceId, nil).Times(1)
+
+	store := mock_objectstore.NewMockObjectStore(t)
+
+	blockService.spaceService = spaceService
+	blockService.resolver = resolver
+	blockService.objectStore = store
+
+	return &fixture{
+		blockService: blockService,
+		sb:           sb,
+		store:        store,
+		spc:          spc,
+	}
+}
+
+func TestService_ModifyDetails(t *testing.T) {
+
+	t.Run("add new details", func(t *testing.T) {
+		// given
+		f := newFixture(t)
+		f.store.EXPECT().FetchRelationByKeys(spaceId, bundle.RelationKeyAperture.String(), bundle.RelationKeyRelationMaxCount.String()).
+			Return(relationutils.Relations{
+				{&model.Relation{
+					Key:    bundle.RelationKeyAperture.String(),
+					Format: model.RelationFormat_longtext,
+				}}, {&model.Relation{
+					Key:    bundle.RelationKeyRelationMaxCount.String(),
+					Format: model.RelationFormat_number,
+				}}}, nil)
+
+		// when
+		err := f.blockService.ModifyDetails(objectId, func(current *types.Struct) (*types.Struct, error) {
+			current.Fields[bundle.RelationKeyAperture.String()] = pbtypes.String("aperture")
+			current.Fields[bundle.RelationKeyRelationMaxCount.String()] = pbtypes.Int64(5)
+			return current, nil
+		})
+
+		// then
+		assert.NoError(t, err)
+
+		value, found := f.sb.Details().Fields[bundle.RelationKeyAperture.String()]
+		assert.True(t, found)
+		assert.Equal(t, pbtypes.String("aperture"), value)
+		assert.True(t, f.sb.HasRelation(f.sb.NewState(), bundle.RelationKeyAperture.String()))
+
+		value, found = f.sb.Details().Fields[bundle.RelationKeyRelationMaxCount.String()]
+		assert.True(t, found)
+		assert.Equal(t, pbtypes.Int64(5), value)
+		assert.True(t, f.sb.HasRelation(f.sb.NewState(), bundle.RelationKeyRelationMaxCount.String()))
+	})
+
+	t.Run("modify details", func(t *testing.T) {
+		// given
+		f := newFixture(t)
+		err := f.sb.SetDetails(nil, []*pb.RpcObjectSetDetailsDetail{{
+			Key:   bundle.RelationKeySpaceDashboardId.String(),
+			Value: pbtypes.String("123"),
+		}}, false)
+		assert.NoError(t, err)
+		f.store.EXPECT().FetchRelationByKeys(spaceId, bundle.RelationKeySpaceDashboardId.String()).
+			Return(relationutils.Relations{
+				{&model.Relation{
+					Key:    bundle.RelationKeySpaceDashboardId.String(),
+					Format: model.RelationFormat_object,
+				}}}, nil)
+
+		// when
+		err = f.blockService.ModifyDetails(objectId, func(current *types.Struct) (*types.Struct, error) {
+			current.Fields[bundle.RelationKeySpaceDashboardId.String()] = pbtypes.String("new123")
+			return current, nil
+		})
+
+		// then
+		assert.NoError(t, err)
+
+		value, found := f.sb.Details().Fields[bundle.RelationKeySpaceDashboardId.String()]
+		assert.True(t, found)
+		assert.Equal(t, pbtypes.String("new123"), value)
+		assert.True(t, f.sb.HasRelation(f.sb.NewState(), bundle.RelationKeySpaceDashboardId.String()))
+	})
+
+	t.Run("delete details", func(t *testing.T) {
+		// given
+		f := newFixture(t)
+		err := f.sb.SetDetails(nil, []*pb.RpcObjectSetDetailsDetail{{
+			Key:   bundle.RelationKeyTargetObjectType.String(),
+			Value: pbtypes.String("note"),
+		}}, false)
+		assert.NoError(t, err)
+		f.store.EXPECT().FetchRelationByKeys(spaceId).Return(nil, nil)
+
+		// when
+		err = f.blockService.ModifyDetails(objectId, func(current *types.Struct) (*types.Struct, error) {
+			delete(current.Fields, bundle.RelationKeyTargetObjectType.String())
+			return current, nil
+		})
+
+		// then
+		assert.NoError(t, err)
+
+		value, found := f.sb.Details().Fields[bundle.RelationKeyTargetObjectType.String()]
+		assert.False(t, found)
+		assert.Nil(t, value)
+		assert.False(t, f.sb.HasRelation(f.sb.NewState(), bundle.RelationKeyTargetObjectType.String()))
+	})
+}

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "d9166ff25c421f94e3fd6b640fa6ad8652b0d4a676e9963ffddb447d9a20e2ae"
+const RelationChecksum = "d56fa782bf2d25bfc0e8e83717c349d63e49d1c3e96c6e83a342b1383942ffbf"
 const (
 	RelationKeyTag                       domain.RelationKey = "tag"
 	RelationKeyCamera                    domain.RelationKey = "camera"
@@ -859,7 +859,7 @@ var (
 		},
 		RelationKeyGlobalName: {
 
-			DataSource:       model.Relation_details,
+			DataSource:       model.Relation_derived,
 			Description:      "Name of profile that the user could be mentioned by",
 			Format:           model.RelationFormat_shorttext,
 			Id:               "_brglobalName",

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1697,6 +1697,6 @@
     "maxCount": 1,
     "name": "Global name",
     "readonly": true,
-    "source": "details"
+    "source": "derived"
   }
 ]


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3210/relationlinks-identity-and-globalname-are-not-added-to-participant

https://linear.app/anytype/issue/GO-3211/update-global-name-in-multispaces


1. Make globalName a derived relation, so it is included in Identity object on Init stage
2. Add relation links on details modification