### PR TITLE
GO-3865 Fix panic on analytics insert

### DIFF
--- a/cmd/usecasevalidator/main.go
+++ b/cmd/usecasevalidator/main.go
@@ -436,6 +436,9 @@ func validate(snapshot *pb.SnapshotWithType, info *useCaseInfo) (err error) {
 }
 
 func insertAnalyticsData(s *pb.ChangeSnapshot, info *useCaseInfo) {
+	if s == nil || s.Data == nil || len(s.Data.Blocks) == 0 {
+		return
+	}
 	root := s.Data.Blocks[0]
 	id := pbtypes.GetString(s.Data.Details, bundle.RelationKeyId.String())
 	f := root.GetFields().GetFields()


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3865/provide-name-of-use-case-from-gallery-for-imported-with-use-case

We do not check state and its blocks on nil, that's why usecase validator paniced sometimes