### PR TITLE
GO-3762 Add links as dependents

### DIFF
--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -109,7 +109,6 @@ var ignoredKeys = map[string]struct{}{
 	bundle.RelationKeyId.String():                {},
 	bundle.RelationKeySpaceId.String():           {}, // relation format for spaceId has mistakenly set to Object instead of shorttext
 	bundle.RelationKeyFeaturedRelations.String(): {}, // relation format for featuredRelations has mistakenly set to Object instead of shorttext
-	bundle.RelationKeyLinks.String():             {}, // skip links because it's aggregated from other relations and blocks
 }
 
 func (ds *dependencyService) isRelationObject(key string) bool {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3762/links-are-not-displayed-in-objects-of-set

We should add Links in a list of relations dependent subscription is built on, because links include not only objects mentioned in details, but also objects mentioned in blocks