### PR TITLE
GO-3210 Fix participant.modifyDetails

### DIFF
--- a/core/block/editor/participant.go
+++ b/core/block/editor/participant.go
@@ -81,9 +81,9 @@ func (p *participant) TryClose(objectTTL time.Duration) (bool, error) {
 }
 
 func (p *participant) modifyDetails(newDetails *types.Struct) (err error) {
-	newState := p.NewState()
-	newState.SetDetails(pbtypes.StructMerge(p.CombinedDetails(), newDetails, false))
-	return p.Apply(newState)
+	return p.DetailsUpdatable.UpdateDetails(func(current *types.Struct) (*types.Struct, error) {
+		return pbtypes.StructMerge(p.CombinedDetails(), newDetails, false), nil
+	})
 }
 
 func buildParticipantDetails(

--- a/core/block/editor/participant_test.go
+++ b/core/block/editor/participant_test.go
@@ -5,16 +5,20 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/anyproto/anytype-heart/core/block/editor/basic"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
 	"github.com/anyproto/anytype-heart/core/block/migration"
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space/spaceinfo"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 func TestParticipant_ModifyProfileDetails(t *testing.T) {
+	// given
 	fx := newParticipantFixture(t)
 	defer fx.finish()
 	details := pbtypes.ToStruct(map[string]interface{}{
@@ -24,20 +28,29 @@ func TestParticipant_ModifyProfileDetails(t *testing.T) {
 		bundle.RelationKeyId.String():          "profile",
 		bundle.RelationKeyGlobalName.String():  "global",
 	})
+
+	// when
 	err := fx.ModifyProfileDetails(details)
+
+	// then
 	require.NoError(t, err)
 	details.Fields[bundle.RelationKeyIdentityProfileLink.String()] = pbtypes.String("profile")
 	delete(details.Fields, bundle.RelationKeyId.String())
 	fields := details.GetFields()
 	participantFields := fx.CombinedDetails().GetFields()
+	participantRelationLinks := fx.GetRelationLinks()
 	for key, _ := range details.Fields {
 		require.Equal(t, fields[key], participantFields[key])
+		require.True(t, participantRelationLinks.Has(key))
 	}
 }
 
 func TestParticipant_ModifyParticipantAclState(t *testing.T) {
+	// given
 	fx := newParticipantFixture(t)
 	defer fx.finish()
+
+	// when
 	err := fx.ModifyParticipantAclState(spaceinfo.ParticipantAclInfo{
 		Id:          "id",
 		SpaceId:     "spaceId",
@@ -45,6 +58,8 @@ func TestParticipant_ModifyParticipantAclState(t *testing.T) {
 		Permissions: model.ParticipantPermissions_Owner,
 		Status:      model.ParticipantStatus_Active,
 	})
+
+	// then
 	require.NoError(t, err)
 	details := pbtypes.ToStruct(map[string]interface{}{
 		bundle.RelationKeyId.String():                     "id",
@@ -57,12 +72,15 @@ func TestParticipant_ModifyParticipantAclState(t *testing.T) {
 	})
 	fields := details.GetFields()
 	participantFields := fx.CombinedDetails().GetFields()
+	participantRelationLinks := fx.GetRelationLinks()
 	for key, _ := range details.Fields {
 		require.Equal(t, fields[key], participantFields[key])
+		require.True(t, participantRelationLinks.Has(key))
 	}
 }
 
 func TestParticipant_ModifyIdentityDetails(t *testing.T) {
+	// given
 	fx := newParticipantFixture(t)
 	defer fx.finish()
 	identity := &model.IdentityProfile{
@@ -71,7 +89,11 @@ func TestParticipant_ModifyIdentityDetails(t *testing.T) {
 		IconCid:     "icon",
 		GlobalName:  "global",
 	}
+
+	// when
 	err := fx.ModifyIdentityDetails(identity)
+
+	// then
 	require.NoError(t, err)
 	details := pbtypes.ToStruct(map[string]interface{}{
 		bundle.RelationKeyName.String():        "name",
@@ -81,15 +103,42 @@ func TestParticipant_ModifyIdentityDetails(t *testing.T) {
 	})
 	fields := details.GetFields()
 	participantFields := fx.CombinedDetails().GetFields()
+	participantRelationLinks := fx.GetRelationLinks()
 	for key, _ := range details.Fields {
 		require.Equal(t, fields[key], participantFields[key])
+		require.True(t, participantRelationLinks.Has(key))
 	}
 }
 
-func newParticipantTest() (*participant, error) {
+func newStoreFixture(t *testing.T) *objectstore.StoreFixture {
+	store := objectstore.NewStoreFixture(t)
+
+	for _, rel := range []domain.RelationKey{
+		bundle.RelationKeyFeaturedRelations, bundle.RelationKeyIdentity, bundle.RelationKeyName,
+		bundle.RelationKeyIdentityProfileLink, bundle.RelationKeyIsReadonly, bundle.RelationKeyIsArchived,
+		bundle.RelationKeyDescription, bundle.RelationKeyIsHidden, bundle.RelationKeyLayout,
+		bundle.RelationKeyLayoutAlign, bundle.RelationKeyIconImage, bundle.RelationKeyGlobalName,
+		bundle.RelationKeyId, bundle.RelationKeyParticipantPermissions, bundle.RelationKeyLastModifiedBy,
+		bundle.RelationKeySpaceId, bundle.RelationKeyParticipantStatus, bundle.RelationKeyIsHiddenDiscovery,
+	} {
+		store.AddObjects(t, []objectstore.TestObject{{
+			bundle.RelationKeySpaceId:     pbtypes.String(""),
+			bundle.RelationKeyUniqueKey:   pbtypes.String(rel.URL()),
+			bundle.RelationKeyId:          pbtypes.String(rel.String()),
+			bundle.RelationKeyRelationKey: pbtypes.String(rel.String()),
+		}})
+	}
+
+	return store
+}
+
+func newParticipantTest(t *testing.T) (*participant, error) {
 	sb := smarttest.New("root")
+	store := newStoreFixture(t)
+	basicComponent := basic.NewBasic(sb, store, nil)
 	p := &participant{
-		SmartBlock: sb,
+		SmartBlock:       sb,
+		DetailsUpdatable: basicComponent,
 	}
 
 	initCtx := &smartblock.InitContext{
@@ -110,7 +159,7 @@ type participantFixture struct {
 }
 
 func newParticipantFixture(t *testing.T) *participantFixture {
-	p, err := newParticipantTest()
+	p, err := newParticipantTest(t)
 	require.NoError(t, err)
 	return &participantFixture{
 		p,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3210/relationlinks-identity-and-globalname-are-not-added-to-participant

Fix participant.modifyDetails after ACL manager refactoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the update mechanism for participant details to enhance performance and reliability.
- **Tests**
	- Enhanced testing for participant details updates to ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->