### PR TITLE
GO-3814 Add recommendedRelations value revision for system types

### DIFF
--- a/pkg/lib/bundle/types.gen.go
+++ b/pkg/lib/bundle/types.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const TypeChecksum = "745e40062786ba9e43273b0009612a02af1eb9920ecaf6fab191f86b5cdd33f3"
+const TypeChecksum = "8b79add6b322acbcee123ad178c1aee523a2d9b9f219c391903530b29e554a1e"
 const (
 	TypePrefix = "_ot"
 )
@@ -54,6 +54,7 @@ var (
 			Readonly:               true,
 			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyArtist), MustGetRelationLink(RelationKeyAudioAlbum), MustGetRelationLink(RelationKeyAudioAlbumTrackNumber), MustGetRelationLink(RelationKeyAudioGenre), MustGetRelationLink(RelationKeyAudioLyrics), MustGetRelationLink(RelationKeyReleasedYear), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
 			RestrictObjectCreation: true,
+			Revision:               1,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "audio",
 		},
@@ -144,6 +145,7 @@ var (
 			Readonly:               true,
 			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
 			RestrictObjectCreation: true,
+			Revision:               1,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "file",
 		},
@@ -167,6 +169,7 @@ var (
 			Readonly:               true,
 			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyWidthInPixels), MustGetRelationLink(RelationKeyCamera), MustGetRelationLink(RelationKeyHeightInPixels), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyCameraIso), MustGetRelationLink(RelationKeyAperture), MustGetRelationLink(RelationKeyExposure), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFocalRatio), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
 			RestrictObjectCreation: true,
+			Revision:               1,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "image",
 		},
@@ -351,6 +354,7 @@ var (
 			Readonly:               true,
 			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyCamera), MustGetRelationLink(RelationKeyHeightInPixels), MustGetRelationLink(RelationKeyWidthInPixels), MustGetRelationLink(RelationKeyCameraIso), MustGetRelationLink(RelationKeyAperture), MustGetRelationLink(RelationKeyExposure), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
 			RestrictObjectCreation: true,
+			Revision:               1,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "video",
 		},

--- a/pkg/lib/bundle/types.json
+++ b/pkg/lib/bundle/types.json
@@ -156,7 +156,8 @@
       "origin"
     ],
     "description": "The recording of moving visual images",
-    "restrictObjectCreation": true
+    "restrictObjectCreation": true,
+    "revision": 1
   },
   {
     "id": "dashboard",
@@ -358,7 +359,8 @@
       "origin"
     ],
     "description": "A representation of the external form of a person or thing in art",
-    "restrictObjectCreation": true
+    "restrictObjectCreation": true,
+    "revision": 1
   },
   {
     "id": "profile",
@@ -398,7 +400,8 @@
       "origin"
     ],
     "description": "Sound when recorded, with ability to reproduce",
-    "restrictObjectCreation": true
+    "restrictObjectCreation": true,
+    "revision": 1
   },
   {
     "id": "goal",
@@ -435,7 +438,8 @@
       "origin"
     ],
     "description": "Computer resource for recording data in a computer storage device",
-    "restrictObjectCreation": true
+    "restrictObjectCreation": true,
+    "revision": 1
   },
   {
     "id": "project",

--- a/space/internal/components/dependencies/spacewithctx.go
+++ b/space/internal/components/dependencies/spacewithctx.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
+	"github.com/anyproto/anytype-heart/core/domain"
 )
 
 type SpaceWithCtx interface {
 	DoCtx(ctx context.Context, objectId string, apply func(sb smartblock.SmartBlock) error) error
 	Id() string
+	DeriveObjectID(ctx context.Context, uniqueKey domain.UniqueKey) (id string, err error)
 }

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/anyproto/any-sync/app/logger"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/gogo/protobuf/types"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
@@ -179,7 +180,12 @@ func checkRecommendedRelations(ctx context.Context, space dependencies.SpaceWith
 			return nil, err
 		}
 
-		// TODO: we derive ids from space, but the very objects could be not installed to space
+		// we should add only system relations to object types, because non-system could be not installed to space yet
+		if !lo.Contains(bundle.SystemRelations, domain.RelationKey(uk.InternalKey())) {
+			log.Debug("recommended relation is not system, so we are not adding it to the type object", zap.String("relation key", key))
+			continue
+		}
+
 		id, err := space.DeriveObjectID(ctx, uk)
 		if err != nil {
 			return nil, fmt.Errorf("failed to derive recommended relation with key '%s': %w", key, err)

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
@@ -236,7 +236,7 @@ func TestReviseSystemObject(t *testing.T) {
 		}).Maybe()
 
 		// when
-		marketObjects["_otpage"].Fields["recommendedRelations"] = pbtypes.StringList([]string{"_brname", "_brtag"})
+		marketObjects["_otpage"].Fields["recommendedRelations"] = pbtypes.StringList([]string{"_brname", "_brorigin"})
 		toRevise, err := reviseSystemObject(ctx, log, space, rel, marketObjects)
 
 		// then
@@ -251,6 +251,28 @@ func TestReviseSystemObject(t *testing.T) {
 			bundle.RelationKeySourceObject.String():         pbtypes.String("_otpage"),
 			bundle.RelationKeyUniqueKey.String():            pbtypes.String("ot-page"),
 			bundle.RelationKeyRecommendedRelations.String(): pbtypes.StringList([]string{"rel-name", "rel-tag"}),
+		}}
+		space := mock_space.NewMockSpace(t)
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return addr.ObjectTypeKeyToIdPrefix + key.InternalKey(), nil
+		}).Maybe()
+
+		// when
+		marketObjects["_otpage"].Fields["recommendedRelations"] = pbtypes.StringList([]string{"_brname", "_brtag"})
+		toRevise, err := reviseSystemObject(ctx, log, space, rel, marketObjects)
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, toRevise)
+	})
+
+	t.Run("recommendedRelations list is updated by not system relations", func(t *testing.T) {
+		// given
+		rel := &types.Struct{Fields: map[string]*types.Value{
+			bundle.RelationKeyRevision.String():             pbtypes.Int64(2),
+			bundle.RelationKeySourceObject.String():         pbtypes.String("_otpage"),
+			bundle.RelationKeyUniqueKey.String():            pbtypes.String("ot-page"),
+			bundle.RelationKeyRecommendedRelations.String(): pbtypes.StringList([]string{"rel-name"}),
 		}}
 		space := mock_space.NewMockSpace(t)
 		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	mock_space "github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
@@ -216,5 +218,51 @@ func TestReviseSystemObject(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.True(t, toRevise)
+	})
+
+	t.Run("recommendedRelations list is updated", func(t *testing.T) {
+		// given
+		rel := &types.Struct{Fields: map[string]*types.Value{
+			bundle.RelationKeyRevision.String():             pbtypes.Int64(1),
+			bundle.RelationKeySourceObject.String():         pbtypes.String("_otpage"),
+			bundle.RelationKeyUniqueKey.String():            pbtypes.String("ot-page"),
+			bundle.RelationKeyRecommendedRelations.String(): pbtypes.StringList([]string{"rel-name"}),
+		}}
+		space := mock_space.NewMockSpace(t)
+		space.EXPECT().DoCtx(mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
+		space.EXPECT().Id().Times(1).Return("")
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return addr.ObjectTypeKeyToIdPrefix + key.InternalKey(), nil
+		}).Maybe()
+
+		// when
+		marketObjects["_otpage"].Fields["recommendedRelations"] = pbtypes.StringList([]string{"_brname", "_brtag"})
+		toRevise, err := reviseSystemObject(ctx, log, space, rel, marketObjects)
+
+		// then
+		assert.NoError(t, err)
+		assert.True(t, toRevise)
+	})
+
+	t.Run("recommendedRelations list is not updated", func(t *testing.T) {
+		// given
+		rel := &types.Struct{Fields: map[string]*types.Value{
+			bundle.RelationKeyRevision.String():             pbtypes.Int64(2),
+			bundle.RelationKeySourceObject.String():         pbtypes.String("_otpage"),
+			bundle.RelationKeyUniqueKey.String():            pbtypes.String("ot-page"),
+			bundle.RelationKeyRecommendedRelations.String(): pbtypes.StringList([]string{"rel-name", "rel-tag"}),
+		}}
+		space := mock_space.NewMockSpace(t)
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return addr.ObjectTypeKeyToIdPrefix + key.InternalKey(), nil
+		}).Maybe()
+
+		// when
+		marketObjects["_otpage"].Fields["recommendedRelations"] = pbtypes.StringList([]string{"_brname", "_brtag"})
+		toRevise, err := reviseSystemObject(ctx, log, space, rel, marketObjects)
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, toRevise)
 	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3814/add-origin-relation-to-all-files-as-recommended

SystemObjectReviser should be able to update list of recommendedRelations.
Origin was added for file object types (File, Image, Video, Audio) in #1436 , but object types' objects did not added it to their recommended relations in existing spaces. This PR fixes that