### PR TITLE
GO-3779 Allow description in notes

### DIFF
--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -185,7 +185,6 @@ func (p *Page) CreationStateMigration(ctx *smartblock.InitContext) migration.Mig
 					template.WithNameToFirstBlock,
 					template.WithFirstTextBlock,
 					template.WithNoTitle,
-					template.WithNoDescription,
 				)
 			case model.ObjectType_todo:
 				templates = append(templates,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3779/the-description-disappears-from-featured-relations-after-creating-an

CreationMigration wipes description from state. It seems we should remove this logic to allow descriptions in notes