### PR TITLE
GO-3366 sub async: fix select cases order

### DIFF
--- a/pkg/lib/database/subscription.go
+++ b/pkg/lib/database/subscription.go
@@ -94,9 +94,9 @@ func (sub *subscription) processQueue() {
 			return
 		}
 		select {
-		case sub.ch <- msg:
 		case <-sub.quit:
 			log.Warnf("subscription %p is closed, dropping message", sub)
+		case sub.ch <- msg:
 		}
 	}
 }

--- a/pkg/lib/database/subscription.go
+++ b/pkg/lib/database/subscription.go
@@ -79,7 +79,6 @@ func (sub *subscription) processQueue() {
 			log.Warnf("subscription %p has %d unprocessed messages in the async queue", sub, unprocessed)
 		}
 	}()
-	sub.wg.Add(1)
 	defer sub.wg.Done()
 	var (
 		msg *types.Struct
@@ -116,6 +115,7 @@ func (sub *subscription) PublishAsync(id string, msg *types.Struct) bool {
 	}
 	sub.RUnlock()
 	sub.processQueueOnce.Do(func() {
+		sub.wg.Add(1)
 		go sub.processQueue()
 	})
 	log.Debugf("objStore subscription sendasync %s %p", id, sub)

--- a/pkg/lib/database/subscription.go
+++ b/pkg/lib/database/subscription.go
@@ -79,7 +79,8 @@ func (sub *subscription) processQueue() {
 			log.Warnf("subscription %p has %d unprocessed messages in the async queue", sub, unprocessed)
 		}
 	}()
-
+	sub.wg.Add(1)
+	defer sub.wg.Done()
 	var (
 		msg *types.Struct
 		err error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved subscription handling to prevent sending messages on closed subscriptions.
	- Adjusted order of operations in subscription processing to ensure proper completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->