### PR TITLE
GO-3998 fix import of notion files foe windows 

### DIFF
--- a/core/block/import/notion/api/files/file.go
+++ b/core/block/import/notion/api/files/file.go
@@ -142,6 +142,7 @@ func (f *file) downloadFile(ctx context.Context) error {
 	case <-progressCh:
 		return fmt.Errorf("failed to download file, no progress")
 	default:
+		f.Close()
 		return os.Rename(f.File.Name(), f.localPath)
 	}
 }


### PR DESCRIPTION
We can't rename files in windows before we close it