### PR TITLE
fix coverId handling in FileRelationKeys

### DIFF
--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -1093,8 +1093,14 @@ func (s *State) FileRelationKeys() []string {
 	var keys []string
 	for _, rel := range s.GetRelationLinks() {
 		// coverId can contain both hash or predefined cover id
-		if rel.Format == model.RelationFormat_file || rel.Key == bundle.RelationKeyCoverId.String() {
+		if rel.Format == model.RelationFormat_file {
 			if slice.FindPos(keys, rel.Key) == -1 {
+				keys = append(keys, rel.Key)
+			}
+		}
+		if rel.Key == bundle.RelationKeyCoverId.String() {
+			coverType := pbtypes.GetInt64(s.Details(), bundle.RelationKeyCoverType.String())
+			if (coverType == 1 || coverType == 4) && slice.FindPos(keys, rel.Key) == -1 {
 				keys = append(keys, rel.Key)
 			}
 		}

--- a/core/block/editor/state/state_test.go
+++ b/core/block/editor/state/state_test.go
@@ -2820,3 +2820,137 @@ func TestAddBundledRealtionLinks(t *testing.T) {
 		assert.Equal(t, want, st)
 	})
 }
+
+func TestState_FileRelationKeys(t *testing.T) {
+	t.Run("no file relations", func(t *testing.T) {
+		// given
+		s := &State{}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		assert.Empty(t, keys)
+	})
+	t.Run("there are file relations", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Format: model.RelationFormat_file, Key: "fileKey1"},
+				{Format: model.RelationFormat_file, Key: "fileKey2"},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		expectedKeys := []string{"fileKey1", "fileKey2"}
+		assert.ElementsMatch(t, keys, expectedKeys)
+	})
+	t.Run("duplicated file relations", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Format: model.RelationFormat_file, Key: "fileKey1"},
+				{Format: model.RelationFormat_file, Key: "fileKey1"},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		expectedKeys := []string{"fileKey1"}
+		assert.ElementsMatch(t, keys, expectedKeys)
+	})
+	t.Run("coverId relation", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Key: bundle.RelationKeyCoverId.String()},
+			},
+			details: &types.Struct{Fields: map[string]*types.Value{
+				bundle.RelationKeyCoverType.String(): pbtypes.Int64(1),
+			},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		expectedKeys := []string{bundle.RelationKeyCoverId.String()}
+		assert.ElementsMatch(t, keys, expectedKeys)
+	})
+	t.Run("skip coverId relation", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Key: bundle.RelationKeyCoverId.String()},
+			},
+			details: &types.Struct{Fields: map[string]*types.Value{
+				bundle.RelationKeyCoverType.String(): pbtypes.Int64(2),
+			},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		assert.Len(t, keys, 0)
+	})
+	t.Run("skip gradient coverId relation", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Key: bundle.RelationKeyCoverId.String()},
+			},
+			details: &types.Struct{Fields: map[string]*types.Value{
+				bundle.RelationKeyCoverType.String(): pbtypes.Int64(3),
+			},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		assert.Len(t, keys, 0)
+	})
+	t.Run("mixed relations", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Format: model.RelationFormat_file, Key: "fileKey1"},
+				{Key: bundle.RelationKeyCoverId.String()},
+			},
+			details: &types.Struct{Fields: map[string]*types.Value{
+				bundle.RelationKeyCoverType.String(): pbtypes.Int64(4),
+			},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		expectedKeys := []string{"fileKey1", bundle.RelationKeyCoverId.String()}
+		assert.ElementsMatch(t, keys, expectedKeys, "Expected both file keys and cover ID")
+	})
+	t.Run("coverType not in details", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Key: bundle.RelationKeyCoverId.String()},
+			},
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		assert.Len(t, keys, 0)
+	})
+}


### PR DESCRIPTION
Skip `coverId` in `FileRelationKeys` in case relation `coverType` is not marked as file