### PR TITLE
GO-3515: cannot export object with linked objects

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -710,13 +710,11 @@ func (e *export) getRelatedDerivedObjects(objects map[string]*types.Struct) ([]d
 	return derivedObjects, nil
 }
 
-func (e *export) iterateObjects(objects map[string]*types.Struct) ([]database.Record, []database.Record, error) {
-	var (
-		allObjects, typesAndTemplates []database.Record
-		relations                     []string
-	)
+func (e *export) iterateObjects(objects map[string]*types.Struct,
+) (allObjects []database.Record, typesAndTemplates []database.Record, err error) {
+	var relations []string
 	for id, object := range objects {
-		err := cache.Do(e.picker, id, func(b sb.SmartBlock) error {
+		err = cache.Do(e.picker, id, func(b sb.SmartBlock) error {
 			state := b.NewState()
 			relations = e.getObjectRelations(state, relations)
 			details := state.Details()


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3515/cannot-export-object-with-linked-objects
1. Skip export of recommended relation if it's not exist in object store
2. Add optimization - now we try to get derived objects only from object types or templates, because currently for relations it's useless as they have only system relations and type