### PR TITLE
GO-3645: Add link settings to BlockListConvertToObjects

### DIFF
--- a/core/block/editor/basic/extract_objects.go
+++ b/core/block/editor/basic/extract_objects.go
@@ -136,9 +136,10 @@ func (bs *basic) changeToBlockWithLink(newState *state.State, blockToReplace sim
 			link.TargetBlockId = objectID
 		}
 	}
+	linkBlockCopy := pbtypes.CopyBlock(linkBlock)
 	return bs.CreateBlock(newState, pb.RpcBlockCreateRequest{
 		TargetId: blockToReplace.Model().Id,
-		Block:    linkBlock,
+		Block:    linkBlockCopy,
 		Position: model.Block_Replace,
 	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3645/add-link-settings-to-blocklistconverttoobjects

Add fix for editing multiple blocks and following problem, when returned events contain the same blocks

![image](https://github.com/anyproto/anytype-heart/assets/36507473/04d4c483-fabf-4967-b5af-45e46b509c57)
