### PR TITLE
GO-3925: Add notIncludeVersion parameter in HistoryGetVersions

### DIFF
--- a/core/history.go
+++ b/core/history.go
@@ -85,7 +85,7 @@ func (mw *Middleware) HistoryGetVersions(cctx context.Context, req *pb.RpcHistor
 		vers, err = hs.Versions(domain.FullID{
 			SpaceID:  spaceID,
 			ObjectID: req.ObjectId,
-		}, req.LastVersionId, int(req.Limit))
+		}, req.LastVersionId, int(req.Limit), req.NotIncludeVersion)
 		return
 	}); err != nil {
 		return response(nil, err)

--- a/core/history/history.go
+++ b/core/history/history.go
@@ -53,7 +53,7 @@ func New() History {
 
 type History interface {
 	Show(id domain.FullID, versionId string) (bs *model.ObjectView, ver *pb.RpcHistoryVersion, err error)
-	Versions(id domain.FullID, lastVersionId string, limit int) (resp []*pb.RpcHistoryVersion, err error)
+	Versions(id domain.FullID, lastVersionId string, limit int, notIncludeVersion bool) (resp []*pb.RpcHistoryVersion, err error)
 	SetVersion(id domain.FullID, versionId string) (err error)
 	DiffVersions(req *pb.RpcHistoryDiffVersionsRequest) ([]*pb.EventMessage, *model.ObjectView, error)
 	GetBlocksParticipants(id domain.FullID, versionId string, blocks []*model.Block) ([]*model.ObjectViewBlockParticipant, error)
@@ -131,13 +131,13 @@ func (h *history) Show(id domain.FullID, versionID string) (bs *model.ObjectView
 	}, ver, nil
 }
 
-func (h *history) Versions(id domain.FullID, lastVersionId string, limit int) (resp []*pb.RpcHistoryVersion, err error) {
+func (h *history) Versions(id domain.FullID, lastVersionId string, limit int, notIncludeVersion bool) (resp []*pb.RpcHistoryVersion, err error) {
 	hasher := hashersPool.Get().(*blake3.Hasher)
 	defer hashersPool.Put(hasher)
 	if limit <= 0 {
 		limit = 100
 	}
-	var includeLastId = true
+	var includeLastId = !notIncludeVersion
 
 	reverse := func(vers []*pb.RpcHistoryVersion) []*pb.RpcHistoryVersion {
 		for i, j := 0, len(vers)-1; i < j; i, j = i+1, j-1 {

--- a/core/history/history_test.go
+++ b/core/history/history_test.go
@@ -852,7 +852,7 @@ func TestHistory_Versions(t *testing.T) {
 		history := newFixture(t, currChange, objectId, spaceID, versionId)
 
 		// when
-		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 0)
+		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 0, false)
 
 		// then
 		assert.Nil(t, err)
@@ -907,7 +907,7 @@ func TestHistory_Versions(t *testing.T) {
 		history := newFixture(t, currChange, objectId, spaceID, versionId)
 
 		// when
-		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10)
+		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10, false)
 
 		// then
 		assert.Nil(t, err)
@@ -958,7 +958,7 @@ func TestHistory_Versions(t *testing.T) {
 		history := newFixture(t, currChange, objectId, spaceID, versionId)
 
 		// when
-		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10)
+		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10, false)
 
 		// then
 		assert.Nil(t, err)
@@ -984,7 +984,7 @@ func TestHistory_Versions(t *testing.T) {
 		history.spaceService = spaceService
 
 		// when
-		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10)
+		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10, false)
 
 		// then
 		assert.Nil(t, err)
@@ -1089,7 +1089,7 @@ func TestHistory_Versions(t *testing.T) {
 		history := newFixture(t, currChange, objectId, spaceID, versionId)
 
 		// when
-		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10)
+		resp, err := history.Versions(domain.FullID{ObjectID: objectId, SpaceID: spaceID}, versionId, 10, false)
 
 		// then
 		assert.Nil(t, err)

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -11388,6 +11388,7 @@ returns list of versions (changes)
 | objectId | [string](#string) |  |  |
 | lastVersionId | [string](#string) |  | when indicated, results will include versions before given id |
 | limit | [int32](#int32) |  | desired count of versions |
+| notIncludeVersion | [bool](#bool) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -3032,6 +3032,7 @@ message Rpc {
                 string lastVersionId = 2;
                 // desired count of versions
                 int32 limit = 3;
+                bool notIncludeVersion = 4;
             }
 
             message Response {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3925/add-notincludeversion-parameter-in-historygetversions