### PR TITLE
GO-3299: Add invite acl check

### DIFF
--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -380,6 +380,9 @@ func (a *aclService) ViewInvite(ctx context.Context, inviteCid cid.Cid, inviteFi
 	if err != nil {
 		return inviteservice.InviteView{}, convertedOrAclRequestError(err)
 	}
+	if len(recs) == 0 {
+		return inviteservice.InviteView{}, fmt.Errorf("no acl records found for space: %s, %w", res.SpaceId, ErrAclRequestFailed)
+	}
 	store, err := liststorage.NewInMemoryAclListStorage(recs[0].Id, recs)
 	if err != nil {
 		return inviteservice.InviteView{}, convertedOrAclRequestError(err)

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/commonspace/acl/aclclient"
 	"github.com/anyproto/any-sync/commonspace/object/acl/list"
+	"github.com/anyproto/any-sync/commonspace/object/acl/liststorage"
 	"github.com/anyproto/any-sync/coordinator/coordinatorclient"
 	"github.com/anyproto/any-sync/coordinator/coordinatorproto"
 	"github.com/anyproto/any-sync/util/crypto"
@@ -366,8 +367,33 @@ func (a *aclService) Join(ctx context.Context, spaceId string, inviteCid cid.Cid
 	return nil
 }
 
-func (a *aclService) ViewInvite(ctx context.Context, inviteCid cid.Cid, inviteFileKey crypto.SymKey) (inviteservice.InviteView, error) {
-	return a.inviteService.View(ctx, inviteCid, inviteFileKey)
+func (a *aclService) ViewInvite(ctx context.Context, inviteCid cid.Cid, inviteFileKey crypto.SymKey) (view inviteservice.InviteView, err error) {
+	res, err := a.inviteService.View(ctx, inviteCid, inviteFileKey)
+	if err != nil {
+		return inviteservice.InviteView{}, convertedOrInternalError("view invite", err)
+	}
+	inviteKey, err := crypto.UnmarshalEd25519PrivateKeyProto(res.InviteKey)
+	if err != nil {
+		return inviteservice.InviteView{}, convertedOrInternalError("unmarshal invite key", err)
+	}
+	recs, err := a.joiningClient.AclGetRecords(ctx, res.SpaceId, "")
+	if err != nil {
+		return inviteservice.InviteView{}, convertedOrAclRequestError(err)
+	}
+	store, err := liststorage.NewInMemoryAclListStorage(recs[0].Id, recs)
+	if err != nil {
+		return inviteservice.InviteView{}, convertedOrAclRequestError(err)
+	}
+	lst, err := list.BuildAclList(store, list.NoOpAcceptorVerifier{})
+	if err != nil {
+		return inviteservice.InviteView{}, convertedOrAclRequestError(err)
+	}
+	for _, inv := range lst.AclState().Invites() {
+		if inviteKey.GetPublic().Equals(inv) {
+			return res, nil
+		}
+	}
+	return inviteservice.InviteView{}, inviteservice.ErrInviteNotExists
 }
 
 func (a *aclService) Accept(ctx context.Context, spaceId string, identity crypto.PubKey, permissions model.ParticipantPermissions) error {

--- a/core/acl/aclservice_test.go
+++ b/core/acl/aclservice_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/commonspace/acl/aclclient/mock_aclclient"
 	"github.com/anyproto/any-sync/commonspace/mock_commonspace"
+	"github.com/anyproto/any-sync/commonspace/object/accountdata"
 	"github.com/anyproto/any-sync/commonspace/object/acl/list"
 	"github.com/anyproto/any-sync/commonspace/object/acl/list/mock_list"
 	"github.com/anyproto/any-sync/commonspace/object/acl/syncacl/headupdater"
@@ -24,6 +25,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/anyproto/anytype-heart/core/anytype/account/mock_account"
+	"github.com/anyproto/anytype-heart/core/inviteservice"
 	"github.com/anyproto/anytype-heart/core/inviteservice/mock_inviteservice"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space"
@@ -271,6 +273,75 @@ func TestService_ApproveLeave(t *testing.T) {
 		mockCommonSpace.EXPECT().Acl().Return(acl)
 		err := fx.ApproveLeave(ctx, spaceId, []crypto.PubKey{identityB, identityC})
 		require.Error(t, err)
+	})
+}
+
+func TestService_ViewInvite(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		keys, err := accountdata.NewRandom()
+		require.NoError(t, err)
+		aclList, err := list.NewTestDerivedAcl("spaceId", keys)
+		require.NoError(t, err)
+		inv, err := aclList.RecordBuilder().BuildInvite()
+		require.NoError(t, err)
+		err = aclList.AddRawRecord(list.WrapAclRecord(inv.InviteRec))
+		require.NoError(t, err)
+		recs, err := aclList.RecordsAfter(ctx, "")
+		require.NoError(t, err)
+		cidString, err := cidutil.NewCidFromBytes([]byte("spaceId"))
+		require.NoError(t, err)
+		realCid, err := cid.Decode(cidString)
+		require.NoError(t, err)
+		protoKey, err := inv.InviteKey.Marshall()
+		require.NoError(t, err)
+		symKey, err := crypto.NewRandomAES()
+		require.NoError(t, err)
+		fx.mockInviteService.EXPECT().View(ctx, realCid, symKey).Return(inviteservice.InviteView{
+			InviteKey: protoKey,
+			SpaceId:   "spaceId",
+		}, nil)
+		fx.mockJoiningClient.EXPECT().AclGetRecords(ctx, "spaceId", "").Return(recs, nil)
+		invite, err := fx.ViewInvite(ctx, realCid, symKey)
+		require.NoError(t, err)
+		require.Equal(t, "spaceId", invite.SpaceId)
+	})
+	t.Run("fail", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		keys, err := accountdata.NewRandom()
+		require.NoError(t, err)
+		aclList, err := list.NewTestDerivedAcl("spaceId", keys)
+		require.NoError(t, err)
+		inv, err := aclList.RecordBuilder().BuildInvite()
+		require.NoError(t, err)
+		err = aclList.AddRawRecord(list.WrapAclRecord(inv.InviteRec))
+		require.NoError(t, err)
+		invRecIds := aclList.AclState().InviteIds()
+		removeInv, err := aclList.RecordBuilder().BuildBatchRequest(list.BatchRequestPayload{
+			InviteRevokes: invRecIds,
+		})
+		require.NoError(t, err)
+		err = aclList.AddRawRecord(list.WrapAclRecord(removeInv))
+		require.NoError(t, err)
+		recs, err := aclList.RecordsAfter(ctx, "")
+		require.NoError(t, err)
+		cidString, err := cidutil.NewCidFromBytes([]byte("spaceId"))
+		require.NoError(t, err)
+		realCid, err := cid.Decode(cidString)
+		require.NoError(t, err)
+		protoKey, err := inv.InviteKey.Marshall()
+		require.NoError(t, err)
+		symKey, err := crypto.NewRandomAES()
+		require.NoError(t, err)
+		fx.mockInviteService.EXPECT().View(ctx, realCid, symKey).Return(inviteservice.InviteView{
+			InviteKey: protoKey,
+			SpaceId:   "spaceId",
+		}, nil)
+		fx.mockJoiningClient.EXPECT().AclGetRecords(ctx, "spaceId", "").Return(recs, nil)
+		_, err = fx.ViewInvite(ctx, realCid, symKey)
+		require.Equal(t, inviteservice.ErrInviteNotExists, err)
 	})
 }
 

--- a/core/inviteservice/inviteservice.go
+++ b/core/inviteservice/inviteservice.go
@@ -36,6 +36,7 @@ type InviteView struct {
 	SpaceName    string
 	SpaceIconCid string
 	CreatorName  string
+	InviteKey    []byte
 }
 
 type InviteService interface {
@@ -90,6 +91,7 @@ func (i *inviteService) View(ctx context.Context, inviteCid cid.Cid, inviteFileK
 		SpaceName:    invitePayload.SpaceName,
 		SpaceIconCid: invitePayload.SpaceIconCid,
 		CreatorName:  invitePayload.CreatorName,
+		InviteKey:    invitePayload.InviteKey,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the invite viewing functionality to handle additional conditions.
- **Bug Fixes**
	- Added `InviteKey` to improve the invite detail display.
- **Tests**
	- Implemented new tests for the updated invite viewing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->