### PR TITLE
GO-4530 Return dataview and setof to dates

### DIFF
--- a/core/block/detailservice/relations.go
+++ b/core/block/detailservice/relations.go
@@ -132,7 +132,7 @@ func generateFilter(value *types.Value) func(v *types.Value) bool {
 		return equalOrHasFilter
 	}
 
-	shortId := dateutil.TimeToShortDateId(ts)
+	shortId := dateutil.TimeToDateId(ts)
 
 	start := ts.Truncate(24 * time.Hour)
 	end := start.Add(24 * time.Hour)

--- a/core/block/import/notion/api/block/text_test.go
+++ b/core/block/import/notion/api/block/text_test.go
@@ -174,7 +174,7 @@ func Test_GetTextBlocksDateMention(t *testing.T) {
 	assert.Equal(t, bl.Blocks[0].GetText().Style, model.BlockContentText_Paragraph)
 	assert.Len(t, bl.Blocks[0].GetText().Marks.Marks, 1)
 	assert.Equal(t, bl.Blocks[0].GetText().Marks.Marks[0].Type, model.BlockContentTextMark_Mention)
-	assert.Equal(t, bl.Blocks[0].GetText().Marks.Marks[0].Param, "_date_2022-11-14-00-00-00")
+	assert.Equal(t, bl.Blocks[0].GetText().Marks.Marks[0].Param, "_date_2022-11-14")
 }
 
 func Test_GetTextBlocksLinkPreview(t *testing.T) {

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -194,12 +194,19 @@ func buildDateObject(space clientspace.Space, details *types.Struct) (string, *t
 		return "", nil, fmt.Errorf("failed to find Date type to build Date object: %w", err)
 	}
 
+	// TODO: GO-4494 - Remove links relation id fetch
+	linksRelationId, err := space.GetRelationIdByKey(context.Background(), bundle.RelationKeyLinks)
+	if err != nil {
+		return "", nil, fmt.Errorf("get links relation id: %w", err)
+	}
+
 	dateSource := source.NewDate(source.DateSourceParams{
 		Id: domain.FullID{
 			ObjectID: id,
 			SpaceID:  space.Id(),
 		},
 		DateObjectTypeId: typeId,
+		LinksRelationId:  linksRelationId,
 	})
 
 	detailsGetter, ok := dateSource.(source.SourceIdEndodedDetails)

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -135,7 +135,7 @@ func TestService_CreateObject(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		assert.True(t, strings.HasPrefix(id, dateutil.TimeToShortDateId(ts)))
+		assert.True(t, strings.HasPrefix(id, dateutil.TimeToDateId(ts)))
 		assert.Equal(t, spaceId, pbtypes.GetString(details, bundle.RelationKeySpaceId.String()))
 		assert.Equal(t, bundle.TypeKeyDate.URL(), pbtypes.GetString(details, bundle.RelationKeyType.String()))
 	})

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -117,6 +117,11 @@ func TestService_CreateObject(t *testing.T) {
 			assert.Equal(t, bundle.TypeKeyDate, key)
 			return bundle.TypeKeyDate.URL(), nil
 		})
+		// TODO: GO-4494 - Remove links relation id fetch
+		f.spc.EXPECT().GetRelationIdByKey(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key domain.RelationKey) (string, error) {
+			assert.Equal(t, bundle.RelationKeyLinks, key)
+			return bundle.RelationKeyLinks.URL(), nil
+		})
 		ts := time.Now()
 		name := dateutil.TimeToDateName(ts)
 

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -46,6 +46,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space"
+	"github.com/anyproto/anytype-heart/util/dateutil"
 	"github.com/anyproto/anytype-heart/util/internalflag"
 	"github.com/anyproto/anytype-heart/util/mutex"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
@@ -222,6 +223,10 @@ func (s *Service) DoFullId(id domain.FullID, apply func(sb smartblock.SmartBlock
 
 // resolveFullId resolves missing spaceId
 func (s *Service) resolveFullId(id domain.FullID) domain.FullID {
+	// TODO: GO-4494 - Do not resolve spaceId in case of date object id. This logic should be reviewed
+	if _, parseErr := dateutil.ParseDateId(id.ObjectID); parseErr == nil && id.SpaceID != "" {
+		return id
+	}
 	// First try to resolve space. It's necessary if client accidentally passes wrong spaceId
 	spaceId, err := s.resolver.ResolveSpaceID(id.ObjectID)
 	if err == nil {

--- a/core/block/source/service.go
+++ b/core/block/source/service.go
@@ -22,13 +22,10 @@ import (
 	"github.com/anyproto/anytype-heart/core/files"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
-	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
-	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space/spacecore/storage"
 	"github.com/anyproto/anytype-heart/space/spacecore/typeprovider"
-	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 const CName = "source"
@@ -63,6 +60,12 @@ type Service interface {
 	app.Component
 }
 
+// TODO: GO-4494 - Remove this interface
+type derivedObjectIdGetter interface {
+	GetRelationIdByKey(ctx context.Context, spaceId string, key domain.RelationKey) (id string, err error)
+	GetTypeIdByKey(ctx context.Context, spaceId string, key domain.TypeKey) (id string, err error)
+}
+
 type service struct {
 	sbtProvider        typeprovider.SmartBlockTypeProvider
 	accountService     accountService
@@ -71,6 +74,9 @@ type service struct {
 	fileService        files.Service
 	objectStore        objectstore.ObjectStore
 	fileObjectMigrator fileObjectMigrator
+
+	// TODO: GO-4494 - Remove derivedObjectIdGetter
+	derivedObjectIdGetter derivedObjectIdGetter
 
 	mu        sync.Mutex
 	staticIds map[string]Source
@@ -87,6 +93,9 @@ func (s *service) Init(a *app.App) (err error) {
 
 	s.fileService = app.MustComponent[files.Service](a)
 	s.fileObjectMigrator = app.MustComponent[fileObjectMigrator](a)
+
+	// TODO: GO-4494 - Remove derivedObjectIdGetter
+	s.derivedObjectIdGetter = app.MustComponent[derivedObjectIdGetter](a)
 	return
 }
 
@@ -227,31 +236,21 @@ func (s *service) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, err
 		return nil, fmt.Errorf("unsupported id")
 	}
 
-	records, err := s.objectStore.SpaceIndex(id.SpaceID).Query(database.Query{
-		Filters: []*model.BlockContentDataviewFilter{{
-			Condition:   model.BlockContentDataviewFilter_Equal,
-			RelationKey: bundle.RelationKeyUniqueKey.String(),
-			Value:       pbtypes.String(bundle.TypeKeyDate.URL()),
-		}},
-	})
-
-	if len(records) != 1 && err == nil {
-		err = fmt.Errorf("expected 1 record, got %d", len(records))
-	}
-
+	// TODO: GO-4494 - Remove date type id fetch
+	dateObjectId, err := s.derivedObjectIdGetter.GetTypeIdByKey(context.Background(), id.SpaceID, bundle.TypeKeyDate)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query details of Date type object: %w", err)
+		return nil, fmt.Errorf("failed to get id of Date type object: %w", err)
 	}
 
 	// TODO: GO-4494 - Remove links relation id fetch
-	linksId, err := s.getLinksRelationId(id.SpaceID)
+	linksId, err := s.derivedObjectIdGetter.GetRelationIdByKey(context.Background(), id.SpaceID, bundle.RelationKeyLinks)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query details of Links relation object: %w", err)
+		return nil, fmt.Errorf("failed to get id of Links relation object: %w", err)
 	}
 
 	ss := NewDate(DateSourceParams{
 		Id:               id,
-		DateObjectTypeId: pbtypes.GetString(records[0].Details, bundle.RelationKeyId.String()),
+		DateObjectTypeId: dateObjectId,
 		LinksRelationId:  linksId,
 	})
 	defer ss.Close()
@@ -260,27 +259,6 @@ func (s *service) DetailsFromIdBasedSource(id domain.FullID) (*types.Struct, err
 	}
 	_ = ss.Close()
 	return nil, fmt.Errorf("date source miss the details")
-}
-
-// TODO: GO-4494 - Remove links relation id fetch
-func (s *service) getLinksRelationId(spaceId string) (string, error) {
-	records, err := s.objectStore.SpaceIndex(spaceId).Query(database.Query{
-		Filters: []*model.BlockContentDataviewFilter{{
-			Condition:   model.BlockContentDataviewFilter_Equal,
-			RelationKey: bundle.RelationKeyUniqueKey.String(),
-			Value:       pbtypes.String(bundle.RelationKeyLinks.URL()),
-		}},
-	})
-
-	if len(records) != 1 && err == nil {
-		err = fmt.Errorf("expected 1 record, got %d", len(records))
-	}
-
-	if err != nil {
-		return "", fmt.Errorf("failed to query details of Date type object: %w", err)
-	}
-
-	return pbtypes.GetString(records[0].Details, bundle.RelationKeyId.String()), nil
 }
 
 func (s *service) RegisterStaticSource(src Source) error {

--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -131,12 +131,19 @@ func makeSuggestedDateRecord(spc source.Space, t time.Time) (database.Record, er
 		return database.Record{}, fmt.Errorf("failed to find Date type to build Date object: %w", err)
 	}
 
+	// TODO: GO-4494 - Remove links relation id fetch
+	linksRelationId, err := spc.GetRelationIdByKey(context.Background(), bundle.RelationKeyLinks)
+	if err != nil {
+		return database.Record{}, fmt.Errorf("get links relation id: %w", err)
+	}
+
 	dateSource := source.NewDate(source.DateSourceParams{
 		Id: domain.FullID{
 			ObjectID: id,
 			SpaceID:  spc.Id(),
 		},
 		DateObjectTypeId: typeId,
+		LinksRelationId:  linksRelationId,
 	})
 
 	v, ok := dateSource.(source.SourceIdEndodedDetails)

--- a/pkg/lib/database/filter.go
+++ b/pkg/lib/database/filter.go
@@ -154,7 +154,7 @@ func makeFilterByCondition(spaceID string, rawFilter *model.BlockContentDataview
 		if ts, err := dateutil.ParseDateId(rawFilter.Value.GetStringValue()); err == nil {
 			return FilterHasPrefix{
 				Key:    rawFilter.RelationKey,
-				Prefix: dateutil.TimeToShortDateId(ts),
+				Prefix: dateutil.TimeToDateId(ts),
 			}, nil
 		}
 		list, err := pbtypes.ValueListWrapper(rawFilter.Value)

--- a/pkg/lib/database/filter_test.go
+++ b/pkg/lib/database/filter_test.go
@@ -939,7 +939,7 @@ func TestFilterHasPrefix_FilterObject(t *testing.T) {
 		now := time.Now()
 		f := FilterHasPrefix{
 			Key:    key,
-			Prefix: dateutil.TimeToShortDateId(now), // _date_YYYY-MM-DD
+			Prefix: dateutil.TimeToDateId(now), // _date_YYYY-MM-DD
 		}
 		obj1 := &types.Struct{Fields: map[string]*types.Value{
 			key: pbtypes.StringList([]string{"obj2", dateutil.TimeToDateId(now.Add(30 * time.Minute)), "obj3"}), // _date_YYYY-MM-DD-hh-mm-ss
@@ -948,7 +948,7 @@ func TestFilterHasPrefix_FilterObject(t *testing.T) {
 			key: pbtypes.StringList([]string{dateutil.TimeToDateId(now.Add(24 * time.Hour)), "obj1", "obj3"}), // same format, but next day
 		}}
 		obj3 := &types.Struct{Fields: map[string]*types.Value{
-			key: pbtypes.StringList([]string{"obj2", "obj3", dateutil.TimeToShortDateId(now.Add(30 * time.Minute))}), // _date_YYYY-MM-DD
+			key: pbtypes.StringList([]string{"obj2", "obj3", dateutil.TimeToDateId(now.Add(30 * time.Minute))}), // _date_YYYY-MM-DD
 		}}
 		assertFilter(t, f, obj1, true)
 		assertFilter(t, f, obj2, false)

--- a/space/mock_space/mock_Service.go
+++ b/space/mock_space/mock_Service.go
@@ -10,6 +10,8 @@ import (
 
 	crypto "github.com/anyproto/any-sync/util/crypto"
 
+	domain "github.com/anyproto/anytype-heart/core/domain"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -435,6 +437,64 @@ func (_c *MockService_GetPersonalSpace_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// GetRelationIdByKey provides a mock function with given fields: ctx, spaceId, key
+func (_m *MockService) GetRelationIdByKey(ctx context.Context, spaceId string, key domain.RelationKey) (string, error) {
+	ret := _m.Called(ctx, spaceId, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRelationIdByKey")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, domain.RelationKey) (string, error)); ok {
+		return rf(ctx, spaceId, key)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, domain.RelationKey) string); ok {
+		r0 = rf(ctx, spaceId, key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, domain.RelationKey) error); ok {
+		r1 = rf(ctx, spaceId, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_GetRelationIdByKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRelationIdByKey'
+type MockService_GetRelationIdByKey_Call struct {
+	*mock.Call
+}
+
+// GetRelationIdByKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - spaceId string
+//   - key domain.RelationKey
+func (_e *MockService_Expecter) GetRelationIdByKey(ctx interface{}, spaceId interface{}, key interface{}) *MockService_GetRelationIdByKey_Call {
+	return &MockService_GetRelationIdByKey_Call{Call: _e.mock.On("GetRelationIdByKey", ctx, spaceId, key)}
+}
+
+func (_c *MockService_GetRelationIdByKey_Call) Run(run func(ctx context.Context, spaceId string, key domain.RelationKey)) *MockService_GetRelationIdByKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(domain.RelationKey))
+	})
+	return _c
+}
+
+func (_c *MockService_GetRelationIdByKey_Call) Return(id string, err error) *MockService_GetRelationIdByKey_Call {
+	_c.Call.Return(id, err)
+	return _c
+}
+
+func (_c *MockService_GetRelationIdByKey_Call) RunAndReturn(run func(context.Context, string, domain.RelationKey) (string, error)) *MockService_GetRelationIdByKey_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTechSpace provides a mock function with given fields: ctx
 func (_m *MockService) GetTechSpace(ctx context.Context) (clientspace.Space, error) {
 	ret := _m.Called(ctx)
@@ -489,6 +549,64 @@ func (_c *MockService_GetTechSpace_Call) Return(_a0 clientspace.Space, err error
 }
 
 func (_c *MockService_GetTechSpace_Call) RunAndReturn(run func(context.Context) (clientspace.Space, error)) *MockService_GetTechSpace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTypeIdByKey provides a mock function with given fields: ctx, spaceId, key
+func (_m *MockService) GetTypeIdByKey(ctx context.Context, spaceId string, key domain.TypeKey) (string, error) {
+	ret := _m.Called(ctx, spaceId, key)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTypeIdByKey")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, domain.TypeKey) (string, error)); ok {
+		return rf(ctx, spaceId, key)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, domain.TypeKey) string); ok {
+		r0 = rf(ctx, spaceId, key)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, domain.TypeKey) error); ok {
+		r1 = rf(ctx, spaceId, key)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_GetTypeIdByKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTypeIdByKey'
+type MockService_GetTypeIdByKey_Call struct {
+	*mock.Call
+}
+
+// GetTypeIdByKey is a helper method to define mock.On call
+//   - ctx context.Context
+//   - spaceId string
+//   - key domain.TypeKey
+func (_e *MockService_Expecter) GetTypeIdByKey(ctx interface{}, spaceId interface{}, key interface{}) *MockService_GetTypeIdByKey_Call {
+	return &MockService_GetTypeIdByKey_Call{Call: _e.mock.On("GetTypeIdByKey", ctx, spaceId, key)}
+}
+
+func (_c *MockService_GetTypeIdByKey_Call) Run(run func(ctx context.Context, spaceId string, key domain.TypeKey)) *MockService_GetTypeIdByKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(domain.TypeKey))
+	})
+	return _c
+}
+
+func (_c *MockService_GetTypeIdByKey_Call) Return(id string, err error) *MockService_GetTypeIdByKey_Call {
+	_c.Call.Return(id, err)
+	return _c
+}
+
+func (_c *MockService_GetTypeIdByKey_Call) RunAndReturn(run func(context.Context, string, domain.TypeKey) (string, error)) *MockService_GetTypeIdByKey_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/space/service.go
+++ b/space/service.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/anytype/config"
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -70,6 +71,11 @@ type Service interface {
 	AccountMetadataSymKey() crypto.SymKey
 	AccountMetadataPayload() []byte
 	WaitPersonalSpaceMigration(ctx context.Context) (err error)
+
+	// TODO: GO-4494 - Remove these temporary methods
+	GetRelationIdByKey(ctx context.Context, spaceId string, key domain.RelationKey) (id string, err error)
+	GetTypeIdByKey(ctx context.Context, spaceId string, key domain.TypeKey) (id string, err error)
+
 	app.ComponentRunnable
 }
 
@@ -488,4 +494,24 @@ func (s *service) getTechSpace(ctx context.Context) (*clientspace.TechSpace, err
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
+}
+
+// TODO: GO-4494 - Remove this temporary method
+func (s *service) GetRelationIdByKey(ctx context.Context, spaceId string, key domain.RelationKey) (id string, err error) {
+	spc, err := s.Get(ctx, spaceId)
+	if err != nil {
+		return "", err
+	}
+
+	return spc.GetRelationIdByKey(ctx, key)
+}
+
+// TODO: GO-4494 - Remove this temporary method
+func (s *service) GetTypeIdByKey(ctx context.Context, spaceId string, key domain.TypeKey) (id string, err error) {
+	spc, err := s.Get(ctx, spaceId)
+	if err != nil {
+		return "", err
+	}
+
+	return spc.GetTypeIdByKey(ctx, key)
 }

--- a/util/dateutil/util.go
+++ b/util/dateutil/util.go
@@ -8,26 +8,16 @@ import (
 )
 
 const (
-	shortDateIdLayout = "2006-01-02"
-	dateIdLayout      = "2006-01-02-15-04-05"
-	dateNameLayout    = "02 Jan 2006"
+	dateIdLayout   = "2006-01-02"
+	dateNameLayout = "02 Jan 2006"
 )
 
 func TimeToDateId(t time.Time) string {
 	return addr.DatePrefix + t.Format(dateIdLayout)
 }
 
-// TimeToShortDateId should not be used to generate Date object id. Use TimeToDateId instead
-func TimeToShortDateId(t time.Time) string {
-	return addr.DatePrefix + t.Format(shortDateIdLayout)
-}
-
 func ParseDateId(id string) (time.Time, error) {
-	t, err := time.Parse(dateIdLayout, strings.TrimPrefix(id, addr.DatePrefix))
-	if err == nil {
-		return t, nil
-	}
-	return time.Parse(shortDateIdLayout, strings.TrimPrefix(id, addr.DatePrefix))
+	return time.Parse(dateIdLayout, strings.TrimPrefix(id, addr.DatePrefix))
 }
 
 func TimeToDateName(t time.Time) string {

--- a/util/dateutil/util_test.go
+++ b/util/dateutil/util_test.go
@@ -5,20 +5,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 )
 
 func TestTimeToDateId(t *testing.T) {
-	assert.Equal(t, "_date_2024-11-07-12-25-59", TimeToDateId(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC)))
-	assert.Equal(t, "_date_1998-01-01-00-01-01", TimeToDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC)))
-	assert.Equal(t, "_date_2124-12-25-23-34-00", TimeToDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC)))
-}
-
-func TestTimeToShortDateId(t *testing.T) {
-	assert.Equal(t, "_date_2024-11-07", TimeToShortDateId(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC)))
-	assert.Equal(t, "_date_1998-01-01", TimeToShortDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC)))
-	assert.Equal(t, "_date_2124-12-25", TimeToShortDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC)))
+	assert.Equal(t, "_date_2024-11-07", TimeToDateId(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC)))
+	assert.Equal(t, "_date_1998-01-01", TimeToDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC)))
+	assert.Equal(t, "_date_2124-12-25", TimeToDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC)))
 }
 
 func TestTimeToDateName(t *testing.T) {
@@ -28,25 +20,23 @@ func TestTimeToDateName(t *testing.T) {
 }
 
 func TestParseDateId(t *testing.T) {
-	t.Run("current date format", func(t *testing.T) {
+	t.Run("date format", func(t *testing.T) {
 		for _, ts := range []time.Time{
 			time.Date(2024, time.December, 7, 12, 25, 59, 0, time.UTC),
 			time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
 			time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
 			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
 		} {
-			ts2, err := ParseDateId(TimeToDateId(ts))
+			dateId := TimeToDateId(ts)
+			ts2, err := ParseDateId(dateId)
 			assert.NoError(t, err)
-			assert.Equal(t, ts, ts2)
+			assert.Equal(t, ts.Year(), ts2.Year())
+			assert.Equal(t, ts.Month(), ts2.Month())
+			assert.Equal(t, ts.Day(), ts2.Day())
+			assert.Zero(t, ts2.Hour())
+			assert.Zero(t, ts2.Minute())
+			assert.Zero(t, ts2.Second())
 		}
-	})
-
-	t.Run("old date format", func(t *testing.T) {
-		ts := time.Date(2025, time.June, 8, 2, 25, 39, 0, time.UTC)
-		ts2, err := ParseDateId(addr.DatePrefix + ts.Format(shortDateIdLayout))
-		ts = ts.Truncate(24 * time.Hour)
-		assert.NoError(t, err)
-		assert.Equal(t, ts, ts2)
 	})
 
 	t.Run("wrong format", func(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4530/revert-date-as-an-object-changes

We should return Dataview block and setOf relation to Date objects for backward compatibility with clients releasing 7.1