### PR TITLE
Go 4256 read exported ipld tree with assets and render

### DIFF
--- a/core/publish.go
+++ b/core/publish.go
@@ -11,7 +11,6 @@ func (mw *Middleware) ObjectPublish(ctx context.Context, req *pb.RpcObjectPublis
 	publishService := getService[publish.Service](mw)
 
 	res, err := publishService.Publish(ctx, req.SpaceId, req.ObjectId)
-
 	code := mapErrorCode(err,
 		errToCode(nil, pb.RpcObjectPublishResponseError_NULL))
 

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -83,6 +83,13 @@ type fileObject struct {
 	Content  []byte
 }
 
+// current structure of published ufs dir:
+// ```
+// - keys.json <- encrypted with main key, has keys for all the other files
+// - index.json <- renderer input
+// - asset1
+// - asset2....
+// ```
 func (s *service) publishUfs(ctx context.Context, spaceId, pageId string) (res PublishResult, err error) {
 	dagService := s.dagServiceForSpace(spaceId)
 	outer := uio.NewDirectory(dagService)

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -237,6 +237,11 @@ func (s *service) publishUfs(ctx context.Context, spaceId, pageId string) (res P
 		return
 	}
 
+	err = dagService.Add(ctx, outerNode)
+	if err != nil {
+		return
+	}
+
 	outerNodeCid := outerNode.Cid().String()
 
 	// upload ufs root node Cid
@@ -256,7 +261,6 @@ func (s *service) Publish(ctx context.Context, spaceId, input string) (res Publi
 	// so I just pass the whole object for now instead of id.
 	res, err = s.publishUfs(ctx, spaceId, input)
 	if err != nil {
-		// {"level":"ERROR","ts":"2024-10-17T19:41:59.212+0200","logger":"common.core.publishservice","msg":"Failed to publish","error":"check blocks availability: walk DAG: walk DAG: get root node: CID not found"}
 		log.Error("Failed to publish", zap.Error(err))
 	}
 

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -3,18 +3,31 @@ package publish
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/app/logger"
 	"github.com/anyproto/any-sync/commonfile/fileservice"
 	"github.com/anyproto/any-sync/util/crypto"
+	uio "github.com/ipfs/boxo/ipld/unixfs/io"
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	mh "github.com/multiformats/go-multihash"
+	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/files/filehelper"
+	"github.com/anyproto/anytype-heart/core/files/fileuploader"
 	"github.com/anyproto/anytype-heart/core/filestorage/filesync"
+	"github.com/anyproto/anytype-heart/pkg/lib/ipfs/helpers"
 	"github.com/anyproto/anytype-heart/space"
 	"github.com/anyproto/anytype-heart/util/encode"
 )
 
 const CName = "common.core.publishservice"
+
+var log = logger.NewNamed(CName)
+var cidBuilder = cid.V1Builder{Codec: cid.DagProtobuf, MhType: mh.SHA2_256}
 
 type PublishResult struct {
 	Cid string
@@ -26,10 +39,12 @@ type Service interface {
 }
 
 type service struct {
-	commonFile      fileservice.FileService
-	fileSyncService filesync.FileSync
-	spaceService    space.Service
-	techSpaceId     string
+	commonFile          fileservice.FileService
+	fileUploaderService fileuploader.Service
+	fileSyncService     filesync.FileSync
+	spaceService        space.Service
+	dagService          ipld.DAGService
+	techSpaceId         string
 }
 
 func New() Service {
@@ -37,9 +52,12 @@ func New() Service {
 }
 
 func (s *service) Init(a *app.App) error {
+	s.fileUploaderService = app.MustComponent[fileuploader.Service](a)
 	s.commonFile = app.MustComponent[fileservice.FileService](a)
+	s.dagService = s.commonFile.DAGService()
 	s.fileSyncService = app.MustComponent[filesync.FileSync](a)
 	s.spaceService = app.MustComponent[space.Service](a)
+
 	return nil
 }
 
@@ -54,6 +72,10 @@ func (s *service) Close(_ context.Context) error {
 
 func (s *service) Name() (name string) {
 	return CName
+}
+
+func (s *service) dagServiceForSpace(spaceID string) ipld.DAGService {
+	return filehelper.NewDAGServiceWithSpaceID(spaceID, s.dagService)
 }
 
 func (s *service) publishData(ctx context.Context, spaceId, input string) (res PublishResult, err error) {
@@ -73,7 +95,7 @@ func (s *service) publishData(ctx context.Context, spaceId, input string) (res P
 	}
 
 	cidStr := node.Cid().String()
-	err = s.fileSyncService.UploadSynchronously(ctx, s.techSpaceId, domain.FileId(cidStr))
+	err = s.fileSyncService.UploadSynchronously(ctx, spaceId, domain.FileId(cidStr))
 	if err != nil {
 		return
 	}
@@ -88,8 +110,156 @@ func (s *service) publishData(ctx context.Context, spaceId, input string) (res P
 	return
 }
 
+type keyObject struct {
+	Cid string `json:"cid"`
+	Key string `json:"key"`
+}
+
+type fileObject struct {
+	FileName string
+	Content  []byte
+}
+
+func (s *service) publishUfs(ctx context.Context, spaceId, pageId string) (res PublishResult, err error) {
+	dagService := s.dagServiceForSpace(spaceId)
+	outer := uio.NewDirectory(dagService)
+	outer.SetCidBuilder(cidBuilder)
+
+	mainKey, err := crypto.NewRandomAES()
+	if err != nil {
+		return
+	}
+	// will be converted to json and encrypted by main key
+	keys := make(map[string]keyObject, 0)
+
+	// will be added via commonFile.AddFile
+	files := make([]fileObject, 0)
+
+	// pageId is json content for now
+	indexJson := fileObject{
+		FileName: "index.json",
+		Content:  []byte(pageId),
+	}
+
+	asset1 := fileObject{
+		FileName: "foo.jpg",
+		Content:  []byte("foo.jpg content"),
+	}
+	asset2 := fileObject{
+		FileName: "bar.jpg",
+		Content:  []byte("bar.jpg content"),
+	}
+
+	files = append(files, indexJson, asset1, asset2)
+
+	// add all files via common file, to outer ipfs dir and to keys
+	for _, file := range files {
+		var key *crypto.AESKey
+		key, err = crypto.NewRandomAES()
+		if err != nil {
+			return
+		}
+
+		var encContent []byte
+		encContent, err = key.Encrypt([]byte(file.Content))
+		if err != nil {
+			return
+		}
+
+		var node ipld.Node
+		node, err = s.commonFile.AddFile(ctx, bytes.NewReader(encContent))
+		if err != nil {
+			return
+		}
+
+		err = dagService.Add(ctx, node)
+		if err != nil {
+			return
+		}
+
+		cid := node.Cid().String()
+		err = helpers.AddLinkToDirectory(ctx, dagService, outer, file.FileName, cid)
+		if err != nil {
+			return
+		}
+
+		var keyStr string
+		keyStr, err = encode.EncodeKeyToBase58(key)
+		if err != nil {
+			return
+		}
+
+		keys[file.FileName] = keyObject{
+			Cid: cid,
+			Key: keyStr,
+		}
+	}
+
+	// now, add keys to files and encrypt with the main key which will be returned
+	var keysJson []byte
+	keysJson, err = json.Marshal(keys)
+	if err != nil {
+		return
+	}
+
+	var encKeys []byte
+	encKeys, err = mainKey.Encrypt(keysJson)
+	if err != nil {
+		return
+	}
+
+	var node ipld.Node
+	node, err = s.commonFile.AddFile(ctx, bytes.NewReader(encKeys))
+	if err != nil {
+		return
+	}
+
+	err = dagService.Add(ctx, node)
+	if err != nil {
+		return
+	}
+
+	cid := node.Cid().String()
+	err = helpers.AddLinkToDirectory(ctx, dagService, outer, "keys.json", cid)
+	if err != nil {
+		return
+	}
+
+	var mainKeyStr string
+	mainKeyStr, err = encode.EncodeKeyToBase58(mainKey)
+	if err != nil {
+		return
+	}
+
+	var outerNode ipld.Node
+	outerNode, err = outer.GetNode()
+	if err != nil {
+		return
+	}
+
+	outerNodeCid := outerNode.Cid().String()
+
+	// upload ufs root node Cid
+	err = s.fileSyncService.UploadSynchronously(ctx, spaceId, domain.FileId(outerNodeCid))
+	if err != nil {
+		return
+	}
+
+	// and return node Cid and mainKey
+	res.Cid = outerNodeCid
+	res.Key = mainKeyStr
+	return
+}
+
 func (s *service) Publish(ctx context.Context, spaceId, input string) (res PublishResult, err error) {
 	// shortcut, because anytype-ts uses custom mapping to make json object
 	// so I just pass the whole object for now instead of id.
-	return s.publishData(ctx, spaceId, input)
+	res, err = s.publishUfs(ctx, spaceId, input)
+	if err != nil {
+		// {"level":"ERROR","ts":"2024-10-17T19:41:59.212+0200","logger":"common.core.publishservice","msg":"Failed to publish","error":"check blocks availability: walk DAG: walk DAG: get root node: CID not found"}
+		log.Error("Failed to publish", zap.Error(err))
+	}
+
+	return
+
 }


### PR DESCRIPTION
implements initial support for publishing multiple files, implemented via ufs. For now, I'm just sending dummy assets (for testing purposes) and next step would be to send real web page assets, such as images. Same goes for renderer on gateway, -- it doesn't support any assets at the moment.

current structure of published ufs dir:
```
- keys.json <- encrypted with main key, has keys for all the other files
- index.json <- renderer input 
- asset1
- asset2....
```

Uploading implemented via same mechanism which we use for invites but for the future I'm thinking about how to implement it on top of  `UploadFile`. It will also allow us to get rid of custom encryption scheme (`keys.json`) and reuse standard anytype-heart encryption mechanics for file objects.  So we need a dedicated file type for publishing, so it requires some design according to our current requirements. 