### PR TITLE
GO-3512 fix exif reuse problem

### DIFF
--- a/core/files/files.go
+++ b/core/files/files.go
@@ -401,7 +401,12 @@ func (s *service) addFileNode(ctx context.Context, spaceID string, mill m.Mill, 
 	}
 
 	if variant, err := s.fileStore.GetFileVariantByChecksum(mill.ID(), variantChecksum); err == nil {
-		return newExistingFileResult(variant)
+		if variant.Source == conf.checksum {
+			// we may have same variant checksum for different files
+			// e.g. empty image exif with the same resolution
+			// reuse the whole file only in case the checksum of the original file is the same
+			return newExistingFileResult(variant)
+		}
 	}
 
 	_, err = conf.Reader.Seek(0, io.SeekStart)

--- a/core/files/images_test.go
+++ b/core/files/images_test.go
@@ -1,7 +1,9 @@
 package files
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -100,6 +102,52 @@ func TestImageAddWithCustomEncryptionKeys(t *testing.T) {
 	got.Commit()
 
 	assertCustomEncryptionKeys(t, fx, got, customKeys)
+}
+
+func TestImageAddReuse(t *testing.T) {
+	fx := newFixture(t)
+
+	f, err := os.Open("../../pkg/lib/mill/testdata/image.jpeg")
+	require.NoError(t, err)
+	defer f.Close()
+
+	fileName := "myFile"
+	lastModifiedDate := time.Now()
+	opts := []AddOption{
+		WithName(fileName),
+		WithLastModifiedDate(lastModifiedDate.Unix()),
+		WithReader(f),
+	}
+	got1, err := fx.ImageAdd(context.Background(), spaceId, opts...)
+	require.NoError(t, err)
+	got1.Commit()
+
+	f.Seek(0, 0)
+	got2, err := fx.ImageAdd(context.Background(), spaceId, opts...)
+	require.NoError(t, err)
+	got2.Commit()
+	require.True(t, got2.IsExisting)
+	require.Equal(t, got1.FileId.String(), got2.FileId.String())
+	require.Equal(t, got1.EncryptionKeys.EncryptionKeys, got2.EncryptionKeys.EncryptionKeys)
+
+	b, err := io.ReadAll(f)
+	require.NoError(t, err)
+	b[10000] = 0x00
+	// patch the original image so it will have the different source hash, but the same(empty) exif
+	patchedReader := bytes.NewReader(b)
+	opts = []AddOption{
+		WithName(fileName),
+		WithLastModifiedDate(lastModifiedDate.Unix()),
+		WithReader(patchedReader),
+	}
+	// exif will be the same but images are different
+	got3, err := fx.ImageAdd(context.Background(), spaceId, opts...)
+	require.NoError(t, err)
+	got3.Commit()
+	fileId3 := got3.FileId.String()
+
+	require.NotEqual(t, got1.FileId.String(), fileId3)
+	require.False(t, got3.IsExisting)
 }
 
 func assertCustomEncryptionKeys(t *testing.T, fx *fixture, got *AddResult, customKeys map[string]string) {


### PR DESCRIPTION
This PR is instead of #1273
This approach is more robust and doesn't require to modify the image's exif