### PR TITLE
GO-3757 graceful shutdown for long objectstore queries

### DIFF
--- a/pkg/lib/localstore/objectstore/fixture.go
+++ b/pkg/lib/localstore/objectstore/fixture.go
@@ -53,6 +53,7 @@ func NewStoreFixture(t *testing.T) *StoreFixture {
 		fts:           fullText,
 		sourceService: &detailsFromId{},
 		db:            db,
+		isClosingCh:   make(chan struct{}),
 	}
 	err = ds.initCache()
 	require.NoError(t, err)

--- a/pkg/lib/localstore/objectstore/links.go
+++ b/pkg/lib/localstore/objectstore/links.go
@@ -17,6 +17,9 @@ type LinksUpdateInfo struct {
 func (s *dsObjectStore) GetWithLinksInfoByID(spaceID string, id string) (*model.ObjectInfoWithLinks, error) {
 	var res *model.ObjectInfoWithLinks
 	err := s.db.View(func(txn *badger.Txn) error {
+		s.runningQueriesWG.Add(1)
+		defer s.runningQueriesWG.Done()
+
 		pages, err := s.getObjectsInfo(txn, spaceID, []string{id})
 		if err != nil {
 			return err
@@ -62,6 +65,8 @@ func (s *dsObjectStore) GetWithLinksInfoByID(spaceID string, id string) (*model.
 func (s *dsObjectStore) GetOutboundLinksByID(id string) ([]string, error) {
 	var links []string
 	err := s.db.View(func(txn *badger.Txn) error {
+		s.runningQueriesWG.Add(1)
+		defer s.runningQueriesWG.Done()
 		var err error
 		links, err = findOutboundLinks(txn, id)
 		return err
@@ -72,6 +77,8 @@ func (s *dsObjectStore) GetOutboundLinksByID(id string) ([]string, error) {
 func (s *dsObjectStore) GetInboundLinksByID(id string) ([]string, error) {
 	var links []string
 	err := s.db.View(func(txn *badger.Txn) error {
+		s.runningQueriesWG.Add(1)
+		defer s.runningQueriesWG.Done()
 		var err error
 		links, err = findInboundLinks(txn, id)
 		return err

--- a/pkg/lib/localstore/objectstore/objects.go
+++ b/pkg/lib/localstore/objectstore/objects.go
@@ -31,6 +31,7 @@ import (
 
 var log = logging.Logger("anytype-localstore")
 var ErrDetailsNotChanged = errors.New("details not changed")
+var ErrStoreIsClosing = errors.New("store is closing")
 
 const CName = "objectstore"
 
@@ -60,7 +61,7 @@ var (
 )
 
 func New() ObjectStore {
-	return &dsObjectStore{}
+	return &dsObjectStore{isClosingCh: make(chan struct{})}
 }
 
 type SourceDetailsFromID interface {
@@ -191,8 +192,10 @@ var ErrNotAnObject = fmt.Errorf("not an object")
 type dsObjectStore struct {
 	sourceService SourceDetailsFromID
 
-	cache *lru.Cache[string, *model.ObjectDetails]
-	db    *badger.DB
+	runningQueriesWG sync.WaitGroup
+	isClosingCh      chan struct{}
+	cache            *lru.Cache[string, *model.ObjectDetails]
+	db               *badger.DB
 
 	fts ftsearch.FTSearch
 
@@ -207,6 +210,10 @@ func (s *dsObjectStore) Run(context.Context) (err error) {
 }
 
 func (s *dsObjectStore) Close(_ context.Context) (err error) {
+	close(s.isClosingCh)
+	// wait long queries with iterator to gracefully finish,
+	// otherwise, closing the db may cause panics in iterators in badger
+	s.runningQueriesWG.Wait()
 	return nil
 }
 
@@ -344,6 +351,8 @@ func (s *dsObjectStore) ListIdsBySpace(spaceId string) ([]string, error) {
 func (s *dsObjectStore) ListIds() ([]string, error) {
 	var ids []string
 	err := s.db.View(func(txn *badger.Txn) error {
+		s.runningQueriesWG.Add(1)
+		defer s.runningQueriesWG.Done()
 		var err error
 		ids, err = listIDsByPrefix(txn, pagesDetailsBase.Bytes())
 		return err


### PR DESCRIPTION
- add `isClosingCh` for the objectstore
- add waitgroup for store queries that are using iterator
- fail long queries fast when `isClosingCh` is closed. (not possible for all queries, requires refactoring)
- wait all queries to finish on objectStore close