### PR TITLE
GO-3541 Async fetchGlobalName

### DIFF
--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -206,7 +206,7 @@ func (s *ownProfileSubscription) handleOwnProfileDetails(profileDetails *types.S
 }
 
 func (s *ownProfileSubscription) fetchGlobalName(ctx context.Context, ns nameserviceclient.AnyNsClientService) {
-	if ctx == nil || ns == nil {
+	if ns == nil {
 		log.Error("error fetching global name of our own identity from Naming Service as the service is not initialized")
 		return
 	}
@@ -219,7 +219,12 @@ func (s *ownProfileSubscription) fetchGlobalName(ctx context.Context, ns nameser
 		log.Debug("globalName was not found for our own identity in Naming Service")
 		return
 	}
-	s.handleGlobalNameUpdate(response.Name)
+	// getting name from NS could be a long operation, so we need to check if component is still opened
+	if err = ctx.Err(); err != nil {
+		log.Error("failed to update global name of our own identity, as component context exceeded")
+		return
+	}
+	s.updateGlobalName(response.Name)
 }
 
 func (s *ownProfileSubscription) updateGlobalName(globalName string) {

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -223,11 +223,12 @@ func (s *ownProfileSubscription) fetchGlobalName(ctx context.Context, ns nameser
 }
 
 func (s *ownProfileSubscription) updateGlobalName(globalName string) {
-	if err := s.componentCtx.Err(); err != nil {
-		log.Error("failed to update global name of our own identity, as component context exceeded")
+	select {
+	case <-s.componentCtx.Done():
+		return
+	case s.globalNameUpdatedCh <- globalName:
 		return
 	}
-	s.globalNameUpdatedCh <- globalName
 }
 
 func (s *ownProfileSubscription) handleGlobalNameUpdate(globalName string) {

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -219,15 +219,14 @@ func (s *ownProfileSubscription) fetchGlobalName(ctx context.Context, ns nameser
 		log.Debug("globalName was not found for our own identity in Naming Service")
 		return
 	}
-	// getting name from NS could be a long operation, so we need to check if component is still opened
-	if err = ctx.Err(); err != nil {
-		log.Error("failed to update global name of our own identity, as component context exceeded")
-		return
-	}
 	s.updateGlobalName(response.Name)
 }
 
 func (s *ownProfileSubscription) updateGlobalName(globalName string) {
+	if err := s.componentCtx.Err(); err != nil {
+		log.Error("failed to update global name of our own identity, as component context exceeded")
+		return
+	}
 	s.globalNameUpdatedCh <- globalName
 }
 

--- a/core/identity/ownidentity.go
+++ b/core/identity/ownidentity.go
@@ -133,7 +133,7 @@ func (s *ownProfileSubscription) run(ctx context.Context) (err error) {
 		s.handleOwnProfileDetails(records[0].Details)
 	}
 
-	s.fetchGlobalName()
+	go s.fetchGlobalName(s.componentCtx, s.namingService)
 
 	go func() {
 		for {
@@ -205,8 +205,12 @@ func (s *ownProfileSubscription) handleOwnProfileDetails(profileDetails *types.S
 	s.enqueuePush()
 }
 
-func (s *ownProfileSubscription) fetchGlobalName() {
-	response, err := s.namingService.GetNameByAnyId(s.componentCtx, &nameserviceproto.NameByAnyIdRequest{AnyAddress: s.myIdentity})
+func (s *ownProfileSubscription) fetchGlobalName(ctx context.Context, ns nameserviceclient.AnyNsClientService) {
+	if ctx == nil || ns == nil {
+		log.Error("error fetching global name of our own identity from Naming Service as the service is not initialized")
+		return
+	}
+	response, err := ns.GetNameByAnyId(ctx, &nameserviceproto.NameByAnyIdRequest{AnyAddress: s.myIdentity})
 	if err != nil || response == nil {
 		log.Error("error fetching global name of our own identity from Naming Service", zap.Error(err))
 		return

--- a/core/identity/ownidentity_test.go
+++ b/core/identity/ownidentity_test.go
@@ -135,6 +135,8 @@ func TestOwnProfileSubscription(t *testing.T) {
 		err := fx.run(context.Background())
 		require.NoError(t, err)
 
+		time.Sleep(testBatchTimeout / 4)
+
 		fx.objectStoreFixture.AddObjects(t, []objectstore.TestObject{
 			{
 				bundle.RelationKeyId:          pbtypes.String(testProfileObjectId),
@@ -201,6 +203,8 @@ func TestOwnProfileSubscription(t *testing.T) {
 		err := fx.run(context.Background())
 		require.NoError(t, err)
 
+		time.Sleep(testBatchTimeout / 4)
+
 		fx.updateGlobalName(newName)
 
 		time.Sleep(2 * testBatchTimeout)
@@ -253,6 +257,8 @@ func TestOwnProfileSubscription(t *testing.T) {
 
 		err := fx.run(context.Background())
 		require.NoError(t, err)
+
+		time.Sleep(testBatchTimeout / 4)
 
 		fx.objectStoreFixture.AddObjects(t, []objectstore.TestObject{
 			{


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3541/avoid-sync-fetchglobalname-on-app-start

We should not do network operations on component start, so fetchGlobalName for ownIdentity should be done asyncrhonously 