### PR TITLE
GO-3967: implement migration from tag relation options to tag object

### DIFF
--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -232,5 +232,45 @@ func (p *Page) StateMigrations() migration.Migrations {
 			Version: 2,
 			Proc:    template.WithAddedFeaturedRelation(bundle.RelationKeyBacklinks),
 		},
+		{
+			Version: 3,
+			Proc: func(s *state.State) {
+				p.migrateRelationOptions(s)
+			},
+		},
 	})
+}
+
+func (p *Page) migrateRelationOptions(s *state.State) {
+	if layout, _ := s.Layout(); layout == model.ObjectType_relationOption {
+		relationKey := pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyRelationKey.String())
+		if relationKey != bundle.RelationKeyTag.String() {
+			return
+		}
+		s.RemoveRelation([]string{bundle.RelationKeyRelationKey.String(), bundle.RelationKeyUniqueKey.String()}...)
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_tag)))
+		tagType, _, err := p.objectStore.QueryObjectIDs(database.Query{
+			Filters: []*model.BlockContentDataviewFilter{
+				{
+					RelationKey: bundle.RelationKeyUniqueKey.String(),
+					Condition:   model.BlockContentDataviewFilter_Equal,
+					Value:       pbtypes.String(bundle.TypeKeyTag.URL()),
+				},
+				{
+					RelationKey: bundle.RelationKeySpaceId.String(),
+					Condition:   model.BlockContentDataviewFilter_NotEqual,
+					Value:       pbtypes.String(p.SpaceID()),
+				},
+			},
+		})
+		if err != nil {
+			log.Errorf("failed to get object by unique key: %v", err)
+			return
+		}
+		if len(tagType) == 0 {
+			log.Errorf("type not exists")
+			return
+		}
+		s.SetDetail(bundle.RelationKeyType.String(), pbtypes.String(tagType[0]))
+	}
 }

--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -248,7 +248,8 @@ func (p *Page) migrateRelationOptions(s *state.State) {
 		if relationKey != bundle.RelationKeyTag.String() {
 			return
 		}
-		s.RemoveRelation([]string{bundle.RelationKeyRelationKey.String(), bundle.RelationKeyUniqueKey.String()}...)
+		s.RemoveRelation(bundle.RelationKeyRelationKey.String())
+		s.RemoveRelation(bundle.RelationKeyUniqueKey.String())
 		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_tag)))
 		tagType, _, err := p.objectStore.QueryObjectIDs(database.Query{
 			Filters: []*model.BlockContentDataviewFilter{

--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -258,7 +258,7 @@ func (p *Page) migrateRelationOptions(s *state.State) {
 				},
 				{
 					RelationKey: bundle.RelationKeySpaceId.String(),
-					Condition:   model.BlockContentDataviewFilter_NotEqual,
+					Condition:   model.BlockContentDataviewFilter_Equal,
 					Value:       pbtypes.String(p.SpaceID()),
 				},
 			},

--- a/core/block/editor/page.go
+++ b/core/block/editor/page.go
@@ -272,5 +272,6 @@ func (p *Page) migrateRelationOptions(s *state.State) {
 			return
 		}
 		s.SetDetail(bundle.RelationKeyType.String(), pbtypes.String(tagType[0]))
+		s.SetObjectTypeKey(bundle.TypeKeyTag)
 	}
 }

--- a/core/block/editor/page_test.go
+++ b/core/block/editor/page_test.go
@@ -1,0 +1,174 @@
+package editor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+func Test_migrateRelationOptions(t *testing.T) {
+	t.Run("not relation option", func(t *testing.T) {
+		// given
+		page := &Page{objectStore: newStoreFixture(t)}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_basic)))
+
+		// when
+		page.migrateRelationOptions(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_basic), pbtypes.GetInt64(s.Details(), bundle.RelationKeyLayout.String()))
+	})
+	t.Run("not tag relation option", func(t *testing.T) {
+		// given
+		page := &Page{objectStore: newStoreFixture(t)}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relationOption)))
+		s.SetDetail(bundle.RelationKeyRelationKey.String(), pbtypes.String("key"))
+
+		// when
+		page.migrateRelationOptions(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_relationOption), pbtypes.GetInt64(s.Details(), bundle.RelationKeyLayout.String()))
+		assert.Equal(t, "key", pbtypes.GetString(s.Details(), bundle.RelationKeyRelationKey.String()))
+	})
+	t.Run("migrate relation option", func(t *testing.T) {
+		// given
+		storeFixture := newStoreFixture(t)
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:        pbtypes.String("id1"),
+				bundle.RelationKeyUniqueKey: pbtypes.String(bundle.TypeKeyTag.URL()),
+				bundle.RelationKeySpaceId:   pbtypes.String("spaceId"),
+			},
+		})
+		smartTest := smarttest.New("id2")
+		smartTest.SetSpaceId("spaceId")
+		page := &Page{objectStore: storeFixture, SmartBlock: smartTest}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relationOption)))
+		s.SetDetail(bundle.RelationKeyRelationKey.String(), pbtypes.String(bundle.RelationKeyTag.String()))
+		s.SetDetail(bundle.RelationKeyUniqueKey.String(), pbtypes.String("key"))
+
+		// when
+		page.migrateRelationOptions(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_tag), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyLayout.String()))
+		assert.Equal(t, "id1", pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyType.String()))
+		assert.Empty(t, pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyUniqueKey.String()))
+		assert.Empty(t, pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyRelationKey.String()))
+	})
+	t.Run("type tage not exist - not migrate", func(t *testing.T) {
+		// given
+		smartTest := smarttest.New("id2")
+		smartTest.SetSpaceId("spaceId")
+		page := &Page{objectStore: newStoreFixture(t), SmartBlock: smartTest}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relationOption)))
+		s.SetDetail(bundle.RelationKeyRelationKey.String(), pbtypes.String(bundle.RelationKeyTag.String()))
+		s.SetDetail(bundle.RelationKeyUniqueKey.String(), pbtypes.String("key"))
+
+		// when
+		page.migrateRelationOptions(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_relationOption), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyLayout.String()))
+		assert.Equal(t, bundle.RelationKeyTag.String(), pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyRelationKey.String()))
+		assert.Equal(t, "key", pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyUniqueKey.String()))
+	})
+}
+
+func Test_migrateRelation(t *testing.T) {
+	t.Run("not relation", func(t *testing.T) {
+		// given
+		page := &Page{objectStore: newStoreFixture(t)}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_basic)))
+
+		// when
+		page.migrateRelation(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_basic), pbtypes.GetInt64(s.Details(), bundle.RelationKeyLayout.String()))
+	})
+	t.Run("not tag relation", func(t *testing.T) {
+		// given
+		page := &Page{objectStore: newStoreFixture(t)}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relation)))
+		s.SetDetail(bundle.RelationKeyUniqueKey.String(), pbtypes.String("key"))
+
+		// when
+		page.migrateRelation(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_relation), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyLayout.String()))
+		assert.Equal(t, "key", pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyUniqueKey.String()))
+	})
+	t.Run("not tag format relation", func(t *testing.T) {
+		// given
+		page := &Page{objectStore: newStoreFixture(t)}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relation)))
+		s.SetDetail(bundle.RelationKeyUniqueKey.String(), pbtypes.String(bundle.RelationKeyTag.URL()))
+		s.SetDetail(bundle.RelationKeyRelationFormat.String(), pbtypes.Int64(int64(model.RelationFormat_object)))
+
+		// when
+		page.migrateRelation(s)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_relation), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyLayout.String()))
+		assert.Equal(t, bundle.RelationKeyTag.URL(), pbtypes.GetString(s.CombinedDetails(), bundle.RelationKeyUniqueKey.String()))
+		assert.Equal(t, int64(model.RelationFormat_object), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyRelationFormat.String()))
+	})
+	t.Run("migrate relation", func(t *testing.T) {
+		// given
+		storeFixture := newStoreFixture(t)
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:        pbtypes.String("id1"),
+				bundle.RelationKeyUniqueKey: pbtypes.String(bundle.TypeKeyTag.URL()),
+				bundle.RelationKeySpaceId:   pbtypes.String("spaceId"),
+			},
+		})
+		smartTest := smarttest.New("id2")
+		smartTest.SetSpaceId("spaceId")
+		page := &Page{objectStore: storeFixture, SmartBlock: smartTest}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relation)))
+		s.SetDetail(bundle.RelationKeyUniqueKey.String(), pbtypes.String(bundle.RelationKeyTag.URL()))
+		s.SetDetail(bundle.RelationKeyRelationFormat.String(), pbtypes.Int64(int64(model.RelationFormat_tag)))
+
+		// when
+		page.migrateRelation(s)
+
+		// then
+		assert.Equal(t, int64(model.RelationFormat_object), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyRelationFormat.String()))
+		assert.Equal(t, []string{"id1"}, pbtypes.GetStringList(s.CombinedDetails(), bundle.RelationKeyRelationFormatObjectTypes.String()))
+	})
+	t.Run("type tage not exist - not migrate", func(t *testing.T) {
+		// given
+		smartTest := smarttest.New("id2")
+		smartTest.SetSpaceId("spaceId")
+		page := &Page{objectStore: newStoreFixture(t), SmartBlock: smartTest}
+		s := &state.State{}
+		s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(model.ObjectType_relation)))
+		s.SetDetail(bundle.RelationKeyUniqueKey.String(), pbtypes.String(bundle.RelationKeyTag.URL()))
+		s.SetDetail(bundle.RelationKeyRelationFormat.String(), pbtypes.Int64(int64(model.RelationFormat_tag)))
+
+		// when
+		page.migrateRelation(s)
+
+		// then
+		assert.Equal(t, int64(model.RelationFormat_tag), pbtypes.GetInt64(s.CombinedDetails(), bundle.RelationKeyRelationFormat.String()))
+	})
+}

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -229,7 +229,7 @@ func (i *indexer) migrateRelationOptions(space clientspace.Space) {
 			},
 			{
 				RelationKey: bundle.RelationKeySpaceId.String(),
-				Condition:   model.BlockContentDataviewFilter_NotEqual,
+				Condition:   model.BlockContentDataviewFilter_Equal,
 				Value:       pbtypes.String(space.Id()),
 			},
 		},

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -207,44 +207,8 @@ func (i *indexer) ReindexSpace(space clientspace.Space) (err error) {
 		}
 	}
 
-	if !flags.objects {
-		i.migrateRelationOptions(space)
-	}
 	i.addSyncDetails(space)
 	return i.saveLatestChecksums(space.Id())
-}
-
-func (i *indexer) migrateRelationOptions(space clientspace.Space) {
-	relationOptions, _, err := i.store.QueryObjectIDs(database.Query{
-		Filters: []*model.BlockContentDataviewFilter{
-			{
-				RelationKey: bundle.RelationKeyLayout.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.Int64(int64(model.ObjectType_relationOption)),
-			},
-			{
-				RelationKey: bundle.RelationKeyRelationKey.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.String(bundle.RelationKeyTag.String()),
-			},
-			{
-				RelationKey: bundle.RelationKeySpaceId.String(),
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       pbtypes.String(space.Id()),
-			},
-		},
-	})
-	if err != nil {
-		return
-	}
-	for _, optionId := range relationOptions {
-		err = space.Do(optionId, func(sb smartblock.SmartBlock) error {
-			return nil
-		})
-		if err != nil {
-			log.Debug("failed to migrate relation option", zap.Error(err))
-		}
-	}
 }
 
 func (i *indexer) addSyncDetails(space clientspace.Space) {

--- a/space/clientspace/space.go
+++ b/space/clientspace/space.go
@@ -245,10 +245,9 @@ func (s *space) migrateTag(objectStore objectstore.ObjectStore) error {
 	if len(relation) == 0 {
 		return nil
 	}
-	err = s.Do(relation[0], func(sb smartblock.SmartBlock) error {
+	return s.Do(relation[0], func(sb smartblock.SmartBlock) error {
 		return nil
 	})
-	return nil
 }
 
 func (s *space) Id() string {

--- a/space/clientspace/space.go
+++ b/space/clientspace/space.go
@@ -215,7 +215,7 @@ func (s *space) migrateRelationOptions(objectStore objectstore.ObjectStore) erro
 }
 
 func (s *space) migrateTag(objectStore objectstore.ObjectStore) error {
-	ralation, _, err := objectStore.QueryObjectIDs(database.Query{
+	relation, _, err := objectStore.QueryObjectIDs(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{
 				RelationKey: bundle.RelationKeyLayout.String(),
@@ -228,6 +228,11 @@ func (s *space) migrateTag(objectStore objectstore.ObjectStore) error {
 				Value:       pbtypes.String(bundle.RelationKeyTag.URL()),
 			},
 			{
+				RelationKey: bundle.RelationKeyRelationFormat.String(),
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       pbtypes.Int64(int64(model.RelationFormat_tag)),
+			},
+			{
 				RelationKey: bundle.RelationKeySpaceId.String(),
 				Condition:   model.BlockContentDataviewFilter_Equal,
 				Value:       pbtypes.String(s.Id()),
@@ -237,10 +242,10 @@ func (s *space) migrateTag(objectStore objectstore.ObjectStore) error {
 	if err != nil {
 		return err
 	}
-	if len(ralation) == 0 {
+	if len(relation) == 0 {
 		return nil
 	}
-	err = s.Do(ralation[0], func(sb smartblock.SmartBlock) error {
+	err = s.Do(relation[0], func(sb smartblock.SmartBlock) error {
 		return nil
 	})
 	return nil

--- a/space/clientspace/space.go
+++ b/space/clientspace/space.go
@@ -23,11 +23,15 @@ import (
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/database"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/pkg/lib/threads"
 	"github.com/anyproto/anytype-heart/space/internal/objectprovider"
 	"github.com/anyproto/anytype-heart/space/spacecore"
 	"github.com/anyproto/anytype-heart/space/spacecore/peermanager"
 	"github.com/anyproto/anytype-heart/space/spacecore/storage"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 type Space interface {
@@ -100,6 +104,7 @@ type SpaceDeps struct {
 	PersonalSpaceId   string
 	LoadCtx           context.Context
 	DisableRemoteLoad bool
+	ObjectStore       objectstore.ObjectStore
 }
 
 func BuildSpace(ctx context.Context, deps SpaceDeps) (Space, error) {
@@ -132,11 +137,11 @@ func BuildSpace(ctx context.Context, deps SpaceDeps) (Space, error) {
 			return nil, fmt.Errorf("install bundled objects: %w", err)
 		}
 	}
-	go sp.mandatoryObjectsLoad(deps.LoadCtx, deps.DisableRemoteLoad)
+	go sp.mandatoryObjectsLoad(deps.LoadCtx, deps.DisableRemoteLoad, deps.ObjectStore)
 	return sp, nil
 }
 
-func (s *space) mandatoryObjectsLoad(ctx context.Context, disableRemoteLoad bool) {
+func (s *space) mandatoryObjectsLoad(ctx context.Context, disableRemoteLoad bool, objectStore objectstore.ObjectStore) {
 	defer close(s.loadMandatoryObjectsCh)
 	s.loadMandatoryObjectsErr = s.indexer.ReindexSpace(s)
 	if s.loadMandatoryObjectsErr != nil {
@@ -162,9 +167,47 @@ func (s *space) mandatoryObjectsLoad(ctx context.Context, disableRemoteLoad bool
 	if err != nil {
 		log.Error("failed to migrate profile object", zap.Error(err))
 	}
+	err = s.migrateRelationOptions(objectStore)
+	if err != nil {
+		log.Error("failed to migrate relation options", zap.Error(err))
+	}
 	if !disableRemoteLoad {
 		s.common.TreeSyncer().StartSync()
 	}
+}
+
+func (s *space) migrateRelationOptions(objectStore objectstore.ObjectStore) error {
+	relationOptions, _, err := objectStore.QueryObjectIDs(database.Query{
+		Filters: []*model.BlockContentDataviewFilter{
+			{
+				RelationKey: bundle.RelationKeyLayout.String(),
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       pbtypes.Int64(int64(model.ObjectType_relationOption)),
+			},
+			{
+				RelationKey: bundle.RelationKeyRelationKey.String(),
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       pbtypes.String(bundle.RelationKeyTag.String()),
+			},
+			{
+				RelationKey: bundle.RelationKeySpaceId.String(),
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       pbtypes.String(s.Id()),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	for _, optionId := range relationOptions {
+		err = s.Do(optionId, func(sb smartblock.SmartBlock) error {
+			return nil
+		})
+		if err != nil {
+			log.Debug("failed to migrate relation option", zap.Error(err))
+		}
+	}
+	return nil
 }
 
 func (s *space) Id() string {

--- a/space/clientspace/space_test.go
+++ b/space/clientspace/space_test.go
@@ -1,0 +1,161 @@
+package clientspace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anyproto/any-sync/commonspace/mock_commonspace"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/block/object/objectcache/mock_objectcache"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+func Test_migrateRelationOptions(t *testing.T) {
+	t.Run("no relation options", func(t *testing.T) {
+		// given
+		s := space{}
+
+		mockSpace := mock_commonspace.NewMockSpace(gomock.NewController(t))
+		mockSpace.EXPECT().Id().Return("spaceId")
+		s.common = mockSpace
+		// when
+		err := s.migrateRelationOptions(objectstore.NewStoreFixture(t))
+
+		// then
+		assert.Nil(t, err)
+	})
+	t.Run("relation options with not tag relation", func(t *testing.T) {
+		// given
+		s := space{}
+		mockSpace := mock_commonspace.NewMockSpace(gomock.NewController(t))
+		mockSpace.EXPECT().Id().Return("spaceId")
+		s.common = mockSpace
+
+		// when
+		storeFixture := objectstore.NewStoreFixture(t)
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          pbtypes.String("id1"),
+				bundle.RelationKeyLayout:      pbtypes.Int64(int64(model.ObjectType_relationOption)),
+				bundle.RelationKeyRelationKey: pbtypes.String("key"),
+				bundle.RelationKeySpaceId:     pbtypes.String("spaceId"),
+			},
+			{
+				bundle.RelationKeyId:          pbtypes.String("id2"),
+				bundle.RelationKeyLayout:      pbtypes.Int64(int64(model.ObjectType_relationOption)),
+				bundle.RelationKeyRelationKey: pbtypes.String("key"),
+				bundle.RelationKeySpaceId:     pbtypes.String("spaceId"),
+			},
+		})
+		err := s.migrateRelationOptions(storeFixture)
+
+		// then
+		assert.Nil(t, err)
+	})
+	t.Run("tag relation options", func(t *testing.T) {
+		// given
+		s := space{}
+		mockSpace := mock_commonspace.NewMockSpace(gomock.NewController(t))
+		mockSpace.EXPECT().Id().Return("spaceId")
+		s.common = mockSpace
+
+		// when
+		storeFixture := objectstore.NewStoreFixture(t)
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          pbtypes.String("id1"),
+				bundle.RelationKeyLayout:      pbtypes.Int64(int64(model.ObjectType_relationOption)),
+				bundle.RelationKeyRelationKey: pbtypes.String(bundle.RelationKeyTag.String()),
+				bundle.RelationKeySpaceId:     pbtypes.String("spaceId"),
+			},
+			{
+				bundle.RelationKeyId:          pbtypes.String("id2"),
+				bundle.RelationKeyLayout:      pbtypes.Int64(int64(model.ObjectType_relationOption)),
+				bundle.RelationKeyRelationKey: pbtypes.String(bundle.RelationKeyTag.String()),
+				bundle.RelationKeySpaceId:     pbtypes.String("spaceId"),
+			},
+		})
+
+		cache := mock_objectcache.NewMockCache(t)
+		cache.EXPECT().GetObject(context.Background(), "id1").Return(smarttest.New("id1"), nil)
+		cache.EXPECT().GetObject(context.Background(), "id2").Return(smarttest.New("id1"), nil)
+		s.Cache = cache
+
+		err := s.migrateRelationOptions(storeFixture)
+
+		// then
+		assert.Nil(t, err)
+	})
+}
+
+func Test_migrateTag(t *testing.T) {
+	t.Run("no relations", func(t *testing.T) {
+		// given
+		s := space{}
+
+		mockSpace := mock_commonspace.NewMockSpace(gomock.NewController(t))
+		mockSpace.EXPECT().Id().Return("spaceId")
+		s.common = mockSpace
+		// when
+		err := s.migrateTag(objectstore.NewStoreFixture(t))
+
+		// then
+		assert.Nil(t, err)
+	})
+	t.Run("not tag relation", func(t *testing.T) {
+		// given
+		s := space{}
+		mockSpace := mock_commonspace.NewMockSpace(gomock.NewController(t))
+		mockSpace.EXPECT().Id().Return("spaceId")
+		s.common = mockSpace
+
+		// when
+		storeFixture := objectstore.NewStoreFixture(t)
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:        pbtypes.String("id1"),
+				bundle.RelationKeyLayout:    pbtypes.Int64(int64(model.ObjectType_relation)),
+				bundle.RelationKeyUniqueKey: pbtypes.String("key"),
+				bundle.RelationKeySpaceId:   pbtypes.String("spaceId"),
+			},
+		})
+		err := s.migrateTag(storeFixture)
+
+		// then
+		assert.Nil(t, err)
+	})
+	t.Run("migrate tag", func(t *testing.T) {
+		// given
+		s := space{}
+		mockSpace := mock_commonspace.NewMockSpace(gomock.NewController(t))
+		mockSpace.EXPECT().Id().Return("spaceId")
+		s.common = mockSpace
+
+		// when
+		storeFixture := objectstore.NewStoreFixture(t)
+		storeFixture.AddObjects(t, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:             pbtypes.String("id1"),
+				bundle.RelationKeyLayout:         pbtypes.Int64(int64(model.ObjectType_relation)),
+				bundle.RelationKeyUniqueKey:      pbtypes.String(bundle.RelationKeyTag.URL()),
+				bundle.RelationKeySpaceId:        pbtypes.String("spaceId"),
+				bundle.RelationKeyRelationFormat: pbtypes.Int64(int64(model.RelationFormat_tag)),
+			},
+		})
+
+		cache := mock_objectcache.NewMockCache(t)
+		cache.EXPECT().GetObject(context.Background(), "id1").Return(smarttest.New("id1"), nil)
+		s.Cache = cache
+
+		err := s.migrateTag(storeFixture)
+
+		// then
+		assert.Nil(t, err)
+	})
+}

--- a/space/internal/components/builder/builder.go
+++ b/space/internal/components/builder/builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anyproto/any-sync/app"
 
 	"github.com/anyproto/anytype-heart/core/block/object/objectcache"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/space/clientspace"
 	dependencies2 "github.com/anyproto/anytype-heart/space/internal/components/dependencies"
 	"github.com/anyproto/anytype-heart/space/internal/components/spacestatus"
@@ -37,8 +38,9 @@ type spaceBuilder struct {
 	personalSpaceId string
 	status          spacestatus.SpaceStatus
 
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx         context.Context
+	cancel      context.CancelFunc
+	objectStore objectstore.ObjectStore
 }
 
 func (b *spaceBuilder) Init(a *app.App) (err error) {
@@ -51,6 +53,7 @@ func (b *spaceBuilder) Init(a *app.App) (err error) {
 	b.objectFactory = app.MustComponent[objectcache.ObjectFactory](a)
 	b.storageService = app.MustComponent[storage.ClientStorage](a)
 	b.personalSpaceId, err = b.spaceCore.DeriveID(context.Background(), spacecore.SpaceType)
+	b.objectStore = app.MustComponent[objectstore.ObjectStore](a)
 	return
 }
 
@@ -95,6 +98,7 @@ func (b *spaceBuilder) BuildSpace(ctx context.Context, disableRemoteLoad bool) (
 		StorageService:  b.storageService,
 		SpaceCore:       b.spaceCore,
 		LoadCtx:         b.ctx,
+		ObjectStore:     b.objectStore,
 	}
 	space, err := clientspace.BuildSpace(ctx, deps)
 	if err != nil {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3967/implement-migration-from-tag-relation-options-to-tag-object-type

1. Add querying of relation option and tag relation to trigger migration during space init 
2. Add state migration for tag and relation options that removes unnecessary relations, update types and layouts 