### PR TITLE
GO-3537: Missing Import data - Markdown spaced codeblock

### DIFF
--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -121,6 +121,9 @@ func (r *Renderer) renderCodeBlock(_ util.BufWriter,
 	n ast.Node,
 	entering bool) (ast.WalkStatus, error) {
 	r.openTextBlockWithStyle(entering, model.BlockContentText_Code, nil)
+	if entering {
+		r.writeLines(source, n)
+	}
 	return ast.WalkContinue, nil
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3537/missing-import-data-markdown-spaced-codeblock

* Then we get code block NodeKind during rendering markdown input, we forget to add text from code block to our buffer, which is used in anytype text block 
* So I write text from code block to buffer, so it will be added to text block in `CloseTextBlock` function  