### PR TITLE
GO-2331 Make readonly derived

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1420,6 +1420,14 @@ func (sb *smartBlock) injectDerivedDetails(s *state.State, spaceID string, sbt s
 		} else {
 			s.SetDetailAndBundledRelation(bundle.RelationKeyUniqueKey, pbtypes.String(uk.Marshal()))
 		}
+
+		if sbt == smartblock.SmartBlockTypeRelation {
+			if rel, errNotFound := bundle.GetRelation(domain.RelationKey(uk.InternalKey())); errNotFound == nil {
+				s.SetDetailAndBundledRelation(bundle.RelationKeyRelationReadonlyValue, pbtypes.Bool(rel.ReadOnlyRelation))
+			} else {
+				s.SetDetailAndBundledRelation(bundle.RelationKeyRelationReadonlyValue, pbtypes.Bool(false))
+			}
+		}
 	}
 
 	sb.setRestrictionsDetail(s)

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1423,7 +1423,7 @@ func (sb *smartBlock) injectDerivedDetails(s *state.State, spaceID string, sbt s
 
 		if sbt == smartblock.SmartBlockTypeRelation {
 			if rel, errNotFound := bundle.GetRelation(domain.RelationKey(uk.InternalKey())); errNotFound == nil {
-				s.SetDetailAndBundledRelation(bundle.RelationKeyRelationReadonlyValue, pbtypes.Bool(rel.ReadOnlyRelation))
+				s.SetDetailAndBundledRelation(bundle.RelationKeyRelationReadonlyValue, pbtypes.Bool(rel.ReadOnly))
 			} else {
 				s.SetDetailAndBundledRelation(bundle.RelationKeyRelationReadonlyValue, pbtypes.Bool(false))
 			}

--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -269,9 +269,6 @@ func (s *State) applyChange(ch *pb.ChangeContent) (err error) {
 }
 
 func (s *State) changeBlockDetailsSet(set *pb.ChangeDetailsSet) error {
-	// if slices.Contains(bundle.LocalAndDerivedRelationKeys, set.Key) {
-	// 	return nil
-	// }
 	det := s.Details()
 	if det == nil || det.Fields == nil {
 		det = &types.Struct{

--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -269,6 +269,9 @@ func (s *State) applyChange(ch *pb.ChangeContent) (err error) {
 }
 
 func (s *State) changeBlockDetailsSet(set *pb.ChangeDetailsSet) error {
+	// if slices.Contains(bundle.LocalAndDerivedRelationKeys, set.Key) {
+	// 	return nil
+	// }
 	det := s.Details()
 	if det == nil || det.Fields == nil {
 		det = &types.Struct{

--- a/core/relationutils/relation.go
+++ b/core/relationutils/relation.go
@@ -21,7 +21,7 @@ func RelationFromStruct(st *types.Struct) *Relation {
 			DefaultValue:     pbtypes.Get(st, bundle.RelationKeyRelationDefaultValue.String()),
 			DataSource:       model.Relation_details,
 			Hidden:           pbtypes.GetBool(st, bundle.RelationKeyIsHidden.String()),
-			ReadOnly:         pbtypes.GetBool(st, bundle.RelationKeyIsReadonly.String()),
+			ReadOnly:         pbtypes.GetBool(st, bundle.RelationKeyRelationReadonlyValue.String()),
 			ReadOnlyRelation: false,
 			Multi:            maxCount > 1,
 			ObjectTypes:      pbtypes.GetStringList(st, bundle.RelationKeyRelationFormatObjectTypes.String()),

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "b549826bf25e72ff31a5bad9159fdd67388a5c4d2492eba3fab64f81477fbb31"
+const RelationChecksum = "d961cfa25e59540f1d20f2f8fa65dc7b7428e2e582b2383c1be55e778c86956e"
 const (
 	RelationKeyTag                       domain.RelationKey = "tag"
 	RelationKeyCamera                    domain.RelationKey = "camera"
@@ -1821,7 +1821,7 @@ var (
 		},
 		RelationKeyRelationReadonlyValue: {
 
-			DataSource:       model.Relation_details,
+			DataSource:       model.Relation_derived,
 			Description:      "Indicates whether the relation value is readonly",
 			Format:           model.RelationFormat_checkbox,
 			Hidden:           true,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -273,7 +273,7 @@
     "maxCount": 1,
     "name": "Relation value is readonly",
     "readonly": true,
-    "source": "details"
+    "source": "derived"
   },
   {
     "description": "Image icon",


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2331/all-relations-with-tag-or-status-which-i-created-are-locked-and-unable

- make relationReadonlyValue relation derived
- inject this value according to bundle relation values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced smart block functionality to automatically set details and relationships based on block type.
- **Bug Fixes**
	- Updated relation attributes to ensure consistency and accuracy in data handling.
- **Refactor**
	- Refactored the `RelationFromStruct` function to improve data retrieval for the `ReadOnly` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->