### PR TITLE
GO-4272: fix an ObjectImport panics

### DIFF
--- a/core/block/import/csv/converter.go
+++ b/core/block/import/csv/converter.go
@@ -150,6 +150,7 @@ func (c *CSV) getSnapshotsAndObjectsIds(importSource source.Source,
 			allErrors.Add(err)
 			return !allErrors.ShouldAbortImport(len(params.GetPath()), model.Import_Csv)
 		}
+		csvTable = normalizeCSV(csvTable)
 		if params.TransposeRowsAndColumns && len(csvTable) != 0 {
 			csvTable = transpose(csvTable)
 		}
@@ -204,4 +205,36 @@ func transpose(csvTable [][]string) [][]string {
 		}
 	}
 	return result
+}
+
+func normalizeCSV(csvTable [][]string) [][]string {
+	if isMatrix(csvTable) {
+		return csvTable
+	}
+	maxColumns := 0
+	for _, row := range csvTable {
+		if len(row) > maxColumns {
+			maxColumns = len(row)
+		}
+	}
+	for i, row := range csvTable {
+		for len(row) < maxColumns {
+			row = append(row, "")
+		}
+		csvTable[i] = row
+	}
+	return csvTable
+}
+
+func isMatrix(arr [][]string) bool {
+	if len(arr) == 0 {
+		return true
+	}
+	columnCount := len(arr[0])
+	for _, row := range arr {
+		if len(row) != columnCount {
+			return false
+		}
+	}
+	return true
 }

--- a/core/block/import/csv/testdata/transpose_not_matrix.csv
+++ b/core/block/import/csv/testdata/transpose_not_matrix.csv
@@ -1,0 +1,2 @@
+name;sony
+price123


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4272/fix-an-objectimport-panics

The problem is that we create CSV reader with following option`csvReader.FieldsPerRecord = -1`. That means that we doesn't check number of column per row. And we allow to import files like this for example
```
name
price;1
```
I decided not to remove this check and allow to import such files, but I transform them into matrix, to avoid problems with transpose (because we assume that during transpose we have a matrix). So after normalization we will get csv table in slices with added empty strings - representation of missed columns 

before fix
```
[][]string{
    []string{"name"};
    []string{"price", "1"}
}

```
after fix
```
[][]string{
    []string{"name", ""};
    []string{"price", "1"}
}
```
