### PR TITLE
GO-3383 IsNameValid: add error descriptions

### DIFF
--- a/core/payments/cache/cache.go
+++ b/core/payments/cache/cache.go
@@ -31,7 +31,7 @@ var (
 
 // once you change the cache format, you need to update this variable
 // it will cause cache to be dropped and recreated
-const LAST_CACHE_VERSION = 4
+const LAST_CACHE_VERSION = 5
 
 var dbKey = "payments/subscription/v" + strconv.Itoa(LAST_CACHE_VERSION)
 

--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -431,7 +431,7 @@ func (s *service) IsNameValid(ctx context.Context, req *pb.RpcMembershipIsNameVa
 		out.Error.Description = "Tier does not support any names"
 	case proto.IsNameValidResponse_CanNotReserve:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_CAN_NOT_RESERVE
-		out.Error.Description = "Can not reserve this name"
+		out.Error.Description = "Cannot reserve this name"
 	default:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_UNKNOWN_ERROR
 		out.Error.Description = "Unknown error"

--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -244,6 +244,9 @@ func (s *service) GetSubscriptionStatus(ctx context.Context, req *pb.RpcMembersh
 
 	out := pb.RpcMembershipGetStatusResponse{
 		Data: &model.Membership{},
+		Error: &pb.RpcMembershipGetStatusResponseError{
+			Code: pb.RpcMembershipGetStatusResponseError_NULL,
+		},
 	}
 
 	out.Data.Tier = status.Tier
@@ -341,7 +344,11 @@ func (s *service) IsNameValid(ctx context.Context, req *pb.RpcMembershipIsNameVa
 	var code proto.IsNameValidResponse_Code
 	var desc string
 
-	out := pb.RpcMembershipIsNameValidResponse{}
+	out := pb.RpcMembershipIsNameValidResponse{
+		Error: &pb.RpcMembershipIsNameValidResponseError{
+			Code: pb.RpcMembershipIsNameValidResponseError_NULL,
+		},
+	}
 
 	// 1 - send request to PP node and ask her please
 	invr := proto.IsNameValidRequest{
@@ -512,6 +519,9 @@ func (s *service) RegisterPaymentRequest(ctx context.Context, req *pb.RpcMembers
 	out := pb.RpcMembershipGetPaymentUrlResponse{
 		PaymentUrl: bsRet.PaymentUrl,
 		BillingId:  bsRet.BillingID,
+		Error: &pb.RpcMembershipGetPaymentUrlResponseError{
+			Code: pb.RpcMembershipGetPaymentUrlResponseError_NULL,
+		},
 	}
 
 	// 2 - disable cache for 30 minutes
@@ -558,6 +568,9 @@ func (s *service) GetPortalLink(ctx context.Context, req *pb.RpcMembershipGetPor
 
 	var out pb.RpcMembershipGetPortalLinkUrlResponse
 	out.PortalUrl = bsRet.PortalUrl
+	out.Error = &pb.RpcMembershipGetPortalLinkUrlResponseError{
+		Code: pb.RpcMembershipGetPortalLinkUrlResponseError_NULL,
+	}
 
 	// 2 - disable cache for 30 minutes
 	log.Debug("disabling cache for 30 minutes after portal link was received")
@@ -603,6 +616,10 @@ func (s *service) GetVerificationEmail(ctx context.Context, req *pb.RpcMembershi
 	}
 
 	var out pb.RpcMembershipGetVerificationEmailResponse
+	out.Error = &pb.RpcMembershipGetVerificationEmailResponseError{
+		Code: pb.RpcMembershipGetVerificationEmailResponseError_NULL,
+	}
+
 	return &out, nil
 }
 
@@ -649,6 +666,10 @@ func (s *service) VerifyEmailCode(ctx context.Context, req *pb.RpcMembershipVeri
 
 	// return out
 	var out pb.RpcMembershipVerifyEmailCodeResponse
+	out.Error = &pb.RpcMembershipVerifyEmailCodeResponseError{
+		Code: pb.RpcMembershipVerifyEmailCodeResponseError_NULL,
+	}
+
 	return &out, nil
 }
 
@@ -695,6 +716,10 @@ func (s *service) FinalizeSubscription(ctx context.Context, req *pb.RpcMembershi
 
 	// return out
 	var out pb.RpcMembershipFinalizeResponse
+	out.Error = &pb.RpcMembershipFinalizeResponseError{
+		Code: pb.RpcMembershipFinalizeResponseError_NULL,
+	}
+
 	return &out, nil
 }
 
@@ -778,6 +803,9 @@ func (s *service) getAllTiers(ctx context.Context, req *pb.RpcMembershipGetTiers
 
 	// 3 - return out
 	var out pb.RpcMembershipGetTiersResponse
+	out.Error = &pb.RpcMembershipGetTiersResponseError{
+		Code: pb.RpcMembershipGetTiersResponseError_NULL,
+	}
 
 	out.Tiers = make([]*model.MembershipTierData, len(tiers.Tiers))
 	for i, tier := range tiers.Tiers {
@@ -863,5 +891,9 @@ func (s *service) VerifyAppStoreReceipt(ctx context.Context, req *pb.RpcMembersh
 		return nil, err
 	}
 
-	return &pb.RpcMembershipVerifyAppStoreReceiptResponse{}, nil
+	return &pb.RpcMembershipVerifyAppStoreReceiptResponse{
+		Error: &pb.RpcMembershipVerifyAppStoreReceiptResponseError{
+			Code: pb.RpcMembershipVerifyAppStoreReceiptResponseError_NULL,
+		},
+	}, nil
 }

--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -412,16 +412,22 @@ func (s *service) IsNameValid(ctx context.Context, req *pb.RpcMembershipIsNameVa
 		out.Error.Description = "No .any at the end of the name"
 	case proto.IsNameValidResponse_TooShort:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_TOO_SHORT
+		out.Error.Description = "Name is too short"
 	case proto.IsNameValidResponse_TooLong:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_TOO_LONG
+		out.Error.Description = "Name is too long"
 	case proto.IsNameValidResponse_HasInvalidChars:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_HAS_INVALID_CHARS
+		out.Error.Description = "Name has invalid characters"
 	case proto.IsNameValidResponse_TierFeatureNoName:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_TIER_FEATURES_NO_NAME
+		out.Error.Description = "Tier does not support any names"
 	case proto.IsNameValidResponse_CanNotReserve:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_CAN_NOT_RESERVE
+		out.Error.Description = "Can not reserve this name"
 	default:
 		out.Error.Code = pb.RpcMembershipIsNameValidResponseError_UNKNOWN_ERROR
+		out.Error.Description = "Unknown error"
 	}
 
 	out.Error.Description = desc

--- a/core/payments/payments_test.go
+++ b/core/payments/payments_test.go
@@ -1291,7 +1291,6 @@ func TestIsNameValid(t *testing.T) {
 		}
 		resp, err := fx.IsNameValid(ctx, &req)
 		assert.NoError(t, err)
-		//assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
 		assert.Equal(t, pb.RpcMembershipIsNameValidResponseErrorCode(0), resp.Error.Code)
 	})
 }

--- a/core/payments/payments_test.go
+++ b/core/payments/payments_test.go
@@ -285,6 +285,9 @@ func TestGetStatus(t *testing.T) {
 		}
 
 		psgsr := pb.RpcMembershipGetStatusResponse{
+			Error: &pb.RpcMembershipGetStatusResponseError{
+				Code: pb.RpcMembershipGetStatusResponseError_NULL,
+			},
 			Data: &model.Membership{
 				Tier:          uint32(sr.Tier),
 				Status:        model.MembershipStatus(sr.Status),
@@ -360,6 +363,9 @@ func TestGetStatus(t *testing.T) {
 		}
 
 		psgsr := pb.RpcMembershipGetStatusResponse{
+			Error: &pb.RpcMembershipGetStatusResponseError{
+				Code: pb.RpcMembershipGetStatusResponseError_NULL,
+			},
 			Data: &model.Membership{
 				Tier:          uint32(sr.Tier),
 				Status:        model.MembershipStatus(sr.Status),
@@ -411,6 +417,9 @@ func TestGetStatus(t *testing.T) {
 
 		// this is from DB
 		psgsr := pb.RpcMembershipGetStatusResponse{
+			Error: &pb.RpcMembershipGetStatusResponseError{
+				Code: pb.RpcMembershipGetStatusResponseError_NULL,
+			},
 			Data: &model.Membership{
 				Tier:          uint32(psp.SubscriptionTier_TierExplorer),
 				Status:        model.MembershipStatus(sr.Status),
@@ -589,7 +598,7 @@ func TestGetVerificationEmail(t *testing.T) {
 		// Call the function being tested
 		resp, err := fx.GetVerificationEmail(ctx, req)
 		assert.NoError(t, err)
-		assert.True(t, resp.Error == nil)
+		assert.Equal(t, pb.RpcMembershipGetVerificationEmailResponseErrorCode(0), resp.Error.Code)
 	})
 }
 
@@ -1282,7 +1291,8 @@ func TestIsNameValid(t *testing.T) {
 		}
 		resp, err := fx.IsNameValid(ctx, &req)
 		assert.NoError(t, err)
-		assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
+		//assert.Equal(t, (*pb.RpcMembershipIsNameValidResponseError)(nil), resp.Error)
+		assert.Equal(t, pb.RpcMembershipIsNameValidResponseErrorCode(0), resp.Error.Code)
 	})
 }
 
@@ -1326,6 +1336,6 @@ func TestVerifyAppStoreReceipt(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, (*pb.RpcMembershipVerifyAppStoreReceiptResponseError)(nil), resp.Error)
+		assert.Equal(t, pb.RpcMembershipVerifyAppStoreReceiptResponseErrorCode(0), resp.Error.Code)
 	})
 }


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error descriptions in name validation for payments, improving clarity on issues like name length and character validity.
	- Updated cache versioning mechanism to version 5 for improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->