### PR TITLE
GO-3258 temp disable blocks parent cache

### DIFF
--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -346,6 +346,9 @@ func (s *State) ResetParentIdsCache() {
 }
 
 func (s *State) EnableParentIdsCache() bool {
+	// temporary disable the cache
+	// todo: enable after we cover everything with tests
+	return false
 	if s.isParentIdsCacheEnabled {
 		return true
 	}

--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -348,7 +348,7 @@ func (s *State) ResetParentIdsCache() {
 func (s *State) EnableParentIdsCache() bool {
 	// temporary disable the cache
 	// todo: enable after we cover everything with tests
-	return false
+	return true
 	if s.isParentIdsCacheEnabled {
 		return true
 	}


### PR DESCRIPTION
In some cases the cache state is invalid and leads to error when apply changes "target without parent"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Temporarily disabled the parent IDs cache in the editor to enhance testing. Cache will be re-enabled after test coverage is verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->