### PR TITLE
GO-3963 Change API for RelationListWithValue

### DIFF
--- a/core/block/detailservice/mock_detailservice/mock_Service.go
+++ b/core/block/detailservice/mock_detailservice/mock_Service.go
@@ -80,42 +80,33 @@ func (_c *MockService_Init_Call) RunAndReturn(run func(*app.App) error) *MockSer
 }
 
 // ListRelationsWithValue provides a mock function with given fields: spaceId, value
-func (_m *MockService) ListRelationsWithValue(spaceId string, value *types.Value) ([]string, []int64, error) {
+func (_m *MockService) ListRelationsWithValue(spaceId string, value *types.Value) ([]*pb.RpcRelationListWithValueResponseResponseItem, error) {
 	ret := _m.Called(spaceId, value)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListRelationsWithValue")
 	}
 
-	var r0 []string
-	var r1 []int64
-	var r2 error
-	if rf, ok := ret.Get(0).(func(string, *types.Value) ([]string, []int64, error)); ok {
+	var r0 []*pb.RpcRelationListWithValueResponseResponseItem
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, *types.Value) ([]*pb.RpcRelationListWithValueResponseResponseItem, error)); ok {
 		return rf(spaceId, value)
 	}
-	if rf, ok := ret.Get(0).(func(string, *types.Value) []string); ok {
+	if rf, ok := ret.Get(0).(func(string, *types.Value) []*pb.RpcRelationListWithValueResponseResponseItem); ok {
 		r0 = rf(spaceId, value)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]string)
+			r0 = ret.Get(0).([]*pb.RpcRelationListWithValueResponseResponseItem)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, *types.Value) []int64); ok {
+	if rf, ok := ret.Get(1).(func(string, *types.Value) error); ok {
 		r1 = rf(spaceId, value)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).([]int64)
-		}
+		r1 = ret.Error(1)
 	}
 
-	if rf, ok := ret.Get(2).(func(string, *types.Value) error); ok {
-		r2 = rf(spaceId, value)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
+	return r0, r1
 }
 
 // MockService_ListRelationsWithValue_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListRelationsWithValue'
@@ -137,12 +128,12 @@ func (_c *MockService_ListRelationsWithValue_Call) Run(run func(spaceId string, 
 	return _c
 }
 
-func (_c *MockService_ListRelationsWithValue_Call) Return(keys []string, counters []int64, err error) *MockService_ListRelationsWithValue_Call {
-	_c.Call.Return(keys, counters, err)
+func (_c *MockService_ListRelationsWithValue_Call) Return(_a0 []*pb.RpcRelationListWithValueResponseResponseItem, _a1 error) *MockService_ListRelationsWithValue_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockService_ListRelationsWithValue_Call) RunAndReturn(run func(string, *types.Value) ([]string, []int64, error)) *MockService_ListRelationsWithValue_Call {
+func (_c *MockService_ListRelationsWithValue_Call) RunAndReturn(run func(string, *types.Value) ([]*pb.RpcRelationListWithValueResponseResponseItem, error)) *MockService_ListRelationsWithValue_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/block/detailservice/relations_test.go
+++ b/core/block/detailservice/relations_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -83,43 +84,66 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 		value            *types.Value
 		expectedKeys     []string
 		expectedCounters []int64
+		expectedList     []*pb.RpcRelationListWithValueResponseResponseItem
 	}{
 		{
 			"date object - today",
 			pbtypes.String(dateutil.TimeToDateId(now)),
 			[]string{bundle.RelationKeyAddedDate.String(), bundle.RelationKeyCreatedDate.String(), bundle.RelationKeyLastModifiedDate.String(), bundle.RelationKeyMentions.String(), bundle.RelationKeyName.String()},
 			[]int64{1, 2, 3, 1, 1},
+			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyAddedDate.String(), 1},
+				{bundle.RelationKeyCreatedDate.String(), 2},
+				{bundle.RelationKeyLastModifiedDate.String(), 3},
+				{bundle.RelationKeyMentions.String(), 1},
+				{bundle.RelationKeyName.String(), 1},
+			},
 		},
 		{
 			"date object - yesterday",
 			pbtypes.String(dateutil.TimeToDateId(now.Add(-24 * time.Hour))),
 			[]string{bundle.RelationKeyAddedDate.String(), bundle.RelationKeyCreatedDate.String(), bundle.RelationKeyMentions.String()},
 			[]int64{1, 1, 1},
+			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyAddedDate.String(), 1},
+				{bundle.RelationKeyCreatedDate.String(), 1},
+				{bundle.RelationKeyMentions.String(), 1},
+			},
 		},
 		{
 			"number",
 			pbtypes.Int64(300),
 			[]string{bundle.RelationKeyCoverX.String(), "daysTillSummer"},
 			[]int64{2, 1},
+			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyCoverX.String(), 2},
+				{"daysTillSummer", 1},
+			},
 		},
 		{
 			"bool",
 			pbtypes.Bool(true),
 			[]string{bundle.RelationKeyIsFavorite.String(), bundle.RelationKeyIsHidden.String()},
 			[]int64{2, 1},
+			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyIsFavorite.String(), 2},
+				{bundle.RelationKeyIsHidden.String(), 1},
+			},
 		},
 		{
 			"string list",
 			pbtypes.StringList([]string{"obj2", "obj3"}),
 			[]string{bundle.RelationKeyLinks.String()},
 			[]int64{1},
+			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyLinks.String(), 1},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			keys, counters, err := bs.ListRelationsWithValue(spaceId, tc.value)
+			list, err := bs.ListRelationsWithValue(spaceId, tc.value)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedKeys, keys)
-			assert.Equal(t, tc.expectedCounters, counters)
+			assert.Equal(t, tc.expectedList, list)
 		})
 	}
 }

--- a/core/block/detailservice/service.go
+++ b/core/block/detailservice/service.go
@@ -41,7 +41,7 @@ type Service interface {
 	ObjectTypeAddRelations(ctx context.Context, objectTypeId string, relationKeys []domain.RelationKey) error
 	ObjectTypeRemoveRelations(ctx context.Context, objectTypeId string, relationKeys []domain.RelationKey) error
 
-	ListRelationsWithValue(spaceId string, value *types.Value) (keys []string, counters []int64, err error)
+	ListRelationsWithValue(spaceId string, value *types.Value) ([]*pb.RpcRelationListWithValueResponseResponseItem, error)
 
 	SetSpaceInfo(spaceId string, details *types.Struct) error
 	SetWorkspaceDashboardId(ctx session.Context, workspaceId string, id string) (setId string, err error)

--- a/core/block/object/objectcreator/mock_objectcreator/mock_Service.go
+++ b/core/block/object/objectcreator/mock_objectcreator/mock_Service.go
@@ -32,6 +32,64 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
+// AddChatDerivedObject provides a mock function with given fields: ctx, space, chatObjectId
+func (_m *MockService) AddChatDerivedObject(ctx context.Context, space clientspace.Space, chatObjectId string) (string, error) {
+	ret := _m.Called(ctx, space, chatObjectId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddChatDerivedObject")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, clientspace.Space, string) (string, error)); ok {
+		return rf(ctx, space, chatObjectId)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, clientspace.Space, string) string); ok {
+		r0 = rf(ctx, space, chatObjectId)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, clientspace.Space, string) error); ok {
+		r1 = rf(ctx, space, chatObjectId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_AddChatDerivedObject_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddChatDerivedObject'
+type MockService_AddChatDerivedObject_Call struct {
+	*mock.Call
+}
+
+// AddChatDerivedObject is a helper method to define mock.On call
+//   - ctx context.Context
+//   - space clientspace.Space
+//   - chatObjectId string
+func (_e *MockService_Expecter) AddChatDerivedObject(ctx interface{}, space interface{}, chatObjectId interface{}) *MockService_AddChatDerivedObject_Call {
+	return &MockService_AddChatDerivedObject_Call{Call: _e.mock.On("AddChatDerivedObject", ctx, space, chatObjectId)}
+}
+
+func (_c *MockService_AddChatDerivedObject_Call) Run(run func(ctx context.Context, space clientspace.Space, chatObjectId string)) *MockService_AddChatDerivedObject_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(clientspace.Space), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockService_AddChatDerivedObject_Call) Return(chatId string, err error) *MockService_AddChatDerivedObject_Call {
+	_c.Call.Return(chatId, err)
+	return _c
+}
+
+func (_c *MockService_AddChatDerivedObject_Call) RunAndReturn(run func(context.Context, clientspace.Space, string) (string, error)) *MockService_AddChatDerivedObject_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // CreateObject provides a mock function with given fields: ctx, spaceID, req
 func (_m *MockService) CreateObject(ctx context.Context, spaceID string, req objectcreator.CreateObjectRequest) (string, *types.Struct, error) {
 	ret := _m.Called(ctx, spaceID, req)

--- a/core/relations.go
+++ b/core/relations.go
@@ -87,17 +87,16 @@ func (mw *Middleware) RelationOptions(_ context.Context, _ *pb.RpcRelationOption
 }
 
 func (mw *Middleware) RelationListWithValue(_ context.Context, req *pb.RpcRelationListWithValueRequest) *pb.RpcRelationListWithValueResponse {
-	response := func(keys []string, counters []int64, err error) *pb.RpcRelationListWithValueResponse {
+	response := func(list []*pb.RpcRelationListWithValueResponseResponseItem, err error) *pb.RpcRelationListWithValueResponse {
 		m := &pb.RpcRelationListWithValueResponse{Error: &pb.RpcRelationListWithValueResponseError{Code: pb.RpcRelationListWithValueResponseError_NULL}}
 		if err != nil {
 			m.Error.Description = getErrorDescription(err)
 		} else {
-			m.RelationKeys = keys
-			m.Counters = counters
+			m.List = list
 		}
 		return m
 	}
 
-	keys, counters, err := getService[detailservice.Service](mw).ListRelationsWithValue(req.SpaceId, req.Value)
-	return response(keys, counters, err)
+	list, err := getService[detailservice.Service](mw).ListRelationsWithValue(req.SpaceId, req.Value)
+	return response(list, err)
 }

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -1082,6 +1082,7 @@
     - [Rpc.Relation.ListWithValue.Request](#anytype-Rpc-Relation-ListWithValue-Request)
     - [Rpc.Relation.ListWithValue.Response](#anytype-Rpc-Relation-ListWithValue-Response)
     - [Rpc.Relation.ListWithValue.Response.Error](#anytype-Rpc-Relation-ListWithValue-Response-Error)
+    - [Rpc.Relation.ListWithValue.Response.ResponseItem](#anytype-Rpc-Relation-ListWithValue-Response-ResponseItem)
     - [Rpc.Relation.Options](#anytype-Rpc-Relation-Options)
     - [Rpc.Relation.Options.Request](#anytype-Rpc-Relation-Options-Request)
     - [Rpc.Relation.Options.Response](#anytype-Rpc-Relation-Options-Response)
@@ -17881,8 +17882,7 @@ Available undo/redo operations
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | error | [Rpc.Relation.ListWithValue.Response.Error](#anytype-Rpc-Relation-ListWithValue-Response-Error) |  |  |
-| relationKeys | [string](#string) | repeated |  |
-| counters | [int64](#int64) | repeated |  |
+| list | [Rpc.Relation.ListWithValue.Response.ResponseItem](#anytype-Rpc-Relation-ListWithValue-Response-ResponseItem) | repeated |  |
 
 
 
@@ -17899,6 +17899,22 @@ Available undo/redo operations
 | ----- | ---- | ----- | ----------- |
 | code | [Rpc.Relation.ListWithValue.Response.Error.Code](#anytype-Rpc-Relation-ListWithValue-Response-Error-Code) |  |  |
 | description | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="anytype-Rpc-Relation-ListWithValue-Response-ResponseItem"></a>
+
+### Rpc.Relation.ListWithValue.Response.ResponseItem
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| relationKey | [string](#string) |  |  |
+| counter | [int64](#int64) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -3119,8 +3119,12 @@ message Rpc {
 
             message Response {
                 Error error = 1;
-                repeated string relationKeys = 2;
-                repeated int64 counters = 3;
+                repeated ResponseItem list = 2;
+
+                message ResponseItem {
+                    string relationKey = 1;
+                    int64 counter = 2;
+                }
 
                 message Error {
                     Code code = 1;


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3963/[epic]-release-8-or-date-as-an-object

Slightly change output of RelationListWithValue cmd. 
Instead of separate counters and relationKeys fields, unite them in list