### PR TITLE
GO-3849 Fix IsEmpty for sets

### DIFF
--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -1385,7 +1385,8 @@ func (s *State) IsEmpty(checkTitle bool) bool {
 	return true
 }
 
-// isEmptyDataview is a separate emptiness check for sets and collections, as
+// isEmptyDataview is a separate emptiness check for sets and collections,
+// as changes on object are done upon dataview block, not text one
 func (s *State) isEmptyDataview() bool {
 	details := s.Details()
 

--- a/core/block/editor/state/state_test.go
+++ b/core/block/editor/state/state_test.go
@@ -435,6 +435,52 @@ func TestState_IsEmpty(t *testing.T) {
 		assert.False(t, s.IsEmpty(true))
 		assert.False(t, s.IsEmpty(false))
 	})
+
+	t.Run("with empty title block and filled child block", func(t *testing.T) {
+		s := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{
+				Id:          "root",
+				ChildrenIds: []string{"header", "text"},
+			}),
+			"header": simple.New(&model.Block{Id: "header", ChildrenIds: []string{"title"}}),
+			"title": simple.New(&model.Block{Id: "title",
+				Content: &model.BlockContentOfText{
+					Text: &model.BlockContentText{Marks: &model.BlockContentTextMarks{}},
+				}}),
+			"text": simple.New(&model.Block{Id: "text",
+				Content: &model.BlockContentOfText{
+					Text: &model.BlockContentText{Marks: &model.BlockContentTextMarks{}, Text: "1"},
+				}}),
+		}).(*State)
+
+		assert.False(t, s.IsEmpty(true))
+		assert.False(t, s.IsEmpty(false))
+	})
+
+	t.Run("with empty name and not empty dataview", func(t *testing.T) {
+		s := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{
+				Id:          "root",
+				ChildrenIds: []string{"header", "dataview"},
+			}),
+			"header": simple.New(&model.Block{Id: "header", ChildrenIds: []string{"title"}}),
+			"title": simple.New(&model.Block{Id: "title",
+				Content: &model.BlockContentOfText{
+					Text: &model.BlockContentText{Marks: &model.BlockContentTextMarks{}},
+				}}),
+			"dataview": simple.New(&model.Block{Id: "text",
+				Content: &model.BlockContentOfDataview{
+					Dataview: &model.BlockContentDataview{Views: []*model.BlockContentDataviewView{{
+						Id:                "All",
+						DefaultTemplateId: "templateId",
+					}}},
+				}}),
+		}).(*State)
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_set)))
+
+		assert.False(t, s.IsEmpty(true))
+		assert.False(t, s.IsEmpty(false))
+	})
 }
 
 func TestState_Descendants(t *testing.T) {

--- a/core/block/simple/dataview/dataview.go
+++ b/core/block/simple/dataview/dataview.go
@@ -545,6 +545,6 @@ func (d *Dataview) HasEmptyContent() bool {
 		view.Type != model.BlockContentDataviewView_Table {
 		return false
 	}
-	
+
 	return true
 }

--- a/core/block/simple/dataview/dataview.go
+++ b/core/block/simple/dataview/dataview.go
@@ -86,6 +86,8 @@ type Block interface {
 	RemoveViewRelations(viewID string, relationKeys []string) error
 	ReplaceViewRelation(viewID string, relationKey string, relation *model.BlockContentDataviewRelation) error
 	ReorderViewRelations(viewID string, relationKeys []string) error
+
+	HasEmptyContent() bool
 }
 
 type Dataview struct {
@@ -519,4 +521,30 @@ func (s *Dataview) UpdateRelationOld(relationKey string, rel model.Relation) err
 
 func (d *Dataview) IsEmpty() bool {
 	return d.content.TargetObjectId == "" && len(d.content.Views) == 0
+}
+
+func (d *Dataview) HasEmptyContent() bool {
+	if d.content == nil {
+		return true
+	}
+
+	var view *model.BlockContentDataviewView
+	switch len(d.content.Views) {
+	case 0:
+		return true
+	case 1:
+		view = d.content.Views[0]
+	default:
+		return false
+	}
+
+	if view.DefaultObjectTypeId != "" ||
+		view.DefaultTemplateId != "" ||
+		len(view.Filters) != 0 ||
+		len(view.Sorts) > 1 ||
+		view.Type != model.BlockContentDataviewView_Table {
+		return false
+	}
+	
+	return true
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3849/need-to-save-the-setcollection-if-you-have-not-entered-a-name

DeleteIfEmpty internal flag is unset on state.IsEmpty returning false. However this check analyzes only text block contents.
Sets and collections have only standard blocks, so separate logic to check object emptiness must be supported