### PR TITLE
GO-3977 Do not show deleted tags in kanban

### DIFF
--- a/core/block/detailservice/mock_detailservice/mock_Service.go
+++ b/core/block/detailservice/mock_detailservice/mock_Service.go
@@ -17,8 +17,6 @@ import (
 
 	session "github.com/anyproto/anytype-heart/core/session"
 
-	smartblock "github.com/anyproto/anytype-heart/core/block/editor/smartblock"
-
 	types "github.com/gogo/protobuf/types"
 )
 
@@ -33,124 +31,6 @@ type MockService_Expecter struct {
 
 func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
-}
-
-// GetObject provides a mock function with given fields: ctx, objectID
-func (_m *MockService) GetObject(ctx context.Context, objectID string) (smartblock.SmartBlock, error) {
-	ret := _m.Called(ctx, objectID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetObject")
-	}
-
-	var r0 smartblock.SmartBlock
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (smartblock.SmartBlock, error)); ok {
-		return rf(ctx, objectID)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) smartblock.SmartBlock); ok {
-		r0 = rf(ctx, objectID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(smartblock.SmartBlock)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, objectID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockService_GetObject_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetObject'
-type MockService_GetObject_Call struct {
-	*mock.Call
-}
-
-// GetObject is a helper method to define mock.On call
-//   - ctx context.Context
-//   - objectID string
-func (_e *MockService_Expecter) GetObject(ctx interface{}, objectID interface{}) *MockService_GetObject_Call {
-	return &MockService_GetObject_Call{Call: _e.mock.On("GetObject", ctx, objectID)}
-}
-
-func (_c *MockService_GetObject_Call) Run(run func(ctx context.Context, objectID string)) *MockService_GetObject_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockService_GetObject_Call) Return(sb smartblock.SmartBlock, err error) *MockService_GetObject_Call {
-	_c.Call.Return(sb, err)
-	return _c
-}
-
-func (_c *MockService_GetObject_Call) RunAndReturn(run func(context.Context, string) (smartblock.SmartBlock, error)) *MockService_GetObject_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetObjectByFullID provides a mock function with given fields: ctx, id
-func (_m *MockService) GetObjectByFullID(ctx context.Context, id domain.FullID) (smartblock.SmartBlock, error) {
-	ret := _m.Called(ctx, id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetObjectByFullID")
-	}
-
-	var r0 smartblock.SmartBlock
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, domain.FullID) (smartblock.SmartBlock, error)); ok {
-		return rf(ctx, id)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, domain.FullID) smartblock.SmartBlock); ok {
-		r0 = rf(ctx, id)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(smartblock.SmartBlock)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, domain.FullID) error); ok {
-		r1 = rf(ctx, id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockService_GetObjectByFullID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetObjectByFullID'
-type MockService_GetObjectByFullID_Call struct {
-	*mock.Call
-}
-
-// GetObjectByFullID is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id domain.FullID
-func (_e *MockService_Expecter) GetObjectByFullID(ctx interface{}, id interface{}) *MockService_GetObjectByFullID_Call {
-	return &MockService_GetObjectByFullID_Call{Call: _e.mock.On("GetObjectByFullID", ctx, id)}
-}
-
-func (_c *MockService_GetObjectByFullID_Call) Run(run func(ctx context.Context, id domain.FullID)) *MockService_GetObjectByFullID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(domain.FullID))
-	})
-	return _c
-}
-
-func (_c *MockService_GetObjectByFullID_Call) Return(sb smartblock.SmartBlock, err error) *MockService_GetObjectByFullID_Call {
-	_c.Call.Return(sb, err)
-	return _c
-}
-
-func (_c *MockService_GetObjectByFullID_Call) RunAndReturn(run func(context.Context, domain.FullID) (smartblock.SmartBlock, error)) *MockService_GetObjectByFullID_Call {
-	_c.Call.Return(run)
-	return _c
 }
 
 // Init provides a mock function with given fields: a
@@ -829,54 +709,6 @@ func (_c *MockService_SetListIsFavorite_Call) Return(_a0 error) *MockService_Set
 }
 
 func (_c *MockService_SetListIsFavorite_Call) RunAndReturn(run func([]string, bool) error) *MockService_SetListIsFavorite_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetSource provides a mock function with given fields: ctx, objectId, source
-func (_m *MockService) SetSource(ctx session.Context, objectId string, source []string) error {
-	ret := _m.Called(ctx, objectId, source)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetSource")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(session.Context, string, []string) error); ok {
-		r0 = rf(ctx, objectId, source)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockService_SetSource_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetSource'
-type MockService_SetSource_Call struct {
-	*mock.Call
-}
-
-// SetSource is a helper method to define mock.On call
-//   - ctx session.Context
-//   - objectId string
-//   - source []string
-func (_e *MockService_Expecter) SetSource(ctx interface{}, objectId interface{}, source interface{}) *MockService_SetSource_Call {
-	return &MockService_SetSource_Call{Call: _e.mock.On("SetSource", ctx, objectId, source)}
-}
-
-func (_c *MockService_SetSource_Call) Run(run func(ctx session.Context, objectId string, source []string)) *MockService_SetSource_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(session.Context), args[1].(string), args[2].([]string))
-	})
-	return _c
-}
-
-func (_c *MockService_SetSource_Call) Return(_a0 error) *MockService_SetSource_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockService_SetSource_Call) RunAndReturn(run func(session.Context, string, []string) error) *MockService_SetSource_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/kanban/group_tag.go
+++ b/core/kanban/group_tag.go
@@ -47,6 +47,16 @@ func (t *GroupTag) InitGroups(spaceID string, f *database.Filters) error {
 			Cond:  model.BlockContentDataviewFilter_Equal,
 			Value: pbtypes.Int64(int64(model.ObjectType_relationOption)),
 		},
+		database.FilterEq{
+			Key:   bundle.RelationKeyIsArchived.String(),
+			Cond:  model.BlockContentDataviewFilter_NotEqual,
+			Value: pbtypes.Bool(true),
+		},
+		database.FilterEq{
+			Key:   bundle.RelationKeyIsDeleted.String(),
+			Cond:  model.BlockContentDataviewFilter_NotEqual,
+			Value: pbtypes.Bool(true),
+		},
 	}
 	if spaceID != "" {
 		relationOptionFilter = append(relationOptionFilter, spaceFilter)

--- a/core/object.go
+++ b/core/object.go
@@ -352,8 +352,7 @@ func (mw *Middleware) ObjectSearchSubscribe(cctx context.Context, req *pb.RpcObj
 	}
 }
 
-func (mw *Middleware) ObjectGroupsSubscribe(cctx context.Context, req *pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse {
-	ctx := mw.newContext(cctx)
+func (mw *Middleware) ObjectGroupsSubscribe(_ context.Context, req *pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse {
 	errResponse := func(err error) *pb.RpcObjectGroupsSubscribeResponse {
 		r := &pb.RpcObjectGroupsSubscribeResponse{
 			Error: &pb.RpcObjectGroupsSubscribeResponseError{
@@ -372,7 +371,7 @@ func (mw *Middleware) ObjectGroupsSubscribe(cctx context.Context, req *pb.RpcObj
 
 	subService := mw.applicationService.GetApp().MustComponent(subscription.CName).(subscription.Service)
 
-	resp, err := subService.SubscribeGroups(ctx, *req)
+	resp, err := subService.SubscribeGroups(*req)
 	if err != nil {
 		return errResponse(err)
 	}

--- a/core/subscription/mock_subscription/mock_Service.go
+++ b/core/subscription/mock_subscription/mock_Service.go
@@ -11,8 +11,6 @@ import (
 
 	pb "github.com/anyproto/anytype-heart/pb"
 
-	session "github.com/anyproto/anytype-heart/core/session"
-
 	subscription "github.com/anyproto/anytype-heart/core/subscription"
 
 	types "github.com/gogo/protobuf/types"
@@ -272,9 +270,9 @@ func (_c *MockService_Search_Call) RunAndReturn(run func(subscription.SubscribeR
 	return _c
 }
 
-// SubscribeGroups provides a mock function with given fields: ctx, req
-func (_m *MockService) SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
-	ret := _m.Called(ctx, req)
+// SubscribeGroups provides a mock function with given fields: req
+func (_m *MockService) SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
+	ret := _m.Called(req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SubscribeGroups")
@@ -282,19 +280,19 @@ func (_m *MockService) SubscribeGroups(ctx session.Context, req pb.RpcObjectGrou
 
 	var r0 *pb.RpcObjectGroupsSubscribeResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(session.Context, pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)); ok {
-		return rf(ctx, req)
+	if rf, ok := ret.Get(0).(func(pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)); ok {
+		return rf(req)
 	}
-	if rf, ok := ret.Get(0).(func(session.Context, pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse); ok {
-		r0 = rf(ctx, req)
+	if rf, ok := ret.Get(0).(func(pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse); ok {
+		r0 = rf(req)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*pb.RpcObjectGroupsSubscribeResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(session.Context, pb.RpcObjectGroupsSubscribeRequest) error); ok {
-		r1 = rf(ctx, req)
+	if rf, ok := ret.Get(1).(func(pb.RpcObjectGroupsSubscribeRequest) error); ok {
+		r1 = rf(req)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -308,15 +306,14 @@ type MockService_SubscribeGroups_Call struct {
 }
 
 // SubscribeGroups is a helper method to define mock.On call
-//   - ctx session.Context
 //   - req pb.RpcObjectGroupsSubscribeRequest
-func (_e *MockService_Expecter) SubscribeGroups(ctx interface{}, req interface{}) *MockService_SubscribeGroups_Call {
-	return &MockService_SubscribeGroups_Call{Call: _e.mock.On("SubscribeGroups", ctx, req)}
+func (_e *MockService_Expecter) SubscribeGroups(req interface{}) *MockService_SubscribeGroups_Call {
+	return &MockService_SubscribeGroups_Call{Call: _e.mock.On("SubscribeGroups", req)}
 }
 
-func (_c *MockService_SubscribeGroups_Call) Run(run func(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest)) *MockService_SubscribeGroups_Call {
+func (_c *MockService_SubscribeGroups_Call) Run(run func(req pb.RpcObjectGroupsSubscribeRequest)) *MockService_SubscribeGroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(session.Context), args[1].(pb.RpcObjectGroupsSubscribeRequest))
+		run(args[0].(pb.RpcObjectGroupsSubscribeRequest))
 	})
 	return _c
 }
@@ -326,7 +323,7 @@ func (_c *MockService_SubscribeGroups_Call) Return(_a0 *pb.RpcObjectGroupsSubscr
 	return _c
 }
 
-func (_c *MockService_SubscribeGroups_Call) RunAndReturn(run func(session.Context, pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)) *MockService_SubscribeGroups_Call {
+func (_c *MockService_SubscribeGroups_Call) RunAndReturn(run func(pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)) *MockService_SubscribeGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/event"
 	"github.com/anyproto/anytype-heart/core/kanban"
-	"github.com/anyproto/anytype-heart/core/session"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
@@ -77,7 +76,7 @@ type Service interface {
 	Search(req SubscribeRequest) (resp *SubscribeResponse, err error)
 	SubscribeIdsReq(req pb.RpcObjectSubscribeIdsRequest) (resp *pb.RpcObjectSubscribeIdsResponse, err error)
 	SubscribeIds(subId string, ids []string) (records []*types.Struct, err error)
-	SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)
+	SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)
 	Unsubscribe(subIds ...string) (err error)
 	UnsubscribeAll() (err error)
 	SubscriptionIDs() []string
@@ -388,7 +387,7 @@ func (s *service) SubscribeIdsReq(req pb.RpcObjectSubscribeIdsRequest) (resp *pb
 	}, nil
 }
 
-func (s *service) SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
+func (s *service) SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
 	subId := ""
 
 	s.m.Lock()

--- a/core/subscription/service_test.go
+++ b/core/subscription/service_test.go
@@ -840,7 +840,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:      spaceID,
 			RelationKey:  relationKey,
 			Source:       []string{source},
@@ -903,7 +903,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:      spaceID,
 			RelationKey:  relationKey,
 			Source:       []string{source},
@@ -967,7 +967,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:     spaceID,
 			RelationKey: relationKey,
 			Source:      []string{source},
@@ -1021,7 +1021,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:     spaceID,
 			RelationKey: relationKey,
 			Source:      []string{source},
@@ -1069,7 +1069,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:     spaceID,
 			RelationKey: relationKey,
 			Source:      []string{source},


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3977/deleted-tags-still-showing

On ObjectGroupSubscribe we used to call store.QueryRaw without isDeleted and isArchived filters, so deleted tags showed up as well