### PR TITLE
Fix sync bugs and notification object indexing

### DIFF
--- a/core/domain/syncstatus.go
+++ b/core/domain/syncstatus.go
@@ -14,6 +14,7 @@ const (
 	Syncing SpaceSyncStatus = 1
 	Error   SpaceSyncStatus = 2
 	Offline SpaceSyncStatus = 3
+	Unknown SpaceSyncStatus = 4
 )
 
 type ObjectSyncStatus int32

--- a/core/syncstatus/detailsupdater/updater.go
+++ b/core/syncstatus/detailsupdater/updater.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/editor/basic"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/syncstatus/detailsupdater/helper"
 	"github.com/anyproto/anytype-heart/core/syncstatus/filesyncstatus"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
@@ -250,6 +251,9 @@ func mapFileStatus(status filesyncstatus.Status) (domain.ObjectSyncStatus, domai
 }
 
 func (u *syncStatusUpdater) setSyncDetails(sb smartblock.SmartBlock, status domain.ObjectSyncStatus, syncError domain.SyncError) error {
+	if !slices.Contains(helper.SyncRelationsSmartblockTypes(), sb.Type()) {
+		return nil
+	}
 	if d, ok := sb.(basic.DetailsSettable); ok {
 		syncStatusDetails := []*model.Detail{
 			{

--- a/core/syncstatus/spacesyncstatus/filestate.go
+++ b/core/syncstatus/spacesyncstatus/filestate.go
@@ -79,7 +79,10 @@ func (f *FileState) SetSyncStatusAndErr(status domain.SpaceSyncStatus, syncErr d
 func (f *FileState) GetSyncStatus(spaceId string) domain.SpaceSyncStatus {
 	f.Lock()
 	defer f.Unlock()
-	return f.fileSyncStatusBySpace[spaceId]
+	if status, ok := f.fileSyncStatusBySpace[spaceId]; ok {
+		return status
+	}
+	return domain.Unknown
 }
 
 func (f *FileState) GetSyncObjectCount(spaceId string) int {

--- a/core/syncstatus/spacesyncstatus/filestate_test.go
+++ b/core/syncstatus/spacesyncstatus/filestate_test.go
@@ -56,7 +56,7 @@ func TestFileState_GetSyncStatus(t *testing.T) {
 		syncStatus := fileState.GetSyncStatus("spaceId")
 
 		// then
-		assert.Equal(t, domain.Synced, syncStatus)
+		assert.Equal(t, domain.Unknown, syncStatus)
 	})
 }
 

--- a/core/syncstatus/spacesyncstatus/mock_spacesyncstatus/mock_SpaceIdGetter.go
+++ b/core/syncstatus/spacesyncstatus/mock_spacesyncstatus/mock_SpaceIdGetter.go
@@ -158,51 +158,6 @@ func (_c *MockSpaceIdGetter_Name_Call) RunAndReturn(run func() string) *MockSpac
 	return _c
 }
 
-// PersonalSpaceId provides a mock function with given fields:
-func (_m *MockSpaceIdGetter) PersonalSpaceId() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for PersonalSpaceId")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// MockSpaceIdGetter_PersonalSpaceId_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PersonalSpaceId'
-type MockSpaceIdGetter_PersonalSpaceId_Call struct {
-	*mock.Call
-}
-
-// PersonalSpaceId is a helper method to define mock.On call
-func (_e *MockSpaceIdGetter_Expecter) PersonalSpaceId() *MockSpaceIdGetter_PersonalSpaceId_Call {
-	return &MockSpaceIdGetter_PersonalSpaceId_Call{Call: _e.mock.On("PersonalSpaceId")}
-}
-
-func (_c *MockSpaceIdGetter_PersonalSpaceId_Call) Run(run func()) *MockSpaceIdGetter_PersonalSpaceId_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSpaceIdGetter_PersonalSpaceId_Call) Return(_a0 string) *MockSpaceIdGetter_PersonalSpaceId_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockSpaceIdGetter_PersonalSpaceId_Call) RunAndReturn(run func() string) *MockSpaceIdGetter_PersonalSpaceId_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // TechSpaceId provides a mock function with given fields:
 func (_m *MockSpaceIdGetter) TechSpaceId() string {
 	ret := _m.Called()

--- a/core/syncstatus/spacesyncstatus/objectstate.go
+++ b/core/syncstatus/spacesyncstatus/objectstate.go
@@ -87,7 +87,10 @@ func (o *ObjectState) SetSyncStatusAndErr(status domain.SpaceSyncStatus, syncErr
 func (o *ObjectState) GetSyncStatus(spaceId string) domain.SpaceSyncStatus {
 	o.Lock()
 	defer o.Unlock()
-	return o.objectSyncStatusBySpace[spaceId]
+	if status, ok := o.objectSyncStatusBySpace[spaceId]; ok {
+		return status
+	}
+	return domain.Unknown
 }
 
 func (o *ObjectState) GetSyncObjectCount(spaceId string) int {

--- a/core/syncstatus/spacesyncstatus/objectstate_test.go
+++ b/core/syncstatus/spacesyncstatus/objectstate_test.go
@@ -55,7 +55,7 @@ func TestObjectState_GetSyncStatus(t *testing.T) {
 		syncStatus := objectState.GetSyncStatus("spaceId")
 
 		// then
-		assert.Equal(t, domain.Synced, syncStatus)
+		assert.Equal(t, domain.Unknown, syncStatus)
 	})
 }
 

--- a/core/syncstatus/spacesyncstatus/spacestatus.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus.go
@@ -26,7 +26,6 @@ type Updater interface {
 type SpaceIdGetter interface {
 	app.Component
 	TechSpaceId() string
-	PersonalSpaceId() string
 	AllSpaceIds() []string
 }
 
@@ -89,7 +88,7 @@ func (s *spaceSyncStatus) Run(ctx context.Context) (err error) {
 		close(s.finish)
 		return
 	} else {
-		s.sendStartEvent(s.spaceIdGetter.PersonalSpaceId())
+		s.sendStartEvent(s.spaceIdGetter.AllSpaceIds())
 	}
 	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
 	go s.processEvents()
@@ -106,14 +105,16 @@ func (s *spaceSyncStatus) sendEventToSession(spaceId, token string) {
 	})
 }
 
-func (s *spaceSyncStatus) sendStartEvent(spaceId string) {
-	s.eventSender.Broadcast(&pb.Event{
-		Messages: []*pb.EventMessage{{
-			Value: &pb.EventMessageValueOfSpaceSyncStatusUpdate{
-				SpaceSyncStatusUpdate: s.makeSpaceSyncEvent(spaceId),
-			},
-		}},
-	})
+func (s *spaceSyncStatus) sendStartEvent(spaceIds []string) {
+	for _, id := range spaceIds {
+		s.eventSender.Broadcast(&pb.Event{
+			Messages: []*pb.EventMessage{{
+				Value: &pb.EventMessageValueOfSpaceSyncStatusUpdate{
+					SpaceSyncStatusUpdate: s.makeSpaceSyncEvent(id),
+				},
+			}},
+		})
+	}
 }
 
 func (s *spaceSyncStatus) sendLocalOnlyEvent() {
@@ -183,7 +184,11 @@ func (s *spaceSyncStatus) isStatusNotChanged(status *domain.SpaceSync) bool {
 		return false
 	}
 	syncErrNotChanged := s.getError(status.SpaceId) == mapError(status.SyncError)
-	statusNotChanged := s.getSpaceSyncStatus(status.SpaceId) == status.Status
+	syncStatus := s.getSpaceSyncStatus(status.SpaceId)
+	if syncStatus == domain.Unknown {
+		return false
+	}
+	statusNotChanged := syncStatus == status.Status
 	if syncErrNotChanged && statusNotChanged {
 		return true
 	}
@@ -221,6 +226,9 @@ func (s *spaceSyncStatus) getSpaceSyncStatus(spaceId string) domain.SpaceSyncSta
 	filesStatus := s.filesState.GetSyncStatus(spaceId)
 	objectsStatus := s.objectsState.GetSyncStatus(spaceId)
 
+	if s.isUnknown(filesStatus, objectsStatus) {
+		return domain.Unknown
+	}
 	if s.isOfflineStatus(filesStatus, objectsStatus) {
 		return domain.Offline
 	}
@@ -274,6 +282,10 @@ func (s *spaceSyncStatus) getError(spaceId string) pb.EventSpaceSyncError {
 	}
 
 	return pb.EventSpace_Null
+}
+
+func (s *spaceSyncStatus) isUnknown(filesStatus domain.SpaceSyncStatus, objectsStatus domain.SpaceSyncStatus) bool {
+	return filesStatus == domain.Unknown && objectsStatus == domain.Unknown
 }
 
 func mapNetworkMode(mode pb.RpcAccountNetworkMode) pb.EventSpaceNetwork {

--- a/pkg/lib/core/smartblock/smartblock.go
+++ b/pkg/lib/core/smartblock/smartblock.go
@@ -68,7 +68,7 @@ func (sbt SmartBlockType) IsOneOf(sbts ...SmartBlockType) bool {
 // Indexable determines if the object of specific type need to be proceeded by the indexer in order to appear in sets
 func (sbt SmartBlockType) Indexable() (details, outgoingLinks bool) {
 	switch sbt {
-	case SmartBlockTypeDate, SmartBlockTypeAccountOld, SmartBlockTypeArchive, SmartBlockTypeHome:
+	case SmartBlockTypeDate, SmartBlockTypeAccountOld, SmartBlockTypeArchive, SmartBlockTypeHome, SmartBlockTypeNotificationObject:
 		return false, false
 	case SmartBlockTypeWidget:
 		return true, false


### PR DESCRIPTION
1. Don't add sync relations to system objects
2. Send space sync event for all objects at start
3. Send sync status event if status is unknown
4. Not index notification object