### PR TITLE
GO-2632: middleware updates details of system objects frequently

### DIFF
--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -44,7 +44,7 @@ func (ds *dependencyService) depIdsByEntries(entries []*entry, depKeys, forceIds
 	for _, e := range entries {
 		for _, k := range depKeys {
 			for _, depId := range pbtypes.GetStringList(e.data, k) {
-				if depId != "" && slice.FindPos(depIds, depId) == -1 {
+				if depId != "" && slice.FindPos(depIds, depId) == -1 && depId != e.id {
 					depIds = append(depIds, depId)
 				}
 			}

--- a/core/subscription/service_test.go
+++ b/core/subscription/service_test.go
@@ -85,7 +85,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		require.Len(t, fx.Service.(*service).cache.entries, 3)
-		assert.Len(t, fx.Service.(*service).cache.entries["1"].SubIds(), 2)
+		assert.Len(t, fx.Service.(*service).cache.entries["1"].SubIds(), 1)
 		assert.Len(t, fx.Service.(*service).cache.entries["author2"].SubIds(), 1)
 		assert.Len(t, fx.Service.(*service).cache.entries["author3"].SubIds(), 1)
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2632/middleware-updates-details-of-system-objects-frequently#comment-21102ce0

The problem was in dependencies subscriptions of files. Files can be dependent objects of themselves, because they have icons with the same id as theirs. So I could try not to add to dependent objects the objects with the same id as original entry
