### PR TITLE
GO-4360: Cannot filter by Action Done in 0.43.0

### DIFF
--- a/space/internal/components/migration/readonlyfixer/relationsfixer.go
+++ b/space/internal/components/migration/readonlyfixer/relationsfixer.go
@@ -31,7 +31,7 @@ func (Migration) Name() string {
 	return MName
 }
 
-func (Migration) Run(ctx context.Context, log logger.CtxLogger, store dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (Migration) Run(ctx context.Context, log logger.CtxLogger, store, _ dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	spaceId := space.Id()
 
 	relations, err := listReadonlyTagAndStatusRelations(store, spaceId)

--- a/space/internal/components/migration/readonlyfixer/relationsfixer_test.go
+++ b/space/internal/components/migration/readonlyfixer/relationsfixer_test.go
@@ -82,7 +82,7 @@ func TestFixReadonlyInRelations(t *testing.T) {
 		).Times(2)
 
 		// when
-		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space1"), spc)
+		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space1"), nil, spc)
 
 		// then
 		assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestFixReadonlyInRelations(t *testing.T) {
 		// sp.EXPECT().Do(mock.Anything, mock.Anything).Times(1).Return(nil)
 
 		// when
-		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space2"), spc)
+		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space2"), nil, spc)
 
 		// then
 		assert.NoError(t, err)
@@ -116,7 +116,7 @@ func TestFixReadonlyInRelations(t *testing.T) {
 		// sp.EXPECT().Do(mock.Anything, mock.Anything).Times(1).Return(nil)
 
 		// when
-		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space3"), spc)
+		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space3"), nil, spc)
 
 		// then
 		assert.NoError(t, err)

--- a/space/internal/components/migration/runner.go
+++ b/space/internal/components/migration/runner.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anyproto/any-sync/app/logger"
 	"go.uber.org/zap"
 
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/space/clientspace"
 	"github.com/anyproto/anytype-heart/space/internal/components/dependencies"
@@ -25,7 +26,7 @@ const (
 var log = logger.NewNamed(CName)
 
 type Migration interface {
-	Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error)
+	Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error)
 	Name() string
 }
 
@@ -104,13 +105,14 @@ func (r *Runner) run(migrations ...Migration) (err error) {
 	spaceId := r.spc.Id()
 
 	store := r.store.SpaceIndex(spaceId)
+	marketPlaceStore := r.store.SpaceIndex(addr.AnytypeMarketplaceWorkspace)
 
 	for _, m := range migrations {
 		if e := r.ctx.Err(); e != nil {
 			err = errors.Join(err, e)
 			return
 		}
-		toMigrate, migrated, e := m.Run(r.ctx, log, store, r.spc)
+		toMigrate, migrated, e := m.Run(r.ctx, log, store, marketPlaceStore, r.spc)
 		if e != nil {
 			err = errors.Join(err, wrapError(e, m.Name(), spaceId, migrated, toMigrate))
 			continue

--- a/space/internal/components/migration/runner_test.go
+++ b/space/internal/components/migration/runner_test.go
@@ -138,7 +138,7 @@ func (longStoreMigration) Name() string {
 	return "long migration"
 }
 
-func (longStoreMigration) Run(ctx context.Context, _ logger.CtxLogger, store dependencies.QueryableStore, _ dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (longStoreMigration) Run(ctx context.Context, _ logger.CtxLogger, store, queryableStore dependencies.QueryableStore, _ dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	for {
 		if _, err = store.Query(database.Query{}); err != nil {
 			return 0, 0, err
@@ -152,7 +152,7 @@ func (longSpaceMigration) Name() string {
 	return "long migration"
 }
 
-func (longSpaceMigration) Run(ctx context.Context, _ logger.CtxLogger, _ dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (longSpaceMigration) Run(ctx context.Context, _ logger.CtxLogger, _, store dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	for {
 		if err = space.DoCtx(ctx, "", func(smartblock.SmartBlock) error {
 			// do smth
@@ -169,6 +169,6 @@ func (instantMigration) Name() string {
 	return "instant migration"
 }
 
-func (instantMigration) Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (instantMigration) Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	return 0, 0, nil
 }

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
@@ -43,13 +43,13 @@ func (Migration) Name() string {
 	return MName
 }
 
-func (Migration) Run(ctx context.Context, log logger.CtxLogger, store dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
-	spaceObjects, err := listAllTypesAndRelations(store, space.Id())
+func (Migration) Run(ctx context.Context, log logger.CtxLogger, store, marketPlace dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+	spaceObjects, err := listAllTypesAndRelations(store)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get relations and types from client space: %w", err)
 	}
 
-	marketObjects, err := listAllTypesAndRelations(store, addr.AnytypeMarketplaceWorkspace)
+	marketObjects, err := listAllTypesAndRelations(marketPlace)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get relations from marketplace space: %w", err)
 	}
@@ -69,7 +69,7 @@ func (Migration) Run(ctx context.Context, log logger.CtxLogger, store dependenci
 	return
 }
 
-func listAllTypesAndRelations(store dependencies.QueryableStore, spaceId string) (map[string]*types.Struct, error) {
+func listAllTypesAndRelations(store dependencies.QueryableStore) (map[string]*types.Struct, error) {
 	records, err := store.Query(database.Query{
 		Filters: []*model.BlockContentDataviewFilter{
 			{


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4360/cannot-filter-by-action-done-in-0430

The problem were in system objects revision migrator. It didn't work for new `Done` relation revision, because it compares the same the same objects, because stores for space are the same. So I fixed it by adding store for Marketplace in function.