### PR TITLE
[release 6] GO-3737 - Fix type reinstall

### DIFF
--- a/core/block/editor/archive_test.go
+++ b/core/block/editor/archive_test.go
@@ -17,7 +17,7 @@ func NewArchiveTest(ctrl *gomock.Controller) (*Archive, error) {
 	sb := smarttest.New("root")
 	objectStore := testMock.NewMockObjectStore(ctrl)
 	objectStore.EXPECT().GetDetails(gomock.Any()).AnyTimes()
-	objectStore.EXPECT().Query(gomock.Any()).AnyTimes()
+	objectStore.EXPECT().QueryRaw(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	a := &Archive{
 		SmartBlock:  sb,
 		Collection:  collection.NewCollection(sb, objectStore),

--- a/core/block/object/objectcreator/installer.go
+++ b/core/block/object/objectcreator/installer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/anyproto/any-sync/commonspace/object/tree/treestorage"
 	"github.com/gogo/protobuf/types"
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/objecttype"
@@ -165,15 +164,6 @@ func (s *service) reinstallBundledObjects(ctx context.Context, sourceSpace clien
 		return nil, nil, fmt.Errorf("query deleted objects: %w", err)
 	}
 
-	archivedObjects, err := s.queryArchivedObjects(space, sourceObjectIDs)
-	if err != nil {
-		log.Errorf("query archived objects: %w", err)
-	}
-
-	deletedObjects = lo.UniqBy(append(deletedObjects, archivedObjects...), func(record database.Record) string {
-		return pbtypes.GetString(record.Details, bundle.RelationKeyId.String())
-	})
-
 	var (
 		ids     []string
 		objects []*types.Struct
@@ -279,48 +269,32 @@ func (s *service) prepareDetailsForInstallingObject(
 	return details, nil
 }
 
-func (s *service) queryDeletedObjects(space clientspace.Space, sourceObjectIDs []string) (deletedObjects []database.Record, err error) {
-	deletedObjects, err = s.objectStore.Query(database.Query{
-		Filters: []*model.BlockContentDataviewFilter{
-			{
-				RelationKey: bundle.RelationKeySourceObject.String(),
-				Condition:   model.BlockContentDataviewFilter_In,
-				Value:       pbtypes.StringList(sourceObjectIDs),
+func (s *service) queryDeletedObjects(space clientspace.Space, sourceObjectIDs []string) ([]database.Record, error) {
+	sourceList, err := pbtypes.ValueListWrapper(pbtypes.StringList(sourceObjectIDs))
+	if err != nil {
+		return nil, err
+	}
+	return s.objectStore.QueryRaw(&database.Filters{FilterObj: database.FiltersAnd{
+		database.FilterIn{
+			Key:   bundle.RelationKeySourceObject.String(),
+			Value: sourceList,
+		},
+		database.FilterEq{
+			Key:   bundle.RelationKeySpaceId.String(),
+			Cond:  model.BlockContentDataviewFilter_Equal,
+			Value: pbtypes.String(space.Id()),
+		},
+		database.FiltersOr{
+			database.FilterEq{
+				Key:   bundle.RelationKeyIsDeleted.String(),
+				Cond:  model.BlockContentDataviewFilter_Equal,
+				Value: pbtypes.Bool(true),
 			},
-			{
-				RelationKey: bundle.RelationKeySpaceId.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.String(space.Id()),
-			},
-			{
-				RelationKey: bundle.RelationKeyIsDeleted.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.Bool(true),
+			database.FilterEq{
+				Key:   bundle.RelationKeyIsArchived.String(),
+				Cond:  model.BlockContentDataviewFilter_Equal,
+				Value: pbtypes.Bool(true),
 			},
 		},
-	})
-	return
-}
-
-func (s *service) queryArchivedObjects(space clientspace.Space, sourceObjectIDs []string) (archivedObjects []database.Record, err error) {
-	archivedObjects, err = s.objectStore.Query(database.Query{
-		Filters: []*model.BlockContentDataviewFilter{
-			{
-				RelationKey: bundle.RelationKeySourceObject.String(),
-				Condition:   model.BlockContentDataviewFilter_In,
-				Value:       pbtypes.StringList(sourceObjectIDs),
-			},
-			{
-				RelationKey: bundle.RelationKeySpaceId.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.String(space.Id()),
-			},
-			{
-				RelationKey: bundle.RelationKeyIsArchived.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.Bool(true),
-			},
-		},
-	})
-	return
+	}}, 0, 0)
 }

--- a/core/block/object/objectcreator/installer_test.go
+++ b/core/block/object/objectcreator/installer_test.go
@@ -1,0 +1,72 @@
+package objectcreator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+type objKey interface {
+	URL() string
+	BundledURL() string
+}
+
+func TestInstaller_queryDeletedObjects(t *testing.T) {
+	// given
+	var (
+		spaceId         = "spaceId"
+		sourceObjectIds = []string{}
+		validObjectIds  = []string{}
+	)
+
+	store := objectstore.NewStoreFixture(t)
+
+	for _, obj := range []struct {
+		isDeleted, isArchived bool
+		spaceId               string
+		key                   objKey
+	}{
+		{false, false, spaceId, bundle.TypeKeyGoal},
+		{false, false, spaceId, bundle.RelationKeyGenre},
+		{true, false, spaceId, bundle.TypeKeyDailyPlan},
+		{true, false, spaceId, bundle.RelationKeyLinkedProjects},
+		{false, true, spaceId, bundle.TypeKeyBook},
+		{false, true, spaceId, bundle.RelationKeyStarred},
+		{true, true, spaceId, bundle.TypeKeyProject},    // not valid, but we should handle this
+		{true, true, spaceId, bundle.RelationKeyArtist}, // not valid, but we should handle this
+		{false, true, "otherSpaceId", bundle.TypeKeyDiaryEntry},
+		{true, false, "otherSpaceId", bundle.RelationKeyComposer},
+	} {
+		store.AddObjects(t, []objectstore.TestObject{{
+			bundle.RelationKeyId:           pbtypes.String(obj.key.URL()),
+			bundle.RelationKeySpaceId:      pbtypes.String(obj.spaceId),
+			bundle.RelationKeySourceObject: pbtypes.String(obj.key.BundledURL()),
+			bundle.RelationKeyIsDeleted:    pbtypes.Bool(obj.isDeleted),
+			bundle.RelationKeyIsArchived:   pbtypes.Bool(obj.isArchived),
+		}})
+		sourceObjectIds = append(sourceObjectIds, obj.key.BundledURL())
+		if obj.spaceId == spaceId && (obj.isDeleted || obj.isArchived) {
+			validObjectIds = append(validObjectIds, obj.key.URL())
+		}
+	}
+
+	spc := mock_clientspace.NewMockSpace(t)
+	spc.EXPECT().Id().Return(spaceId)
+
+	s := service{objectStore: store}
+
+	// when
+	records, err := s.queryDeletedObjects(spc, sourceObjectIds)
+
+	// then
+	assert.NoError(t, err)
+	assert.Len(t, records, 6)
+	for _, det := range records {
+		assert.Contains(t, validObjectIds, pbtypes.GetString(det.Details, bundle.RelationKeyId.String()))
+	}
+}

--- a/pkg/lib/localstore/objectstore/objects.go
+++ b/pkg/lib/localstore/objectstore/objects.go
@@ -111,6 +111,7 @@ type ObjectStore interface {
 
 	SubscribeForAll(callback func(rec database.Record))
 
+	// Query adds implicit filters on isArchived, isDeleted and objectType relations! To avoid them use QueryRaw
 	Query(q database.Query) (records []database.Record, err error)
 
 	QueryRaw(f *database.Filters, limit int, offset int) (records []database.Record, err error)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3737/after-deleting-the-type-it-is-not-installed

Fix type reinstallation. The error was connected with implicit addition of isDeleted and isArchived filters to db query