### PR TITLE
GO-4244 Restrict chat duplication

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -24,7 +24,7 @@ var (
 		model.Restrictions_Template,
 		model.Restrictions_Duplicate,
 	}
-	objFileRestrictions = ObjectRestrictions{
+	objRestrictEditDup = ObjectRestrictions{
 		model.Restrictions_Blocks,
 		model.Restrictions_LayoutChange,
 		model.Restrictions_TypeChange,
@@ -63,7 +63,7 @@ var (
 		model.ObjectType_collection: objRestrictEdit,
 		model.ObjectType_objectType: objRestrictEdit,
 		model.ObjectType_relation:   objRestrictEdit,
-		model.ObjectType_file:       objFileRestrictions,
+		model.ObjectType_file:       objRestrictEditDup,
 		model.ObjectType_dashboard: {
 			model.Restrictions_Details,
 			model.Restrictions_Relations,
@@ -85,8 +85,8 @@ var (
 			model.Restrictions_Template,
 		},
 		model.ObjectType_participant: objRestrictAll,
-		model.ObjectType_chat:        objRestrictEdit,
-		model.ObjectType_chatDerived: objRestrictEdit,
+		model.ObjectType_chat:        objRestrictEditDup,
+		model.ObjectType_chatDerived: objRestrictEditDup,
 		model.ObjectType_tag:         objRestrictEdit,
 	}
 
@@ -117,7 +117,7 @@ var (
 			model.Restrictions_Template,
 			model.Restrictions_Duplicate,
 		},
-		smartblock.SmartBlockTypeFileObject:        objFileRestrictions,
+		smartblock.SmartBlockTypeFileObject:        objRestrictEditDup,
 		smartblock.SmartBlockTypeArchive:           objRestrictAll,
 		smartblock.SmartBlockTypeBundledRelation:   objRestrictAll,
 		smartblock.SmartBlockTypeSubObject:         objRestrictEdit,
@@ -143,7 +143,9 @@ var (
 		smartblock.SmartBlockTypeAccountOld: {
 			model.Restrictions_Template,
 		},
-		smartblock.SmartBlockTypeParticipant: objRestrictAll,
+		smartblock.SmartBlockTypeParticipant:       objRestrictAll,
+		smartblock.SmartBlockTypeChatObject:        objRestrictEditDup,
+		smartblock.SmartBlockTypeChatDerivedObject: objRestrictEditDup,
 	}
 )
 

--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -24,7 +24,7 @@ var (
 		model.Restrictions_Template,
 		model.Restrictions_Duplicate,
 	}
-	objRestrictEditDup = ObjectRestrictions{
+	objRestrictEditAndDuplicate = ObjectRestrictions{
 		model.Restrictions_Blocks,
 		model.Restrictions_LayoutChange,
 		model.Restrictions_TypeChange,
@@ -63,7 +63,7 @@ var (
 		model.ObjectType_collection: objRestrictEdit,
 		model.ObjectType_objectType: objRestrictEdit,
 		model.ObjectType_relation:   objRestrictEdit,
-		model.ObjectType_file:       objRestrictEditDup,
+		model.ObjectType_file:       objRestrictEditAndDuplicate,
 		model.ObjectType_dashboard: {
 			model.Restrictions_Details,
 			model.Restrictions_Relations,
@@ -85,8 +85,8 @@ var (
 			model.Restrictions_Template,
 		},
 		model.ObjectType_participant: objRestrictAll,
-		model.ObjectType_chat:        objRestrictEditDup,
-		model.ObjectType_chatDerived: objRestrictEditDup,
+		model.ObjectType_chat:        objRestrictEditAndDuplicate,
+		model.ObjectType_chatDerived: objRestrictEditAndDuplicate,
 		model.ObjectType_tag:         objRestrictEdit,
 	}
 
@@ -117,7 +117,7 @@ var (
 			model.Restrictions_Template,
 			model.Restrictions_Duplicate,
 		},
-		smartblock.SmartBlockTypeFileObject:        objRestrictEditDup,
+		smartblock.SmartBlockTypeFileObject:        objRestrictEditAndDuplicate,
 		smartblock.SmartBlockTypeArchive:           objRestrictAll,
 		smartblock.SmartBlockTypeBundledRelation:   objRestrictAll,
 		smartblock.SmartBlockTypeSubObject:         objRestrictEdit,
@@ -144,8 +144,8 @@ var (
 			model.Restrictions_Template,
 		},
 		smartblock.SmartBlockTypeParticipant:       objRestrictAll,
-		smartblock.SmartBlockTypeChatObject:        objRestrictEditDup,
-		smartblock.SmartBlockTypeChatDerivedObject: objRestrictEditDup,
+		smartblock.SmartBlockTypeChatObject:        objRestrictEditAndDuplicate,
+		smartblock.SmartBlockTypeChatDerivedObject: objRestrictEditAndDuplicate,
 	}
 )
 

--- a/core/block/restriction/object_test.go
+++ b/core/block/restriction/object_test.go
@@ -95,7 +95,7 @@ func TestService_ObjectRestrictionsById(t *testing.T) {
 
 	t.Run("chat should have edit and duplication restrictions", func(t *testing.T) {
 		assert.ErrorIs(t, rs.GetRestrictions(givenRestrictionHolder(coresb.SmartBlockTypeChatObject, bundle.TypeKeyChat)).Object.Check(
-			objRestrictEditDup...,
+			objRestrictEditAndDuplicate...,
 		), ErrRestricted)
 	})
 }

--- a/core/block/restriction/object_test.go
+++ b/core/block/restriction/object_test.go
@@ -92,6 +92,12 @@ func TestService_ObjectRestrictionsById(t *testing.T) {
 		bundledRelation := givenRestrictionHolder(coresb.SmartBlockTypeBundledRelation, bundle.TypeKeyRelation)
 		assert.ErrorIs(t, rs.GetRestrictions(bundledRelation).Object.Check(objRestrictAll...), ErrRestricted)
 	})
+
+	t.Run("chat should have edit and duplication restrictions", func(t *testing.T) {
+		assert.ErrorIs(t, rs.GetRestrictions(givenRestrictionHolder(coresb.SmartBlockTypeChatObject, bundle.TypeKeyChat)).Object.Check(
+			objRestrictEditDup...,
+		), ErrRestricted)
+	})
 }
 
 func TestTemplateRestriction(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4244/restricted-duplication-of-objects-in-the-menu

Duplication should be restricted for Chat object