### PR TITLE
GO-3635 Inject links along with derived relations + some smartblock refactoring

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -1087,7 +1087,7 @@ func TestClipboard_TitleOps(t *testing.T) {
 	t.Run("do not paste if Blocks restriction is set to smartblock", func(t *testing.T) {
 		// given
 		sb := smarttest.New("test")
-		sb.SetRestrictions(restriction.Restrictions{Object: restriction.ObjectRestrictions{model.Restrictions_Blocks}})
+		sb.TestRestrictions = restriction.Restrictions{Object: restriction.ObjectRestrictions{model.Restrictions_Blocks}}
 		cb := newFixture(t, sb)
 
 		// when

--- a/core/block/editor/file/file_test.go
+++ b/core/block/editor/file/file_test.go
@@ -110,7 +110,7 @@ func TestDropFiles(t *testing.T) {
 	t.Run("do not drop files to object with Blocks restriction", func(t *testing.T) {
 		// given
 		fx := newFixture(t)
-		fx.sb.SetRestrictions(restriction.Restrictions{Object: restriction.ObjectRestrictions{model.Restrictions_Blocks}})
+		fx.sb.TestRestrictions = restriction.Restrictions{Object: restriction.ObjectRestrictions{model.Restrictions_Blocks}}
 
 		// when
 		err := fx.sfile.DropFiles(pb.RpcFileDropRequest{})

--- a/core/block/editor/smartblock/links.go
+++ b/core/block/editor/smartblock/links.go
@@ -29,8 +29,6 @@ func (sb *smartBlock) updateBackLinks(s *state.State) {
 func (sb *smartBlock) injectLinksDetails(s *state.State) {
 	links := sb.navigationalLinks(s)
 	links = slice.RemoveMut(links, sb.Id())
-
-	// todo: we need to move it to the injectDerivedDetails, but we don't call it now on apply
 	s.SetLocalDetail(bundle.RelationKeyLinks.String(), pbtypes.StringList(links))
 }
 

--- a/core/block/editor/smartblock/smarttest/smarttest.go
+++ b/core/block/editor/smartblock/smarttest/smarttest.go
@@ -175,10 +175,6 @@ func (st *SmartTest) Tree() objecttree.ObjectTree {
 	return st.objectTree
 }
 
-func (st *SmartTest) SetRestrictions(r restriction.Restrictions) {
-	st.TestRestrictions = r
-}
-
 func (st *SmartTest) Restrictions() restriction.Restrictions {
 	return st.TestRestrictions
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3635/update-backlinks-reactively-in-the-objectstore

StateAppend did not update links of smartblock, as injectLinks was not called explicitly. Now injectLinks is called inside injectDerivedDetails, so changes are applied for objects on other devices even if they are not uploaded in cache.

Additionally some refactoring in smartblock pkg is made. Details are in the code comments