### PR TITLE
GO-4241: The name of the Space member is not displayed

### DIFF
--- a/core/block/editor/participant.go
+++ b/core/block/editor/participant.go
@@ -55,6 +55,13 @@ func (p *participant) Init(ctx *smartblock.InitContext) (err error) {
 	ctx.State.SetDetailAndBundledRelation(bundle.RelationKeyLayout, pbtypes.Int64(int64(model.ObjectType_participant)))
 	ctx.State.SetDetailAndBundledRelation(bundle.RelationKeyLayoutAlign, pbtypes.Int64(int64(model.Block_AlignCenter)))
 
+	records, err := p.objectStore.QueryByIds([]string{p.Id()})
+	if err != nil {
+		return err
+	}
+	if len(records) > 0 {
+		ctx.State.SetDetails(records[0].Details)
+	}
 	template.InitTemplate(ctx.State,
 		template.WithEmpty,
 		template.WithTitle,
@@ -63,15 +70,6 @@ func (p *participant) Init(ctx *smartblock.InitContext) (err error) {
 		template.WithAddedFeaturedRelation(bundle.RelationKeyType),
 		template.WithAddedFeaturedRelation(bundle.RelationKeyBacklinks),
 	)
-
-	records, err := p.objectStore.QueryByIds([]string{p.Id()})
-	if err != nil {
-		return err
-	}
-	if len(records) > 0 {
-		ctx.State.SetDetails(records[0].Details)
-	}
-
 	return nil
 }
 

--- a/core/block/editor/participant_test.go
+++ b/core/block/editor/participant_test.go
@@ -135,7 +135,7 @@ func TestParticipant_Init(t *testing.T) {
 			IsNewObject: true,
 		}
 
-		// then
+		// when
 		err := p.Init(initCtx)
 		assert.NoError(t, err)
 		migration.RunMigrations(p, initCtx)
@@ -146,7 +146,7 @@ func TestParticipant_Init(t *testing.T) {
 		assert.NotNil(t, p.NewState().Get(state.TitleBlockID))
 		assert.Equal(t, "test", p.NewState().Get(state.TitleBlockID).Model().GetText().GetText())
 	})
-	t.Run("title block is not empty", func(t *testing.T) {
+	t.Run("title block is empty", func(t *testing.T) {
 		// given
 		sb := smarttest.New("root")
 		store := newStoreFixture(t)
@@ -162,7 +162,7 @@ func TestParticipant_Init(t *testing.T) {
 			IsNewObject: true,
 		}
 
-		// then
+		// when
 		err := p.Init(initCtx)
 		assert.NoError(t, err)
 		migration.RunMigrations(p, initCtx)


### PR DESCRIPTION
We initialize title block before `SetDetails` call, so it is turned out to be empty after participant creation. 
So the fix is to call title block creation in `template.InitTemplate` after `SetDetails` call