### PR TITLE
GO-3849 Do not GC set if source is set

### DIFF
--- a/core/block/service.go
+++ b/core/block/service.go
@@ -528,7 +528,13 @@ func (s *Service) SetSource(ctx session.Context, req pb.RpcObjectSetSourceReques
 			return true
 		})
 		st.SetDetailAndBundledRelation(bundle.RelationKeySetOf, pbtypes.StringList(req.Source))
-		return sb.Apply(st, smartblock.NoRestrictions)
+
+		flags := internalflag.NewFromState(st)
+		// set with source is no longer empty
+		flags.Remove(model.InternalFlag_editorDeleteEmpty)
+		flags.AddToState(st)
+
+		return sb.Apply(st, smartblock.NoRestrictions, smartblock.KeepInternalFlags)
 	})
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3849/need-to-save-the-setcollection-if-you-have-not-entered-a-name

We need to unset DeleteIfEmpty flag in case source of set is set