### PR TITLE
GO-3314 RPC ObjectOpen/ObjectShow: add code OBJECT_DELETED

### DIFF
--- a/docs/proto.md
+++ b/docs/proto.md
@@ -20723,6 +20723,7 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 | BAD_INPUT | 2 |  |
 | NOT_FOUND | 3 |  |
 | ANYTYPE_NEEDS_UPGRADE | 10 | failed to read unknown data format – need to upgrade anytype |
+| OBJECT_DELETED | 4 | ... |
 
 
 
@@ -20920,6 +20921,7 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 | UNKNOWN_ERROR | 1 |  |
 | BAD_INPUT | 2 |  |
 | NOT_FOUND | 3 |  |
+| OBJECT_DELETED | 4 |  |
 | ANYTYPE_NEEDS_UPGRADE | 10 | failed to read unknown data format – need to upgrade anytype |
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -1341,6 +1341,7 @@ message Rpc {
 
                         NOT_FOUND = 3;
                         ANYTYPE_NEEDS_UPGRADE = 10; // failed to read unknown data format – need to upgrade anytype
+                        OBJECT_DELETED = 4;
                         // ...
                     }
                 }
@@ -1394,7 +1395,9 @@ message Rpc {
                         UNKNOWN_ERROR = 1;
                         BAD_INPUT = 2;
                         NOT_FOUND = 3;
+                        OBJECT_DELETED = 4;
                         ANYTYPE_NEEDS_UPGRADE = 10; // failed to read unknown data format – need to upgrade anytype
+
                         // ...
                     }
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new error code `OBJECT_DELETED` to enhance error handling in responses.
- **Refactor**
	- Improved error handling in object management functions.
- **Documentation**
	- Updated documentation to include new error code details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->