### PR TITLE
GO-3645: Add link settings to BlockListConvertToObjects

### DIFF
--- a/core/block/editor/basic/extract_objects.go
+++ b/core/block/editor/basic/extract_objects.go
@@ -118,9 +118,9 @@ func insertBlocksToState(
 	objState.Set(simple.New(rootB))
 }
 
-func (bs *basic) changeToBlockWithLink(newState *state.State, blockToChange simple.Block, objectID string, block *model.Block) (string, error) {
-	if block == nil {
-		block = &model.Block{
+func (bs *basic) changeToBlockWithLink(newState *state.State, blockToReplace simple.Block, objectID string, linkBlock *model.Block) (string, error) {
+	if linkBlock == nil {
+		linkBlock = &model.Block{
 			Content: &model.BlockContentOfLink{
 				Link: &model.BlockContentLink{
 					TargetBlockId: objectID,
@@ -129,16 +129,16 @@ func (bs *basic) changeToBlockWithLink(newState *state.State, blockToChange simp
 			},
 		}
 	} else {
-		link := block.GetLink()
+		link := linkBlock.GetLink()
 		if link == nil {
-			return "", errors.New("block content is not a link")
+			return "", errors.New("linkBlock content is not a link")
 		} else {
 			link.TargetBlockId = objectID
 		}
 	}
 	return bs.CreateBlock(newState, pb.RpcBlockCreateRequest{
-		TargetId: blockToChange.Model().Id,
-		Block:    block,
+		TargetId: blockToReplace.Model().Id,
+		Block:    linkBlock,
 		Position: model.Block_Replace,
 	})
 }

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -3939,6 +3939,7 @@ common simple block command
 | blockIds | [string](#string) | repeated |  |
 | objectTypeUniqueKey | [string](#string) |  |  |
 | templateId | [string](#string) |  |  |
+| block | [model.Block](#anytype-model-Block) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -4118,6 +4118,7 @@ message Rpc {
                 repeated string blockIds = 2;
                 string objectTypeUniqueKey = 3;
                 string templateId = 4;
+                anytype.model.Block block = 5;
             }
 
             message Response {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3645/add-link-settings-to-blocklistconverttoobjects

Add block param in request `BlockListConvertToObjects` and use it to create link block in given object