### PR TITLE
GO-3361: Identity service: use cache to index members faster, add glo…

### DIFF
--- a/core/identity/identity.go
+++ b/core/identity/identity.go
@@ -111,7 +111,7 @@ func (s *service) Init(a *app.App) (err error) {
 
 	s.ownProfileSubscription = newOwnProfileSubscription(
 		spaceService, objectStore, s.accountService, s.identityRepoClient,
-		s.fileAclService, s, s.namingService, s.pushIdentityBatchTimeout,
+		s.fileAclService, s, s.namingService, s.dbProvider, s.pushIdentityBatchTimeout,
 	)
 	return
 }

--- a/core/identity/identity_test.go
+++ b/core/identity/identity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/anyproto/anytype-heart/space/mock_space"
 	"github.com/anyproto/anytype-heart/tests/testutil"
 	"github.com/anyproto/anytype-heart/util/badgerhelper"
+	"github.com/anyproto/anytype-heart/util/mutex"
 )
 
 type fixture struct {
@@ -36,12 +38,11 @@ type fixture struct {
 }
 
 const (
-	testObserverPeriod = 1 * time.Millisecond
-	globalName         = "anytypeuser.any"
-	testIdentity       = "identity1"
+	globalName   = "anytypeuser.any"
+	testIdentity = "identity1"
 )
 
-func newFixture(t *testing.T) *fixture {
+func newFixture(t *testing.T, testObserverPeriod time.Duration) *fixture {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 
@@ -121,6 +122,12 @@ func newInMemoryIdentityRepo() *inMemoryIdentityRepo {
 	}
 }
 
+func (d *inMemoryIdentityRepo) setCallback(callback func(identities []string, kinds []string, res []*identityrepoproto.DataWithIdentity, resErr error)) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.getCallback = callback
+}
+
 func (d *inMemoryIdentityRepo) Init(a *app.App) (err error) {
 	return nil
 }
@@ -171,39 +178,83 @@ func (d *inMemoryIdentityRepo) IdentityRepoGet(ctx context.Context, identities [
 }
 
 func TestIdentityProfileCache(t *testing.T) {
-	fx := newFixture(t)
+	t.Run("with available cache, use it while registering identity", func(t *testing.T) {
+		fx := newFixture(t, time.Minute)
 
-	spaceId := "space1"
-	identity := "identity1"
+		spaceId := "space1"
+		identity := "identity1"
 
-	fx.coordinatorClient.setUnavailable()
+		profileSymKey, err := crypto.NewRandomAES()
+		require.NoError(t, err)
+		wantProfile := &model.IdentityProfile{
+			Identity: identity,
+			Name:     "name1",
+		}
+		wantData := marshalProfile(t, wantProfile, profileSymKey)
+		// Global name is cached separately
+		wantProfile.GlobalName = globalName
 
-	profileSymKey, err := crypto.NewRandomAES()
-	require.NoError(t, err)
-	wantProfile := &model.IdentityProfile{
-		Identity:   identity,
-		Name:       "name1",
-		GlobalName: globalName,
-	}
-	wantData := marshalProfile(t, wantProfile, profileSymKey)
+		err = badgerhelper.SetValue(fx.db, makeIdentityProfileKey(identity), wantData)
+		require.NoError(t, err)
+		err = badgerhelper.SetValue(fx.db, makeGlobalNameKey(identity), globalName)
+		require.NoError(t, err)
 
-	err = badgerhelper.SetValue(fx.db, makeIdentityProfileKey(identity), wantData)
-	require.NoError(t, err)
+		var (
+			gotIdentity string
+			gotProfile  *model.IdentityProfile
+		)
+		err = fx.RegisterIdentity(spaceId, identity, profileSymKey, func(callbackIdentity string, profile *model.IdentityProfile) {
+			gotIdentity = callbackIdentity
+			gotProfile = profile
+		})
+		require.NoError(t, err)
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	err = fx.RegisterIdentity(spaceId, identity, profileSymKey, func(gotIdentity string, gotProfile *model.IdentityProfile) {
 		assert.Equal(t, identity, gotIdentity)
 		assert.Equal(t, wantProfile, gotProfile)
-		wg.Done()
 	})
-	require.NoError(t, err)
 
-	wg.Wait()
+	t.Run("with available cache and unavailable identity repo, use cache instead of remote service", func(t *testing.T) {
+		testObserverPeriod := 10 * time.Millisecond
+		fx := newFixture(t, testObserverPeriod)
+
+		spaceId := "space1"
+		identity := "identity1"
+
+		fx.coordinatorClient.setUnavailable()
+
+		profileSymKey, err := crypto.NewRandomAES()
+		require.NoError(t, err)
+		wantProfile := &model.IdentityProfile{
+			Identity: identity,
+			Name:     "name1",
+		}
+		wantData := marshalProfile(t, wantProfile, profileSymKey)
+		// Global name is cached separately
+		wantProfile.GlobalName = globalName
+
+		err = badgerhelper.SetValue(fx.db, makeGlobalNameKey(identity), globalName)
+		require.NoError(t, err)
+
+		var called uint64
+		err = fx.RegisterIdentity(spaceId, identity, profileSymKey, func(callbackIdentity string, profile *model.IdentityProfile) {
+			atomic.AddUint64(&called, 1)
+			assert.Equal(t, identity, callbackIdentity)
+			assert.Equal(t, wantProfile, profile)
+		})
+		require.NoError(t, err)
+
+		err = badgerhelper.SetValue(fx.db, makeIdentityProfileKey(identity), wantData)
+		require.NoError(t, err)
+
+		time.Sleep(testObserverPeriod * 2)
+		assert.Equal(t, uint64(1), atomic.LoadUint64(&called))
+	})
+
 }
 
 func TestObservers(t *testing.T) {
-	fx := newFixture(t)
+	testObserverPeriod := 10 * time.Millisecond
+	fx := newFixture(t, testObserverPeriod)
 
 	spaceId := "space1"
 	identity := "identity1"
@@ -281,14 +332,19 @@ func TestObservers(t *testing.T) {
 		wg.Wait()
 	})
 
+}
+
+func TestGetIdentitiesDataFromRepo(t *testing.T) {
 	t.Run("empty identities", func(t *testing.T) {
-		called := false
-		fx.coordinatorClient.getCallback = func(_ []string, _ []string, _ []*identityrepoproto.DataWithIdentity, _ error) {
-			called = true
-		}
+		fx := newFixture(t, time.Millisecond)
+
+		called := mutex.NewValue(false)
+		fx.coordinatorClient.setCallback(func(_ []string, _ []string, _ []*identityrepoproto.DataWithIdentity, _ error) {
+			called.Set(true)
+		})
 		list, err := fx.getIdentitiesDataFromRepo(context.Background(), nil)
 		require.NoError(t, err)
 		require.Empty(t, list)
-		require.False(t, called)
+		require.False(t, called.Get())
 	})
 }

--- a/core/identity/ownidentity_test.go
+++ b/core/identity/ownidentity_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/anytype/account/mock_account"
 	"github.com/anyproto/anytype-heart/core/files/fileacl/mock_fileacl"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/datastore"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
@@ -65,6 +66,8 @@ func newOwnSubscriptionFixture(t *testing.T) *ownSubscriptionFixture {
 	objectStore := objectstore.NewStoreFixture(t)
 	coordinatorClient := newInMemoryIdentityRepo()
 	fileAclService := mock_fileacl.NewMockService(t)
+	dataStoreProvider, err := datastore.NewInMemory()
+	require.NoError(t, err)
 	testObserver := &testObserver{}
 	ctrl := gomock.NewController(t)
 	nsClient := mock_nameserviceclient.NewMockAnyNsClientService(ctrl)
@@ -77,7 +80,12 @@ func newOwnSubscriptionFixture(t *testing.T) *ownSubscriptionFixture {
 
 	accountService.EXPECT().AccountID().Return("identity1")
 
-	sub := newOwnProfileSubscription(spaceService, objectStore, accountService, coordinatorClient, fileAclService, testObserver, nsClient, testBatchTimeout)
+	err = dataStoreProvider.Run(context.Background())
+	require.NoError(t, err)
+	// db, err := dataStoreProvider.LocalStorage()
+	// require.NoError(t, err)
+
+	sub := newOwnProfileSubscription(spaceService, objectStore, accountService, coordinatorClient, fileAclService, testObserver, nsClient, dataStoreProvider, testBatchTimeout)
 
 	return &ownSubscriptionFixture{
 		ownProfileSubscription: sub,


### PR DESCRIPTION
=

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced identity management to utilize cached data for better performance and reliability.
- **Bug Fixes**
	- Improved the initialization process in the `RegisterIdentity` method.
- **Tests**
	- Expanded testing suite to cover new caching functionalities and observer patterns in identity management.
- **Refactor**
	- Updated `fetchGlobalNames` method to handle identities and results.
	- Modified `RegisterIdentity` method to utilize cached data and set initialization status.
	- Added functions for caching global names and identity profiles.
	- Initialized `dbProvider` and `db` fields in `ownProfileSubscription`.
	- Updated `pushProfileToIdentityRegistry` to save data to `badger` database.
- **Documentation**
	- Added import statements and initialization details in `ownidentity.go`.
	- Documented changes in `ownidentity_test.go`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->