### PR TITLE
GO-3173: send to client number of objects which was imported within one import procedure

### DIFF
--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -195,7 +195,15 @@ func (i *Import) importFromBuiltinConverter(ctx context.Context,
 	if resultErr != nil {
 		rootCollectionID = ""
 	}
-	return rootCollectionID, int64(len(details)), resultErr
+	return rootCollectionID, i.getObjectCount(details, rootCollectionID), resultErr
+}
+
+func (i *Import) getObjectCount(details map[string]*types.Struct, rootCollectionID string) int64 {
+	objectsCount := int64(len(details))
+	if rootCollectionID != "" && objectsCount > 0 {
+		objectsCount-- // exclude root collection object from counter
+	}
+	return objectsCount
 }
 
 func (i *Import) importFromExternalSource(ctx context.Context,

--- a/core/block/import/importer_test.go
+++ b/core/block/import/importer_test.go
@@ -798,6 +798,7 @@ func Test_ImportRootCollectionInResponse(t *testing.T) {
 		// then
 		assert.Nil(t, res.Err)
 		assert.Equal(t, expectedRootCollectionID, res.RootCollectionId)
+		assert.Equal(t, int64(0), res.ObjectsCount) // doesn't count root collection
 	})
 
 	t.Run("return empty root collection id in case of error", func(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3173/send-to-client-number-of-objects-which-was-imported-within-one-import

Don't count root collection object in analytics, because we need to count only imported objects