### PR TITLE
GO-3609 Anonymize link marks in text blocks

### DIFF
--- a/util/anonymize/anonymize.go
+++ b/util/anonymize/anonymize.go
@@ -103,6 +103,11 @@ func Event(e *pb.EventMessage) (res *pb.EventMessage) {
 	case *pb.EventMessageValueOfBlockSetText:
 		if v.BlockSetText.Text != nil {
 			v.BlockSetText.Text.Value = Text(v.BlockSetText.Text.Value)
+			if v.BlockSetText.Marks != nil && v.BlockSetText.Marks.Value != nil {
+				for i, mark := range v.BlockSetText.Marks.Value.Marks {
+					v.BlockSetText.Marks.Value.Marks[i].Param = Text(mark.Param)
+				}
+			}
 		}
 	case *pb.EventMessageValueOfBlockSetFile:
 		if v.BlockSetFile.Name != nil {

--- a/util/anonymize/anonymize_test.go
+++ b/util/anonymize/anonymize_test.go
@@ -34,6 +34,12 @@ func TestChange(t *testing.T) {
 								Content: &model.BlockContentOfText{
 									Text: &model.BlockContentText{
 										Text: "block create text",
+										Marks: &model.BlockContentTextMarks{
+											Marks: []*model.BlockContentTextMark{{
+												Param: "https://randomsite.com/kosilica",
+												Type:  model.BlockContentTextMark_Link,
+											}},
+										},
 									},
 								},
 							},
@@ -43,9 +49,18 @@ func TestChange(t *testing.T) {
 			},
 			changeUpdate(&pb.EventMessage{
 				Value: &pb.EventMessageValueOfBlockSetText{
-					BlockSetText: &pb.EventBlockSetText{Id: "text", Text: &pb.EventBlockSetTextText{
-						Value: "set text event",
-					}},
+					BlockSetText: &pb.EventBlockSetText{
+						Id: "text",
+						Text: &pb.EventBlockSetTextText{
+							Value: "set text event",
+						},
+						Marks: &pb.EventBlockSetTextMarks{Value: &model.BlockContentTextMarks{
+							Marks: []*model.BlockContentTextMark{{
+								Param: "https://randomsite.com/kosilica",
+								Type:  model.BlockContentTextMark_Link,
+							}},
+						}},
+					},
 				},
 			}),
 		},
@@ -62,14 +77,25 @@ func TestChange(t *testing.T) {
 	)
 	assert.NotEqual(
 		t,
+		in.Content[0].GetBlockCreate().Blocks[0].GetText().Marks.Marks[0].Param,
+		out.Content[0].GetBlockCreate().Blocks[0].GetText().Marks.Marks[0].Param,
+	)
+	assert.NotEqual(
+		t,
 		in.Content[1].GetBlockUpdate().Events[0].GetBlockSetText().Text,
 		out.Content[1].GetBlockUpdate().Events[0].GetBlockSetText().Text,
+	)
+	assert.NotEqual(
+		t,
+		in.Content[1].GetBlockUpdate().Events[0].GetBlockSetText().Marks.Value.Marks[0].Param,
+		out.Content[1].GetBlockUpdate().Events[0].GetBlockSetText().Marks.Value.Marks[0].Param,
 	)
 }
 
 func TestText(t *testing.T) {
 	in := "Some string with ютф. Symbols? http://123.com"
 	out := Text(in)
+	assert.NotEqual(t, in, out)
 	assert.Equal(t, text.UTF16RuneCountString(in), text.UTF16RuneCountString(out))
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3609/links-in-text-blocks-should-be-anonymized-in-debug-output

Make link marks of text blocks anonymized in a bunch of events on DebugTree