### PR TITLE
GO-3777 Fix convert for templates

### DIFF
--- a/core/block/editor/basic/extract_objects.go
+++ b/core/block/editor/basic/extract_objects.go
@@ -7,6 +7,7 @@ import (
 	"github.com/globalsign/mgo/bson"
 	"github.com/gogo/protobuf/types"
 
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/simple"
 	"github.com/anyproto/anytype-heart/core/domain"
@@ -23,6 +24,7 @@ type ObjectCreator interface {
 
 type TemplateStateCreator interface {
 	CreateTemplateStateWithDetails(templateId string, details *types.Struct) (*state.State, error)
+	CreateTemplateStateFromSmartBlock(sb smartblock.SmartBlock, details *types.Struct) *state.State
 }
 
 // ExtractBlocksToObjects extracts child blocks from the object to separate objects and
@@ -80,6 +82,11 @@ func (bs *basic) prepareObjectState(
 	if err != nil {
 		return nil, fmt.Errorf("prepare target details: %w", err)
 	}
+
+	if req.ContextId == req.TemplateId {
+		return creator.CreateTemplateStateFromSmartBlock(bs, details), nil
+	}
+
 	return creator.CreateTemplateStateWithDetails(req.TemplateId, details)
 }
 

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -124,6 +124,7 @@ type builtinObjects interface {
 
 type templateService interface {
 	CreateTemplateStateWithDetails(templateId string, details *types.Struct) (*state.State, error)
+	CreateTemplateStateFromSmartBlock(sb smartblock.SmartBlock, details *types.Struct) *state.State
 }
 
 type openedObjects struct {

--- a/core/block/template/service_test.go
+++ b/core/block/template/service_test.go
@@ -232,7 +232,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 		tmpl.Doc.(*state.State).SetOriginalCreatedTimestamp(sometime)
 		err := tmpl.SetDetails(nil, []*model.Detail{{Key: bundle.RelationKeyAddedDate.String(), Value: pbtypes.Int64(sometime)}}, false)
 		require.NoError(t, err)
-		
+
 		s := service{picker: &testPicker{tmpl}}
 
 		// when
@@ -243,6 +243,36 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 		assert.Zero(t, st.OriginalCreatedTimestamp())
 		assert.Zero(t, pbtypes.GetInt64(st.Details(), bundle.RelationKeyAddedDate.String()))
 		assert.Zero(t, pbtypes.GetInt64(st.Details(), bundle.RelationKeyCreatedDate.String()))
+	})
+}
+
+func TestCreateTemplateStateFromSmartBlock(t *testing.T) {
+	t.Run("if failed to build state -> return blank template", func(t *testing.T) {
+		// given
+		s := service{converter: converter.NewLayoutConverter()}
+
+		// when
+		st := s.CreateTemplateStateFromSmartBlock(nil, &types.Struct{Fields: map[string]*types.Value{
+			bundle.RelationKeyLayout.String(): pbtypes.Int64(int64(model.ObjectType_todo)),
+		}})
+
+		// then
+		assert.Equal(t, BlankTemplateId, st.RootId())
+		assert.Contains(t, pbtypes.GetStringList(st.Details(), bundle.RelationKeyFeaturedRelations.String()), bundle.RelationKeyTag.String())
+		assert.True(t, pbtypes.Exists(st.Details(), bundle.RelationKeyTag.String()))
+	})
+
+	t.Run("create state from template smartblock", func(t *testing.T) {
+		// given
+		tmpl := NewTemplateTest("template", bundle.TypeKeyProject.String())
+		s := service{}
+
+		// when
+		st := s.CreateTemplateStateFromSmartBlock(tmpl, nil)
+
+		// then
+		assert.Equal(t, "template", pbtypes.GetString(st.Details(), bundle.RelationKeyName.String()))
+		assert.Equal(t, "template", pbtypes.GetString(st.Details(), bundle.RelationKeyDescription.String()))
 	})
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3777/the-template-breaks-after-turn-into-object-in-the-template-editor

In case we are trying to convert blocks of template into objects and this template is chosen as basis for new blocks, app meets deadlock, because we are taking lock on template's smartblock twice.

I introduce new method of template service **CreateTemplateStateFromSmartBlock** that accepts smartblock directly as an argument and therefore does not need to take lock one more time