### PR TITLE
GO-3210 Fix SetDetails in participant

### DIFF
--- a/core/block/editor/participant.go
+++ b/core/block/editor/participant.go
@@ -82,7 +82,7 @@ func (p *participant) TryClose(objectTTL time.Duration) (bool, error) {
 
 func (p *participant) modifyDetails(newDetails *types.Struct) (err error) {
 	return p.DetailsUpdatable.UpdateDetails(func(current *types.Struct) (*types.Struct, error) {
-		return pbtypes.StructMerge(p.CombinedDetails(), newDetails, false), nil
+		return pbtypes.StructMerge(current, newDetails, false), nil
 	})
 }
 


### PR DESCRIPTION
Use current instead of CurrentDetails()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the method for updating participant details to enhance performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->