### PR TITLE
GO-3568 Add tag to details of custom object

### DIFF
--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -306,6 +306,7 @@ func (s *service) createBlankTemplateState(layout model.ObjectTypeLayout) (st *s
 		template.WithDefaultFeaturedRelations,
 		template.WithFeaturedRelations,
 		template.WithAddedFeaturedRelation(bundle.RelationKeyTag),
+		template.WithDetail(bundle.RelationKeyTag, pbtypes.StringList(nil)),
 		template.WithRequiredRelations(),
 		template.WithTitle,
 	)

--- a/core/block/template/service_test.go
+++ b/core/block/template/service_test.go
@@ -167,6 +167,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, BlankTemplateId, st.RootId())
 			assert.Contains(t, pbtypes.GetStringList(st.Details(), bundle.RelationKeyFeaturedRelations.String()), bundle.RelationKeyTag.String())
+			assert.True(t, pbtypes.Exists(st.Details(), bundle.RelationKeyTag.String()))
 		})
 	}
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3568/there-is-no-tag-in-details-though-it-is-featured

Add empty tag detail to all new objects