### PR TITLE
GO-3322: Identity service: refactor: split into two services

### DIFF
--- a/core/files/fileacl/mock_fileacl/mock_Service.go
+++ b/core/files/fileacl/mock_fileacl/mock_Service.go
@@ -3,10 +3,7 @@
 package mock_fileacl
 
 import (
-	context "context"
-
 	app "github.com/anyproto/any-sync/app"
-
 	domain "github.com/anyproto/anytype-heart/core/domain"
 
 	mock "github.com/stretchr/testify/mock"
@@ -27,9 +24,9 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
-// GetInfoForFileSharing provides a mock function with given fields: ctx, fileObjectId
-func (_m *MockService) GetInfoForFileSharing(ctx context.Context, fileObjectId string) (string, []*model.FileEncryptionKey, error) {
-	ret := _m.Called(ctx, fileObjectId)
+// GetInfoForFileSharing provides a mock function with given fields: fileObjectId
+func (_m *MockService) GetInfoForFileSharing(fileObjectId string) (string, []*model.FileEncryptionKey, error) {
+	ret := _m.Called(fileObjectId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetInfoForFileSharing")
@@ -38,25 +35,25 @@ func (_m *MockService) GetInfoForFileSharing(ctx context.Context, fileObjectId s
 	var r0 string
 	var r1 []*model.FileEncryptionKey
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, []*model.FileEncryptionKey, error)); ok {
-		return rf(ctx, fileObjectId)
+	if rf, ok := ret.Get(0).(func(string) (string, []*model.FileEncryptionKey, error)); ok {
+		return rf(fileObjectId)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
-		r0 = rf(ctx, fileObjectId)
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(fileObjectId)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) []*model.FileEncryptionKey); ok {
-		r1 = rf(ctx, fileObjectId)
+	if rf, ok := ret.Get(1).(func(string) []*model.FileEncryptionKey); ok {
+		r1 = rf(fileObjectId)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]*model.FileEncryptionKey)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string) error); ok {
-		r2 = rf(ctx, fileObjectId)
+	if rf, ok := ret.Get(2).(func(string) error); ok {
+		r2 = rf(fileObjectId)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -70,15 +67,14 @@ type MockService_GetInfoForFileSharing_Call struct {
 }
 
 // GetInfoForFileSharing is a helper method to define mock.On call
-//   - ctx context.Context
 //   - fileObjectId string
-func (_e *MockService_Expecter) GetInfoForFileSharing(ctx interface{}, fileObjectId interface{}) *MockService_GetInfoForFileSharing_Call {
-	return &MockService_GetInfoForFileSharing_Call{Call: _e.mock.On("GetInfoForFileSharing", ctx, fileObjectId)}
+func (_e *MockService_Expecter) GetInfoForFileSharing(fileObjectId interface{}) *MockService_GetInfoForFileSharing_Call {
+	return &MockService_GetInfoForFileSharing_Call{Call: _e.mock.On("GetInfoForFileSharing", fileObjectId)}
 }
 
-func (_c *MockService_GetInfoForFileSharing_Call) Run(run func(ctx context.Context, fileObjectId string)) *MockService_GetInfoForFileSharing_Call {
+func (_c *MockService_GetInfoForFileSharing_Call) Run(run func(fileObjectId string)) *MockService_GetInfoForFileSharing_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(string))
 	})
 	return _c
 }
@@ -88,7 +84,7 @@ func (_c *MockService_GetInfoForFileSharing_Call) Return(cid string, encryptionK
 	return _c
 }
 
-func (_c *MockService_GetInfoForFileSharing_Call) RunAndReturn(run func(context.Context, string) (string, []*model.FileEncryptionKey, error)) *MockService_GetInfoForFileSharing_Call {
+func (_c *MockService_GetInfoForFileSharing_Call) RunAndReturn(run func(string) (string, []*model.FileEncryptionKey, error)) *MockService_GetInfoForFileSharing_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/files/fileacl/service.go
+++ b/core/files/fileacl/service.go
@@ -1,7 +1,6 @@
 package fileacl
 
 import (
-	"context"
 	"fmt"
 	"sort"
 
@@ -19,7 +18,7 @@ const CName = "fileacl"
 type Service interface {
 	app.Component
 
-	GetInfoForFileSharing(ctx context.Context, fileObjectId string) (cid string, encryptionKeys []*model.FileEncryptionKey, err error)
+	GetInfoForFileSharing(fileObjectId string) (cid string, encryptionKeys []*model.FileEncryptionKey, err error)
 	StoreFileKeys(fileId domain.FileId, fileKeys []*model.FileEncryptionKey) error
 }
 
@@ -44,7 +43,7 @@ func (s *service) Name() (name string) {
 	return CName
 }
 
-func (s *service) GetInfoForFileSharing(ctx context.Context, fileObjectId string) (cid string, encryptionKeys []*model.FileEncryptionKey, err error) {
+func (s *service) GetInfoForFileSharing(fileObjectId string) (cid string, encryptionKeys []*model.FileEncryptionKey, err error) {
 	fileId, err := s.fileObjectService.GetFileIdFromObject(fileObjectId)
 	if err != nil {
 		return "", nil, fmt.Errorf("get file id from object: %w", err)

--- a/core/identity/identity.go
+++ b/core/identity/identity.go
@@ -354,10 +354,13 @@ func (s *service) broadcastMyIdentityProfile(identityProfile *model.IdentityProf
 }
 
 func (s *service) findProfile(identityData *identityrepoproto.DataWithIdentity) (profile *model.IdentityProfile, rawProfile []byte, err error) {
+	return extractProfile(identityData, s.identityEncryptionKeys[identityData.Identity])
+}
+
+func extractProfile(identityData *identityrepoproto.DataWithIdentity, symKey crypto.SymKey) (profile *model.IdentityProfile, rawData []byte, err error) {
 	for _, data := range identityData.Data {
 		if data.Kind == identityRepoDataKind {
-			rawProfile = data.Data
-			symKey := s.identityEncryptionKeys[identityData.Identity]
+			rawData = data.Data
 			rawProfile, err := symKey.Decrypt(data.Data)
 			if err != nil {
 				return nil, nil, fmt.Errorf("decrypt identity profile: %w", err)
@@ -372,7 +375,7 @@ func (s *service) findProfile(identityData *identityrepoproto.DataWithIdentity) 
 	if profile == nil {
 		return nil, nil, fmt.Errorf("no profile data found")
 	}
-	return profile, rawProfile, nil
+	return profile, rawData, nil
 }
 
 func (s *service) fetchGlobalNames(identities []string, forceUpdate bool) error {

--- a/core/identity/identity_test.go
+++ b/core/identity/identity_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/anyproto/any-sync/nameservice/nameserviceproto"
 	"github.com/anyproto/any-sync/util/crypto"
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
@@ -90,7 +88,8 @@ func newFixture(t *testing.T) *fixture {
 	db, err := dataStoreProvider.LocalStorage()
 	require.NoError(t, err)
 	svcRef.db = db
-	svcRef.currentProfileDetails = &types.Struct{Fields: make(map[string]*types.Value)}
+	// TODO
+	// svcRef.currentProfileDetails = &types.Struct{Fields: make(map[string]*types.Value)}
 	fx := &fixture{
 		service:           svcRef,
 		spaceService:      spaceService,
@@ -303,40 +302,4 @@ func (s spaceIdDeriverStub) Name() (name string) { return "spaceIdDeriverStub" }
 
 func (s spaceIdDeriverStub) DeriveID(ctx context.Context, spaceType string) (id string, err error) {
 	return fmt.Sprintf("spaceId-%s", spaceType), nil
-}
-
-func TestStartWithError(t *testing.T) {
-	fx := newFixture(t)
-
-	fx.accountService.EXPECT().AccountID().Return("identity1")
-	fx.spaceService.EXPECT().GetPersonalSpace(mock.Anything).Return(nil, fmt.Errorf("space error"))
-
-	t.Run("GetMyProfileDetails before run with cancelled input context", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		identity, key, details := fx.GetMyProfileDetails(ctx)
-		assert.Empty(t, identity)
-		assert.Nil(t, key)
-		assert.Nil(t, details)
-	})
-
-	err := fx.Run(context.Background())
-	require.Error(t, err)
-
-	err = fx.Close(context.Background())
-	require.NoError(t, err)
-
-	done := make(chan struct{})
-
-	go func() {
-		_, _, _ = fx.GetMyProfileDetails(context.Background())
-		close(done)
-	}()
-
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("GetMyProfileDetails should not block")
-	case <-done:
-	}
 }

--- a/core/identity/identity_test.go
+++ b/core/identity/identity_test.go
@@ -38,7 +38,7 @@ type fixture struct {
 const (
 	testObserverPeriod = 1 * time.Millisecond
 	globalName         = "anytypeuser.any"
-	identity           = "identity1"
+	testIdentity       = "identity1"
 )
 
 func newFixture(t *testing.T) *fixture {
@@ -54,7 +54,7 @@ func newFixture(t *testing.T) *fixture {
 	require.NoError(t, err)
 	wallet := mock_wallet.NewMockWallet(t)
 	nsClient := mock_nameserviceclient.NewMockAnyNsClientService(ctrl)
-	nsClient.EXPECT().BatchGetNameByAnyId(gomock.Any(), &nameserviceproto.BatchNameByAnyIdRequest{AnyAddresses: []string{identity, ""}}).AnyTimes().
+	nsClient.EXPECT().BatchGetNameByAnyId(gomock.Any(), &nameserviceproto.BatchNameByAnyIdRequest{AnyAddresses: []string{testIdentity, ""}}).AnyTimes().
 		Return(&nameserviceproto.BatchNameByAddressResponse{Results: []*nameserviceproto.NameByAddressResponse{{
 			Found: true,
 			Name:  globalName,
@@ -67,7 +67,6 @@ func newFixture(t *testing.T) *fixture {
 	require.NoError(t, err)
 
 	a := new(app.App)
-	a.Register(&spaceIdDeriverStub{})
 	a.Register(dataStoreProvider)
 	a.Register(objectStore)
 	a.Register(identityRepoClient)
@@ -292,14 +291,4 @@ func TestObservers(t *testing.T) {
 		require.Empty(t, list)
 		require.False(t, called)
 	})
-}
-
-type spaceIdDeriverStub struct{}
-
-func (s spaceIdDeriverStub) Init(a *app.App) (err error) { return nil }
-
-func (s spaceIdDeriverStub) Name() (name string) { return "spaceIdDeriverStub" }
-
-func (s spaceIdDeriverStub) DeriveID(ctx context.Context, spaceType string) (id string, err error) {
-	return fmt.Sprintf("spaceId-%s", spaceType), nil
 }

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -1,0 +1,291 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/anyproto/any-sync/identityrepo/identityrepoproto"
+	"github.com/anyproto/any-sync/util/crypto"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"go.uber.org/zap"
+
+	"github.com/anyproto/anytype-heart/core/anytype/account"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/files/fileacl"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/database"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/space"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+type observerService interface {
+	broadcastMyIdentityProfile(identityProfile *model.IdentityProfile)
+}
+
+type ownProfileSubscription struct {
+	spaceService       space.Service
+	objectStore        objectstore.ObjectStore
+	accountService     account.Service
+	identityRepoClient identityRepoClient
+	fileAclService     fileacl.Service
+	observerService    observerService
+
+	myIdentity          string
+	globalNameUpdatedCh chan string
+	gotDetailsCh        chan struct{}
+
+	detailsLock sync.RWMutex
+	gotDetails  bool
+	details     *types.Struct // save details to batch update operation
+
+	pushIdentityTimer        *time.Timer // timer for batching
+	pushIdentityBatchTimeout time.Duration
+
+	componentCtx       context.Context
+	componentCtxCancel context.CancelFunc
+}
+
+func newOwnProfileSubscription(
+	spaceService space.Service,
+	objectStore objectstore.ObjectStore,
+	accountService account.Service,
+	identityRepoClient identityRepoClient,
+	fileAclService fileacl.Service,
+	observerService observerService,
+	pushIdentityBatchTimeout time.Duration,
+) *ownProfileSubscription {
+	componentCtx, componentCtxCancel := context.WithCancel(context.Background())
+	return &ownProfileSubscription{
+		spaceService:             spaceService,
+		objectStore:              objectStore,
+		accountService:           accountService,
+		identityRepoClient:       identityRepoClient,
+		fileAclService:           fileAclService,
+		observerService:          observerService,
+		globalNameUpdatedCh:      make(chan string),
+		gotDetailsCh:             make(chan struct{}),
+		pushIdentityBatchTimeout: pushIdentityBatchTimeout,
+		componentCtx:             componentCtx,
+		componentCtxCancel:       componentCtxCancel,
+	}
+}
+
+func (s *ownProfileSubscription) run(ctx context.Context) (err error) {
+	s.myIdentity = s.accountService.AccountID()
+
+	uniqueKey, err := domain.NewUniqueKey(coresb.SmartBlockTypeProfilePage, "")
+	if err != nil {
+		return err
+	}
+	personalSpace, err := s.spaceService.GetPersonalSpace(ctx)
+	if err != nil {
+		return fmt.Errorf("get space: %w", err)
+	}
+	profileObjectId, err := personalSpace.DeriveObjectID(ctx, uniqueKey)
+	if err != nil {
+		return err
+	}
+
+	recordsCh := make(chan *types.Struct)
+	sub := database.NewSubscription(nil, recordsCh)
+
+	var (
+		records  []database.Record
+		closeSub func()
+	)
+
+	records, closeSub, err = s.objectStore.QueryByIDAndSubscribeForChanges([]string{profileObjectId}, sub)
+	if err != nil {
+		return err
+	}
+	go func() {
+		select {
+		case <-s.componentCtx.Done():
+			closeSub()
+			return
+		}
+	}()
+
+	if len(records) > 0 {
+		s.handleOwnProfileDetails(records[0].Details)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-s.componentCtx.Done():
+				return
+			case rec, ok := <-recordsCh:
+				if !ok {
+					return
+				}
+				s.handleOwnProfileDetails(rec)
+
+			case globalName := <-s.globalNameUpdatedCh:
+				s.handleGlobalNameUpdate(globalName)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (s *ownProfileSubscription) close() {
+	s.componentCtxCancel()
+	close(s.globalNameUpdatedCh)
+}
+
+func (s *ownProfileSubscription) updateGlobalName(globalName string) {
+	s.globalNameUpdatedCh <- globalName
+}
+
+func (s *ownProfileSubscription) enqueuePush() {
+	if s.pushIdentityTimer == nil {
+		s.pushIdentityTimer = time.AfterFunc(0, func() {
+			pushErr := s.pushProfileToIdentityRegistry(context.Background())
+			if pushErr != nil {
+				log.Error("push profile to identity registry", zap.Error(pushErr))
+			}
+		})
+	} else {
+		s.pushIdentityTimer.Reset(s.pushIdentityBatchTimeout)
+	}
+}
+
+func (s *ownProfileSubscription) handleOwnProfileDetails(profileDetails *types.Struct) {
+	if profileDetails == nil {
+		return
+	}
+	s.detailsLock.Lock()
+	if !s.gotDetails {
+		close(s.gotDetailsCh)
+		s.gotDetails = true
+	}
+
+	if s.details == nil {
+		s.details = &types.Struct{
+			Fields: map[string]*types.Value{},
+		}
+	}
+	for _, key := range []domain.RelationKey{
+		bundle.RelationKeyName,
+		bundle.RelationKeyDescription,
+		bundle.RelationKeyIconImage,
+	} {
+		s.details.Fields[key.String()] = profileDetails.Fields[key.String()]
+	}
+	identityProfile := s.prepareIdentityProfile()
+	s.detailsLock.Unlock()
+
+	s.observerService.broadcastMyIdentityProfile(identityProfile)
+	s.enqueuePush()
+}
+
+func (s *ownProfileSubscription) handleGlobalNameUpdate(globalName string) {
+	s.detailsLock.Lock()
+	if s.details == nil {
+		s.details = &types.Struct{
+			Fields: map[string]*types.Value{},
+		}
+	}
+	s.details.Fields[bundle.RelationKeyGlobalName.String()] = pbtypes.String(globalName)
+	identityProfile := s.prepareIdentityProfile()
+	s.detailsLock.Unlock()
+
+	s.observerService.broadcastMyIdentityProfile(identityProfile)
+
+	s.enqueuePush()
+}
+
+func (s *ownProfileSubscription) prepareIdentityProfile() *model.IdentityProfile {
+	return &model.IdentityProfile{
+		Identity:    s.myIdentity,
+		Name:        pbtypes.GetString(s.details, bundle.RelationKeyName.String()),
+		Description: pbtypes.GetString(s.details, bundle.RelationKeyDescription.String()),
+		IconCid:     pbtypes.GetString(s.details, bundle.RelationKeyIconImage.String()),
+		GlobalName:  pbtypes.GetString(s.details, bundle.RelationKeyGlobalName.String()),
+	}
+}
+
+func (s *ownProfileSubscription) pushProfileToIdentityRegistry(ctx context.Context) error {
+	identityProfile, err := s.prepareOwnIdentityProfile()
+	if err != nil {
+		return fmt.Errorf("prepare own identity profile: %w", err)
+	}
+	data, err := proto.Marshal(identityProfile)
+	if err != nil {
+		return fmt.Errorf("marshal identity profile: %w", err)
+	}
+
+	symKey := s.spaceService.AccountMetadataSymKey()
+	data, err = symKey.Encrypt(data)
+	if err != nil {
+		return fmt.Errorf("encrypt data: %w", err)
+	}
+
+	signature, err := s.accountService.SignData(data)
+	if err != nil {
+		return fmt.Errorf("failed to sign profile data: %w", err)
+	}
+
+	err = s.identityRepoClient.IdentityRepoPut(ctx, s.myIdentity, []*identityrepoproto.Data{
+		{
+			Kind:      "profile",
+			Data:      data,
+			Signature: signature,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to push identity: %w", err)
+	}
+	return nil
+}
+
+func (s *ownProfileSubscription) prepareOwnIdentityProfile() (*model.IdentityProfile, error) {
+	s.detailsLock.RLock()
+	defer s.detailsLock.RUnlock()
+
+	iconImageObjectId := pbtypes.GetString(s.details, bundle.RelationKeyIconImage.String())
+	iconCid, iconEncryptionKeys, err := s.prepareIconImageInfo(iconImageObjectId)
+	if err != nil {
+		return nil, fmt.Errorf("prepare icon image info: %w", err)
+	}
+
+	identity := s.accountService.AccountID()
+	return &model.IdentityProfile{
+		Identity:           identity,
+		Name:               pbtypes.GetString(s.details, bundle.RelationKeyName.String()),
+		Description:        pbtypes.GetString(s.details, bundle.RelationKeyDescription.String()),
+		IconCid:            iconCid,
+		IconEncryptionKeys: iconEncryptionKeys,
+		GlobalName:         pbtypes.GetString(s.details, bundle.RelationKeyGlobalName.String()),
+	}, nil
+}
+
+func (s *ownProfileSubscription) prepareIconImageInfo(iconImageObjectId string) (iconCid string, iconEncryptionKeys []*model.FileEncryptionKey, err error) {
+	if iconImageObjectId == "" {
+		return "", nil, nil
+	}
+	return s.fileAclService.GetInfoForFileSharing(iconImageObjectId)
+}
+
+func (s *ownProfileSubscription) getDetails(ctx context.Context) (identity string, metadataKey crypto.SymKey, details *types.Struct) {
+	select {
+	case <-s.gotDetailsCh:
+
+	case <-ctx.Done():
+		return "", nil, nil
+	case <-s.componentCtx.Done():
+		return "", nil, nil
+	}
+	s.detailsLock.RLock()
+	defer s.detailsLock.RUnlock()
+
+	return s.myIdentity, s.spaceService.AccountMetadataSymKey(), s.details
+}

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -179,7 +179,9 @@ func (s *ownProfileSubscription) handleOwnProfileDetails(profileDetails *types.S
 		bundle.RelationKeyDescription,
 		bundle.RelationKeyIconImage,
 	} {
-		s.details.Fields[key.String()] = profileDetails.Fields[key.String()]
+		if _, ok := profileDetails.Fields[key.String()]; ok {
+			s.details.Fields[key.String()] = profileDetails.Fields[key.String()]
+		}
 	}
 	identityProfile := s.prepareIdentityProfile()
 	s.detailsLock.Unlock()

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -275,6 +275,8 @@ func (s *ownProfileSubscription) prepareIconImageInfo(iconImageObjectId string) 
 	return s.fileAclService.GetInfoForFileSharing(iconImageObjectId)
 }
 
+// TODO Return IdentityProfile instead of details!!!
+// TODO remove symkey from return
 func (s *ownProfileSubscription) getDetails(ctx context.Context) (identity string, metadataKey crypto.SymKey, details *types.Struct) {
 	select {
 	case <-s.gotDetailsCh:

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -40,7 +40,7 @@ type ownProfileSubscription struct {
 	globalNameUpdatedCh chan string
 	gotDetailsCh        chan struct{}
 
-	detailsLock sync.RWMutex
+	detailsLock sync.Mutex
 	gotDetails  bool
 	details     *types.Struct // save details to batch update operation
 
@@ -251,8 +251,8 @@ func (s *ownProfileSubscription) pushProfileToIdentityRegistry(ctx context.Conte
 }
 
 func (s *ownProfileSubscription) prepareOwnIdentityProfile() (*model.IdentityProfile, error) {
-	s.detailsLock.RLock()
-	defer s.detailsLock.RUnlock()
+	s.detailsLock.Lock()
+	defer s.detailsLock.Unlock()
 
 	iconImageObjectId := pbtypes.GetString(s.details, bundle.RelationKeyIconImage.String())
 	iconCid, iconEncryptionKeys, err := s.prepareIconImageInfo(iconImageObjectId)
@@ -287,8 +287,8 @@ func (s *ownProfileSubscription) getDetails(ctx context.Context) (identity strin
 	case <-s.componentCtx.Done():
 		return "", nil, nil
 	}
-	s.detailsLock.RLock()
-	defer s.detailsLock.RUnlock()
+	s.detailsLock.Lock()
+	defer s.detailsLock.Unlock()
 
 	return s.myIdentity, s.spaceService.AccountMetadataSymKey(), s.details
 }

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -174,6 +174,7 @@ func (s *ownProfileSubscription) handleOwnProfileDetails(profileDetails *types.S
 		}
 	}
 	for _, key := range []domain.RelationKey{
+		bundle.RelationKeyId,
 		bundle.RelationKeyName,
 		bundle.RelationKeyDescription,
 		bundle.RelationKeyIconImage,
@@ -275,8 +276,6 @@ func (s *ownProfileSubscription) prepareIconImageInfo(iconImageObjectId string) 
 	return s.fileAclService.GetInfoForFileSharing(iconImageObjectId)
 }
 
-// TODO Return IdentityProfile instead of details!!!
-// TODO remove symkey from return
 func (s *ownProfileSubscription) getDetails(ctx context.Context) (identity string, metadataKey crypto.SymKey, details *types.Struct) {
 	select {
 	case <-s.gotDetailsCh:

--- a/core/identity/ownidentity_test.go
+++ b/core/identity/ownidentity_test.go
@@ -212,13 +212,6 @@ func TestOwnProfileSubscription(t *testing.T) {
 			return privKey.Sign(data)
 		})
 
-		// Push the first profile version and the last
-		fx.fileAclService.EXPECT().GetInfoForFileSharing("fileObjectId").Return("fileCid1", []*model.FileEncryptionKey{
-			{
-				Path: "/0/original",
-				Key:  "key1",
-			},
-		}, nil)
 		fx.fileAclService.EXPECT().GetInfoForFileSharing("fileObjectId2").Return("fileCid2", []*model.FileEncryptionKey{
 			{
 				Path: "/0/original",
@@ -234,7 +227,6 @@ func TestOwnProfileSubscription(t *testing.T) {
 				bundle.RelationKeyId:          pbtypes.String(testProfileObjectId),
 				bundle.RelationKeySpaceId:     pbtypes.String("space1"),
 				bundle.RelationKeyGlobalName:  pbtypes.String("foobar"),
-				bundle.RelationKeyIconImage:   pbtypes.String("fileObjectId"),
 				bundle.RelationKeyName:        pbtypes.String("John Doe"),
 				bundle.RelationKeyDescription: pbtypes.String("Description"),
 			},
@@ -265,13 +257,11 @@ func TestOwnProfileSubscription(t *testing.T) {
 				Identity:    "identity1",
 				Name:        "John Doe",
 				Description: "Description",
-				IconCid:     "fileObjectId",
 			},
 			{
 				Identity:    "identity1",
 				Name:        "John Doe",
 				Description: "Description",
-				IconCid:     "fileObjectId",
 				GlobalName:  globalName,
 			},
 			{

--- a/core/identity/ownidentity_test.go
+++ b/core/identity/ownidentity_test.go
@@ -361,6 +361,7 @@ func TestWaitForDetails(t *testing.T) {
 
 		wantDetails := &types.Struct{
 			Fields: map[string]*types.Value{
+				bundle.RelationKeyId.String():          pbtypes.String(testProfileObjectId),
 				bundle.RelationKeyName.String():        pbtypes.String("John Doe"),
 				bundle.RelationKeyDescription.String(): pbtypes.String("Description"),
 				bundle.RelationKeyGlobalName.String():  pbtypes.String(globalName),

--- a/core/identity/ownidentity_test.go
+++ b/core/identity/ownidentity_test.go
@@ -1,0 +1,101 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/anytype/account/mock_account"
+	"github.com/anyproto/anytype-heart/core/files/fileacl/mock_fileacl"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/space/mock_space"
+)
+
+type ownSubscriptionFixture struct {
+	*ownProfileSubscription
+
+	spaceService      *mock_space.MockService
+	coordinatorClient *inMemoryIdentityRepo
+	testObserver      *testObserver
+}
+
+type testObserver struct {
+	lock     sync.Mutex
+	profiles []*model.IdentityProfile
+}
+
+func (t *testObserver) broadcastMyIdentityProfile(identityProfile *model.IdentityProfile) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.profiles = append(t.profiles, identityProfile)
+}
+
+func newOwnSubscriptionFixture(t *testing.T) *ownSubscriptionFixture {
+	accountService := mock_account.NewMockService(t)
+	spaceService := mock_space.NewMockService(t)
+	objectStore := objectstore.NewStoreFixture(t)
+	coordinatorClient := newInMemoryIdentityRepo()
+	fileAclService := mock_fileacl.NewMockService(t)
+	testObserver := &testObserver{}
+
+	accountService.EXPECT().AccountID().Return("identity1")
+
+	sub := newOwnProfileSubscription(spaceService, objectStore, accountService, coordinatorClient, fileAclService, testObserver, time.Second)
+
+	return &ownSubscriptionFixture{
+		ownProfileSubscription: sub,
+		spaceService:           spaceService,
+		coordinatorClient:      coordinatorClient,
+		testObserver:           testObserver,
+	}
+}
+
+func TestOwnProfileSubscription(t *testing.T) {
+	t.Run("do not rewrite global name from profile details", func(t *testing.T) {
+
+	})
+
+	t.Run("rewrite global name from channel signal", func(t *testing.T) {
+
+	})
+}
+
+func TestStartWithError(t *testing.T) {
+	fx := newOwnSubscriptionFixture(t)
+	fx.spaceService.EXPECT().GetPersonalSpace(mock.Anything).Return(nil, fmt.Errorf("space error"))
+
+	t.Run("GetMyProfileDetails before run with cancelled input context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		identity, key, details := fx.getDetails(ctx)
+		assert.Empty(t, identity)
+		assert.Nil(t, key)
+		assert.Nil(t, details)
+	})
+
+	err := fx.run(context.Background())
+	require.Error(t, err)
+
+	fx.close()
+
+	done := make(chan struct{})
+
+	go func() {
+		_, _, _ = fx.getDetails(context.Background())
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("GetMyProfileDetails should not block")
+	case <-done:
+	}
+}

--- a/core/identity/ownidentity_test.go
+++ b/core/identity/ownidentity_test.go
@@ -7,23 +7,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/anyproto/any-sync/util/crypto"
+	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/anytype/account/mock_account"
 	"github.com/anyproto/anytype-heart/core/files/fileacl/mock_fileacl"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
 	"github.com/anyproto/anytype-heart/space/mock_space"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 type ownSubscriptionFixture struct {
 	*ownProfileSubscription
 
-	spaceService      *mock_space.MockService
-	coordinatorClient *inMemoryIdentityRepo
-	testObserver      *testObserver
+	accountService     *mock_account.MockService
+	objectStoreFixture *objectstore.StoreFixture
+	spaceService       *mock_space.MockService
+	fileAclService     *mock_fileacl.MockService
+	coordinatorClient  *inMemoryIdentityRepo
+	testObserver       *testObserver
 }
 
 type testObserver struct {
@@ -37,6 +45,17 @@ func (t *testObserver) broadcastMyIdentityProfile(identityProfile *model.Identit
 	t.profiles = append(t.profiles, identityProfile)
 }
 
+func (t *testObserver) listObservedProfiles() []*model.IdentityProfile {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	return t.profiles
+}
+
+const (
+	testProfileObjectId = "testProfileObjectId"
+	testBatchTimeout    = 100 * time.Millisecond
+)
+
 func newOwnSubscriptionFixture(t *testing.T) *ownSubscriptionFixture {
 	accountService := mock_account.NewMockService(t)
 	spaceService := mock_space.NewMockService(t)
@@ -47,23 +66,308 @@ func newOwnSubscriptionFixture(t *testing.T) *ownSubscriptionFixture {
 
 	accountService.EXPECT().AccountID().Return("identity1")
 
-	sub := newOwnProfileSubscription(spaceService, objectStore, accountService, coordinatorClient, fileAclService, testObserver, time.Second)
+	sub := newOwnProfileSubscription(spaceService, objectStore, accountService, coordinatorClient, fileAclService, testObserver, testBatchTimeout)
 
 	return &ownSubscriptionFixture{
 		ownProfileSubscription: sub,
 		spaceService:           spaceService,
 		coordinatorClient:      coordinatorClient,
 		testObserver:           testObserver,
+		objectStoreFixture:     objectStore,
+		fileAclService:         fileAclService,
+		accountService:         accountService,
 	}
 }
 
-func TestOwnProfileSubscription(t *testing.T) {
-	t.Run("do not rewrite global name from profile details", func(t *testing.T) {
+func (fx *ownSubscriptionFixture) getDataFromTestRepo(t *testing.T, accountSymKey crypto.SymKey) *model.IdentityProfile {
+	data, err := fx.identityRepoClient.IdentityRepoGet(context.Background(), []string{"identity1"}, []string{identityRepoDataKind})
+	require.NoError(t, err)
+	require.Len(t, data, 1)
 
+	profile, _, err := extractProfile(data[0], accountSymKey)
+	require.NoError(t, err)
+	return profile
+}
+
+func TestOwnProfileSubscription(t *testing.T) {
+	t.Run("do not take global name from profile details", func(t *testing.T) {
+		fx := newOwnSubscriptionFixture(t)
+		personalSpace := mock_clientspace.NewMockSpace(t)
+		personalSpace.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(testProfileObjectId, nil)
+		fx.spaceService.EXPECT().GetPersonalSpace(mock.Anything).Return(personalSpace, nil)
+		accountSymKey := crypto.NewAES()
+		fx.spaceService.EXPECT().AccountMetadataSymKey().Return(accountSymKey)
+		fx.accountService.EXPECT().SignData(mock.Anything).RunAndReturn(func(data []byte) ([]byte, error) {
+			privKey, _, err := crypto.GenerateRandomEd25519KeyPair()
+			if err != nil {
+				return nil, err
+			}
+			return privKey.Sign(data)
+		})
+
+		fx.fileAclService.EXPECT().GetInfoForFileSharing("fileObjectId").Return("fileCid1", []*model.FileEncryptionKey{
+			{
+				Path: "/0/original",
+				Key:  "key1",
+			},
+		}, nil)
+
+		err := fx.run(context.Background())
+		require.NoError(t, err)
+
+		fx.objectStoreFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          pbtypes.String(testProfileObjectId),
+				bundle.RelationKeySpaceId:     pbtypes.String("space1"),
+				bundle.RelationKeyGlobalName:  pbtypes.String("foobar"),
+				bundle.RelationKeyIconImage:   pbtypes.String("fileObjectId"),
+				bundle.RelationKeyName:        pbtypes.String("John Doe"),
+				bundle.RelationKeyDescription: pbtypes.String("Description"),
+			},
+		})
+
+		time.Sleep(2 * testBatchTimeout)
+
+		got := fx.testObserver.listObservedProfiles()
+
+		want := []*model.IdentityProfile{
+			{
+				Identity:    "identity1",
+				Name:        "John Doe",
+				Description: "Description",
+				IconCid:     "fileObjectId",
+			},
+		}
+		assert.Equal(t, want, got)
+
+		gotProfile := fx.getDataFromTestRepo(t, accountSymKey)
+		wantProfile := &model.IdentityProfile{
+			Identity:    "identity1",
+			Name:        "John Doe",
+			Description: "Description",
+			IconCid:     "fileCid1",
+			IconEncryptionKeys: []*model.FileEncryptionKey{
+				{
+					Path: "/0/original",
+					Key:  "key1",
+				},
+			},
+		}
+		assert.Equal(t, wantProfile, gotProfile)
 	})
 
 	t.Run("rewrite global name from channel signal", func(t *testing.T) {
+		fx := newOwnSubscriptionFixture(t)
+		personalSpace := mock_clientspace.NewMockSpace(t)
+		personalSpace.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(testProfileObjectId, nil)
+		fx.spaceService.EXPECT().GetPersonalSpace(mock.Anything).Return(personalSpace, nil)
+		accountSymKey := crypto.NewAES()
+		fx.spaceService.EXPECT().AccountMetadataSymKey().Return(accountSymKey)
+		fx.accountService.EXPECT().SignData(mock.Anything).RunAndReturn(func(data []byte) ([]byte, error) {
+			privKey, _, err := crypto.GenerateRandomEd25519KeyPair()
+			if err != nil {
+				return nil, err
+			}
+			return privKey.Sign(data)
+		})
 
+		err := fx.run(context.Background())
+		require.NoError(t, err)
+
+		fx.updateGlobalName(globalName)
+
+		time.Sleep(2 * testBatchTimeout)
+
+		got := fx.testObserver.listObservedProfiles()
+
+		want := []*model.IdentityProfile{
+			{
+				Identity:   testIdentity,
+				GlobalName: globalName,
+			},
+		}
+		assert.Equal(t, want, got)
+
+		gotProfile := fx.getDataFromTestRepo(t, accountSymKey)
+		wantProfile := &model.IdentityProfile{
+			Identity:   testIdentity,
+			GlobalName: globalName,
+		}
+
+		assert.Equal(t, wantProfile, gotProfile)
+	})
+
+	t.Run("push profile to identity repo in batches", func(t *testing.T) {
+		fx := newOwnSubscriptionFixture(t)
+		personalSpace := mock_clientspace.NewMockSpace(t)
+		personalSpace.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(testProfileObjectId, nil)
+		fx.spaceService.EXPECT().GetPersonalSpace(mock.Anything).Return(personalSpace, nil)
+		accountSymKey := crypto.NewAES()
+		fx.spaceService.EXPECT().AccountMetadataSymKey().Return(accountSymKey)
+		fx.accountService.EXPECT().SignData(mock.Anything).RunAndReturn(func(data []byte) ([]byte, error) {
+			privKey, _, err := crypto.GenerateRandomEd25519KeyPair()
+			if err != nil {
+				return nil, err
+			}
+			return privKey.Sign(data)
+		})
+
+		// Push the first profile version and the last
+		fx.fileAclService.EXPECT().GetInfoForFileSharing("fileObjectId").Return("fileCid1", []*model.FileEncryptionKey{
+			{
+				Path: "/0/original",
+				Key:  "key1",
+			},
+		}, nil)
+		fx.fileAclService.EXPECT().GetInfoForFileSharing("fileObjectId2").Return("fileCid2", []*model.FileEncryptionKey{
+			{
+				Path: "/0/original",
+				Key:  "key2",
+			},
+		}, nil)
+
+		err := fx.run(context.Background())
+		require.NoError(t, err)
+
+		fx.objectStoreFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          pbtypes.String(testProfileObjectId),
+				bundle.RelationKeySpaceId:     pbtypes.String("space1"),
+				bundle.RelationKeyGlobalName:  pbtypes.String("foobar"),
+				bundle.RelationKeyIconImage:   pbtypes.String("fileObjectId"),
+				bundle.RelationKeyName:        pbtypes.String("John Doe"),
+				bundle.RelationKeyDescription: pbtypes.String("Description"),
+			},
+		})
+		time.Sleep(testBatchTimeout / 4)
+
+		fx.updateGlobalName(globalName)
+		time.Sleep(testBatchTimeout / 4)
+
+		fx.objectStoreFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          pbtypes.String(testProfileObjectId),
+				bundle.RelationKeySpaceId:     pbtypes.String("space1"),
+				bundle.RelationKeyGlobalName:  pbtypes.String("foobar2"),
+				bundle.RelationKeyIconImage:   pbtypes.String("fileObjectId2"),
+				bundle.RelationKeyName:        pbtypes.String("John Doe2"),
+				bundle.RelationKeyDescription: pbtypes.String("Description2"),
+			},
+		})
+		time.Sleep(testBatchTimeout / 4)
+
+		time.Sleep(testBatchTimeout)
+
+		got := fx.testObserver.listObservedProfiles()
+
+		want := []*model.IdentityProfile{
+			{
+				Identity:    "identity1",
+				Name:        "John Doe",
+				Description: "Description",
+				IconCid:     "fileObjectId",
+			},
+			{
+				Identity:    "identity1",
+				Name:        "John Doe",
+				Description: "Description",
+				IconCid:     "fileObjectId",
+				GlobalName:  globalName,
+			},
+			{
+				Identity:    "identity1",
+				Name:        "John Doe2",
+				Description: "Description2",
+				IconCid:     "fileObjectId2",
+				GlobalName:  globalName,
+			},
+		}
+		assert.Equal(t, want, got)
+
+		gotProfile := fx.getDataFromTestRepo(t, accountSymKey)
+		wantProfile := &model.IdentityProfile{
+			Identity:    "identity1",
+			Name:        "John Doe2",
+			Description: "Description2",
+			IconCid:     "fileCid2",
+			GlobalName:  globalName,
+			IconEncryptionKeys: []*model.FileEncryptionKey{
+				{
+					Path: "/0/original",
+					Key:  "key2",
+				},
+			},
+		}
+		assert.Equal(t, wantProfile, gotProfile)
+	})
+}
+
+func TestWaitForDetails(t *testing.T) {
+	fx := newOwnSubscriptionFixture(t)
+	personalSpace := mock_clientspace.NewMockSpace(t)
+	personalSpace.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(testProfileObjectId, nil)
+	fx.spaceService.EXPECT().GetPersonalSpace(mock.Anything).Return(personalSpace, nil)
+	accountSymKey := crypto.NewAES()
+	fx.spaceService.EXPECT().AccountMetadataSymKey().Return(accountSymKey)
+	fx.accountService.EXPECT().SignData(mock.Anything).RunAndReturn(func(data []byte) ([]byte, error) {
+		privKey, _, err := crypto.GenerateRandomEd25519KeyPair()
+		if err != nil {
+			return nil, err
+		}
+		return privKey.Sign(data)
+	})
+
+	err := fx.run(context.Background())
+	require.NoError(t, err)
+
+	fx.updateGlobalName(globalName)
+	time.Sleep(2 * testBatchTimeout)
+
+	t.Run("ignore when only global name is updated", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		identity, metadataKey, details := fx.getDetails(ctx)
+		assert.Empty(t, identity)
+		assert.Nil(t, metadataKey)
+		assert.Nil(t, details)
+	})
+
+	fx.fileAclService.EXPECT().GetInfoForFileSharing("fileObjectId").Return("fileCid1", []*model.FileEncryptionKey{
+		{
+			Path: "/0/original",
+			Key:  "key1",
+		},
+	}, nil)
+	fx.objectStoreFixture.AddObjects(t, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:          pbtypes.String(testProfileObjectId),
+			bundle.RelationKeySpaceId:     pbtypes.String("space1"),
+			bundle.RelationKeyGlobalName:  pbtypes.String("foobar"),
+			bundle.RelationKeyIconImage:   pbtypes.String("fileObjectId"),
+			bundle.RelationKeyName:        pbtypes.String("John Doe"),
+			bundle.RelationKeyDescription: pbtypes.String("Description"),
+		},
+	})
+	time.Sleep(2 * testBatchTimeout)
+
+	t.Run("expect ok when profile is updated", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		identity, metadataKey, details := fx.getDetails(ctx)
+		assert.Equal(t, testIdentity, identity)
+		assert.Equal(t, accountSymKey, metadataKey)
+
+		wantDetails := &types.Struct{
+			Fields: map[string]*types.Value{
+				bundle.RelationKeyName.String():        pbtypes.String("John Doe"),
+				bundle.RelationKeyDescription.String(): pbtypes.String("Description"),
+				bundle.RelationKeyGlobalName.String():  pbtypes.String(globalName),
+				bundle.RelationKeyIconImage.String():   pbtypes.String("fileObjectId"),
+			},
+		}
+		assert.Equal(t, wantDetails, details)
 	})
 }
 

--- a/core/inviteservice/inviteservice.go
+++ b/core/inviteservice/inviteservice.go
@@ -292,7 +292,7 @@ func (i *inviteService) buildInvitePayload(ctx context.Context, spaceId string, 
 		return nil, fmt.Errorf("get space description: %w", err)
 	}
 	if description.IconImage != "" {
-		iconCid, iconEncryptionKeys, err := i.fileAcl.GetInfoForFileSharing(ctx, description.IconImage)
+		iconCid, iconEncryptionKeys, err := i.fileAcl.GetInfoForFileSharing(description.IconImage)
 		if err == nil {
 			invitePayload.SpaceIconCid = iconCid
 			invitePayload.SpaceIconEncryptionKeys = iconEncryptionKeys


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified the method signature for file sharing information retrieval, enhancing ease of use.
	- Restructured identity management components for better organization and simplified responsibilities.

- **New Features**
	- Added capabilities for users to manage and update their own identity profiles, including name and icon image.

- **Tests**
	- Updated identity management tests and added new test cases for user profile management functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->