### PR TITLE
GO-4398 Update backlinks on adding to collection

### DIFF
--- a/core/block/backlinks/watcher.go
+++ b/core/block/backlinks/watcher.go
@@ -26,7 +26,11 @@ import (
 	"github.com/anyproto/anytype-heart/util/slice"
 )
 
-const CName = "backlinks-update-watcher"
+const (
+	CName = "backlinks-update-watcher"
+
+	defaultAggregationInterval = time.Second * 5
+)
 
 var log = logging.Logger(CName)
 
@@ -39,51 +43,67 @@ type backLinksUpdate struct {
 	removed []string
 }
 
-type UpdateWatcher struct {
+type UpdateWatcher interface {
 	app.ComponentRunnable
 
+	FlushUpdates()
+}
+
+type watcher struct {
 	updater      backlinksUpdater
 	store        objectstore.ObjectStore
 	resolver     idresolver.Resolver
 	spaceService space.Service
 
-	infoBatch *mb.MB
+	infoBatch            *mb.MB
+	lock                 sync.Mutex
+	accumulatedBacklinks map[string]*backLinksUpdate
+	aggregationInterval  time.Duration
 }
 
-func New() app.Component {
-	return &UpdateWatcher{}
+func New() UpdateWatcher {
+	return &watcher{}
 }
 
-func (uw *UpdateWatcher) Name() string {
+func (w *watcher) Name() string {
 	return CName
 }
 
-func (uw *UpdateWatcher) Init(a *app.App) error {
-	uw.updater = app.MustComponent[backlinksUpdater](a)
-	uw.store = app.MustComponent[objectstore.ObjectStore](a)
-	uw.resolver = app.MustComponent[idresolver.Resolver](a)
-	uw.spaceService = app.MustComponent[space.Service](a)
-	uw.infoBatch = mb.New(0)
+func (w *watcher) Init(a *app.App) error {
+	w.updater = app.MustComponent[backlinksUpdater](a)
+	w.store = app.MustComponent[objectstore.ObjectStore](a)
+	w.resolver = app.MustComponent[idresolver.Resolver](a)
+	w.spaceService = app.MustComponent[space.Service](a)
 
+	w.infoBatch = mb.New(0)
+	w.accumulatedBacklinks = make(map[string]*backLinksUpdate)
+	w.aggregationInterval = defaultAggregationInterval
 	return nil
 }
 
-func (uw *UpdateWatcher) Close(context.Context) error {
-	if err := uw.infoBatch.Close(); err != nil {
+func (w *watcher) Close(context.Context) error {
+	if err := w.infoBatch.Close(); err != nil {
 		log.Errorf("failed to close message batch: %v", err)
 	}
 	return nil
 }
 
-func (uw *UpdateWatcher) Run(context.Context) error {
-	uw.updater.SubscribeLinksUpdate(func(info spaceindex.LinksUpdateInfo) {
-		if err := uw.infoBatch.Add(info); err != nil {
+func (w *watcher) Run(context.Context) error {
+	w.updater.SubscribeLinksUpdate(func(info spaceindex.LinksUpdateInfo) {
+		if err := w.infoBatch.Add(info); err != nil {
 			log.With("objectId", info.LinksFromId).Errorf("failed to add backlinks update info to message batch: %v", err)
 		}
 	})
 
-	go uw.backlinksUpdateHandler()
+	go w.backlinksUpdateHandler()
 	return nil
+}
+
+func (w *watcher) FlushUpdates() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	w.updateAccumulatedBacklinks()
 }
 
 func applyUpdates(m map[string]*backLinksUpdate, update spaceindex.LinksUpdateInfo) {
@@ -116,71 +136,69 @@ func applyUpdates(m map[string]*backLinksUpdate, update spaceindex.LinksUpdateIn
 	}
 }
 
-func (uw *UpdateWatcher) backlinksUpdateHandler() {
+func (w *watcher) backlinksUpdateHandler() {
 	var (
-		accumulatedBacklinks = make(map[string]*backLinksUpdate)
-		l                    sync.Mutex
-		lastReceivedUpdates  time.Time
-		closedCh             = make(chan struct{})
-		aggregationInterval  = time.Second * 5
+		lastReceivedUpdates time.Time
+		closedCh            = make(chan struct{})
 	)
 	defer close(closedCh)
 
 	go func() {
-		process := func() {
-			log.Debugf("updating backlinks for %d objects", len(accumulatedBacklinks))
-			for id, updates := range accumulatedBacklinks {
-				uw.updateBackLinksInObject(id, updates)
-			}
-			accumulatedBacklinks = make(map[string]*backLinksUpdate)
-		}
 		for {
 			select {
 			case <-closedCh:
-				l.Lock()
-				process()
-				l.Unlock()
+				w.lock.Lock()
+				w.updateAccumulatedBacklinks()
+				w.lock.Unlock()
 				return
-			case <-time.After(aggregationInterval):
-				l.Lock()
-				if time.Since(lastReceivedUpdates) < aggregationInterval || len(accumulatedBacklinks) == 0 {
-					l.Unlock()
+			case <-time.After(w.aggregationInterval):
+				w.lock.Lock()
+				if time.Since(lastReceivedUpdates) < w.aggregationInterval || len(w.accumulatedBacklinks) == 0 {
+					w.lock.Unlock()
 					continue
 				}
 
-				process()
-				l.Unlock()
+				w.updateAccumulatedBacklinks()
+				w.lock.Unlock()
 			}
 		}
 	}()
 
 	for {
-		msgs := uw.infoBatch.Wait()
+		msgs := w.infoBatch.Wait()
 		if len(msgs) == 0 {
 			return
 		}
 
-		l.Lock()
+		w.lock.Lock()
 		for _, msg := range msgs {
 			info, ok := msg.(spaceindex.LinksUpdateInfo)
 			if !ok || hasSelfLinks(info) {
 				continue
 			}
 
-			applyUpdates(accumulatedBacklinks, info)
+			applyUpdates(w.accumulatedBacklinks, info)
 		}
 		lastReceivedUpdates = time.Now()
-		l.Unlock()
+		w.lock.Unlock()
 	}
 }
 
-func (uw *UpdateWatcher) updateBackLinksInObject(id string, backlinksUpdate *backLinksUpdate) {
-	spaceId, err := uw.resolver.ResolveSpaceID(id)
+func (w *watcher) updateAccumulatedBacklinks() {
+	log.Debugf("updating backlinks for %d objects", len(w.accumulatedBacklinks))
+	for id, updates := range w.accumulatedBacklinks {
+		w.updateBackLinksInObject(id, updates)
+	}
+	w.accumulatedBacklinks = make(map[string]*backLinksUpdate)
+}
+
+func (w *watcher) updateBackLinksInObject(id string, backlinksUpdate *backLinksUpdate) {
+	spaceId, err := w.resolver.ResolveSpaceID(id)
 	if err != nil {
 		log.With("objectId", id).Errorf("failed to resolve space id for object: %v", err)
 		return
 	}
-	spc, err := uw.spaceService.Get(context.Background(), spaceId)
+	spc, err := w.spaceService.Get(context.Background(), spaceId)
 	if err != nil {
 		log.With("objectId", id, "spaceId", spaceId).Errorf("failed to get space: %v", err)
 		return
@@ -207,7 +225,7 @@ func (uw *UpdateWatcher) updateBackLinksInObject(id string, backlinksUpdate *bac
 	}
 
 	err = spc.DoLockedIfNotExists(id, func() error {
-		return uw.store.SpaceIndex(spaceId).ModifyObjectDetails(id, func(details *types.Struct) (*types.Struct, bool, error) {
+		return w.store.SpaceIndex(spaceId).ModifyObjectDetails(id, func(details *types.Struct) (*types.Struct, bool, error) {
 			return updateBacklinks(details, backlinksUpdate)
 		})
 	})

--- a/core/block/backlinks/watcher_test.go
+++ b/core/block/backlinks/watcher_test.go
@@ -1,0 +1,177 @@
+package backlinks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/anyproto/any-sync/app/ocache"
+	"github.com/cheggaaa/mb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/object/idresolver/mock_idresolver"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/space/mock_space"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+const spaceId = "spc1"
+
+type testUpdater struct {
+	callback func(info spaceindex.LinksUpdateInfo)
+	runFunc  func(callback func(info spaceindex.LinksUpdateInfo))
+}
+
+func (u *testUpdater) SubscribeLinksUpdate(callback func(info spaceindex.LinksUpdateInfo)) {
+	u.callback = callback
+}
+
+func (u *testUpdater) start() {
+	go u.runFunc(u.callback)
+}
+
+type fixture struct {
+	store        *objectstore.StoreFixture
+	resolver     *mock_idresolver.MockResolver
+	spaceService *mock_space.MockService
+	updater      *testUpdater
+	*watcher
+}
+
+func newFixture(t *testing.T, aggregationInterval time.Duration) *fixture {
+	updater := &testUpdater{}
+	store := objectstore.NewStoreFixture(t)
+	resolver := mock_idresolver.NewMockResolver(t)
+	spaceSvc := mock_space.NewMockService(t)
+
+	w := &watcher{
+		updater:      updater,
+		store:        store,
+		resolver:     resolver,
+		spaceService: spaceSvc,
+
+		aggregationInterval:  aggregationInterval,
+		infoBatch:            mb.New(0),
+		accumulatedBacklinks: make(map[string]*backLinksUpdate),
+	}
+
+	return &fixture{
+		store:        store,
+		resolver:     resolver,
+		spaceService: spaceSvc,
+		updater:      updater,
+		watcher:      w,
+	}
+}
+
+func TestWatcher_Run(t *testing.T) {
+	t.Run("backlinks update asynchronously", func(t *testing.T) {
+		// given
+		interval := 500 * time.Millisecond
+		f := newFixture(t, interval)
+
+		f.resolver.EXPECT().ResolveSpaceID(mock.Anything).Return(spaceId, nil)
+
+		f.updater.runFunc = func(callback func(info spaceindex.LinksUpdateInfo)) {
+			callback(spaceindex.LinksUpdateInfo{
+				LinksFromId: "obj1",
+				Added:       []string{"obj2", "obj3"},
+				Removed:     nil,
+			})
+			time.Sleep(interval / 2)
+			callback(spaceindex.LinksUpdateInfo{
+				LinksFromId: "obj1",
+				Added:       []string{"obj4", "obj5"},
+				Removed:     []string{"obj2"},
+			})
+			time.Sleep(interval / 2)
+			callback(spaceindex.LinksUpdateInfo{
+				LinksFromId: "obj1",
+				Added:       []string{"obj6"},
+				Removed:     []string{"obj5"},
+			})
+		}
+
+		spc := mock_clientspace.NewMockSpace(t)
+		f.spaceService.EXPECT().Get(mock.Anything, spaceId).Return(spc, nil)
+
+		spc.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).RunAndReturn(func(id string, apply func() error) error {
+			if id == "obj2" {
+				return ocache.ErrExists
+			}
+			return nil
+		})
+
+		spc.EXPECT().Do(mock.Anything, mock.Anything).Return(nil)
+
+		// when
+		err := f.watcher.Run(nil)
+		require.NoError(t, err)
+
+		f.updater.start()
+
+		time.Sleep(4 * interval)
+		err = f.watcher.Close(nil)
+
+		// then
+		assert.NoError(t, err)
+	})
+}
+
+func TestWatcher_updateAccumulatedBacklinks(t *testing.T) {
+	t.Run("no errors", func(t *testing.T) {
+		// given
+		f := newFixture(t, time.Second)
+		f.resolver.EXPECT().ResolveSpaceID(mock.Anything).Return(spaceId, nil)
+
+		f.store.AddObjects(t, spaceId, []spaceindex.TestObject{{
+			bundle.RelationKeyId:        pbtypes.String("obj1"),
+			bundle.RelationKeySpaceId:   pbtypes.String(spaceId),
+			bundle.RelationKeyBacklinks: pbtypes.StringList([]string{"obj4", "obj5", "obj6"}),
+		}, {
+			bundle.RelationKeyId:        pbtypes.String("obj3"),
+			bundle.RelationKeySpaceId:   pbtypes.String(spaceId),
+			bundle.RelationKeyBacklinks: pbtypes.StringList([]string{"obj1", "obj2", "obj4"}),
+		}})
+
+		spc := mock_clientspace.NewMockSpace(t)
+		f.spaceService.EXPECT().Get(mock.Anything, spaceId).Return(spc, nil)
+
+		spc.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).RunAndReturn(func(id string, apply func() error) error {
+			if id == "obj2" {
+				return ocache.ErrExists
+			}
+			return apply()
+		})
+
+		spc.EXPECT().Do(mock.Anything, mock.Anything).Return(nil).Once()
+
+		f.watcher.accumulatedBacklinks = map[string]*backLinksUpdate{
+			"obj1": {
+				added:   []string{"obj2", "obj3"},
+				removed: []string{"obj4", "obj5"},
+			},
+			"obj2": {
+				added: []string{"obj4", "obj5"},
+			},
+			"obj3": {
+				removed: []string{"obj1", "obj4"},
+			},
+		}
+
+		// when
+		f.watcher.updateAccumulatedBacklinks()
+
+		// then
+		details, err := f.store.SpaceIndex(spaceId).GetDetails("obj1")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"obj6", "obj2", "obj3"}, pbtypes.GetStringList(details.Details, bundle.RelationKeyBacklinks.String()))
+		details, err = f.store.SpaceIndex(spaceId).GetDetails("obj3")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"obj2"}, pbtypes.GetStringList(details.Details, bundle.RelationKeyBacklinks.String()))
+	})
+}

--- a/core/block/collection/service_test.go
+++ b/core/block/collection/service_test.go
@@ -47,7 +47,19 @@ func (t *testPicker) GetObjectByFullID(ctx context.Context, id domain.FullID) (s
 
 func (t *testPicker) Init(a *app.App) error { return nil }
 
-func (t *testPicker) Name() string { return "" }
+func (t *testPicker) Name() string { return "test.picker" }
+
+type testFlusher struct{}
+
+func (tf *testFlusher) Name() string { return "test.flusher" }
+
+func (tf *testFlusher) Init(*app.App) error { return nil }
+
+func (tf *testFlusher) Run(context.Context) error { return nil }
+
+func (tf *testFlusher) Close(context.Context) error { return nil }
+
+func (tf *testFlusher) FlushUpdates() {}
 
 type fixture struct {
 	picker *testPicker
@@ -56,12 +68,14 @@ type fixture struct {
 }
 
 func newFixture(t *testing.T) *fixture {
-	picker := &testPicker{}
 	a := &app.App{}
+	picker := &testPicker{}
+	flusher := &testFlusher{}
 	objectStore := objectstore.NewStoreFixture(t)
 
 	a.Register(picker)
 	a.Register(objectStore)
+	a.Register(flusher)
 	s := New()
 
 	err := s.Init(a)
@@ -228,8 +242,6 @@ func TestService_Add(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.Equal(t, []string{collectionID}, pbtypes.GetStringList(obj1.LocalDetails(), bundle.RelationKeyBacklinks.String()))
-		assert.Equal(t, []string{collectionID}, pbtypes.GetStringList(obj2.LocalDetails(), bundle.RelationKeyBacklinks.String()))
 		assert.Equal(t, []string{"obj1", "obj2"}, coll.NewState().GetStoreSlice(template.CollectionStoreKey))
 	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4398/objects-title-disappears-when-added-via-collectionset

We can fix objects instant update on adding to collection, by updating backlinks relation directly in AddToCollection request