### PR TITLE
GO-3561 Apply changes for dep subs

### DIFF
--- a/core/subscription/collection.go
+++ b/core/subscription/collection.go
@@ -153,6 +153,10 @@ func (c *collectionSub) hasDep() bool {
 	return c.sortedSub.hasDep()
 }
 
+func (c *collectionSub) getDep() subscription {
+	return c.sortedSub.depSub
+}
+
 func (c *collectionSub) close() {
 	c.observer.close()
 	c.sortedSub.close()

--- a/core/subscription/group.go
+++ b/core/subscription/group.go
@@ -123,6 +123,10 @@ func (gs *groupSub) hasDep() bool {
 	return false
 }
 
+func (gs *groupSub) getDep() subscription {
+	return nil
+}
+
 func (gs *groupSub) close() {
 	for id := range gs.set {
 		gs.cache.RemoveSubId(id, gs.id)

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -56,6 +56,7 @@ type subscription interface {
 	onChange(ctx *opCtx)
 	getActiveRecords() (res []*types.Struct)
 	hasDep() bool
+	getDep() subscription
 	close()
 }
 
@@ -484,6 +485,7 @@ func (s *service) onChange(entries []*entry) time.Duration {
 		sub.onChange(s.ctxBuf)
 		subCount++
 		if sub.hasDep() {
+			sub.getDep().onChange(s.ctxBuf)
 			depCount++
 		}
 	}

--- a/core/subscription/simple.go
+++ b/core/subscription/simple.go
@@ -133,6 +133,10 @@ func (s *simpleSub) hasDep() bool {
 	return s.depSub != nil
 }
 
+func (s *simpleSub) getDep() subscription {
+	return s.depSub
+}
+
 func (s *simpleSub) close() {
 	for id := range s.set {
 		s.cache.RemoveSubId(id, s.id)

--- a/core/subscription/sorted.go
+++ b/core/subscription/sorted.go
@@ -373,6 +373,10 @@ func (s *sortedSub) hasDep() bool {
 	return s.depSub != nil
 }
 
+func (s *sortedSub) getDep() subscription {
+	return s.depSub
+}
+
 func (s *sortedSub) close() {
 	el := s.skl.Front()
 	for el != nil {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3561/the-checkbox-does-not-work-in-the-sets-in-some-relations

Changes coming to Subscription Service listener were not applying for entries of **/dep** subscriptions, because we were not iterating over them