### PR TITLE
GO-3640: do not send similar events for space sync status

### DIFF
--- a/core/syncstatus/spacesyncstatus/filestate.go
+++ b/core/syncstatus/spacesyncstatus/filestate.go
@@ -13,12 +13,10 @@ import (
 )
 
 type FileState struct {
-	fileSyncCountBySpace map[string]int
-	countMu              sync.RWMutex
-
+	fileSyncCountBySpace  map[string]int
 	fileSyncStatusBySpace map[string]domain.SpaceSyncStatus
 	filesErrorBySpace     map[string]domain.SyncError
-	statusMu              sync.RWMutex
+	sync.RWMutex
 
 	store objectstore.ObjectStore
 }
@@ -34,8 +32,8 @@ func NewFileState(store objectstore.ObjectStore) *FileState {
 }
 
 func (f *FileState) SetObjectsNumber(status *domain.SpaceSync) {
-	f.countMu.Lock()
-	defer f.countMu.Unlock()
+	f.Lock()
+	defer f.Unlock()
 	records, err := f.store.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
@@ -57,8 +55,8 @@ func (f *FileState) SetObjectsNumber(status *domain.SpaceSync) {
 }
 
 func (f *FileState) SetSyncStatusAndErr(status *domain.SpaceSync) {
-	f.statusMu.RLock()
-	defer f.statusMu.RUnlock()
+	f.RLock()
+	defer f.RUnlock()
 	switch status.Status {
 	case domain.Synced:
 		f.fileSyncStatusBySpace[status.SpaceId] = domain.Synced
@@ -83,20 +81,20 @@ func (f *FileState) setError(spaceId string, syncErr domain.SyncError) {
 }
 
 func (f *FileState) GetSyncStatus(spaceId string) domain.SpaceSyncStatus {
-	f.statusMu.RLock()
-	defer f.statusMu.RUnlock()
+	f.RLock()
+	defer f.RUnlock()
 	return f.fileSyncStatusBySpace[spaceId]
 }
 
 func (f *FileState) GetSyncObjectCount(spaceId string) int {
-	f.countMu.RLock()
-	defer f.countMu.RUnlock()
+	f.RLock()
+	defer f.RUnlock()
 	return f.fileSyncCountBySpace[spaceId]
 }
 
 func (f *FileState) GetSyncErr(spaceId string) domain.SyncError {
-	f.statusMu.RLock()
-	defer f.statusMu.RUnlock()
+	f.RLock()
+	defer f.RUnlock()
 	return f.filesErrorBySpace[spaceId]
 }
 

--- a/core/syncstatus/spacesyncstatus/filestate.go
+++ b/core/syncstatus/spacesyncstatus/filestate.go
@@ -16,7 +16,7 @@ type FileState struct {
 	fileSyncCountBySpace  map[string]int
 	fileSyncStatusBySpace map[string]domain.SpaceSyncStatus
 	filesErrorBySpace     map[string]domain.SyncError
-	sync.RWMutex
+	sync.Mutex
 
 	store objectstore.ObjectStore
 }
@@ -55,8 +55,8 @@ func (f *FileState) SetObjectsNumber(status *domain.SpaceSync) {
 }
 
 func (f *FileState) SetSyncStatusAndErr(status *domain.SpaceSync) {
-	f.RLock()
-	defer f.RUnlock()
+	f.Lock()
+	defer f.Unlock()
 	switch status.Status {
 	case domain.Synced:
 		f.fileSyncStatusBySpace[status.SpaceId] = domain.Synced
@@ -81,20 +81,20 @@ func (f *FileState) setError(spaceId string, syncErr domain.SyncError) {
 }
 
 func (f *FileState) GetSyncStatus(spaceId string) domain.SpaceSyncStatus {
-	f.RLock()
-	defer f.RUnlock()
+	f.Lock()
+	defer f.Unlock()
 	return f.fileSyncStatusBySpace[spaceId]
 }
 
 func (f *FileState) GetSyncObjectCount(spaceId string) int {
-	f.RLock()
-	defer f.RUnlock()
+	f.Lock()
+	defer f.Unlock()
 	return f.fileSyncCountBySpace[spaceId]
 }
 
 func (f *FileState) GetSyncErr(spaceId string) domain.SyncError {
-	f.RLock()
-	defer f.RUnlock()
+	f.Lock()
+	defer f.Unlock()
 	return f.filesErrorBySpace[spaceId]
 }
 

--- a/core/syncstatus/spacesyncstatus/objectstate.go
+++ b/core/syncstatus/spacesyncstatus/objectstate.go
@@ -13,11 +13,9 @@ import (
 
 type ObjectState struct {
 	objectSyncStatusBySpace map[string]domain.SpaceSyncStatus
-	statusMu                sync.RWMutex
-
-	objectSyncCountBySpace map[string]int
-	objectSyncErrBySpace   map[string]domain.SyncError
-	countMu                sync.RWMutex
+	objectSyncCountBySpace  map[string]int
+	objectSyncErrBySpace    map[string]domain.SyncError
+	sync.RWMutex
 
 	store objectstore.ObjectStore
 }
@@ -32,8 +30,8 @@ func NewObjectState(store objectstore.ObjectStore) *ObjectState {
 }
 
 func (o *ObjectState) SetObjectsNumber(status *domain.SpaceSync) {
-	o.countMu.Lock()
-	defer o.countMu.Unlock()
+	o.Lock()
+	defer o.Unlock()
 	switch status.Status {
 	case domain.Error, domain.Offline:
 		o.objectSyncCountBySpace[status.SpaceId] = 0
@@ -75,8 +73,8 @@ func (o *ObjectState) getSyncingObjects(status *domain.SpaceSync) []database.Rec
 }
 
 func (o *ObjectState) SetSyncStatusAndErr(status *domain.SpaceSync) {
-	o.statusMu.Lock()
-	defer o.statusMu.Unlock()
+	o.Lock()
+	defer o.Unlock()
 
 	if objectNumber, ok := o.objectSyncCountBySpace[status.SpaceId]; ok && objectNumber > 0 {
 		o.objectSyncStatusBySpace[status.SpaceId] = domain.Syncing
@@ -88,19 +86,19 @@ func (o *ObjectState) SetSyncStatusAndErr(status *domain.SpaceSync) {
 }
 
 func (o *ObjectState) GetSyncStatus(spaceId string) domain.SpaceSyncStatus {
-	o.statusMu.RLock()
-	defer o.statusMu.RUnlock()
+	o.RLock()
+	defer o.RUnlock()
 	return o.objectSyncStatusBySpace[spaceId]
 }
 
 func (o *ObjectState) GetSyncObjectCount(spaceId string) int {
-	o.countMu.RLock()
-	defer o.countMu.RUnlock()
+	o.RLock()
+	defer o.RUnlock()
 	return o.objectSyncCountBySpace[spaceId]
 }
 
 func (o *ObjectState) GetSyncErr(spaceId string) domain.SyncError {
-	o.statusMu.RLock()
-	defer o.statusMu.RUnlock()
+	o.RLock()
+	defer o.RUnlock()
 	return o.objectSyncErrBySpace[spaceId]
 }

--- a/core/syncstatus/spacesyncstatus/objectstate.go
+++ b/core/syncstatus/spacesyncstatus/objectstate.go
@@ -15,7 +15,7 @@ type ObjectState struct {
 	objectSyncStatusBySpace map[string]domain.SpaceSyncStatus
 	objectSyncCountBySpace  map[string]int
 	objectSyncErrBySpace    map[string]domain.SyncError
-	sync.RWMutex
+	sync.Mutex
 
 	store objectstore.ObjectStore
 }
@@ -86,19 +86,19 @@ func (o *ObjectState) SetSyncStatusAndErr(status *domain.SpaceSync) {
 }
 
 func (o *ObjectState) GetSyncStatus(spaceId string) domain.SpaceSyncStatus {
-	o.RLock()
-	defer o.RUnlock()
+	o.Lock()
+	defer o.Unlock()
 	return o.objectSyncStatusBySpace[spaceId]
 }
 
 func (o *ObjectState) GetSyncObjectCount(spaceId string) int {
-	o.RLock()
-	defer o.RUnlock()
+	o.Lock()
+	defer o.Unlock()
 	return o.objectSyncCountBySpace[spaceId]
 }
 
 func (o *ObjectState) GetSyncErr(spaceId string) domain.SyncError {
-	o.RLock()
-	defer o.RUnlock()
+	o.Lock()
+	defer o.Unlock()
 	return o.objectSyncErrBySpace[spaceId]
 }

--- a/core/syncstatus/spacesyncstatus/spacestatus.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus.go
@@ -181,9 +181,9 @@ func (s *spaceSyncStatus) isStatusNotChanged(status *domain.SpaceSync) bool {
 		// we need to check if number of syncing object is changed first
 		return false
 	}
-	syncErrNotChange := s.getError(status.SpaceId) == mapError(status.SyncError)
-	statusNotChange := s.getSpaceSyncStatus(status.SpaceId) == status.Status
-	if syncErrNotChange && statusNotChange {
+	syncErrNotChanged := s.getError(status.SpaceId) == mapError(status.SyncError)
+	statusNotChanged := s.getSpaceSyncStatus(status.SpaceId) == status.Status
+	if syncErrNotChanged && statusNotChanged {
 		return true
 	}
 	return false

--- a/core/syncstatus/spacesyncstatus/spacestatus.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus.go
@@ -150,30 +150,51 @@ func (s *spaceSyncStatus) processEvents() {
 	}
 }
 
-func (s *spaceSyncStatus) updateSpaceSyncStatus(status *domain.SpaceSync) {
-	state := s.getCurrentState(status)
-	state.SetObjectsNumber(status)
-	state.SetSyncStatusAndErr(status)
+func (s *spaceSyncStatus) updateSpaceSyncStatus(recievedStatus *domain.SpaceSync) {
+	if s.isStatusNotChanged(recievedStatus) {
+		return
+	}
+	state := s.getCurrentState(recievedStatus)
+	prevObjectNumber := s.getObjectNumber(recievedStatus.SpaceId)
+	state.SetObjectsNumber(recievedStatus)
+	newObjectNumber := s.getObjectNumber(recievedStatus.SpaceId)
+	state.SetSyncStatusAndErr(recievedStatus)
+
+	spaceStatus := s.getSpaceSyncStatus(recievedStatus.SpaceId)
 
 	// send synced event only if files and objects are all synced
-	if !s.needToSendEvent(status) {
+	if !s.needToSendEvent(spaceStatus, prevObjectNumber, newObjectNumber) {
 		return
 	}
 
 	s.eventSender.Broadcast(&pb.Event{
 		Messages: []*pb.EventMessage{{
 			Value: &pb.EventMessageValueOfSpaceSyncStatusUpdate{
-				SpaceSyncStatusUpdate: s.makeSpaceSyncEvent(status.SpaceId),
+				SpaceSyncStatusUpdate: s.makeSpaceSyncEvent(recievedStatus.SpaceId),
 			},
 		}},
 	})
 }
 
-func (s *spaceSyncStatus) needToSendEvent(status *domain.SpaceSync) bool {
-	if status.Status != domain.Synced {
+func (s *spaceSyncStatus) isStatusNotChanged(status *domain.SpaceSync) bool {
+	if status.Status == domain.Syncing {
+		// we need to check if number of syncing object is changed first
+		return false
+	}
+	errNotChange := s.getError(status.SpaceId) == mapError(status.SyncError)
+	statusNotChange := s.getSpaceSyncStatus(status.SpaceId) == status.Status
+	if errNotChange && statusNotChange {
 		return true
 	}
-	return s.getSpaceSyncStatus(status.SpaceId) == domain.Synced && status.Status == domain.Synced
+	return false
+}
+
+func (s *spaceSyncStatus) needToSendEvent(status domain.SpaceSyncStatus, prevObjectNumber int64, newObjectNumber int64) bool {
+	if status == domain.Syncing && prevObjectNumber == newObjectNumber {
+		// that because we get update on syncing objects count, so we need to send updated object counter to client
+		return false
+	}
+	return true
 }
 
 func (s *spaceSyncStatus) Close(ctx context.Context) (err error) {
@@ -190,8 +211,12 @@ func (s *spaceSyncStatus) makeSpaceSyncEvent(spaceId string) *pb.EventSpaceSyncS
 		Status:                mapStatus(s.getSpaceSyncStatus(spaceId)),
 		Network:               mapNetworkMode(s.networkConfig.GetNetworkMode()),
 		Error:                 s.getError(spaceId),
-		SyncingObjectsCounter: int64(s.filesState.GetSyncObjectCount(spaceId) + s.objectsState.GetSyncObjectCount(spaceId)),
+		SyncingObjectsCounter: s.getObjectNumber(spaceId),
 	}
+}
+
+func (s *spaceSyncStatus) getObjectNumber(spaceId string) int64 {
+	return int64(s.filesState.GetSyncObjectCount(spaceId) + s.objectsState.GetSyncObjectCount(spaceId))
 }
 
 func (s *spaceSyncStatus) getSpaceSyncStatus(spaceId string) domain.SpaceSyncStatus {

--- a/core/syncstatus/spacesyncstatus/spacestatus.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus.go
@@ -181,20 +181,17 @@ func (s *spaceSyncStatus) isStatusNotChanged(status *domain.SpaceSync) bool {
 		// we need to check if number of syncing object is changed first
 		return false
 	}
-	errNotChange := s.getError(status.SpaceId) == mapError(status.SyncError)
+	syncErrNotChange := s.getError(status.SpaceId) == mapError(status.SyncError)
 	statusNotChange := s.getSpaceSyncStatus(status.SpaceId) == status.Status
-	if errNotChange && statusNotChange {
+	if syncErrNotChange && statusNotChange {
 		return true
 	}
 	return false
 }
 
 func (s *spaceSyncStatus) needToSendEvent(status domain.SpaceSyncStatus, prevObjectNumber int64, newObjectNumber int64) bool {
-	if status == domain.Syncing && prevObjectNumber == newObjectNumber {
-		// that because we get update on syncing objects count, so we need to send updated object counter to client
-		return false
-	}
-	return true
+	// that because we get update on syncing objects count, so we need to send updated object counter to client
+	return status != domain.Syncing || prevObjectNumber != newObjectNumber
 }
 
 func (s *spaceSyncStatus) Close(ctx context.Context) (err error) {

--- a/core/syncstatus/spacesyncstatus/spacestatus_test.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus_test.go
@@ -384,6 +384,84 @@ func TestSpaceSyncStatus_updateSpaceSyncStatus(t *testing.T) {
 		assert.Equal(t, 0, status.filesState.GetSyncObjectCount("spaceId"))
 		assert.Equal(t, domain.Synced, status.getSpaceSyncStatus(syncStatus.SpaceId))
 	})
+	t.Run("not send not needed synced event", func(t *testing.T) {
+		// given
+		eventSender := mock_event.NewMockSender(t)
+		status := spaceSyncStatus{
+			eventSender:   eventSender,
+			networkConfig: &config.Config{NetworkMode: pb.RpcAccount_CustomConfig},
+			batcher:       mb.New[*domain.SpaceSync](0),
+			filesState:    NewFileState(objectstore.NewStoreFixture(t)),
+			objectsState:  NewObjectState(objectstore.NewStoreFixture(t)),
+		}
+		// then
+
+		syncStatus := domain.MakeSyncStatus("spaceId", domain.Synced, domain.Null, domain.Objects)
+		status.updateSpaceSyncStatus(syncStatus)
+
+		// when
+		eventSender.AssertNotCalled(t, "Broadcast", &pb.Event{
+			Messages: []*pb.EventMessage{{
+				Value: &pb.EventMessageValueOfSpaceSyncStatusUpdate{
+					SpaceSyncStatusUpdate: &pb.EventSpaceSyncStatusUpdate{
+						Id:                    "spaceId",
+						Status:                pb.EventSpace_Synced,
+						Network:               pb.EventSpace_SelfHost,
+						Error:                 pb.EventSpace_Null,
+						SyncingObjectsCounter: 0,
+					},
+				},
+			}},
+		})
+	})
+	t.Run("not send syncing event if object number not changed", func(t *testing.T) {
+		// given
+		eventSender := mock_event.NewMockSender(t)
+		eventSender.EXPECT().Broadcast(&pb.Event{
+			Messages: []*pb.EventMessage{{
+				Value: &pb.EventMessageValueOfSpaceSyncStatusUpdate{
+					SpaceSyncStatusUpdate: &pb.EventSpaceSyncStatusUpdate{
+						Id:                    "spaceId",
+						Status:                pb.EventSpace_Syncing,
+						Network:               pb.EventSpace_SelfHost,
+						Error:                 pb.EventSpace_Null,
+						SyncingObjectsCounter: 2,
+					},
+				},
+			}},
+		}).Return().Times(1)
+
+		storeFixture := objectstore.NewStoreFixture(t)
+		status := spaceSyncStatus{
+			eventSender:   eventSender,
+			networkConfig: &config.Config{NetworkMode: pb.RpcAccount_CustomConfig},
+			batcher:       mb.New[*domain.SpaceSync](0),
+			filesState:    NewFileState(storeFixture),
+			objectsState:  NewObjectState(storeFixture),
+		}
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:         pbtypes.String("id1"),
+				bundle.RelationKeySyncStatus: pbtypes.Int64(int64(domain.Syncing)),
+				bundle.RelationKeySpaceId:    pbtypes.String("spaceId"),
+			},
+			{
+				bundle.RelationKeyId:         pbtypes.String("id2"),
+				bundle.RelationKeySyncStatus: pbtypes.Int64(int64(domain.Synced)),
+				bundle.RelationKeySpaceId:    pbtypes.String("spaceId"),
+			},
+			{
+				bundle.RelationKeyId:         pbtypes.String("id3"),
+				bundle.RelationKeySyncStatus: pbtypes.Int64(int64(domain.Syncing)),
+				bundle.RelationKeySpaceId:    pbtypes.String("spaceId"),
+			},
+		})
+
+		// when
+		syncStatus := domain.MakeSyncStatus("spaceId", domain.Syncing, domain.Null, domain.Objects)
+		status.updateSpaceSyncStatus(syncStatus)
+		status.updateSpaceSyncStatus(syncStatus)
+	})
 }
 
 func TestSpaceSyncStatus_SendUpdate(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3640/dont-send-similar-sync-status-events

1. Fix possible race condition, which can possibly occur during cmd+r
2. Not send event if previous status of object and file sync is the same
3. Not send Syncing event, if syncing object number is not changed