### PR TITLE
GO-3150: fix importing of icons in callout block

### DIFF
--- a/core/block/import/common/common.go
+++ b/core/block/import/common/common.go
@@ -197,14 +197,15 @@ func isBundledObjects(targetObjectID string) bool {
 
 func handleTextBlock(oldIDtoNew map[string]string, block simple.Block, st *state.State, filesIDs []string) {
 	if iconImage := block.Model().GetText().GetIconImage(); iconImage != "" {
-		_, err := cid.Decode(iconImage)
-		if err == nil { // this can be url, because for notion import we store url to picture
-			newTarget := oldIDtoNew[iconImage]
-			if newTarget == "" {
+		newTarget := oldIDtoNew[iconImage]
+		if newTarget == "" {
+			newTarget = iconImage
+			_, err := cid.Decode(newTarget) // this can be url, because for notion import we store url to picture
+			if err == nil {
 				newTarget = addr.MissingObject
 			}
-			block.Model().GetText().IconImage = newTarget
 		}
+		block.Model().GetText().IconImage = newTarget
 	}
 	marks := block.Model().GetText().GetMarks().GetMarks()
 	for i, mark := range marks {

--- a/core/block/import/common/common_test.go
+++ b/core/block/import/common/common_test.go
@@ -3,7 +3,13 @@ package common
 import (
 	"testing"
 
+	"github.com/anyproto/any-sync/util/cidutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
 func TestReplaceChunks(t *testing.T) {
@@ -56,4 +62,107 @@ func TestReplaceChunks(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateLinksToObjects(t *testing.T) {
+	t.Run("icon image is set in text block", func(t *testing.T) {
+		// given
+		rawCid, err := cidutil.NewCidFromBytes([]byte("test"))
+		assert.Nil(t, err)
+		block := &model.Block{
+			Id: "test",
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				IconImage: rawCid,
+			}},
+		}
+		rootBlock := &model.Block{
+			Id:          "root",
+			ChildrenIds: []string{"test"},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}
+		simpleBlock := simple.New(block)
+		rootSimpleBlock := simple.New(rootBlock)
+		st := state.NewDoc("root", map[string]simple.Block{"test": simpleBlock, "root": rootSimpleBlock}).(*state.State)
+
+		oldToNew := map[string]string{rawCid: "newFileObjectId"}
+
+		// when
+		err = UpdateLinksToObjects(st, oldToNew, nil)
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, "newFileObjectId", st.Get("test").Model().GetText().GetIconImage())
+	})
+	t.Run("icon image is not set in text block", func(t *testing.T) {
+		// given
+		block := &model.Block{
+			Id:      "test",
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{}},
+		}
+		rootBlock := &model.Block{
+			Id:          "root",
+			ChildrenIds: []string{"test"},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}
+		simpleBlock := simple.New(block)
+		rootSimpleBlock := simple.New(rootBlock)
+		st := state.NewDoc("root", map[string]simple.Block{"test": simpleBlock, "root": rootSimpleBlock}).(*state.State)
+
+		// when
+		err := UpdateLinksToObjects(st, map[string]string{}, nil)
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, "", st.Get("test").Model().GetText().GetIconImage())
+	})
+	t.Run("icon image is set in text block, but file is not present", func(t *testing.T) {
+		// given
+		rawCid, err := cidutil.NewCidFromBytes([]byte("test"))
+		assert.Nil(t, err)
+		block := &model.Block{
+			Id: "test",
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				IconImage: rawCid,
+			}},
+		}
+		rootBlock := &model.Block{
+			Id:          "root",
+			ChildrenIds: []string{"test"},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}
+		simpleBlock := simple.New(block)
+		rootSimpleBlock := simple.New(rootBlock)
+		st := state.NewDoc("root", map[string]simple.Block{"test": simpleBlock, "root": rootSimpleBlock}).(*state.State)
+
+		// when
+		err = UpdateLinksToObjects(st, map[string]string{}, nil)
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, addr.MissingObject, st.Get("test").Model().GetText().GetIconImage())
+	})
+	t.Run("icon image is url from Notion", func(t *testing.T) {
+		// given
+		block := &model.Block{
+			Id: "test",
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				IconImage: "url",
+			}},
+		}
+		rootBlock := &model.Block{
+			Id:          "root",
+			ChildrenIds: []string{"test"},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}
+		simpleBlock := simple.New(block)
+		rootSimpleBlock := simple.New(rootBlock)
+		st := state.NewDoc("root", map[string]simple.Block{"test": simpleBlock, "root": rootSimpleBlock}).(*state.State)
+
+		// when
+		err := UpdateLinksToObjects(st, map[string]string{}, nil)
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, "url", st.Get("test").Model().GetText().GetIconImage())
+	})
 }


### PR DESCRIPTION
If we have iconImage in text block, we
1. Check if it's file object and it exists in current import archive. If it exist, we update icon image value with new file object id
2. If file object is not exist in archive, we
* Check if it's a valid cid
* If it is a valid cid, we assume that file object is missing and mark it in icon image field in text block
* If it's not valid cid, we assume that it can be url from Notion and do nothing because we load it later in icon syncer
