### PR TITLE
GO-3163 Do not delete empty templates

### DIFF
--- a/core/block/editor/smartblock/smarttest/smarttest.go
+++ b/core/block/editor/smartblock/smarttest/smarttest.go
@@ -119,6 +119,9 @@ func (s *stubSpace) IsPersonal() bool {
 }
 
 func (st *SmartTest) Space() smartblock.Space {
+	if st.space != nil {
+		return st.space
+	}
 	return &stubSpace{}
 }
 
@@ -244,8 +247,8 @@ func (st *SmartTest) RemoveExtraRelations(ctx session.Context, relationKeys []st
 	return nil
 }
 
-func (st *SmartTest) SetObjectTypes(ctx session.Context, objectTypes []string) (err error) {
-	return nil
+func (st *SmartTest) SetObjectTypes(objectTypes []domain.TypeKey) {
+	st.Doc.(*state.State).SetObjectTypeKeys(objectTypes)
 }
 
 func (st *SmartTest) DisableLayouts() {

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -194,7 +194,7 @@ func (s *service) TemplateCreateFromObject(ctx context.Context, id string) (temp
 
 	if err = cache.Do(s.picker, id, func(b smartblock.SmartBlock) error {
 		if b.Type() != coresb.SmartBlockTypePage {
-			return fmt.Errorf("can't make template from this object type")
+			return fmt.Errorf("can't make template from this object type: %s", model.SmartBlockType_name[int32(b.Type())])
 		}
 		st, err = buildTemplateStateFromObject(b)
 		objectTypeKeys = st.ObjectTypeKeys()

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -194,9 +194,9 @@ func (s *service) TemplateCreateFromObject(ctx context.Context, id string) (temp
 
 	if err = cache.Do(s.picker, id, func(b smartblock.SmartBlock) error {
 		if b.Type() != coresb.SmartBlockTypePage {
-			return fmt.Errorf("can't make template from this obect type")
+			return fmt.Errorf("can't make template from this object type")
 		}
-		st, err = s.templateCreateFromObjectState(b)
+		st, err = buildTemplateStateFromObject(b)
 		objectTypeKeys = st.ObjectTypeKeys()
 		return err
 	}); err != nil {
@@ -336,7 +336,7 @@ func (s *service) updateTypeKey(st *state.State) (err error) {
 	return nil
 }
 
-func (s *service) templateCreateFromObjectState(sb smartblock.SmartBlock) (*state.State, error) {
+func buildTemplateStateFromObject(sb smartblock.SmartBlock) (*state.State, error) {
 	st := sb.NewState().Copy()
 	st.SetLocalDetails(nil)
 	targetObjectTypeId, err := sb.Space().GetTypeIdByKey(context.Background(), st.ObjectTypeKey())
@@ -350,5 +350,8 @@ func (s *service) templateCreateFromObjectState(sb smartblock.SmartBlock) (*stat
 			st.RemoveDetail(rel.Key)
 		}
 	}
+	flags := internalflag.NewFromState(st)
+	flags.Remove(model.InternalFlag_editorDeleteEmpty)
+	flags.AddToState(st)
 	return st, nil
 }

--- a/core/block/template/service_test.go
+++ b/core/block/template/service_test.go
@@ -311,3 +311,22 @@ func TestExtractTargetDetails(t *testing.T) {
 		)
 	}
 }
+
+func TestBuildTemplateStateFromObject(t *testing.T) {
+	t.Run("deleteEmpty flag is not set for new templates", func(t *testing.T) {
+		// given
+		obj := smarttest.New("object")
+		err := obj.SetDetails(nil, []*pb.RpcObjectSetDetailsDetail{{
+			Key:   bundle.RelationKeyInternalFlags.String(),
+			Value: pbtypes.IntList(0, 1, 2, 3),
+		}}, false)
+		assert.NoError(t, err)
+
+		// when
+		st, err := buildTemplateStateFromObject(obj)
+
+		// then
+		assert.NoError(t, err)
+		assert.NotContains(t, pbtypes.GetIntList(st.Details(), bundle.RelationKeyInternalFlags.String()), model.InternalFlag_editorDeleteEmpty)
+	})
+}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3163/an-empty-note-type-template-disappears

Do not delete new templates on close if they are empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved function naming and logic for template state construction to enhance clarity and performance.
- **Tests**
	- Added tests to ensure reliable template creation when certain flags are not set.
- **Refactor**
	- Enhanced error handling and logic in the `SmartTest` struct for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->