### PR TITLE
GO-3345: Fix load default space

### DIFF
--- a/core/anytype/account/service.go
+++ b/core/anytype/account/service.go
@@ -178,7 +178,7 @@ func (s *service) GetInfo(ctx context.Context, spaceID string) (*model.AccountIn
 }
 
 func (s *service) getDerivedIds(ctx context.Context, spaceID string) (ids threads.DerivedSmartblockIds, err error) {
-	spc, err := s.spaceService.Get(ctx, spaceID)
+	spc, err := s.spaceService.Wait(ctx, spaceID)
 	if err != nil {
 		return ids, fmt.Errorf("failed to get space: %w", err)
 	}

--- a/space/load.go
+++ b/space/load.go
@@ -19,7 +19,7 @@ type controllerWaiter struct {
 	err  error
 }
 
-func (s *service) getStatus(ctx context.Context, spaceId string) (ctrl spacecontroller.SpaceController, err error) {
+func (s *service) getCtrl(ctx context.Context, spaceId string) (ctrl spacecontroller.SpaceController, err error) {
 	s.mu.Lock()
 	if ctrl, ok := s.spaceControllers[spaceId]; ok {
 		s.mu.Unlock()

--- a/space/mock_space/mock_Service.go
+++ b/space/mock_space/mock_Service.go
@@ -826,6 +826,65 @@ func (_c *MockService_TechSpaceId_Call) RunAndReturn(run func() string) *MockSer
 	return _c
 }
 
+// Wait provides a mock function with given fields: ctx, spaceId
+func (_m *MockService) Wait(ctx context.Context, spaceId string) (clientspace.Space, error) {
+	ret := _m.Called(ctx, spaceId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Wait")
+	}
+
+	var r0 clientspace.Space
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (clientspace.Space, error)); ok {
+		return rf(ctx, spaceId)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) clientspace.Space); ok {
+		r0 = rf(ctx, spaceId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(clientspace.Space)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, spaceId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_Wait_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Wait'
+type MockService_Wait_Call struct {
+	*mock.Call
+}
+
+// Wait is a helper method to define mock.On call
+//   - ctx context.Context
+//   - spaceId string
+func (_e *MockService_Expecter) Wait(ctx interface{}, spaceId interface{}) *MockService_Wait_Call {
+	return &MockService_Wait_Call{Call: _e.mock.On("Wait", ctx, spaceId)}
+}
+
+func (_c *MockService_Wait_Call) Run(run func(ctx context.Context, spaceId string)) *MockService_Wait_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockService_Wait_Call) Return(sp clientspace.Space, err error) *MockService_Wait_Call {
+	_c.Call.Return(sp, err)
+	return _c
+}
+
+func (_c *MockService_Wait_Call) RunAndReturn(run func(context.Context, string) (clientspace.Space, error)) *MockService_Wait_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockService creates a new instance of MockService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockService(t interface {

--- a/space/service.go
+++ b/space/service.go
@@ -313,12 +313,6 @@ func (s *service) sendNotification(spaceId string) {
 	}
 }
 
-func (s *service) getTechSpace() *clientspace.TechSpace {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.techSpace
-}
-
 func (s *service) SpaceViewId(spaceId string) (spaceViewId string, err error) {
 	return s.techSpace.SpaceViewId(spaceId)
 }

--- a/space/techspace/mock_techspace/mock_TechSpace.go
+++ b/space/techspace/mock_techspace/mock_TechSpace.go
@@ -672,6 +672,51 @@ func (_c *MockTechSpace_TechSpaceId_Call) RunAndReturn(run func() string) *MockT
 	return _c
 }
 
+// WaitViews provides a mock function with given fields:
+func (_m *MockTechSpace) WaitViews() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for WaitViews")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockTechSpace_WaitViews_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WaitViews'
+type MockTechSpace_WaitViews_Call struct {
+	*mock.Call
+}
+
+// WaitViews is a helper method to define mock.On call
+func (_e *MockTechSpace_Expecter) WaitViews() *MockTechSpace_WaitViews_Call {
+	return &MockTechSpace_WaitViews_Call{Call: _e.mock.On("WaitViews")}
+}
+
+func (_c *MockTechSpace_WaitViews_Call) Run(run func()) *MockTechSpace_WaitViews_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockTechSpace_WaitViews_Call) Return(_a0 error) *MockTechSpace_WaitViews_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockTechSpace_WaitViews_Call) RunAndReturn(run func() error) *MockTechSpace_WaitViews_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // WakeUpViews provides a mock function with given fields:
 func (_m *MockTechSpace) WakeUpViews() {
 	_m.Called()

--- a/space/techspace/techspace_test.go
+++ b/space/techspace/techspace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/commonspace/mock_commonspace"
@@ -274,6 +275,44 @@ func TestTechSpace_WakeUpViews(t *testing.T) {
 		fx := newFixture(t, []string{"1", "2", "3"})
 		fx.finish(t)
 		fx.WakeUpViews()
+	})
+}
+
+func TestTechSpace_WaitViews(t *testing.T) {
+	t.Run("wait after wake up views", func(t *testing.T) {
+		fx := newFixture(t, []string{"1", "2"})
+		// not calling finish to not wait for the views by default
+		treeSyncer := mock_treesyncer.NewMockTreeSyncer(fx.ctrl)
+		treeSyncer.EXPECT().StartSync()
+		fx.techCore.EXPECT().StoredIds().Return(fx.ids)
+		for _, id := range fx.ids {
+			fx.objectCache.EXPECT().GetObject(mock.Anything, id).RunAndReturn(func(ctx2 context.Context, s string) (smartblock.SmartBlock, error) {
+				// adding sleep to prove that we are indeed waiting
+				time.Sleep(100 * time.Millisecond)
+				return newSpaceViewStub(id), nil
+			})
+		}
+		fx.techCore.EXPECT().TreeSyncer().Return(treeSyncer)
+		fx.WakeUpViews()
+		err := fx.WaitViews()
+		require.NoError(t, err)
+	})
+	t.Run("wait without wake up views", func(t *testing.T) {
+		fx := newFixture(t, []string{})
+		defer fx.finish(t)
+		err := fx.WaitViews()
+		require.Equal(t, ErrNotStarted, err)
+	})
+	t.Run("wait views after close", func(t *testing.T) {
+		fx := newFixture(t, []string{})
+		treeSyncer := mock_treesyncer.NewMockTreeSyncer(fx.ctrl)
+		treeSyncer.EXPECT().StartSync()
+		fx.techCore.EXPECT().StoredIds().Return(fx.ids)
+		fx.techCore.EXPECT().TreeSyncer().Return(treeSyncer)
+		fx.WakeUpViews()
+		fx.finish(t)
+		err := fx.WaitViews()
+		require.Equal(t, fx.TechSpace.(*techSpace).ctx.Err(), err)
 	})
 }
 

--- a/space/waiter.go
+++ b/space/waiter.go
@@ -1,0 +1,61 @@
+package space
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/anyproto/anytype-heart/space/clientspace"
+)
+
+func (s *service) checkControllerExists(spaceId string) bool {
+	s.mu.Lock()
+	_, ctrlOk := s.spaceControllers[spaceId]
+	_, waitingOk := s.waiting[spaceId]
+	s.mu.Unlock()
+	return ctrlOk || waitingOk
+}
+
+type waiterService interface {
+	TechSpace() *clientspace.TechSpace
+	Get(ctx context.Context, spaceId string) (clientspace.Space, error)
+	checkControllerExists(spaceId string) bool
+}
+
+type spaceWaiter struct {
+	svc        waiterService
+	svcCtx     context.Context
+	retryDelay time.Duration
+}
+
+func newSpaceWaiter(svc waiterService, svcCtx context.Context, retryDelay time.Duration) *spaceWaiter {
+	return &spaceWaiter{svc: svc, svcCtx: svcCtx, retryDelay: retryDelay}
+}
+
+func (w *spaceWaiter) waitSpace(ctx context.Context, spaceId string) (sp clientspace.Space, err error) {
+	techSpace := w.svc.TechSpace()
+	// wait until we start the space view loading process
+	if err := techSpace.WaitViews(); err != nil {
+		return nil, fmt.Errorf("wait views: %w", err)
+	}
+	// if there is no such space view then there is no space
+	exists, err := techSpace.SpaceViewExists(ctx, spaceId)
+	if err != nil {
+		return nil, fmt.Errorf("space view exists error: %w", err)
+	}
+	if !exists {
+		return nil, ErrSpaceNotExists
+	}
+	// we should wait a bit until the controller is created
+	for !w.svc.checkControllerExists(spaceId) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-w.svcCtx.Done():
+			return nil, w.svcCtx.Err()
+		case <-time.After(w.retryDelay):
+			break
+		}
+	}
+	return w.svc.Get(ctx, spaceId)
+}

--- a/space/waiter_test.go
+++ b/space/waiter_test.go
@@ -1,0 +1,127 @@
+package space
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/space/clientspace"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/space/techspace"
+	"github.com/anyproto/anytype-heart/space/techspace/mock_techspace"
+)
+
+func TestWaiter_Wait(t *testing.T) {
+	t.Run("space exists", func(t *testing.T) {
+		mockTechSpace := mock_techspace.NewMockTechSpace(t)
+		mockClientSpace := mock_clientspace.NewMockSpace(t)
+		retryDelay := time.Millisecond
+		stub := &waiterStub{
+			clientSpace: mockClientSpace,
+			techSpace:   mockTechSpace,
+			exists:      []bool{true},
+		}
+		wtr := newSpaceWaiter(stub, ctx, retryDelay)
+		mockTechSpace.EXPECT().WaitViews().Return(nil)
+		mockTechSpace.EXPECT().SpaceViewExists(ctx, "spaceId").Return(true, nil)
+		res, err := wtr.waitSpace(ctx, "spaceId")
+		require.NoError(t, err)
+		require.NotNil(t, res)
+	})
+	t.Run("wait multiple times", func(t *testing.T) {
+		mockTechSpace := mock_techspace.NewMockTechSpace(t)
+		mockClientSpace := mock_clientspace.NewMockSpace(t)
+		retryDelay := time.Millisecond
+		stub := &waiterStub{
+			clientSpace: mockClientSpace,
+			techSpace:   mockTechSpace,
+			exists:      []bool{false, false, true},
+		}
+		wtr := newSpaceWaiter(stub, ctx, retryDelay)
+		mockTechSpace.EXPECT().WaitViews().Return(nil)
+		mockTechSpace.EXPECT().SpaceViewExists(ctx, "spaceId").Return(true, nil)
+		res, err := wtr.waitSpace(ctx, "spaceId")
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, 3, stub.cntr)
+	})
+	t.Run("cancel wait, service closed", func(t *testing.T) {
+		mockTechSpace := mock_techspace.NewMockTechSpace(t)
+		mockClientSpace := mock_clientspace.NewMockSpace(t)
+		retryDelay := time.Second
+		stub := &waiterStub{
+			clientSpace: mockClientSpace,
+			techSpace:   mockTechSpace,
+			exists:      []bool{false, false, true},
+		}
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		wtr := newSpaceWaiter(stub, cancelCtx, retryDelay)
+		mockTechSpace.EXPECT().WaitViews().Return(nil)
+		mockTechSpace.EXPECT().SpaceViewExists(ctx, "spaceId").Return(true, nil)
+		cancel()
+		res, err := wtr.waitSpace(ctx, "spaceId")
+		require.Error(t, err)
+		require.Nil(t, res)
+		require.Equal(t, 1, stub.cntr)
+	})
+	t.Run("wait failed", func(t *testing.T) {
+		mockTechSpace := mock_techspace.NewMockTechSpace(t)
+		mockClientSpace := mock_clientspace.NewMockSpace(t)
+		retryDelay := time.Millisecond
+		stub := &waiterStub{
+			clientSpace: mockClientSpace,
+			techSpace:   mockTechSpace,
+		}
+		wtr := newSpaceWaiter(stub, ctx, retryDelay)
+		mockTechSpace.EXPECT().WaitViews().Return(fmt.Errorf("error"))
+		_, err := wtr.waitSpace(ctx, "spaceId")
+		require.Error(t, err)
+	})
+	t.Run("space view not exists", func(t *testing.T) {
+		mockTechSpace := mock_techspace.NewMockTechSpace(t)
+		mockClientSpace := mock_clientspace.NewMockSpace(t)
+		retryDelay := time.Millisecond
+		stub := &waiterStub{
+			clientSpace: mockClientSpace,
+			techSpace:   mockTechSpace,
+			exists:      []bool{true},
+		}
+		// cancelCtx, cancel := context.WithCancel(context.Background())
+		wtr := newSpaceWaiter(stub, ctx, retryDelay)
+		mockTechSpace.EXPECT().WaitViews().Return(nil)
+		mockTechSpace.EXPECT().SpaceViewExists(ctx, "spaceId").Return(false, nil)
+		_, err := wtr.waitSpace(ctx, "spaceId")
+		require.Equal(t, ErrSpaceNotExists, err)
+	})
+}
+
+type waiterStub struct {
+	techSpace   techspace.TechSpace
+	clientSpace clientspace.Space
+	err         error
+	exists      []bool
+	cntr        int
+}
+
+func (w *waiterStub) TechSpace() *clientspace.TechSpace {
+	return &clientspace.TechSpace{
+		TechSpace: w.techSpace,
+	}
+}
+
+func (w *waiterStub) Get(ctx context.Context, spaceId string) (clientspace.Space, error) {
+	if w.err != nil {
+		return nil, w.err
+	}
+	return w.clientSpace, nil
+}
+
+func (w *waiterStub) checkControllerExists(spaceId string) bool {
+	defer func() {
+		w.cntr++
+	}()
+	return w.exists[w.cntr]
+}


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a wait feature to enhance service response times.
- **Enhancements**
	- Improved method naming for clarity.
	- Enhanced method capabilities to retrieve technical space details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->