### PR TITLE
GO-3317 IsNameValid changes: ask pp node directly without using cache

### DIFF
--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -405,8 +405,8 @@ func (s *service) IsNameValid(ctx context.Context, req *pb.RpcMembershipIsNameVa
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS
 	case proto.IsNameValidResponse_TierFeatureNoName:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_TIER_FEATURES_NO_NAME
-	case proto.IsNameValidResponse_InBlacklist:
-		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_IN_BLACKLIST
+	case proto.IsNameValidResponse_CanNotReserve:
+		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_CAN_NOT_RESERVE
 	default:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_UNKNOWN_ERROR
 	}

--- a/core/payments/payments_test.go
+++ b/core/payments/payments_test.go
@@ -1104,121 +1104,18 @@ func TestGetTiers(t *testing.T) {
 }
 
 func TestIsNameValid(t *testing.T) {
-	t.Run("success if reading from cache", func(t *testing.T) {
-		fx := newFixture(t)
-		defer fx.finish(t)
 
-		tgr := pb.RpcMembershipGetTiersResponse{
-			Tiers: []*model.MembershipTierData{
-				{
-					Id:                    1,
-					Name:                  "Explorer",
-					Description:           "Explorer tier",
-					AnyNamesCountIncluded: 1,
-					AnyNameMinLength:      5,
-				},
-				{
-					Id:                    2,
-					Name:                  "Suppa",
-					Description:           "Suppa tieren",
-					AnyNamesCountIncluded: 2,
-					AnyNameMinLength:      7,
-				},
-				{
-					Id:                    3,
-					Name:                  "NoNamme",
-					Description:           "Nicht Suppa tieren",
-					AnyNamesCountIncluded: 0,
-					AnyNameMinLength:      0,
-				},
-			},
-		}
-		fx.cache.EXPECT().CacheGet().Return(nil, &tgr, nil)
+	/*
+		t.Run("success if reading from cache", func(t *testing.T) {
+			fx := newFixture(t)
+			defer fx.finish(t)
 
-		req := pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 0,
-			NsName:        "something",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err := fx.IsNameValid(ctx, &req)
-		assert.Error(t, err)
-		assert.Equal(t, (*pb.RpcMembershipIsNameValidResponse)(nil), resp)
-
-		// 2
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 1,
-			NsName:        "something",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
-
-		// 3
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 2,
-			NsName:        "somet",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TOO_SHORT, resp.Error.Code)
-
-		// 4
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 3,
-			NsName:        "somet",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TIER_FEATURES_NO_NAME, resp.Error.Code)
-
-		// 5 - TIER NOT FOUND will return error immediately
-		// not response
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 4,
-			NsName:        "somet",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		_, err = fx.IsNameValid(ctx, &req)
-		assert.Error(t, err)
-
-		// 6 - space between
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 1,
-			NsName:        "some thing",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS, resp.Error.Code)
-
-		// 7 - dot
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 1,
-			NsName:        "some.thing",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS, resp.Error.Code)
-	})
-
-	t.Run("success if asking directly from node", func(t *testing.T) {
-		fx := newFixture(t)
-		defer fx.finish(t)
-
-		fx.ppclient.EXPECT().GetAllTiers(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx interface{}, in interface{}) (*psp.GetTiersResponse, error) {
-			return &psp.GetTiersResponse{
-
-				Tiers: []*psp.TierData{
+			tgr := pb.RpcMembershipGetTiersResponse{
+				Tiers: []*model.MembershipTierData{
 					{
 						Id:                    1,
 						Name:                  "Explorer",
 						Description:           "Explorer tier",
-						IsActive:              true,
-						IsHiddenTier:          false,
 						AnyNamesCountIncluded: 1,
 						AnyNameMinLength:      5,
 					},
@@ -1226,8 +1123,6 @@ func TestIsNameValid(t *testing.T) {
 						Id:                    2,
 						Name:                  "Suppa",
 						Description:           "Suppa tieren",
-						IsActive:              true,
-						IsHiddenTier:          false,
 						AnyNamesCountIncluded: 2,
 						AnyNameMinLength:      7,
 					},
@@ -1235,66 +1130,212 @@ func TestIsNameValid(t *testing.T) {
 						Id:                    3,
 						Name:                  "NoNamme",
 						Description:           "Nicht Suppa tieren",
-						IsActive:              true,
-						IsHiddenTier:          false,
 						AnyNamesCountIncluded: 0,
 						AnyNameMinLength:      0,
 					},
 				},
+			}
+			fx.cache.EXPECT().CacheGet().Return(nil, &tgr, nil)
+
+			req := pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 0,
+				NsName:        "something",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err := fx.IsNameValid(ctx, &req)
+			assert.Error(t, err)
+			assert.Equal(t, (*pb.RpcMembershipIsNameValidResponse)(nil), resp)
+
+			// 2
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 1,
+				NsName:        "something",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
+
+			// 3
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 2,
+				NsName:        "somet",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TOO_SHORT, resp.Error.Code)
+
+			// 4
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 3,
+				NsName:        "somet",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TIER_FEATURES_NO_NAME, resp.Error.Code)
+
+			// 5 - TIER NOT FOUND will return error immediately
+			// not response
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 4,
+				NsName:        "somet",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			_, err = fx.IsNameValid(ctx, &req)
+			assert.Error(t, err)
+
+			// 6 - space between
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 1,
+				NsName:        "some thing",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS, resp.Error.Code)
+
+			// 7 - dot
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 1,
+				NsName:        "some.thing",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS, resp.Error.Code)
+		})
+
+		t.Run("success if asking directly from node", func(t *testing.T) {
+			fx := newFixture(t)
+			defer fx.finish(t)
+
+			fx.ppclient.EXPECT().GetAllTiers(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx interface{}, in interface{}) (*psp.GetTiersResponse, error) {
+				return &psp.GetTiersResponse{
+
+					Tiers: []*psp.TierData{
+						{
+							Id:                    1,
+							Name:                  "Explorer",
+							Description:           "Explorer tier",
+							IsActive:              true,
+							IsHiddenTier:          false,
+							AnyNamesCountIncluded: 1,
+							AnyNameMinLength:      5,
+						},
+						{
+							Id:                    2,
+							Name:                  "Suppa",
+							Description:           "Suppa tieren",
+							IsActive:              true,
+							IsHiddenTier:          false,
+							AnyNamesCountIncluded: 2,
+							AnyNameMinLength:      7,
+						},
+						{
+							Id:                    3,
+							Name:                  "NoNamme",
+							Description:           "Nicht Suppa tieren",
+							IsActive:              true,
+							IsHiddenTier:          false,
+							AnyNamesCountIncluded: 0,
+							AnyNameMinLength:      0,
+						},
+					},
+				}, nil
+			}).MinTimes(1)
+
+			fx.cache.EXPECT().CacheGet().Return(nil, nil, cache.ErrCacheExpired)
+			fx.cache.EXPECT().CacheSet(mock.AnythingOfType("*pb.RpcMembershipGetStatusResponse"), mock.AnythingOfType("*pb.RpcMembershipGetTiersResponse"), mock.AnythingOfType("time.Time")).RunAndReturn(func(in *pb.RpcMembershipGetStatusResponse, tiers *pb.RpcMembershipGetTiersResponse, expire time.Time) (err error) {
+				return nil
+			})
+
+			req := pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 0,
+				NsName:        "something",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err := fx.IsNameValid(ctx, &req)
+			assert.Error(t, err)
+			assert.Equal(t, (*pb.RpcMembershipIsNameValidResponse)(nil), resp)
+
+			// 2
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 1,
+				NsName:        "something",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
+
+			// 3
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 2,
+				NsName:        "some",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TOO_SHORT, resp.Error.Code)
+
+			// 4
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 3,
+				NsName:        "something",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TIER_FEATURES_NO_NAME, resp.Error.Code)
+
+			// 5
+			req = pb.RpcMembershipIsNameValidRequest{
+				RequestedTier: 4,
+				NsName:        "something",
+				NsNameType:    model.NameserviceNameType_AnyName,
+			}
+			resp, err = fx.IsNameValid(ctx, &req)
+			assert.Error(t, err)
+		})
+	*/
+
+	t.Run("validation error", func(t *testing.T) {
+		fx := newFixture(t)
+
+		fx.ppclient.EXPECT().IsNameValid(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx interface{}, in interface{}) (*psp.IsNameValidResponse, error) {
+			return &psp.IsNameValidResponse{
+				Code: psp.IsNameValidResponse_HasInvalidChars,
 			}, nil
 		}).MinTimes(1)
 
-		fx.cache.EXPECT().CacheGet().Return(nil, nil, cache.ErrCacheExpired)
-		fx.cache.EXPECT().CacheSet(mock.AnythingOfType("*pb.RpcMembershipGetStatusResponse"), mock.AnythingOfType("*pb.RpcMembershipGetTiersResponse"), mock.AnythingOfType("time.Time")).RunAndReturn(func(in *pb.RpcMembershipGetStatusResponse, tiers *pb.RpcMembershipGetTiersResponse, expire time.Time) (err error) {
-			return nil
-		})
-
 		req := pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 0,
-			NsName:        "something",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err := fx.IsNameValid(ctx, &req)
-		assert.Error(t, err)
-		assert.Equal(t, (*pb.RpcMembershipIsNameValidResponse)(nil), resp)
-
-		// 2
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 1,
-			NsName:        "something",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
-
-		// 3
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 2,
-			NsName:        "some",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TOO_SHORT, resp.Error.Code)
-
-		// 4
-		req = pb.RpcMembershipIsNameValidRequest{
-			RequestedTier: 3,
-			NsName:        "something",
-			NsNameType:    model.NameserviceNameType_AnyName,
-		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.NoError(t, err)
-		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_TIER_FEATURES_NO_NAME, resp.Error.Code)
-
-		// 5
-		req = pb.RpcMembershipIsNameValidRequest{
 			RequestedTier: 4,
 			NsName:        "something",
 			NsNameType:    model.NameserviceNameType_AnyName,
 		}
-		resp, err = fx.IsNameValid(ctx, &req)
-		assert.Error(t, err)
+		resp, err := fx.IsNameValid(ctx, &req)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS, resp.Error.Code)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		fx := newFixture(t)
+
+		fx.ppclient.EXPECT().IsNameValid(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx interface{}, in interface{}) (*psp.IsNameValidResponse, error) {
+			return &psp.IsNameValidResponse{
+				Code: psp.IsNameValidResponse_Valid,
+			}, nil
+		}).MinTimes(1)
+
+		req := pb.RpcMembershipIsNameValidRequest{
+			RequestedTier: 4,
+			NsName:        "something",
+			NsNameType:    model.NameserviceNameType_AnyName,
+		}
+		resp, err := fx.IsNameValid(ctx, &req)
+		assert.NoError(t, err)
+		assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
 	})
 }

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -20145,7 +20145,7 @@ Middleware-to-front-end response, that can contain a NULL error or a non-NULL er
 | NOT_LOGGED_IN | 8 |  |
 | PAYMENT_NODE_ERROR | 9 |  |
 | CACHE_ERROR | 10 |  |
-| IN_BLACKLIST | 11 | for some probable future use (if needed) |
+| CAN_NOT_RESERVE | 11 | for some probable future use (if needed) |
 | CAN_NOT_CONNECT | 12 |  |
 
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.9.1
 	github.com/VividCortex/ewma v1.2.0
 	github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
-	github.com/anyproto/any-sync v0.4.5
+	github.com/anyproto/any-sync v0.4.6-0.20240419092938-1599c2514f84
 	github.com/anyproto/go-naturaldate/v2 v2.0.2-0.20230524105841-9829cfd13438
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/avast/retry-go/v4 v4.5.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.9.1
 	github.com/VividCortex/ewma v1.2.0
 	github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
-	github.com/anyproto/any-sync v0.4.6-0.20240419092938-1599c2514f84
+	github.com/anyproto/any-sync v0.4.6
 	github.com/anyproto/go-naturaldate/v2 v2.0.2-0.20230524105841-9829cfd13438
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/avast/retry-go/v4 v4.5.1

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/anyproto/any-sync v0.4.5 h1:E+FATSRxMpaBt1GgmHfi3VkNKSC5SftpwgLa883Wy
 github.com/anyproto/any-sync v0.4.5/go.mod h1:C/byc9JTwLSqhaHd0wCf1+ncU4iDQCMaXuZj4yOKDYw=
 github.com/anyproto/any-sync v0.4.6-0.20240419092938-1599c2514f84 h1:T9ubPdtaPvNw0uic0f9SgW8pdO/2K9VDWvA7MmDYasQ=
 github.com/anyproto/any-sync v0.4.6-0.20240419092938-1599c2514f84/go.mod h1:C/byc9JTwLSqhaHd0wCf1+ncU4iDQCMaXuZj4yOKDYw=
+github.com/anyproto/any-sync v0.4.6 h1:9PE1To9FcRGNHy9Ppmo1iHWwKTVWAl6Lmv06sVNnuKg=
+github.com/anyproto/any-sync v0.4.6/go.mod h1:C/byc9JTwLSqhaHd0wCf1+ncU4iDQCMaXuZj4yOKDYw=
 github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580 h1:Ba80IlCCxkZ9H1GF+7vFu/TSpPvbpDCxXJ5ogc4euYc=
 github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580/go.mod h1:T/uWAYxrXdaXw64ihI++9RMbKTCpKd/yE9+saARew7k=
 github.com/anyproto/go-chash v0.1.0 h1:I9meTPjXFRfXZHRJzjOHC/XF7Q5vzysKkiT/grsogXY=

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/anyproto/any-sync v0.4.5-0.20240417164638-dcc4a1124a13 h1:wpBInpIoNS0
 github.com/anyproto/any-sync v0.4.5-0.20240417164638-dcc4a1124a13/go.mod h1:C/byc9JTwLSqhaHd0wCf1+ncU4iDQCMaXuZj4yOKDYw=
 github.com/anyproto/any-sync v0.4.5 h1:E+FATSRxMpaBt1GgmHfi3VkNKSC5SftpwgLa883Wy3M=
 github.com/anyproto/any-sync v0.4.5/go.mod h1:C/byc9JTwLSqhaHd0wCf1+ncU4iDQCMaXuZj4yOKDYw=
+github.com/anyproto/any-sync v0.4.6-0.20240419092938-1599c2514f84 h1:T9ubPdtaPvNw0uic0f9SgW8pdO/2K9VDWvA7MmDYasQ=
+github.com/anyproto/any-sync v0.4.6-0.20240419092938-1599c2514f84/go.mod h1:C/byc9JTwLSqhaHd0wCf1+ncU4iDQCMaXuZj4yOKDYw=
 github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580 h1:Ba80IlCCxkZ9H1GF+7vFu/TSpPvbpDCxXJ5ogc4euYc=
 github.com/anyproto/badger/v4 v4.2.1-0.20240110160636-80743fa3d580/go.mod h1:T/uWAYxrXdaXw64ihI++9RMbKTCpKd/yE9+saARew7k=
 github.com/anyproto/go-chash v0.1.0 h1:I9meTPjXFRfXZHRJzjOHC/XF7Q5vzysKkiT/grsogXY=

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -6494,7 +6494,7 @@ message Rpc {
                         PAYMENT_NODE_ERROR = 9;
                         CACHE_ERROR = 10;
                         // for some probable future use (if needed)
-                        IN_BLACKLIST = 11;
+                        CAN_NOT_RESERVE = 11;
                         CAN_NOT_CONNECT = 12;
                     }
                 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the logic for validating membership names in the payment service, enhancing efficiency by directly interfacing with the payment processing node.
- **Tests**
	- Updated and restructured test cases for membership name validation to align with the new logic.
- **Documentation**
	- Updated error code in `proto.md` for potential future use.
	- Modified enum value in `commands.proto` for improved error handling semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->