### PR TITLE
GO-3410 Remove total from Query

### DIFF
--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -123,7 +123,7 @@ func (s *service) CreateBookmarkObject(ctx context.Context, spaceID string, deta
 	}
 	url := pbtypes.GetString(details, bundle.RelationKeySource.String())
 
-	records, _, err := s.store.Query(database.Query{
+	records, err := s.store.Query(database.Query{
 		Sorts: []*model.BlockContentDataviewSort{
 			{
 				RelationKey: bundle.RelationKeyLastModifiedDate.String(),

--- a/core/block/editor/archive.go
+++ b/core/block/editor/archive.go
@@ -73,7 +73,7 @@ func (p *Archive) updateObjects(info smartblock.ApplyInfo) (err error) {
 		return
 	}
 
-	records, _, err := p.objectStore.Query(database.Query{
+	records, err := p.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyIsArchived.String(),

--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -192,7 +192,7 @@ func (c *layoutConverter) listIDsFromSet(spaceID string, typesFromSet []string) 
 		return []string{}, nil
 	}
 
-	records, _, err := c.objectStore.Query(
+	records, err := c.objectStore.Query(
 		database.Query{
 			Filters: filters,
 		},

--- a/core/block/editor/dashboard.go
+++ b/core/block/editor/dashboard.go
@@ -72,7 +72,7 @@ func (p *Dashboard) updateObjects(info smartblock.ApplyInfo) (err error) {
 		return
 	}
 
-	records, _, err := p.objectStore.Query(database.Query{
+	records, err := p.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyIsFavorite.String(),

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -259,7 +259,7 @@ func (e *export) docsForExport(spaceID string, req pb.RpcObjectListExportRequest
 
 func (e *export) getObjectsByIDs(spaceId string, reqIds []string, includeNested bool, includeFiles bool, isProtobuf bool) (map[string]*types.Struct, error) {
 	docs := make(map[string]*types.Struct)
-	res, _, err := e.objectStore.Query(database.Query{
+	res, err := e.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyId.String(),
@@ -840,7 +840,7 @@ func (e *export) getRelation(key string) (*database.Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	relation, _, err := e.objectStore.Query(database.Query{
+	relation, err := e.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyUniqueKey.String(),
@@ -904,7 +904,7 @@ func (e *export) getRelationOptions(relationOptions *types.Value) ([]database.Re
 	if filter == nil {
 		return nil, nil
 	}
-	relationOptionsDetails, _, err := e.objectStore.Query(database.Query{
+	relationOptionsDetails, err := e.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			filter,
 			{
@@ -949,7 +949,7 @@ func (e *export) getFilterForStringOption(value *types.Value, filter *model.Bloc
 }
 
 func (e *export) addTemplates(id string, derivedObjects []database.Record) ([]database.Record, error) {
-	templates, _, err := e.objectStore.Query(database.Query{
+	templates, err := e.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyTargetObjectType.String(),
@@ -978,7 +978,7 @@ func (e *export) addTemplates(id string, derivedObjects []database.Record) ([]da
 func (e *export) handleSetOfRelation(object *types.Struct, derivedObjects []database.Record) ([]database.Record, error) {
 	setOfList := pbtypes.GetStringList(object, bundle.RelationKeySetOf.String())
 	if len(setOfList) > 0 {
-		types, _, err := e.objectStore.Query(database.Query{
+		types, err := e.objectStore.Query(database.Query{
 			Filters: []*model.BlockContentDataviewFilter{
 				{
 					RelationKey: bundle.RelationKeyId.String(),

--- a/core/block/object/objectcreator/installer.go
+++ b/core/block/object/objectcreator/installer.go
@@ -137,7 +137,7 @@ func (s *service) installObject(ctx context.Context, space clientspace.Space, in
 }
 
 func (s *service) listInstalledObjects(space clientspace.Space, sourceObjectIds []string) (map[string]*types.Struct, error) {
-	existingObjects, _, err := s.objectStore.Query(database.Query{
+	existingObjects, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeySourceObject.String(),
@@ -282,7 +282,7 @@ func (s *service) prepareDetailsForInstallingObject(
 }
 
 func (s *service) queryDeletedObjects(space clientspace.Space, sourceObjectIDs []string) (deletedObjects []database.Record, err error) {
-	deletedObjects, _, err = s.objectStore.Query(database.Query{
+	deletedObjects, err = s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeySourceObject.String(),
@@ -305,7 +305,7 @@ func (s *service) queryDeletedObjects(space clientspace.Space, sourceObjectIDs [
 }
 
 func (s *service) queryArchivedObjects(space clientspace.Space, sourceObjectIDs []string) (archivedObjects []database.Record, err error) {
-	archivedObjects, _, err = s.objectStore.Query(database.Query{
+	archivedObjects, err = s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeySourceObject.String(),

--- a/core/block/object/objectcreator/object_type.go
+++ b/core/block/object/objectcreator/object_type.go
@@ -101,7 +101,7 @@ func (s *service) prepareRecommendedRelationIds(ctx context.Context, space clien
 }
 
 func (s *service) installTemplatesForObjectType(spc clientspace.Space, typeKey domain.TypeKey) error {
-	bundledTemplates, _, err := s.objectStore.Query(database.Query{
+	bundledTemplates, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyType.String(),
@@ -147,7 +147,7 @@ func (s *service) listInstalledTemplatesForType(spc clientspace.Space, typeKey d
 	if err != nil {
 		return nil, fmt.Errorf("get type id by key: %w", err)
 	}
-	alreadyInstalledTemplates, _, err := s.objectStore.Query(database.Query{
+	alreadyInstalledTemplates, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyType.String(),

--- a/core/block/object/objectcreator/systemobjectreviser.go
+++ b/core/block/object/objectcreator/systemobjectreviser.go
@@ -31,7 +31,7 @@ func (s *service) reviseSystemObjects(space clientspace.Space, objects map[strin
 }
 
 func (s *service) listAllTypesAndRelations(spaceId string) (map[string]*types.Struct, error) {
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyLayout.String(),

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -651,7 +651,7 @@ func (s *Service) RemoveListOption(optionIds []string, checkInObjects bool) erro
 				st := b.NewState()
 				relKey := pbtypes.GetString(st.Details(), bundle.RelationKeyRelationKey.String())
 
-				records, _, err := s.objectStore.Query(database.Query{
+				records, err := s.objectStore.Query(database.Query{
 					Filters: []*model.BlockContentDataviewFilter{
 						{
 							Condition:   model.BlockContentDataviewFilter_Equal,

--- a/core/files/fileobject/fileindex.go
+++ b/core/files/fileobject/fileindex.go
@@ -113,7 +113,7 @@ func (ind *indexer) initQuery() {
 }
 
 func (ind *indexer) addToQueueFromObjectStore(ctx context.Context) error {
-	recs, _, err := ind.objectStore.Query(ind.query)
+	recs, err := ind.objectStore.Query(ind.query)
 	if err != nil {
 		return fmt.Errorf("query: %w", err)
 	}

--- a/core/files/fileobject/service.go
+++ b/core/files/fileobject/service.go
@@ -135,7 +135,7 @@ func (s *service) Run(_ context.Context) error {
 
 // After migrating to new sync queue we need to ensure that all not synced files are added to the queue
 func (s *service) ensureNotSyncedFilesAddedToQueue() error {
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyFileId.String(),
@@ -341,7 +341,7 @@ func (s *service) addToSyncQueue(objectId string, fileId domain.FullFileId, uplo
 }
 
 func (s *service) GetObjectIdByFileId(fileId domain.FullFileId) (string, error) {
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyFileId.String(),
@@ -365,7 +365,7 @@ func (s *service) GetObjectIdByFileId(fileId domain.FullFileId) (string, error) 
 }
 
 func (s *service) GetObjectDetailsByFileId(fileId domain.FullFileId) (string, *types.Struct, error) {
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyFileId.String(),
@@ -499,7 +499,7 @@ func (s *service) FilesOffload(ctx context.Context, objectIds []string, includeN
 }
 
 func (s *service) offloadAllFiles(ctx context.Context, includeNotPinned bool) (filesOffloaded int, totalSize uint64, err error) {
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyFileId.String(),
@@ -526,7 +526,7 @@ func (s *service) offloadAllFiles(ctx context.Context, includeNotPinned bool) (f
 }
 
 func (s *service) FileSpaceOffload(ctx context.Context, spaceId string, includeNotPinned bool) (filesOffloaded int, totalSize uint64, err error) {
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeySpaceId.String(),
@@ -566,7 +566,7 @@ func (s *service) DeleteFileData(objectId string) error {
 	if err != nil {
 		return fmt.Errorf("get file id from object: %w", err)
 	}
-	records, _, err := s.objectStore.Query(database.Query{
+	records, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyId.String(),
@@ -605,7 +605,7 @@ func (s *service) offloadFileSafe(ctx context.Context,
 	record database.Record,
 	includeNotPinned bool,
 ) (uint64, error) {
-	existingObjects, _, err := s.objectStore.Query(database.Query{
+	existingObjects, err := s.objectStore.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyFileId.String(),

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -199,7 +199,7 @@ func (i *indexer) ReindexSpace(space clientspace.Space) (err error) {
 }
 
 func (i *indexer) reindexDeletedObjects(space clientspace.Space) error {
-	recs, _, err := i.store.Query(database.Query{
+	recs, err := i.store.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyIsDeleted.String(),

--- a/core/object.go
+++ b/core/object.go
@@ -115,7 +115,7 @@ func (mw *Middleware) ObjectSearch(cctx context.Context, req *pb.RpcObjectSearch
 	}
 
 	ds := mw.applicationService.GetApp().MustComponent(objectstore.CName).(objectstore.ObjectStore)
-	records, _, err := ds.Query(database.Query{
+	records, err := ds.Query(database.Query{
 		Filters:  req.Filters,
 		Sorts:    req.Sorts,
 		Offset:   int(req.Offset),

--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -273,7 +273,7 @@ func ListRelationOptions(store ObjectStore, spaceID string, relationKey string) 
 			Value:       pbtypes.String(spaceID),
 		})
 	}
-	records, _, err := store.Query(Query{
+	records, err := store.Query(Query{
 		Filters: filters,
 	})
 

--- a/pkg/lib/database/mock_ObjectStore.go
+++ b/pkg/lib/database/mock_ObjectStore.go
@@ -18,7 +18,7 @@ func (_m *MockObjectStore) EXPECT() *MockObjectStore_Expecter {
 }
 
 // Query provides a mock function with given fields: q
-func (_m *MockObjectStore) Query(q Query) ([]Record, int, error) {
+func (_m *MockObjectStore) Query(q Query) ([]Record, error) {
 	ret := _m.Called(q)
 
 	if len(ret) == 0 {
@@ -26,9 +26,8 @@ func (_m *MockObjectStore) Query(q Query) ([]Record, int, error) {
 	}
 
 	var r0 []Record
-	var r1 int
-	var r2 error
-	if rf, ok := ret.Get(0).(func(Query) ([]Record, int, error)); ok {
+	var r1 error
+	if rf, ok := ret.Get(0).(func(Query) ([]Record, error)); ok {
 		return rf(q)
 	}
 	if rf, ok := ret.Get(0).(func(Query) []Record); ok {
@@ -39,19 +38,13 @@ func (_m *MockObjectStore) Query(q Query) ([]Record, int, error) {
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(Query) int); ok {
+	if rf, ok := ret.Get(1).(func(Query) error); ok {
 		r1 = rf(q)
 	} else {
-		r1 = ret.Get(1).(int)
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(Query) error); ok {
-		r2 = rf(q)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockObjectStore_Query_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Query'
@@ -72,12 +65,12 @@ func (_c *MockObjectStore_Query_Call) Run(run func(q Query)) *MockObjectStore_Qu
 	return _c
 }
 
-func (_c *MockObjectStore_Query_Call) Return(records []Record, total int, err error) *MockObjectStore_Query_Call {
-	_c.Call.Return(records, total, err)
+func (_c *MockObjectStore_Query_Call) Return(records []Record, err error) *MockObjectStore_Query_Call {
+	_c.Call.Return(records, err)
 	return _c
 }
 
-func (_c *MockObjectStore_Query_Call) RunAndReturn(run func(Query) ([]Record, int, error)) *MockObjectStore_Query_Call {
+func (_c *MockObjectStore_Query_Call) RunAndReturn(run func(Query) ([]Record, error)) *MockObjectStore_Query_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/lib/database/order.go
+++ b/pkg/lib/database/order.go
@@ -20,7 +20,7 @@ type Order interface {
 
 // ObjectStore interface is used to enrich filters
 type ObjectStore interface {
-	Query(q Query) (records []Record, total int, err error)
+	Query(q Query) (records []Record, err error)
 	QueryRaw(filters *Filters, limit int, offset int) ([]Record, error)
 }
 

--- a/pkg/lib/localstore/objectstore/mock_objectstore/mock_ObjectStore.go
+++ b/pkg/lib/localstore/objectstore/mock_objectstore/mock_ObjectStore.go
@@ -2099,7 +2099,7 @@ func (_c *MockObjectStore_Name_Call) RunAndReturn(run func() string) *MockObject
 }
 
 // Query provides a mock function with given fields: q
-func (_m *MockObjectStore) Query(q database.Query) ([]database.Record, int, error) {
+func (_m *MockObjectStore) Query(q database.Query) ([]database.Record, error) {
 	ret := _m.Called(q)
 
 	if len(ret) == 0 {
@@ -2107,9 +2107,8 @@ func (_m *MockObjectStore) Query(q database.Query) ([]database.Record, int, erro
 	}
 
 	var r0 []database.Record
-	var r1 int
-	var r2 error
-	if rf, ok := ret.Get(0).(func(database.Query) ([]database.Record, int, error)); ok {
+	var r1 error
+	if rf, ok := ret.Get(0).(func(database.Query) ([]database.Record, error)); ok {
 		return rf(q)
 	}
 	if rf, ok := ret.Get(0).(func(database.Query) []database.Record); ok {
@@ -2120,19 +2119,13 @@ func (_m *MockObjectStore) Query(q database.Query) ([]database.Record, int, erro
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(database.Query) int); ok {
+	if rf, ok := ret.Get(1).(func(database.Query) error); ok {
 		r1 = rf(q)
 	} else {
-		r1 = ret.Get(1).(int)
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(database.Query) error); ok {
-		r2 = rf(q)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockObjectStore_Query_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Query'
@@ -2153,12 +2146,12 @@ func (_c *MockObjectStore_Query_Call) Run(run func(q database.Query)) *MockObjec
 	return _c
 }
 
-func (_c *MockObjectStore_Query_Call) Return(records []database.Record, total int, err error) *MockObjectStore_Query_Call {
-	_c.Call.Return(records, total, err)
+func (_c *MockObjectStore_Query_Call) Return(records []database.Record, err error) *MockObjectStore_Query_Call {
+	_c.Call.Return(records, err)
 	return _c
 }
 
-func (_c *MockObjectStore_Query_Call) RunAndReturn(run func(database.Query) ([]database.Record, int, error)) *MockObjectStore_Query_Call {
+func (_c *MockObjectStore_Query_Call) RunAndReturn(run func(database.Query) ([]database.Record, error)) *MockObjectStore_Query_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/lib/localstore/objectstore/objects.go
+++ b/pkg/lib/localstore/objectstore/objects.go
@@ -112,7 +112,7 @@ type ObjectStore interface {
 
 	SubscribeForAll(callback func(rec database.Record))
 
-	Query(q database.Query) (records []database.Record, total int, err error)
+	Query(q database.Query) (records []database.Record, err error)
 	QueryRaw(f *database.Filters, limit int, offset int) (records []database.Record, err error)
 	QueryByID(ids []string) (records []database.Record, err error)
 	QueryByIDAndSubscribeForChanges(ids []string, subscription database.Subscription) (records []database.Record, close func(), err error)
@@ -454,7 +454,7 @@ func (s *dsObjectStore) getObjectsInfo(txn *badger.Txn, spaceID string, ids []st
 }
 
 func (s *dsObjectStore) GetObjectByUniqueKey(spaceId string, uniqueKey domain.UniqueKey) (*model.ObjectDetails, error) {
-	records, _, err := s.Query(database.Query{
+	records, err := s.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				Condition:   model.BlockContentDataviewFilter_Equal,

--- a/pkg/lib/localstore/objectstore/objects_test.go
+++ b/pkg/lib/localstore/objectstore/objects_test.go
@@ -27,7 +27,7 @@ func TestDsObjectStore_UpdateLocalDetails(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	recs, _, err := s.Query(database.Query{})
+	recs, err := s.Query(database.Query{})
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	require.Equal(t, pbtypes.Int64(4), pbtypes.Get(recs[0].Details, bundle.RelationKeyLastOpenedDate.String()))
@@ -37,7 +37,7 @@ func TestDsObjectStore_UpdateLocalDetails(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	recs, _, err = s.Query(database.Query{})
+	recs, err = s.Query(database.Query{})
 	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	require.Nil(t, pbtypes.Get(recs[0].Details, bundle.RelationKeyLastOpenedDate.String()))

--- a/pkg/lib/localstore/objectstore/queries.go
+++ b/pkg/lib/localstore/objectstore/queries.go
@@ -14,13 +14,13 @@ import (
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
-func (s *dsObjectStore) Query(q database.Query) ([]database.Record, int, error) {
+func (s *dsObjectStore) Query(q database.Query) ([]database.Record, error) {
 	filters, err := s.buildQuery(q)
 	if err != nil {
-		return nil, 0, fmt.Errorf("build query: %w", err)
+		return nil, fmt.Errorf("build query: %w", err)
 	}
 	recs, err := s.QueryRaw(filters, q.Limit, q.Offset)
-	return recs, 0, err
+	return recs, err
 }
 
 func (s *dsObjectStore) QueryRaw(filters *database.Filters, limit int, offset int) ([]database.Record, error) {

--- a/pkg/lib/localstore/objectstore/queries_test.go
+++ b/pkg/lib/localstore/objectstore/queries_test.go
@@ -54,7 +54,7 @@ func TestQuery(t *testing.T) {
 		}
 		s.AddObjects(t, []TestObject{obj1, obj2, obj3})
 
-		recs, _, err := s.Query(database.Query{})
+		recs, err := s.Query(database.Query{})
 		require.NoError(t, err)
 
 		assertRecordsEqual(t, []TestObject{
@@ -80,7 +80,7 @@ func TestQuery(t *testing.T) {
 		}
 		s.AddObjects(t, []TestObject{obj1, obj2, obj3})
 
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Filters: []*model.BlockContentDataviewFilter{
 				{
 					RelationKey: bundle.RelationKeyName.String(),
@@ -114,7 +114,7 @@ func TestQuery(t *testing.T) {
 		}
 		s.AddObjects(t, []TestObject{obj1, obj2, obj3})
 
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Filters: []*model.BlockContentDataviewFilter{
 				{
 					RelationKey: bundle.RelationKeyName.String(),
@@ -175,7 +175,7 @@ func TestQuery(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("just full-text", func(t *testing.T) {
-			recs, _, err := s.Query(database.Query{
+			recs, err := s.Query(database.Query{
 				FullText: "important",
 			})
 			require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestQuery(t *testing.T) {
 		})
 
 		t.Run("full-text and filter", func(t *testing.T) {
-			recs, _, err := s.Query(database.Query{
+			recs, err := s.Query(database.Query{
 				FullText: "important",
 				Filters: []*model.BlockContentDataviewFilter{
 					{
@@ -215,7 +215,7 @@ func TestQuery(t *testing.T) {
 		obj4 := makeObjectWithName("id4", "ignore")
 		s.AddObjects(t, []TestObject{obj1, obj2, obj3, obj4})
 
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Filters: []*model.BlockContentDataviewFilter{
 				{
 					RelationKey: bundle.RelationKeyName.String(),
@@ -246,7 +246,7 @@ func TestQuery(t *testing.T) {
 		obj3 := makeObjectWithName("id3", "012")
 		s.AddObjects(t, []TestObject{obj1, obj2, obj3})
 
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Sorts: []*model.BlockContentDataviewSort{
 				{
 					RelationKey: bundle.RelationKeyName.String(),
@@ -271,7 +271,7 @@ func TestQuery(t *testing.T) {
 		obj4 := makeObjectWithNameAndDescription("id4", "bcd", "bar")
 		s.AddObjects(t, []TestObject{obj1, obj2, obj3, obj4})
 
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Sorts: []*model.BlockContentDataviewSort{
 				{
 					RelationKey: bundle.RelationKeyDescription.String(),
@@ -303,7 +303,7 @@ func TestQuery(t *testing.T) {
 		s.AddObjects(t, objects)
 
 		// When
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Sorts: []*model.BlockContentDataviewSort{
 				{
 					RelationKey: bundle.RelationKeyId.String(),
@@ -337,7 +337,7 @@ func TestQuery(t *testing.T) {
 		s.AddObjects(t, objects)
 
 		// When
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Sorts: []*model.BlockContentDataviewSort{
 				{
 					RelationKey: bundle.RelationKeyId.String(),
@@ -372,7 +372,7 @@ func TestQuery(t *testing.T) {
 		// When
 		limit := 15
 		offset := 20
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Sorts: []*model.BlockContentDataviewSort{
 				{
 					RelationKey: bundle.RelationKeyId.String(),
@@ -416,7 +416,7 @@ func TestQuery(t *testing.T) {
 		// When
 		limit := 60
 		offset := 20
-		recs, _, err := s.Query(database.Query{
+		recs, err := s.Query(database.Query{
 			Filters: []*model.BlockContentDataviewFilter{
 				{
 					RelationKey: bundle.RelationKeyName.String(),

--- a/pkg/lib/localstore/objectstore/relations.go
+++ b/pkg/lib/localstore/objectstore/relations.go
@@ -55,7 +55,7 @@ func (s *dsObjectStore) FetchRelationByKey(spaceID string, key string) (relation
 		Value:       pbtypes.String(spaceID),
 	})
 
-	records, _, err := s.Query(q)
+	records, err := s.Query(q)
 	if err != nil {
 		return
 	}
@@ -75,7 +75,7 @@ func (s *dsObjectStore) FetchRelationByKeys(spaceId string, keys ...string) (rel
 		}
 		uks = append(uks, uk.Marshal())
 	}
-	records, _, err := s.Query(database.Query{
+	records, err := s.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyUniqueKey.String(),
@@ -135,7 +135,7 @@ func (s *dsObjectStore) ListAllRelations(spaceId string) (relations relationutil
 		Value:       pbtypes.String(spaceId),
 	})
 
-	relations2, _, err := s.Query(database.Query{
+	relations2, err := s.Query(database.Query{
 		Filters: filters,
 	})
 	if err != nil {
@@ -165,7 +165,7 @@ func (s *dsObjectStore) GetRelationByKey(key string) (*model.Relation, error) {
 		},
 	}
 
-	records, _, err := s.Query(q)
+	records, err := s.Query(q)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/localstore/objectstore/space.go
+++ b/pkg/lib/localstore/objectstore/space.go
@@ -12,7 +12,7 @@ type SpaceNameGetter interface {
 }
 
 func (d *dsObjectStore) GetSpaceName(spaceId string) string {
-	records, _, err := d.Query(database.Query{
+	records, err := d.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyTargetSpaceId.String(),

--- a/util/testMock/objectstore_mock.go
+++ b/util/testMock/objectstore_mock.go
@@ -609,13 +609,12 @@ func (mr *MockObjectStoreMockRecorder) Name() *gomock.Call {
 }
 
 // Query mocks base method.
-func (m *MockObjectStore) Query(arg0 database.Query) ([]database.Record, int, error) {
+func (m *MockObjectStore) Query(arg0 database.Query) ([]database.Record, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Query", arg0)
 	ret0, _ := ret[0].([]database.Record)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Query indicates an expected call of Query.


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3410/remove-total-from-objectstorequery

Remove total return-value from Query method of ObjectStore, as it is not evaluated correctly