### PR TITLE
GO-3977 Do not show deleted tags in kanban

### DIFF
--- a/core/kanban/group_tag.go
+++ b/core/kanban/group_tag.go
@@ -44,6 +44,16 @@ func (t *GroupTag) InitGroups(spaceID string, f *database.Filters) error {
 			Cond:  model.BlockContentDataviewFilter_Equal,
 			Value: pbtypes.Int64(int64(model.ObjectType_relationOption)),
 		},
+		database.FilterEq{
+			Key:   bundle.RelationKeyIsArchived.String(),
+			Cond:  model.BlockContentDataviewFilter_NotEqual,
+			Value: pbtypes.Bool(true),
+		},
+		database.FilterEq{
+			Key:   bundle.RelationKeyIsDeleted.String(),
+			Cond:  model.BlockContentDataviewFilter_NotEqual,
+			Value: pbtypes.Bool(true),
+		},
 	}
 	f.FilterObj = database.FiltersOr{f.FilterObj, relationOptionFilter}
 

--- a/core/object.go
+++ b/core/object.go
@@ -339,8 +339,7 @@ func (mw *Middleware) ObjectSearchSubscribe(cctx context.Context, req *pb.RpcObj
 	}
 }
 
-func (mw *Middleware) ObjectGroupsSubscribe(cctx context.Context, req *pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse {
-	ctx := mw.newContext(cctx)
+func (mw *Middleware) ObjectGroupsSubscribe(_ context.Context, req *pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse {
 	errResponse := func(err error) *pb.RpcObjectGroupsSubscribeResponse {
 		r := &pb.RpcObjectGroupsSubscribeResponse{
 			Error: &pb.RpcObjectGroupsSubscribeResponseError{
@@ -359,7 +358,7 @@ func (mw *Middleware) ObjectGroupsSubscribe(cctx context.Context, req *pb.RpcObj
 
 	subService := mw.applicationService.GetApp().MustComponent(subscription.CName).(subscription.Service)
 
-	resp, err := subService.SubscribeGroups(ctx, *req)
+	resp, err := subService.SubscribeGroups(*req)
 	if err != nil {
 		return errResponse(err)
 	}

--- a/core/subscription/mock_subscription/mock_Service.go
+++ b/core/subscription/mock_subscription/mock_Service.go
@@ -11,8 +11,6 @@ import (
 
 	pb "github.com/anyproto/anytype-heart/pb"
 
-	session "github.com/anyproto/anytype-heart/core/session"
-
 	subscription "github.com/anyproto/anytype-heart/core/subscription"
 
 	types "github.com/gogo/protobuf/types"
@@ -272,9 +270,9 @@ func (_c *MockService_Search_Call) RunAndReturn(run func(subscription.SubscribeR
 	return _c
 }
 
-// SubscribeGroups provides a mock function with given fields: ctx, req
-func (_m *MockService) SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
-	ret := _m.Called(ctx, req)
+// SubscribeGroups provides a mock function with given fields: req
+func (_m *MockService) SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
+	ret := _m.Called(req)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SubscribeGroups")
@@ -282,19 +280,19 @@ func (_m *MockService) SubscribeGroups(ctx session.Context, req pb.RpcObjectGrou
 
 	var r0 *pb.RpcObjectGroupsSubscribeResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func(session.Context, pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)); ok {
-		return rf(ctx, req)
+	if rf, ok := ret.Get(0).(func(pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)); ok {
+		return rf(req)
 	}
-	if rf, ok := ret.Get(0).(func(session.Context, pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse); ok {
-		r0 = rf(ctx, req)
+	if rf, ok := ret.Get(0).(func(pb.RpcObjectGroupsSubscribeRequest) *pb.RpcObjectGroupsSubscribeResponse); ok {
+		r0 = rf(req)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*pb.RpcObjectGroupsSubscribeResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(session.Context, pb.RpcObjectGroupsSubscribeRequest) error); ok {
-		r1 = rf(ctx, req)
+	if rf, ok := ret.Get(1).(func(pb.RpcObjectGroupsSubscribeRequest) error); ok {
+		r1 = rf(req)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -308,15 +306,14 @@ type MockService_SubscribeGroups_Call struct {
 }
 
 // SubscribeGroups is a helper method to define mock.On call
-//   - ctx session.Context
 //   - req pb.RpcObjectGroupsSubscribeRequest
-func (_e *MockService_Expecter) SubscribeGroups(ctx interface{}, req interface{}) *MockService_SubscribeGroups_Call {
-	return &MockService_SubscribeGroups_Call{Call: _e.mock.On("SubscribeGroups", ctx, req)}
+func (_e *MockService_Expecter) SubscribeGroups(req interface{}) *MockService_SubscribeGroups_Call {
+	return &MockService_SubscribeGroups_Call{Call: _e.mock.On("SubscribeGroups", req)}
 }
 
-func (_c *MockService_SubscribeGroups_Call) Run(run func(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest)) *MockService_SubscribeGroups_Call {
+func (_c *MockService_SubscribeGroups_Call) Run(run func(req pb.RpcObjectGroupsSubscribeRequest)) *MockService_SubscribeGroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(session.Context), args[1].(pb.RpcObjectGroupsSubscribeRequest))
+		run(args[0].(pb.RpcObjectGroupsSubscribeRequest))
 	})
 	return _c
 }
@@ -326,7 +323,7 @@ func (_c *MockService_SubscribeGroups_Call) Return(_a0 *pb.RpcObjectGroupsSubscr
 	return _c
 }
 
-func (_c *MockService_SubscribeGroups_Call) RunAndReturn(run func(session.Context, pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)) *MockService_SubscribeGroups_Call {
+func (_c *MockService_SubscribeGroups_Call) RunAndReturn(run func(pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)) *MockService_SubscribeGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/event"
 	"github.com/anyproto/anytype-heart/core/kanban"
-	"github.com/anyproto/anytype-heart/core/session"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
@@ -79,7 +78,7 @@ type Service interface {
 	Search(req SubscribeRequest) (resp *SubscribeResponse, err error)
 	SubscribeIdsReq(req pb.RpcObjectSubscribeIdsRequest) (resp *pb.RpcObjectSubscribeIdsResponse, err error)
 	SubscribeIds(subId string, ids []string) (records []*types.Struct, err error)
-	SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)
+	SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error)
 	Unsubscribe(subIds ...string) (err error)
 	UnsubscribeAll() (err error)
 	SubscriptionIDs() []string
@@ -163,12 +162,12 @@ func (s *service) SubscribeIds(subId string, ids []string) (records []*types.Str
 	return
 }
 
-func (s *service) SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
+func (s *service) SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
 	spaceSubs, err := s.getSpaceSubscriptions(req.SpaceId)
 	if err != nil {
 		return nil, err
 	}
-	return spaceSubs.SubscribeGroups(ctx, req)
+	return spaceSubs.SubscribeGroups(req)
 }
 
 func (s *service) Unsubscribe(subIds ...string) (err error) {
@@ -512,7 +511,7 @@ func (s *spaceSubscriptions) SubscribeIdsReq(req pb.RpcObjectSubscribeIdsRequest
 	}, nil
 }
 
-func (s *spaceSubscriptions) SubscribeGroups(ctx session.Context, req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
+func (s *spaceSubscriptions) SubscribeGroups(req pb.RpcObjectGroupsSubscribeRequest) (*pb.RpcObjectGroupsSubscribeResponse, error) {
 	subId := ""
 
 	s.m.Lock()

--- a/core/subscription/service_test.go
+++ b/core/subscription/service_test.go
@@ -925,7 +925,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:      testSpaceId,
 			RelationKey:  relationKey,
 			Source:       []string{source},
@@ -988,7 +988,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:      testSpaceId,
 			RelationKey:  relationKey,
 			Source:       []string{source},
@@ -1052,7 +1052,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:     testSpaceId,
 			RelationKey: relationKey,
 			Source:      []string{source},
@@ -1106,7 +1106,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:     testSpaceId,
 			RelationKey: relationKey,
 			Source:      []string{source},
@@ -1154,7 +1154,7 @@ func TestService_Search(t *testing.T) {
 		})
 
 		// when
-		groups, err := fx.SubscribeGroups(nil, pb.RpcObjectGroupsSubscribeRequest{
+		groups, err := fx.SubscribeGroups(pb.RpcObjectGroupsSubscribeRequest{
 			SpaceId:     testSpaceId,
 			RelationKey: relationKey,
 			Source:      []string{source},

--- a/space/spacecore/mock_spacecore/mock_SpaceCoreService.go
+++ b/space/spacecore/mock_spacecore/mock_SpaceCoreService.go
@@ -178,9 +178,9 @@ func (_c *MockSpaceCoreService_Create_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
-// Delete provides a mock function with given fields: ctx, spaceID
-func (_m *MockSpaceCoreService) Delete(ctx context.Context, spaceID string) error {
-	ret := _m.Called(ctx, spaceID)
+// Delete provides a mock function with given fields: ctx, spaceId
+func (_m *MockSpaceCoreService) Delete(ctx context.Context, spaceId string) error {
+	ret := _m.Called(ctx, spaceId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
@@ -188,7 +188,7 @@ func (_m *MockSpaceCoreService) Delete(ctx context.Context, spaceID string) erro
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = rf(ctx, spaceID)
+		r0 = rf(ctx, spaceId)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -203,12 +203,12 @@ type MockSpaceCoreService_Delete_Call struct {
 
 // Delete is a helper method to define mock.On call
 //   - ctx context.Context
-//   - spaceID string
-func (_e *MockSpaceCoreService_Expecter) Delete(ctx interface{}, spaceID interface{}) *MockSpaceCoreService_Delete_Call {
-	return &MockSpaceCoreService_Delete_Call{Call: _e.mock.On("Delete", ctx, spaceID)}
+//   - spaceId string
+func (_e *MockSpaceCoreService_Expecter) Delete(ctx interface{}, spaceId interface{}) *MockSpaceCoreService_Delete_Call {
+	return &MockSpaceCoreService_Delete_Call{Call: _e.mock.On("Delete", ctx, spaceId)}
 }
 
-func (_c *MockSpaceCoreService_Delete_Call) Run(run func(ctx context.Context, spaceID string)) *MockSpaceCoreService_Delete_Call {
+func (_c *MockSpaceCoreService_Delete_Call) Run(run func(ctx context.Context, spaceId string)) *MockSpaceCoreService_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})
@@ -596,9 +596,9 @@ func (_c *MockSpaceCoreService_Run_Call) RunAndReturn(run func(context.Context) 
 	return _c
 }
 
-// StorageExistsLocally provides a mock function with given fields: ctx, spaceID
-func (_m *MockSpaceCoreService) StorageExistsLocally(ctx context.Context, spaceID string) (bool, error) {
-	ret := _m.Called(ctx, spaceID)
+// StorageExistsLocally provides a mock function with given fields: ctx, spaceId
+func (_m *MockSpaceCoreService) StorageExistsLocally(ctx context.Context, spaceId string) (bool, error) {
+	ret := _m.Called(ctx, spaceId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for StorageExistsLocally")
@@ -607,16 +607,16 @@ func (_m *MockSpaceCoreService) StorageExistsLocally(ctx context.Context, spaceI
 	var r0 bool
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
-		return rf(ctx, spaceID)
+		return rf(ctx, spaceId)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
-		r0 = rf(ctx, spaceID)
+		r0 = rf(ctx, spaceId)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, spaceID)
+		r1 = rf(ctx, spaceId)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -631,12 +631,12 @@ type MockSpaceCoreService_StorageExistsLocally_Call struct {
 
 // StorageExistsLocally is a helper method to define mock.On call
 //   - ctx context.Context
-//   - spaceID string
-func (_e *MockSpaceCoreService_Expecter) StorageExistsLocally(ctx interface{}, spaceID interface{}) *MockSpaceCoreService_StorageExistsLocally_Call {
-	return &MockSpaceCoreService_StorageExistsLocally_Call{Call: _e.mock.On("StorageExistsLocally", ctx, spaceID)}
+//   - spaceId string
+func (_e *MockSpaceCoreService_Expecter) StorageExistsLocally(ctx interface{}, spaceId interface{}) *MockSpaceCoreService_StorageExistsLocally_Call {
+	return &MockSpaceCoreService_StorageExistsLocally_Call{Call: _e.mock.On("StorageExistsLocally", ctx, spaceId)}
 }
 
-func (_c *MockSpaceCoreService_StorageExistsLocally_Call) Run(run func(ctx context.Context, spaceID string)) *MockSpaceCoreService_StorageExistsLocally_Call {
+func (_c *MockSpaceCoreService_StorageExistsLocally_Call) Run(run func(ctx context.Context, spaceId string)) *MockSpaceCoreService_StorageExistsLocally_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string))
 	})


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3977/deleted-tags-still-showing

On ObjectGroupSubscribe we used to call store.QueryRaw without isDeleted and isArchived filters, so deleted tags showed up as well