### PR TITLE
GO-3813 Set lastUsedDate for relations

### DIFF
--- a/core/application/account_create.go
+++ b/core/application/account_create.go
@@ -153,6 +153,7 @@ func (s *Service) setAccountAndProfileDetails(ctx context.Context, req *pb.RpcAc
 	if err := bs.SetDetails(nil,
 		accountObjects.Profile,
 		profileDetails,
+		false,
 	); err != nil {
 		return errors.Join(ErrSetDetails, err)
 	}
@@ -160,6 +161,7 @@ func (s *Service) setAccountAndProfileDetails(ctx context.Context, req *pb.RpcAc
 	if err := bs.SetDetails(nil,
 		accountObjects.Workspace,
 		commonDetails,
+		false,
 	); err != nil {
 		return errors.Join(ErrSetDetails, err)
 	}

--- a/core/application/account_create_from_export.go
+++ b/core/application/account_create_from_export.go
@@ -172,12 +172,14 @@ func (s *Service) setDetails(profile *pb.Profile, icon int64) error {
 	if err := bs.SetDetails(nil,
 		accountObjects.Profile,
 		profileDetails,
+		false,
 	); err != nil {
 		return err
 	}
 	if err := bs.SetDetails(nil,
 		accountObjects.Workspace,
 		accountDetails,
+		false,
 	); err != nil {
 		return err
 	}

--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -57,7 +57,7 @@ type ObjectCreator interface {
 }
 
 type DetailsSetter interface {
-	SetDetails(ctx session.Context, objectId string, details []*model.Detail) (err error)
+	SetDetails(ctx session.Context, objectId string, details []*model.Detail, updateLastUsed bool) (err error)
 }
 
 type service struct {
@@ -204,7 +204,7 @@ func (s *service) UpdateObject(objectId string, getContent *bookmark.ObjectConte
 		})
 	}
 
-	return s.detailsSetter.SetDetails(nil, objectId, details)
+	return s.detailsSetter.SetDetails(nil, objectId, details, false)
 }
 
 func (s *service) FetchAsync(spaceID string, blockID string, params bookmark.FetchParams) {

--- a/core/block/create.go
+++ b/core/block/create.go
@@ -64,7 +64,7 @@ func (s *Service) CreateWorkspace(ctx context.Context, req *pb.RpcWorkspaceCreat
 				Value: v,
 			})
 		}
-		return b.SetDetails(nil, details, true)
+		return b.SetDetails(nil, details, true, false)
 	})
 	if err != nil {
 		return "", fmt.Errorf("set details for space %s: %w", newSpace.Id(), err)

--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -56,7 +56,7 @@ func (s *Service) MarkArchived(ctx session.Context, id string, archived bool) (e
 				Key:   "isArchived",
 				Value: pbtypes.Bool(archived),
 			},
-		}, true)
+		}, true, false)
 	})
 }
 

--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -64,11 +64,11 @@ type CommonOperations interface {
 }
 
 type DetailsSettable interface {
-	SetDetails(ctx session.Context, details []*model.Detail, showEvent bool) (err error)
+	SetDetails(ctx session.Context, details []*model.Detail, showEvent, updateLastUsed bool) (err error)
 }
 
 type DetailsUpdatable interface {
-	UpdateDetails(update func(current *types.Struct) (*types.Struct, error)) (err error)
+	UpdateDetails(update func(current *types.Struct) (*types.Struct, error), updateLastUsed bool) (err error)
 }
 
 type Restrictionable interface {

--- a/core/block/editor/lastused/lastused_test.go
+++ b/core/block/editor/lastused/lastused_test.go
@@ -1,4 +1,4 @@
-package objecttype
+package lastused
 
 import (
 	"math/rand"

--- a/core/block/editor/participant.go
+++ b/core/block/editor/participant.go
@@ -95,7 +95,7 @@ func (p *participant) TryClose(objectTTL time.Duration) (bool, error) {
 func (p *participant) modifyDetails(newDetails *types.Struct) (err error) {
 	return p.DetailsUpdatable.UpdateDetails(func(current *types.Struct) (*types.Struct, error) {
 		return pbtypes.StructMerge(current, newDetails, false), nil
-	})
+	}, false)
 }
 
 func buildParticipantDetails(

--- a/core/block/editor/profile.go
+++ b/core/block/editor/profile.go
@@ -131,7 +131,7 @@ func (p *Profile) StateMigrations() migration.Migrations {
 }
 
 func (p *Profile) SetDetails(ctx session.Context, details []*model.Detail, showEvent bool) (err error) {
-	if err = p.AllOperations.SetDetails(ctx, details, showEvent); err != nil {
+	if err = p.AllOperations.SetDetails(ctx, details, showEvent, false); err != nil {
 		return
 	}
 

--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -353,7 +353,7 @@ func (oc *ObjectCreator) setSpaceDashboardID(spaceID string, st *state.State) {
 			return
 		}
 		err = cache.Do(oc.service, spc.DerivedIDs().Workspace, func(ws basic.CommonOperations) error {
-			if err := ws.SetDetails(nil, details, false); err != nil {
+			if err := ws.SetDetails(nil, details, false, false); err != nil {
 				return err
 			}
 			return nil

--- a/core/block/object/objectcreator/installer.go
+++ b/core/block/object/objectcreator/installer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"go.uber.org/zap"
 
-	"github.com/anyproto/anytype-heart/core/block/editor/objecttype"
+	"github.com/anyproto/anytype-heart/core/block/editor/lastused"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -226,7 +226,7 @@ func (s *service) prepareDetailsForInstallingObject(
 	details.Fields[bundle.RelationKeyIsReadonly.String()] = pbtypes.Bool(false)
 
 	if isNewSpace {
-		objecttype.SetLastUsedDateForInitialObjectType(sourceId, details)
+		lastused.SetLastUsedDateForInitialObjectType(sourceId, details)
 	}
 
 	bundledRelationIds := pbtypes.GetStringList(details, bundle.RelationKeyRecommendedRelations.String())

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -351,7 +351,7 @@ func (s *Service) SetSpaceInfo(req *pb.RpcWorkspaceSetInfoRequest) error {
 			Value: v,
 		})
 	}
-	return s.SetDetails(nil, workspaceId, setDetails)
+	return s.SetDetails(nil, workspaceId, setDetails, false)
 }
 
 func (s *Service) ObjectShareByLink(req *pb.RpcObjectShareByLinkRequest) (link string, err error) {
@@ -548,7 +548,7 @@ func (s *Service) SetWorkspaceDashboardId(ctx session.Context, workspaceId strin
 				Key:   bundle.RelationKeySpaceDashboardId.String(),
 				Value: pbtypes.String(id),
 			},
-		}, false); err != nil {
+		}, false, false); err != nil {
 			return err
 		}
 		return nil

--- a/core/object.go
+++ b/core/object.go
@@ -44,7 +44,7 @@ func (mw *Middleware) ObjectSetDetails(cctx context.Context, req *pb.RpcObjectSe
 		return m
 	}
 	err := mw.doBlockService(func(bs *block.Service) (err error) {
-		return bs.SetDetails(ctx, req.ContextId, req.GetDetails())
+		return bs.SetDetails(ctx, req.ContextId, req.GetDetails(), true)
 	})
 	if err != nil {
 		return response(pb.RpcObjectSetDetailsResponseError_UNKNOWN_ERROR, err)
@@ -882,7 +882,7 @@ func (mw *Middleware) ObjectSetInternalFlags(cctx context.Context, req *pb.RpcOb
 		return bs.ModifyDetails(req.ContextId, func(current *types.Struct) (*types.Struct, error) {
 			d := pbtypes.CopyStruct(current, false)
 			return internalflag.PutToDetails(d, req.InternalFlags), nil
-		})
+		}, false)
 	})
 	if err != nil {
 		return response(pb.RpcObjectSetInternalFlagsResponseError_UNKNOWN_ERROR, err)

--- a/space/internal/components/migration/readonlyfixer/relationsfixer.go
+++ b/space/internal/components/migration/readonlyfixer/relationsfixer.go
@@ -18,7 +18,7 @@ import (
 )
 
 type detailsSettable interface {
-	SetDetails(ctx session.Context, details []*model.Detail, showEvent bool) (err error)
+	SetDetails(ctx session.Context, details []*model.Detail, showEvent, updateLastUsed bool) (err error)
 }
 
 const MName = "ReadonlyRelationsFixer"
@@ -60,7 +60,7 @@ func (Migration) Run(ctx context.Context, log logger.CtxLogger, store dependenci
 		}}
 		e := space.DoCtx(ctx, pbtypes.GetString(r.Details, bundle.RelationKeyId.String()), func(sb smartblock.SmartBlock) error {
 			if ds, ok := sb.(detailsSettable); ok {
-				return ds.SetDetails(nil, det, false)
+				return ds.SetDetails(nil, det, false, false)
 			}
 			return nil
 		})

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
@@ -23,7 +23,7 @@ import (
 )
 
 type detailsSettable interface {
-	SetDetails(ctx session.Context, details []*model.Detail, showEvent bool) (err error)
+	SetDetails(ctx session.Context, details []*model.Detail, showEvent, updateLastUsed bool) (err error)
 }
 
 const MName = "SystemObjectReviser"
@@ -104,7 +104,7 @@ func reviseSystemObject(ctx context.Context, log logger.CtxLogger, space depende
 		log.Debug("updating system object", zap.String("source", source), zap.String("space", space.Id()))
 		if err := space.DoCtx(ctx, pbtypes.GetString(localObject, bundle.RelationKeyId.String()), func(sb smartblock.SmartBlock) error {
 			if ds, ok := sb.(detailsSettable); ok {
-				return ds.SetDetails(nil, details, false)
+				return ds.SetDetails(nil, details, false, false)
 			}
 			return nil
 		}); err != nil {

--- a/util/builtinobjects/builtinobjects.go
+++ b/util/builtinobjects/builtinobjects.go
@@ -399,7 +399,7 @@ func (b *builtinObjects) setHomePageIdToWorkspace(spc clientspace.Space, id stri
 				Key:   bundle.RelationKeySpaceDashboardId.String(),
 				Value: pbtypes.String(id),
 			},
-		},
+		}, false,
 	); err != nil {
 		log.Errorf("Failed to set SpaceDashboardId relation to Account object: %s", err)
 	}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3813/relations-structure-in-set-collection-menu-options-should-be-clear

On ObjectSetDetails, ObjectListSetDetails and ObjectModifyDetailValues we should update lastUsedDate value of mentioned relations, so clients could sort relation lists