### PR TITLE
GO-3674 Create file object on copying block to other space

### DIFF
--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -19,6 +19,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/simple"
 	"github.com/anyproto/anytype-heart/core/block/simple/text"
 	"github.com/anyproto/anytype-heart/core/converter/html"
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/domain/objectorigin"
 	"github.com/anyproto/anytype-heart/core/files"
 	"github.com/anyproto/anytype-heart/core/files/fileobject"
@@ -386,6 +387,9 @@ func (cb *clipboard) pasteAny(
 				return
 			}
 		}
+		if f, ok := b.Content.(*model.BlockContentOfFile); ok {
+			cb.processFileBlock(f)
+		}
 	}
 	srcState := cb.blocksToState(req.AnySlot)
 	visited := map[string]struct{}{}
@@ -583,6 +587,34 @@ func (cb *clipboard) addRelationLinksToDataview(d *model.BlockContentDataview) (
 
 func (cb *clipboard) newHTMLConverter(s *state.State) *html.HTML {
 	return html.NewHTMLConverter(cb.fileService, s, cb.fileObjectService)
+}
+
+func (cb *clipboard) processFileBlock(f *model.BlockContentOfFile) {
+	if cb.fileObjectService == nil {
+		log.Errorf("file object service is not initialized")
+		return
+	}
+
+	fileId, err := cb.fileObjectService.GetFileIdFromObject(f.File.TargetObjectId)
+	if err != nil {
+		log.Errorf("failed to get fileId: %v", err)
+		return
+	}
+
+	if cb.SpaceID() == fileId.SpaceId {
+		return
+	}
+
+	objectId, err := cb.fileObjectService.CreateFromImport(
+		domain.FullFileId{SpaceId: cb.SpaceID(), FileId: fileId.FileId},
+		objectorigin.ObjectOrigin{Origin: model.ObjectOrigin_clipboard},
+	)
+	if err != nil {
+		log.Errorf("failed to create file object: %v", err)
+		return
+	}
+
+	f.File.TargetObjectId = objectId
 }
 
 func renderText(s *state.State, ignoreStyle bool) string {

--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -590,11 +590,6 @@ func (cb *clipboard) newHTMLConverter(s *state.State) *html.HTML {
 }
 
 func (cb *clipboard) processFileBlock(f *model.BlockContentOfFile) {
-	if cb.fileObjectService == nil {
-		log.Errorf("file object service is not initialized")
-		return
-	}
-
 	fileId, err := cb.fileObjectService.GetFileIdFromObject(f.File.TargetObjectId)
 	if err != nil {
 		log.Errorf("failed to get fileId: %v", err)

--- a/core/block/editor/clipboard/clipboard_helpers_test.go
+++ b/core/block/editor/clipboard/clipboard_helpers_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
 	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/files/fileobject/mock_fileobject"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 
@@ -216,7 +218,9 @@ func checkBlockMarksDebug(t *testing.T, sb *smarttest.SmartTest, marksArr [][]*m
 func newFixture(t *testing.T, sb smartblock.SmartBlock) Clipboard {
 	file := file.NewMockFile(t)
 	file.EXPECT().UploadState(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
-	return NewClipboard(sb, file, nil, nil, nil, nil)
+	fos := mock_fileobject.NewMockService(t)
+	fos.EXPECT().GetFileIdFromObject(mock.Anything).Return(domain.FullFileId{}, fmt.Errorf("no fileId")).Maybe()
+	return NewClipboard(sb, file, nil, nil, nil, fos)
 }
 
 func pasteAny(t *testing.T, sb *smarttest.SmartTest, id string, textRange model.Range, selectedBlockIds []string, blocks []*model.Block) ([]string, bool) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3674/copy-file-blocks-between-spaces

On copying file blocks from one space to another we should create new file object with same hash and keys