### PR TITLE
GO-4192 app start improvements

### DIFF
--- a/core/block/object/objectcreator/installer.go
+++ b/core/block/object/objectcreator/installer.go
@@ -26,7 +26,7 @@ func (s *service) BundledObjectsIdsToInstall(
 	ctx context.Context,
 	space clientspace.Space,
 	sourceObjectIds []string,
-) (objectIds []string, err error) {
+) (ids domain.BundledObjectIds, err error) {
 	marketplaceSpace, err := s.spaceService.Get(ctx, addr.AnytypeMarketplaceWorkspace)
 	if err != nil {
 		return nil, fmt.Errorf("get marketplace space: %w", err)
@@ -51,7 +51,10 @@ func (s *service) BundledObjectsIdsToInstall(
 			if err != nil {
 				return err
 			}
-			objectIds = append(objectIds, objectId)
+			ids = append(ids, domain.BundledObjectId{
+				SourceId:        sourceObjectId,
+				DerivedObjectId: objectId,
+			})
 			return nil
 		})
 		if err != nil {

--- a/core/domain/bundledObject.go
+++ b/core/domain/bundledObject.go
@@ -1,0 +1,38 @@
+package domain
+
+type BundledObjectId struct {
+	SourceId        string
+	DerivedObjectId string
+}
+
+type BundledObjectIds []BundledObjectId
+
+func (b BundledObjectIds) Len() int {
+	return len(b)
+}
+
+func (b BundledObjectIds) SourceIds() []string {
+	var ids = make([]string, 0, len(b))
+	for _, bo := range b {
+		ids = append(ids, bo.SourceId)
+	}
+	return ids
+}
+
+func (b BundledObjectIds) DerivedObjectIds() []string {
+	var ids = make([]string, 0, len(b))
+	for _, bo := range b {
+		ids = append(ids, bo.DerivedObjectId)
+	}
+	return ids
+}
+
+func (b BundledObjectIds) Filter(f func(bo BundledObjectId) bool) BundledObjectIds {
+	var res = make([]BundledObjectId, 0, len(b))
+	for _, bo := range b {
+		if f(bo) {
+			res = append(res, bo)
+		}
+	}
+	return res
+}

--- a/space/internal/components/dependencies/bundledobjects.go
+++ b/space/internal/components/dependencies/bundledobjects.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/gogo/protobuf/types"
 
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/space/clientspace"
 )
 
 type BundledObjectsInstaller interface {
 	InstallBundledObjects(ctx context.Context, spc clientspace.Space, ids []string, isNewSpace bool) ([]string, []*types.Struct, error)
-	BundledObjectsIdsToInstall(ctx context.Context, spc clientspace.Space, sourceObjectIds []string) (objectIds []string, err error)
+	BundledObjectsIdsToInstall(ctx context.Context, spc clientspace.Space, sourceObjectIds []string) (ids domain.BundledObjectIds, err error)
 }

--- a/space/internal/objectprovider/objectprovider.go
+++ b/space/internal/objectprovider/objectprovider.go
@@ -138,6 +138,8 @@ func (o *objectProvider) loadObjectsAsync(ctx context.Context, objIDs []string) 
 		for _, id := range objIDs {
 			select {
 			case <-ctx.Done():
+				log.ErrorCtx(ctx, "loadObjectsAsync context done", zap.Error(ctx.Err()), zap.String("spaceId", o.spaceId), zap.String("objectId", id))
+
 				results <- ctx.Err()
 				continue
 			case limiter <- struct{}{}:
@@ -148,6 +150,8 @@ func (o *objectProvider) loadObjectsAsync(ctx context.Context, objIDs []string) 
 				}()
 				_, err := o.cache.GetObject(ctx, id)
 				if err != nil {
+					log.ErrorCtx(ctx, "loadObjectsAsync failed", zap.Error(ctx.Err()), zap.String("spaceId", o.spaceId), zap.String("objectId", id))
+
 					// we had a bug that allowed some users to remove their profile
 					// this workaround is to allow these users to load their accounts without errors and export their anytype data
 					if id == o.derivedObjectIds.Profile {


### PR DESCRIPTION
- do not wait for system relations/types load/install if missing
- try to load in background, if failed (with 30 sec timeout) then create(derive) the new one 
- if somebody will try to open this object directly - it will hang for the cache loader

Also, current bundled objects install approach work bad during reindex. 
- We have all the bundled object in spacestore, But we don't have them in objectstore
- We check objectstore and then generate payload and try to install of them for all spaces (>1k objects if you have 10 spaces)
- Then we receive tree already exists error for each of them
This PR  improves this by checking StoredIds along with it