### PR TITLE
GO-4282 reindex invalid participant permissions

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -321,10 +321,13 @@ func (bs *basic) addRelationLink(st *state.State, relationKey string) error {
 	return nil
 }
 
+// addRelationLinks is deprecated and will be removed in release 7
 func (bs *basic) addRelationLinks(st *state.State, relationKeys ...string) error {
 	if len(relationKeys) == 0 {
 		return nil
 	}
+	// this code depends on the objectstore being indexed, but can be run on start with empty account
+	// todo: remove this code in release because we will no longer need relationLinks
 	relations, err := bs.objectStore.FetchRelationByKeys(relationKeys...)
 	if err != nil || relations == nil {
 		return fmt.Errorf("failed to get relations: %w", err)

--- a/pkg/lib/localstore/objectstore/spaceindex/relations.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/relations.go
@@ -62,8 +62,14 @@ func (s *dsObjectStore) FetchRelationByKey(key string) (relation *relationutils.
 
 func (s *dsObjectStore) FetchRelationByKeys(keys ...string) (relations relationutils.Relations, err error) {
 	uks := make([]string, 0, len(keys))
-
 	for _, key := range keys {
+		// we should be able to get system relations even when not indexed
+		bundledRel, err := bundle.GetRelation(domain.RelationKey(key))
+		if err == nil {
+			relations = append(relations, &relationutils.Relation{Relation: bundledRel})
+			continue
+		}
+
 		uk, err := domain.NewUniqueKey(smartblock.SmartBlockTypeRelation, key)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
make `FetchRelationByKeys` works the same as `FetchRelationByKey` - to return bundled objects directly from map.
This was called via `ModifyParticipantAclState` and in case of empty objectstore (new account, reindex), failed to add the relationLinks.

RelationLinks will be removed next release, because we will store relation list in the type.