### PR TITLE
GO-4139 | GO-4141 | GO-4142 - Restrict template creation

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -385,6 +385,10 @@ func (bs *basic) SetObjectTypesInState(s *state.State, objectTypeKeys []domain.T
 		if err = bs.Restrictions().Object.Check(model.Restrictions_TypeChange); errors.Is(err, restriction.ErrRestricted) {
 			return fmt.Errorf("objectType change is restricted for object '%s': %w", bs.Id(), err)
 		}
+
+		if objectTypeKeys[0] == bundle.TypeKeyTemplate {
+			return fmt.Errorf("changing object type to template is restricted")
+		}
 	}
 
 	s.SetObjectTypeKeys(objectTypeKeys)

--- a/core/block/editor/basic/details_test.go
+++ b/core/block/editor/basic/details_test.go
@@ -5,9 +5,13 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/converter"
+	"github.com/anyproto/anytype-heart/core/block/editor/lastused/mock_lastused"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/block/restriction"
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
@@ -15,10 +19,11 @@ import (
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
-type duFixture struct {
-	sb    *smarttest.SmartTest
-	store *spaceindex.StoreFixture
-	basic DetailsUpdatable
+type basicFixture struct {
+	sb       *smarttest.SmartTest
+	store    *spaceindex.StoreFixture
+	lastUsed *mock_lastused.MockObjectUsageUpdater
+	basic    CommonOperations
 }
 
 var (
@@ -26,26 +31,28 @@ var (
 	spaceId  = "space1"
 )
 
-func newDUFixture(t *testing.T) *duFixture {
+func newBasicFixture(t *testing.T) *basicFixture {
 	sb := smarttest.New(objectId)
 	sb.SetDetails(nil, nil, false)
 	sb.SetSpaceId(spaceId)
 
 	store := spaceindex.NewStoreFixture(t)
+	lastUsed := mock_lastused.NewMockObjectUsageUpdater(t)
 
-	b := NewBasic(sb, store, converter.NewLayoutConverter(), nil, nil)
+	b := NewBasic(sb, store, converter.NewLayoutConverter(), nil, lastUsed)
 
-	return &duFixture{
-		sb:    sb,
-		store: store,
-		basic: b,
+	return &basicFixture{
+		sb:       sb,
+		store:    store,
+		lastUsed: lastUsed,
+		basic:    b,
 	}
 }
 
 func TestBasic_UpdateDetails(t *testing.T) {
 	t.Run("add new details", func(t *testing.T) {
 		// given
-		f := newDUFixture(t)
+		f := newBasicFixture(t)
 		f.store.AddObjects(t, []objectstore.TestObject{{
 			bundle.RelationKeyId:             pbtypes.String("rel-aperture"),
 			bundle.RelationKeySpaceId:        pbtypes.String(spaceId),
@@ -83,7 +90,7 @@ func TestBasic_UpdateDetails(t *testing.T) {
 
 	t.Run("modify details", func(t *testing.T) {
 		// given
-		f := newDUFixture(t)
+		f := newBasicFixture(t)
 		err := f.sb.SetDetails(nil, []*model.Detail{{
 			Key:   bundle.RelationKeySpaceDashboardId.String(),
 			Value: pbtypes.String("123"),
@@ -114,7 +121,7 @@ func TestBasic_UpdateDetails(t *testing.T) {
 
 	t.Run("delete details", func(t *testing.T) {
 		// given
-		f := newDUFixture(t)
+		f := newBasicFixture(t)
 		err := f.sb.SetDetails(nil, []*model.Detail{{
 			Key:   bundle.RelationKeyTargetObjectType.String(),
 			Value: pbtypes.String("ot-note"),
@@ -134,5 +141,54 @@ func TestBasic_UpdateDetails(t *testing.T) {
 		assert.False(t, found)
 		assert.Nil(t, value)
 		assert.False(t, f.sb.HasRelation(f.sb.NewState(), bundle.RelationKeyTargetObjectType.String()))
+	})
+}
+
+func TestBasic_SetObjectTypesInState(t *testing.T) {
+	t.Run("no error", func(t *testing.T) {
+		// given
+		f := newBasicFixture(t)
+
+		f.lastUsed.EXPECT().UpdateLastUsedDate(mock.Anything, bundle.TypeKeyTask, mock.Anything).Return().Once()
+		f.store.AddObjects(t, []objectstore.TestObject{{
+			bundle.RelationKeySpaceId:   pbtypes.String(spaceId),
+			bundle.RelationKeyId:        pbtypes.String("ot-task"),
+			bundle.RelationKeyUniqueKey: pbtypes.String("ot-task"),
+			bundle.RelationKeyLayout:    pbtypes.Int64(int64(model.ObjectType_todo)),
+		}})
+
+		s := f.sb.NewState()
+
+		// when
+		err := f.basic.SetObjectTypesInState(s, []domain.TypeKey{bundle.TypeKeyTask}, false)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, bundle.TypeKeyTask, s.ObjectTypeKey())
+	})
+
+	t.Run("type change is restricted", func(t *testing.T) {
+		// given
+		f := newBasicFixture(t)
+		f.sb.TestRestrictions = restriction.Restrictions{Object: []model.RestrictionsObjectRestriction{model.Restrictions_TypeChange}}
+		s := f.sb.NewState()
+
+		// when
+		err := f.basic.SetObjectTypesInState(s, []domain.TypeKey{bundle.TypeKeyTask}, false)
+
+		// then
+		assert.ErrorIs(t, err, restriction.ErrRestricted)
+	})
+
+	t.Run("changing to template type is restricted", func(t *testing.T) {
+		// given
+		f := newBasicFixture(t)
+		s := f.sb.NewState()
+
+		// when
+		err := f.basic.SetObjectTypesInState(s, []domain.TypeKey{bundle.TypeKeyTemplate}, false)
+
+		// then
+		assert.Error(t, err)
 	})
 }

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -155,6 +155,10 @@ func (s *service) createObjectInSpace(
 		return s.createChatDerived(ctx, space, details)
 	case bundle.TypeKeyFile:
 		return "", nil, fmt.Errorf("files must be created via fileobject service")
+	case bundle.TypeKeyTemplate:
+		if pbtypes.GetString(details, bundle.RelationKeyTargetObjectType.String()) == "" {
+			return "", nil, fmt.Errorf("cannot create template without target object")
+		}
 	}
 
 	return s.createObjectFromTemplate(ctx, space, []domain.TypeKey{req.ObjectTypeKey}, details, req.TemplateId)

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -1,0 +1,106 @@
+package objectcreator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/lastused/mock_lastused"
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/space/clientspace"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/space/mock_space"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+const spaceId = "spc1"
+
+type fixture struct {
+	spaceService    *mock_space.MockService
+	spc             *mock_clientspace.MockSpace
+	templateService *testTemplateService
+	lastUsedService *mock_lastused.MockObjectUsageUpdater
+	service         Service
+}
+
+func newFixture(t *testing.T) *fixture {
+	spaceService := mock_space.NewMockService(t)
+	spc := mock_clientspace.NewMockSpace(t)
+
+	templateSvc := &testTemplateService{}
+	lastUsedSvc := mock_lastused.NewMockObjectUsageUpdater(t)
+
+	s := &service{
+		spaceService:    spaceService,
+		templateService: templateSvc,
+		lastUsedUpdater: lastUsedSvc,
+	}
+
+	return &fixture{
+		spaceService:    spaceService,
+		spc:             spc,
+		templateService: templateSvc,
+		lastUsedService: lastUsedSvc,
+		service:         s,
+	}
+}
+
+type testTemplateService struct {
+	templates map[string]*state.State
+}
+
+func (tts *testTemplateService) CreateTemplateStateWithDetails(templateId string, details *types.Struct) (*state.State, error) {
+	if tts.templates != nil {
+		if st, found := tts.templates[templateId]; found {
+			return st, nil
+		}
+	}
+	return state.NewDoc(templateId, nil).NewState(), nil
+}
+
+func (tts *testTemplateService) TemplateCloneInSpace(space clientspace.Space, id string) (templateId string, err error) {
+	return "", nil
+}
+
+func TestService_CreateObject(t *testing.T) {
+	t.Run("template creation", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		f := newFixture(t)
+		f.spaceService.EXPECT().Get(mock.Anything, mock.Anything).Return(f.spc, nil)
+		f.spc.EXPECT().CreateTreeObject(mock.Anything, mock.Anything).Return(sb, nil)
+		f.spc.EXPECT().Id().Return(spaceId)
+		f.lastUsedService.EXPECT().UpdateLastUsedDate(spaceId, bundle.TypeKeyTemplate, mock.Anything).Return()
+
+		// when
+		id, _, err := f.service.CreateObject(context.Background(), spaceId, CreateObjectRequest{
+			Details: &types.Struct{Fields: map[string]*types.Value{
+				bundle.RelationKeyTargetObjectType.String(): pbtypes.String(bundle.TypeKeyTask.URL()),
+			}},
+			ObjectTypeKey: bundle.TypeKeyTemplate,
+		})
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "test", id)
+	})
+
+	t.Run("template creation - no target type", func(t *testing.T) {
+		// given
+		f := newFixture(t)
+		f.spaceService.EXPECT().Get(mock.Anything, mock.Anything).Return(f.spc, nil)
+
+		// when
+		_, _, err := f.service.CreateObject(context.Background(), spaceId, CreateObjectRequest{
+			ObjectTypeKey: bundle.TypeKeyTemplate,
+		})
+
+		// then
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4139/unhide-donetemplate-bugs
https://linear.app/anytype/issue/GO-4141/disable-the-ability-to-change-object-type-to-template
https://linear.app/anytype/issue/GO-4142/prohibit-creating-objects-with-type-template

Template type has become unhidden, so we should prohibit:
- creation of Template object without targetObjectType provided
- changing object's type to Template type