### PR TITLE
GO-3315 fix QUIC on android

### DIFF
--- a/clientlibrary/service/lib.go
+++ b/clientlibrary/service/lib.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"runtime"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
@@ -24,6 +25,12 @@ var mw = core.New()
 
 func init() {
 	fixTZ()
+	// if android
+	if runtime.GOOS == "android" {
+		// disable GSO on android because incorrect detection
+		// https://github.com/quic-go/quic-go/pull/4447
+		os.Setenv("QUIC_GO_DISABLE_GSO", "1")
+	}
 	fmt.Printf("mw lib: %s\n", vcs.GetVCSInfo().Description())
 
 	PanicHandler = mw.OnPanic


### PR DESCRIPTION
disable GSO support on android.
Waiting https://github.com/quic-go/quic-go/pull/4447 to be reviewed and merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Disabled GSO on Android to correct an issue with incorrect detection, enhancing network performance stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->