### PR TITLE
GO-3356 Do not wipe own globalName

### DIFF
--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -297,7 +297,9 @@ func (s *service) GetSubscriptionStatus(ctx context.Context, req *pb.RpcMembersh
 	s.sendEvent(&out)
 
 	// 4.2 - update globalName of our own identity
-	s.profileUpdater.UpdateOwnGlobalName(status.RequestedAnyName)
+	if status.RequestedAnyName != "" {
+		s.profileUpdater.UpdateOwnGlobalName(status.RequestedAnyName)
+	}
 
 	// 4.3 - enable cache again (we have received new data)
 	log.Info("enabling cache again")


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3356/nameany-is-not-showing-up-in-anytype-team-tier

Do not wipe our own identity globalName in case an empty one came from Payment Node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured the user's global name is updated only when there is a name change request, preventing unnecessary updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->