### PR TITLE
GO-3542 Do not take Added and Creation dates from template

### DIFF
--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -152,8 +152,15 @@ func (s *service) createCustomTemplateState(templateId string) (targetState *sta
 			return
 		}
 
-		targetState.RemoveDetail(bundle.RelationKeyTargetObjectType.String(), bundle.RelationKeyTemplateIsBundled.String(), bundle.RelationKeyOrigin.String())
+		targetState.RemoveDetail(
+			bundle.RelationKeyTargetObjectType.String(),
+			bundle.RelationKeyTemplateIsBundled.String(),
+			bundle.RelationKeyOrigin.String(),
+			bundle.RelationKeyAddedDate.String(),
+		)
 		targetState.SetDetailAndBundledRelation(bundle.RelationKeySourceObject, pbtypes.String(sb.Id()))
+		// original created timestamp is used to set creationDate for imported objects, not for template-based objects
+		targetState.SetOriginalCreatedTimestamp(0)
 		targetState.SetLocalDetails(nil)
 		return
 	})

--- a/core/block/template/service_test.go
+++ b/core/block/template/service_test.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/commonspace/spacestorage"
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/converter"
@@ -219,6 +221,28 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 			assertLayoutBlocks(t, st, layout)
 		})
 	}
+
+	t.Run("do not inherit addedDate and creationDate", func(t *testing.T) {
+		// given
+		sometime := time.Now().Unix()
+
+		tmpl := smarttest.New(templateName)
+		tmpl.Doc.(*state.State).SetObjectTypeKeys([]domain.TypeKey{bundle.TypeKeyTemplate, bundle.TypeKeyBook})
+		tmpl.Doc.(*state.State).SetOriginalCreatedTimestamp(sometime)
+		err := tmpl.SetDetails(nil, []*model.Detail{{Key: bundle.RelationKeyAddedDate.String(), Value: pbtypes.Int64(sometime)}}, false)
+		require.NoError(t, err)
+		
+		s := service{picker: &testPicker{tmpl}}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateName, nil)
+
+		// then
+		assert.NoError(t, err)
+		assert.Zero(t, st.OriginalCreatedTimestamp())
+		assert.Zero(t, pbtypes.GetInt64(st.Details(), bundle.RelationKeyAddedDate.String()))
+		assert.Zero(t, pbtypes.GetInt64(st.Details(), bundle.RelationKeyCreatedDate.String()))
+	})
 }
 
 func assertLayoutBlocks(t *testing.T, st *state.State, layout model.ObjectTypeLayout) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3542/daily-journal-creation-date-is-wrong

We should not take AddedDate and CreationDate from template object