### PR TITLE
GO-4162 corrupted links in markdown import

### DIFF
--- a/core/block/import/html/converter.go
+++ b/core/block/import/html/converter.go
@@ -189,7 +189,7 @@ func (h *HTML) updateFilesInLinks(block *model.Block, filesSource source.Source,
 			if newFileName, createFileBlock, err = common.ProvideFileName(mark.Param, filesSource, path, h.tempDirProvider); err == nil {
 				mark.Param = newFileName
 				if createFileBlock {
-					anymark.ConvertTextToFile(block)
+					block.Content = anymark.ConvertTextToFile(mark.Param)
 					break
 				}
 				continue

--- a/core/block/import/markdown/anymark/anyblocks.go
+++ b/core/block/import/markdown/anymark/anyblocks.go
@@ -92,10 +92,10 @@ func provideCodeBlock(textArr []string, language string, id string) *model.Block
 	}
 }
 
-func ConvertTextToFile(block *model.Block) {
+func ConvertTextToFile(filePath string) *model.BlockContentOfFile {
 	// "svg" excluded
-	if block.GetText().GetMarks().Marks[0].Param == "" {
-		return
+	if filePath == "" {
+		return nil
 	}
 
 	imageFormats := []string{"jpg", "jpeg", "png", "gif", "webp"}
@@ -104,7 +104,7 @@ func ConvertTextToFile(block *model.Block) {
 	pdfFormat := "pdf"
 
 	fileType := model.BlockContentFile_File
-	fileExt := filepath.Ext(block.GetText().GetMarks().Marks[0].Param)
+	fileExt := filepath.Ext(filePath)
 	if fileExt != "" {
 		fileExt = fileExt[1:]
 		for _, ext := range imageFormats {
@@ -131,14 +131,13 @@ func ConvertTextToFile(block *model.Block) {
 		if strings.EqualFold(fileExt, pdfFormat) {
 			fileType = model.BlockContentFile_PDF
 		}
-
-		block.Content = &model.BlockContentOfFile{
-			File: &model.BlockContentFile{
-				Name:  block.GetText().GetMarks().Marks[0].Param,
-				State: model.BlockContentFile_Empty,
-				Type:  fileType,
-			},
-		}
+	}
+	return &model.BlockContentOfFile{
+		File: &model.BlockContentFile{
+			Name:  filePath,
+			State: model.BlockContentFile_Empty,
+			Type:  fileType,
+		},
 	}
 }
 

--- a/core/block/import/markdown/blockconverter_test.go
+++ b/core/block/import/markdown/blockconverter_test.go
@@ -89,3 +89,155 @@ func Test_processFiles(t *testing.T) {
 		assert.Len(t, fileBlocks, 0)
 	})
 }
+
+func Test_processTextBlock(t *testing.T) {
+	t.Run("block with single markdown - file doesn't exist", func(t *testing.T) {
+		// given
+		mc := mdConverter{}
+		block := getTestTxtBlock("file.md")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{})
+
+		// then
+		assert.NotNil(t, block.GetBookmark())
+	})
+	t.Run("block with single markdown - file exists", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlock("file.md")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{"file.md": {PageID: "id"}})
+
+		// then
+		assert.NotNil(t, block.GetLink())
+		assert.Equal(t, "file.md", block.GetLink().GetTargetBlockId())
+	})
+	t.Run("block with single markdown - file exists, but not md or csv", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlock("file.txt")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{"file.txt": {}})
+
+		// then
+		assert.NotNil(t, block.GetFile())
+		assert.Equal(t, "file.txt", block.GetFile().GetName())
+	})
+	t.Run("block with single markdown - csv file exists", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlock("file.csv")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{"file.csv": {}})
+
+		// then
+		assert.NotNil(t, block.GetLink())
+		assert.Equal(t, "file.csv", block.GetLink().GetTargetBlockId())
+	})
+	t.Run("block with multiple markdown - file doesn't exist", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlockWithMultipleMarks("file.md")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{})
+
+		// then
+		assert.NotNil(t, block.GetBookmark())
+	})
+	t.Run("block with multiple markdown - file exists", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlockWithMultipleMarks("file.md")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{"file.md": {PageID: "id"}})
+
+		// then
+		assert.NotNil(t, block.GetText())
+		assert.Len(t, block.GetText().GetMarks().GetMarks(), 3)
+		assert.Equal(t, "file.md", block.GetText().GetMarks().GetMarks()[1].Param)
+		assert.Equal(t, model.BlockContentTextMark_Object, block.GetText().GetMarks().GetMarks()[1].Type)
+	})
+	t.Run("block with multiple markdown - file exists, but not md or csv", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlockWithMultipleMarks("file.txt")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{"file.txt": {}})
+
+		// then
+		assert.NotNil(t, block.GetFile())
+	})
+	t.Run("block with multiple markdown - csv file exists", func(t *testing.T) {
+		mc := mdConverter{}
+		block := getTestTxtBlockWithMultipleMarks("file.csv")
+
+		// when
+		mc.processTextBlock(block, map[string]*FileInfo{"file.csv": {}})
+
+		// then
+		// then
+		assert.NotNil(t, block.GetText())
+		assert.Len(t, block.GetText().GetMarks().GetMarks(), 3)
+		assert.Equal(t, "file.csv", block.GetText().GetMarks().GetMarks()[1].Param)
+		assert.Equal(t, model.BlockContentTextMark_Object, block.GetText().GetMarks().GetMarks()[1].Type)
+	})
+}
+
+func getTestTxtBlock(filename string) *model.Block {
+	return &model.Block{
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text: "test",
+				Marks: &model.BlockContentTextMarks{
+					Marks: []*model.BlockContentTextMark{
+						{
+							Range: &model.Range{
+								From: 0,
+								To:   4,
+							},
+							Type:  model.BlockContentTextMark_Link,
+							Param: filename,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTestTxtBlockWithMultipleMarks(filename string) *model.Block {
+	return &model.Block{
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text: "test",
+				Marks: &model.BlockContentTextMarks{
+					Marks: []*model.BlockContentTextMark{
+						{
+							Range: &model.Range{
+								From: 0,
+								To:   1,
+							},
+							Type: model.BlockContentTextMark_Bold,
+						},
+						{
+							Range: &model.Range{
+								From: 0,
+								To:   4,
+							},
+							Type:  model.BlockContentTextMark_Link,
+							Param: filename,
+						},
+						{
+							Range: &model.Range{
+								From: 0,
+								To:   2,
+							},
+							Type: model.BlockContentTextMark_Italic,
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4162/corrupted-links-in-markdown-import

The problem is that we don't handle cases, when block have more than one markdown besides links. For example link can be also bold or italic.

To fix it 
* I check if text block have more than one markdown 
* Then I go through all marks in text block and change the type of mark to page mention in case it is link to existing page or file.