### PR TITLE
GO-4219 Support date format

### DIFF
--- a/core/block/source/date.go
+++ b/core/block/source/date.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
@@ -18,17 +19,18 @@ import (
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
-func NewDate(space Space, id string) (s Source) {
+func NewDate(space Space, id domain.FullID) (s Source) {
 	return &date{
-		id:    id,
-		space: space,
+		id:      id.ObjectID,
+		spaceId: id.SpaceID,
+		space:   space,
 	}
 }
 
 type date struct {
-	space Space
-	id    string
-	t     time.Time
+	space       Space
+	id, spaceId string
+	t           time.Time
 }
 
 func (v *date) ListIds() ([]string, error) {
@@ -44,10 +46,13 @@ func (v *date) Id() string {
 }
 
 func (v *date) SpaceID() string {
-	if v.space == nil {
-		return ""
+	if v.space != nil {
+		return v.space.Id()
 	}
-	return v.space.Id()
+	if v.spaceId != "" {
+		return v.spaceId
+	}
+	return ""
 }
 
 func (v *date) Type() smartblock.SmartBlockType {
@@ -64,7 +69,7 @@ func (v *date) getDetails(ctx context.Context) (*types.Struct, error) {
 		return nil, fmt.Errorf("get date type id: %w", err)
 	}
 	return &types.Struct{Fields: map[string]*types.Value{
-		bundle.RelationKeyName.String():       pbtypes.String(v.t.Format("Mon Jan  2 2006")),
+		bundle.RelationKeyName.String():       pbtypes.String(v.t.Format("02 Jan 2006")),
 		bundle.RelationKeyId.String():         pbtypes.String(v.id),
 		bundle.RelationKeyIsReadonly.String(): pbtypes.Bool(true),
 		bundle.RelationKeyIsArchived.String(): pbtypes.Bool(false),
@@ -83,7 +88,7 @@ func (v *date) DetailsFromId() (*types.Struct, error) {
 		return nil, err
 	}
 	return &types.Struct{Fields: map[string]*types.Value{
-		bundle.RelationKeyName.String():       pbtypes.String(v.t.Format("Mon Jan  2 2006")),
+		bundle.RelationKeyName.String():       pbtypes.String(v.t.Format("02 Jan 2006")),
 		bundle.RelationKeyId.String():         pbtypes.String(v.id),
 		bundle.RelationKeyIsReadonly.String(): pbtypes.Bool(true),
 		bundle.RelationKeyIsArchived.String(): pbtypes.Bool(false),
@@ -180,10 +185,10 @@ func (v *date) Heads() []string {
 	return []string{v.id}
 }
 
-func (s *date) GetFileKeysSnapshot() []*pb.ChangeFileKeys {
+func (v *date) GetFileKeysSnapshot() []*pb.ChangeFileKeys {
 	return nil
 }
 
-func (s *date) GetCreationInfo() (creatorObjectId string, createdDate int64, err error) {
+func (v *date) GetCreationInfo() (creatorObjectId string, createdDate int64, err error) {
 	return addr.AnytypeProfileId, 0, nil
 }

--- a/core/block/source/marshall_change_test.go
+++ b/core/block/source/marshall_change_test.go
@@ -1,10 +1,8 @@
 package source
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
 	"github.com/gogo/protobuf/types"
@@ -328,10 +326,4 @@ func changeWithSmallTextUpdate() *pb.Change {
 				}}}},
 		}}},
 	}}
-}
-
-func TestName(t *testing.T) {
-	ts := time.Now()
-	fmt.Println(ts.Format("16 Sep 2024"))
-	fmt.Println(ts.Format("02 Jan 2006"))
 }

--- a/core/block/source/marshall_change_test.go
+++ b/core/block/source/marshall_change_test.go
@@ -1,8 +1,10 @@
 package source
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
 	"github.com/gogo/protobuf/types"
@@ -19,26 +21,26 @@ var text = "-- Еh bien, mon prince. Gênes et Lucques ne sont plus que des apan
 
 func TestMarshallChange(t *testing.T) {
 	t.Run("marshall small change", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSmallTextUpdate()
 
-		//when
+		// when
 		data, dt, err := MarshalChange(c)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.NotZero(t, len(data))
 		assert.Empty(t, dt)
 	})
 
 	t.Run("marshall bigger change", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSetBigDetail(snappyLowerLimit)
 
-		//when
+		// when
 		data, dt, err := MarshalChange(c)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.NotEmpty(t, data)
 		assert.Equal(t, dataTypeSnappy, dt)
@@ -49,97 +51,97 @@ func TestUnmarshallChange(t *testing.T) {
 	invalidDataType := "invalid"
 
 	t.Run("unmarshall small change", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSmallTextUpdate()
 		data, dt, err := MarshalChange(c)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
 		require.Empty(t, dt)
 
-		//when
+		// when
 		res, err := UnmarshalChange(&objecttree.Change{DataType: dt}, data)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.Equal(t, c, res)
 	})
 
 	t.Run("unmarshall bigger change", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSetBigDetail(snappyLowerLimit)
 		data, dt, err := MarshalChange(c)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
 		require.Equal(t, dataTypeSnappy, dt)
 
-		//when
+		// when
 		res, err := UnmarshalChange(&objecttree.Change{DataType: dt}, data)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.Equal(t, c, res)
 	})
 
 	t.Run("unmarshall plain change with invalid data type", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSmallTextUpdate()
 		data, dt, err := MarshalChange(c)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
 		require.Empty(t, dt)
 
-		//when
+		// when
 		res, err := UnmarshalChange(&objecttree.Change{DataType: invalidDataType}, data)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.Equal(t, c, res)
 	})
 
 	t.Run("unmarshall plain change with encoded data type", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSmallTextUpdate()
 		data, dt, err := MarshalChange(c)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
 		require.Empty(t, dt)
 
-		//when
+		// when
 		res, err := UnmarshalChange(&objecttree.Change{DataType: dataTypeSnappy}, data)
 
-		//then
+		// then
 		assert.NoError(t, err)
 		assert.Equal(t, c, res)
 	})
 
 	t.Run("unmarshall bigger change with empty data type", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSetBigDetail(snappyLowerLimit)
 		data, dt, err := MarshalChange(c)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
 		require.Equal(t, dataTypeSnappy, dt)
 
-		//when
+		// when
 		res, err := UnmarshalChange(&objecttree.Change{DataType: ""}, data)
 
-		//then
+		// then
 		assert.Error(t, err)
 		assert.Nil(t, res)
 	})
 
 	t.Run("unmarshall encoded change with invalid data type", func(t *testing.T) {
-		//given
+		// given
 		c := changeWithSetBigDetail(snappyLowerLimit)
 		data, dt, err := MarshalChange(c)
 		require.NoError(t, err)
 		require.NotEmpty(t, data)
 		require.Equal(t, dataTypeSnappy, dt)
 
-		//when
+		// when
 		res, err := UnmarshalChange(&objecttree.Change{DataType: invalidDataType}, data)
 
-		//then
+		// then
 		assert.Error(t, err)
 		assert.Nil(t, res)
 	})
@@ -326,4 +328,10 @@ func changeWithSmallTextUpdate() *pb.Change {
 				}}}},
 		}}},
 	}}
+}
+
+func TestName(t *testing.T) {
+	ts := time.Now()
+	fmt.Println(ts.Format("16 Sep 2024"))
+	fmt.Println(ts.Format("02 Jan 2006"))
 }

--- a/core/block/source/mock_source/mock_Service.go
+++ b/core/block/source/mock_source/mock_Service.go
@@ -7,6 +7,8 @@ import (
 
 	app "github.com/anyproto/any-sync/app"
 
+	domain "github.com/anyproto/anytype-heart/core/domain"
+
 	mock "github.com/stretchr/testify/mock"
 
 	smartblock "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
@@ -30,7 +32,7 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 }
 
 // DetailsFromIdBasedSource provides a mock function with given fields: id
-func (_m *MockService) DetailsFromIdBasedSource(id string) (*types.Struct, error) {
+func (_m *MockService) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error) {
 	ret := _m.Called(id)
 
 	if len(ret) == 0 {
@@ -39,10 +41,10 @@ func (_m *MockService) DetailsFromIdBasedSource(id string) (*types.Struct, error
 
 	var r0 *types.Struct
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*types.Struct, error)); ok {
+	if rf, ok := ret.Get(0).(func(domain.FullID) (*types.Struct, error)); ok {
 		return rf(id)
 	}
-	if rf, ok := ret.Get(0).(func(string) *types.Struct); ok {
+	if rf, ok := ret.Get(0).(func(domain.FullID) *types.Struct); ok {
 		r0 = rf(id)
 	} else {
 		if ret.Get(0) != nil {
@@ -50,7 +52,7 @@ func (_m *MockService) DetailsFromIdBasedSource(id string) (*types.Struct, error
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
+	if rf, ok := ret.Get(1).(func(domain.FullID) error); ok {
 		r1 = rf(id)
 	} else {
 		r1 = ret.Error(1)
@@ -65,14 +67,14 @@ type MockService_DetailsFromIdBasedSource_Call struct {
 }
 
 // DetailsFromIdBasedSource is a helper method to define mock.On call
-//   - id string
+//   - id domain.FullID
 func (_e *MockService_Expecter) DetailsFromIdBasedSource(id interface{}) *MockService_DetailsFromIdBasedSource_Call {
 	return &MockService_DetailsFromIdBasedSource_Call{Call: _e.mock.On("DetailsFromIdBasedSource", id)}
 }
 
-func (_c *MockService_DetailsFromIdBasedSource_Call) Run(run func(id string)) *MockService_DetailsFromIdBasedSource_Call {
+func (_c *MockService_DetailsFromIdBasedSource_Call) Run(run func(id domain.FullID)) *MockService_DetailsFromIdBasedSource_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(domain.FullID))
 	})
 	return _c
 }
@@ -82,7 +84,7 @@ func (_c *MockService_DetailsFromIdBasedSource_Call) Return(_a0 *types.Struct, _
 	return _c
 }
 
-func (_c *MockService_DetailsFromIdBasedSource_Call) RunAndReturn(run func(string) (*types.Struct, error)) *MockService_DetailsFromIdBasedSource_Call {
+func (_c *MockService_DetailsFromIdBasedSource_Call) RunAndReturn(run func(domain.FullID) (*types.Struct, error)) *MockService_DetailsFromIdBasedSource_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/block/source/service.go
+++ b/core/block/source/service.go
@@ -55,7 +55,7 @@ type Service interface {
 	RegisterStaticSource(s Source) error
 	NewStaticSource(params StaticSourceParams) SourceWithType
 
-	DetailsFromIdBasedSource(id string) (*types.Struct, error)
+	DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error)
 	IDsListerBySmartblockType(space Space, blockType smartblock.SmartBlockType) (IDsLister, error)
 	app.Component
 }
@@ -142,7 +142,10 @@ func (s *service) newSource(ctx context.Context, space Space, id string, buildOp
 	if err == nil {
 		switch st {
 		case smartblock.SmartBlockTypeDate:
-			return NewDate(space, id), nil
+			return NewDate(space, domain.FullID{
+				ObjectID: id,
+				SpaceID:  space.Id(),
+			}), nil
 		case smartblock.SmartBlockTypeBundledObjectType:
 			return NewBundledObjectType(id), nil
 		case smartblock.SmartBlockTypeBundledRelation:
@@ -203,11 +206,10 @@ func (s *service) IDsListerBySmartblockType(space Space, blockType smartblock.Sm
 	}
 }
 
-func (s *service) DetailsFromIdBasedSource(id string) (*types.Struct, error) {
-	if !strings.HasPrefix(id, addr.DatePrefix) {
+func (s *service) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error) {
+	if !strings.HasPrefix(id.ObjectID, addr.DatePrefix) {
 		return nil, fmt.Errorf("unsupported id")
 	}
-	// TODO Fix this, but how? It's broken by design, because no one pass spaceId here
 	ss := NewDate(nil, id)
 	defer ss.Close()
 	if v, ok := ss.(SourceIdEndodedDetails); ok {

--- a/core/object.go
+++ b/core/object.go
@@ -283,7 +283,7 @@ func (mw *Middleware) makeSuggestedDateRecord(ctx context.Context, spaceID strin
 	}
 	d := &types.Struct{Fields: map[string]*types.Value{
 		bundle.RelationKeyId.String():        pbtypes.String(id),
-		bundle.RelationKeyName.String():      pbtypes.String(t.Format("Mon Jan  2 2006")),
+		bundle.RelationKeyName.String():      pbtypes.String(t.Format("02 Jan 2006")),
 		bundle.RelationKeyLayout.String():    pbtypes.Int64(int64(model.ObjectType_date)),
 		bundle.RelationKeyType.String():      pbtypes.String(typeId),
 		bundle.RelationKeyIconEmoji.String(): pbtypes.String("📅"),

--- a/pkg/lib/bundle/types.gen.go
+++ b/pkg/lib/bundle/types.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const TypeChecksum = "f3ae9931142aa23ec9696ccb60fe1a68b4fdafcc345e307e0a26d4fb98a0686c"
+const TypeChecksum = "4a3f1aa2ffad920796064537b109a2a1337117914cdaa1a62bd648a0a0855967"
 const (
 	TypePrefix = "_ot"
 )
@@ -143,7 +143,7 @@ var (
 			Description:   "Gregorian calendar date",
 			Hidden:        true,
 			IconEmoji:     "📅",
-			Layout:        model.ObjectType_basic,
+			Layout:        model.ObjectType_date,
 			Name:          "Date",
 			Readonly:      true,
 			RelationLinks: []*model.RelationLink{MustGetRelationLink(RelationKeyTag)},

--- a/pkg/lib/bundle/types.json
+++ b/pkg/lib/bundle/types.json
@@ -70,7 +70,7 @@
     ],
     "emoji": "📅",
     "hidden": true,
-    "layout": "basic",
+    "layout": "date",
     "relations": [
       "tag"
     ],

--- a/pkg/lib/localstore/objectstore/fixture.go
+++ b/pkg/lib/localstore/objectstore/fixture.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/wallet"
 	"github.com/anyproto/anytype-heart/core/wallet/mock_wallet"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -31,7 +32,7 @@ func (fx *StoreFixture) TechSpaceId() string {
 type detailsFromId struct {
 }
 
-func (d *detailsFromId) DetailsFromIdBasedSource(id string) (*types.Struct, error) {
+func (d *detailsFromId) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error) {
 	return nil, fmt.Errorf("not found")
 }
 

--- a/pkg/lib/localstore/objectstore/spaceindex/fixture.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/fixture.go
@@ -34,7 +34,7 @@ const spaceName = "space1"
 type detailsFromId struct {
 }
 
-func (d *detailsFromId) DetailsFromIdBasedSource(id string) (*types.Struct, error) {
+func (d *detailsFromId) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error) {
 	return nil, fmt.Errorf("not found")
 }
 

--- a/pkg/lib/localstore/objectstore/spaceindex/objects.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/objects.go
@@ -84,7 +84,10 @@ func (s *dsObjectStore) GetInfosByIds(ids []string) ([]*model.ObjectInfo, error)
 }
 
 func (s *dsObjectStore) getObjectInfo(ctx context.Context, id string) (*model.ObjectInfo, error) {
-	details, err := s.sourceService.DetailsFromIdBasedSource(id)
+	details, err := s.sourceService.DetailsFromIdBasedSource(domain.FullID{
+		ObjectID: id,
+		SpaceID:  s.SpaceId(),
+	})
 	if err == nil {
 		details.Fields[database.RecordIDField] = pbtypes.ToValue(id)
 		return &model.ObjectInfo{

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -172,7 +172,10 @@ func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, par
 		// Don't use spaceID because expected objects are virtual
 		if sbt, err := typeprovider.SmartblockTypeFromID(res.Path.ObjectId); err == nil {
 			if indexDetails, _ := sbt.Indexable(); !indexDetails && s.sourceService != nil {
-				details, err := s.sourceService.DetailsFromIdBasedSource(res.Path.ObjectId)
+				details, err := s.sourceService.DetailsFromIdBasedSource(domain.FullID{
+					ObjectID: res.Path.ObjectId,
+					SpaceID:  s.SpaceId(),
+				})
 				if err != nil {
 					log.Errorf("QueryByIds failed to GetDetailsFromIdBasedSource id: %s", res.Path.ObjectId)
 					continue
@@ -434,7 +437,10 @@ func (s *dsObjectStore) QueryByIds(ids []string) (records []database.Record, err
 		// Don't use spaceID because expected objects are virtual
 		if sbt, err := typeprovider.SmartblockTypeFromID(id); err == nil {
 			if indexDetails, _ := sbt.Indexable(); !indexDetails && s.sourceService != nil {
-				details, err := s.sourceService.DetailsFromIdBasedSource(id)
+				details, err := s.sourceService.DetailsFromIdBasedSource(domain.FullID{
+					ObjectID: id,
+					SpaceID:  s.SpaceId(),
+				})
 				if err != nil {
 					log.Errorf("QueryByIds failed to GetDetailsFromIdBasedSource id: %s", id)
 					continue

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_test.go
@@ -1038,7 +1038,7 @@ type dummySourceService struct {
 	objectToReturn TestObject
 }
 
-func (s dummySourceService) DetailsFromIdBasedSource(id string) (*types.Struct, error) {
+func (s dummySourceService) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error) {
 	return makeDetails(s.objectToReturn), nil
 }
 

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -92,7 +92,7 @@ type Store interface {
 }
 
 type SourceDetailsFromID interface {
-	DetailsFromIdBasedSource(id string) (*types.Struct, error)
+	DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, error)
 }
 
 type FulltextQueue interface {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4219/support-the-date-format
https://linear.app/anytype/issue/GO-4339/if-i-add-a-date-as-an-object-the-details-for-this-object-do-not-have-a

- support unified date format "02 Sep 2024" while naming Date objects
- add spaceId to details of virtual Date objects
- add Date layout for Date type