### PR TITLE
GO-3275 accountRecover: remove lock

### DIFF
--- a/core/application/account_recover.go
+++ b/core/application/account_recover.go
@@ -9,9 +9,6 @@ import (
 )
 
 func (s *Service) AccountRecover() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	if s.mnemonic == "" {
 		return ErrNoMnemonicProvided
 	}

--- a/core/event/event_grpc.go
+++ b/core/event/event_grpc.go
@@ -81,7 +81,9 @@ func (es *GrpcSender) sendEvent(server SessionServer, event *pb.Event) {
 func (es *GrpcSender) Broadcast(event *pb.Event) {
 	es.ServerMutex.RLock()
 	defer es.ServerMutex.RUnlock()
-
+	if len(es.Servers) == 0 {
+		log.Warnf("no servers to broadcast event")
+	}
 	for _, s := range es.Servers {
 		es.sendEvent(s, event)
 	}


### PR DESCRIPTION
no need for lock here.
This lock results in the missing AccountShow request on client in case ListenEvents and AccountRecover send almost at the same time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the account recovery process by ensuring it proceeds only if a mnemonic is provided.
	- Enhanced event broadcasting reliability with a new warning log if no servers are available for broadcasting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->