### PR TITLE
Fix fileObjects handling in usecase validator

### DIFF
--- a/cmd/usecasevalidator/main.go
+++ b/cmd/usecasevalidator/main.go
@@ -71,7 +71,12 @@ func (f cliFlags) isUpdateNeeded() bool {
 	return f.analytics || f.creator || f.removeRelations || f.exclude || f.rules != ""
 }
 
-const anytypeProfileFilename = addr.AnytypeProfileId + ".pb"
+const (
+	anytypeProfileFilename = addr.AnytypeProfileId + ".pb"
+
+	filesPrefix       = "files"
+	fileObjectsPrefix = "filesObjects"
+)
 
 var (
 	errIncorrectFileFound = fmt.Errorf("incorrect protobuf file was found")
@@ -208,7 +213,7 @@ func collectUseCaseInfo(files []*zip.File, fileName string) (info *useCaseInfo, 
 			continue
 		}
 
-		if (strings.HasPrefix(f.Name, "files") && !strings.HasPrefix(f.Name, "filesObjects")) || f.FileInfo().IsDir() {
+		if (strings.HasPrefix(f.Name, filesPrefix) && !strings.HasPrefix(f.Name, fileObjectsPrefix)) || f.FileInfo().IsDir() {
 			continue
 		}
 

--- a/cmd/usecasevalidator/main.go
+++ b/cmd/usecasevalidator/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/samber/lo"
 
+	"github.com/anyproto/anytype-heart/core/block/export"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -71,12 +72,7 @@ func (f cliFlags) isUpdateNeeded() bool {
 	return f.analytics || f.creator || f.removeRelations || f.exclude || f.rules != ""
 }
 
-const (
-	anytypeProfileFilename = addr.AnytypeProfileId + ".pb"
-
-	filesPrefix       = "files"
-	fileObjectsPrefix = "filesObjects"
-)
+const anytypeProfileFilename = addr.AnytypeProfileId + ".pb"
 
 var (
 	errIncorrectFileFound = fmt.Errorf("incorrect protobuf file was found")
@@ -213,7 +209,7 @@ func collectUseCaseInfo(files []*zip.File, fileName string) (info *useCaseInfo, 
 			continue
 		}
 
-		if (strings.HasPrefix(f.Name, filesPrefix) && !strings.HasPrefix(f.Name, fileObjectsPrefix)) || f.FileInfo().IsDir() {
+		if (strings.HasPrefix(f.Name, export.Files) && !strings.HasPrefix(f.Name, export.FilesObjects)) || f.FileInfo().IsDir() {
 			continue
 		}
 

--- a/cmd/usecasevalidator/main.go
+++ b/cmd/usecasevalidator/main.go
@@ -208,7 +208,7 @@ func collectUseCaseInfo(files []*zip.File, fileName string) (info *useCaseInfo, 
 			continue
 		}
 
-		if strings.HasPrefix(f.Name, "files") || f.FileInfo().IsDir() {
+		if (strings.HasPrefix(f.Name, "files") && !strings.HasPrefix(f.Name, "filesObjects")) || f.FileInfo().IsDir() {
 			continue
 		}
 
@@ -471,6 +471,7 @@ func removeAccountRelatedDetails(s *pb.ChangeSnapshot) {
 			bundle.RelationKeySourceFilePath.String(),
 			bundle.RelationKeyLinks.String(),
 			bundle.RelationKeyBacklinks.String(),
+			bundle.RelationKeyMentions.String(),
 			bundle.RelationKeyWorkspaceId.String(),
 			bundle.RelationKeyIdentityProfileLink.String(),
 			bundle.RelationKeyAddedDate.String(),

--- a/cmd/usecasevalidator/validators.go
+++ b/cmd/usecasevalidator/validators.go
@@ -246,7 +246,8 @@ func validateRelationOption(s *pb.SnapshotWithType, info *useCaseInfo) error {
 
 	if _, found := info.customTypesAndRelations[key]; !found {
 		id := pbtypes.GetString(s.Snapshot.Data.Details, bundle.RelationKeyId.String())
-		return fmt.Errorf("failed to find relation key %s of relation option %s", key, id)
+		fmt.Println("WARNING: relation key", key, "of relation option", id, "is not presented in the archive, so it will be skipped")
+		return errSkipObject
 	}
 	return nil
 }

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -60,7 +60,9 @@ const (
 	relationsDirectory        = "relations"
 	relationsOptionsDirectory = "relationsOptions"
 	templatesDirectory        = "templates"
-	filesObjects              = "filesObjects"
+
+	FilesObjects = "filesObjects"
+	Files        = "files"
 )
 
 var log = logging.Logger("anytype-mw-export")
@@ -971,7 +973,7 @@ func (e *exportContext) saveFile(ctx context.Context, wr writer, fileObject sb.S
 		}
 	}
 	origName := file.Meta().Name
-	rootPath := "files"
+	rootPath := Files
 	if exportAllSpaces {
 		rootPath = filepath.Join(spaceDirectory, fileObject.Space().Id(), rootPath)
 	}
@@ -1055,7 +1057,7 @@ func provideFileDirectory(blockType smartblock.SmartBlockType) string {
 	case smartblock.SmartBlockTypeTemplate:
 		return templatesDirectory
 	case smartblock.SmartBlockTypeFile, smartblock.SmartBlockTypeFileObject:
-		return filesObjects
+		return FilesObjects
 	default:
 		return objectsDirectory
 	}

--- a/core/block/export/export_test.go
+++ b/core/block/export/export_test.go
@@ -1427,7 +1427,7 @@ func Test_provideFileName(t *testing.T) {
 		fileName := makeFileName("docId", spaceId, pbjson.NewConverter(nil).Ext(), nil, smartblock.SmartBlockTypeFileObject)
 
 		// then
-		assert.Equal(t, filesObjects+string(filepath.Separator)+"docId.pb.json", fileName)
+		assert.Equal(t, FilesObjects+string(filepath.Separator)+"docId.pb.json", fileName)
 	})
 	t.Run("space is not provided", func(t *testing.T) {
 		// given
@@ -1438,7 +1438,7 @@ func Test_provideFileName(t *testing.T) {
 		fileName := makeFileName("docId", "", pbjson.NewConverter(st).Ext(), st, smartblock.SmartBlockTypeFileObject)
 
 		// then
-		assert.Equal(t, spaceDirectory+string(filepath.Separator)+spaceId+string(filepath.Separator)+filesObjects+string(filepath.Separator)+"docId.pb.json", fileName)
+		assert.Equal(t, spaceDirectory+string(filepath.Separator)+spaceId+string(filepath.Separator)+FilesObjects+string(filepath.Separator)+"docId.pb.json", fileName)
 	})
 }
 


### PR DESCRIPTION
- FileObjects were not handled, because of dumb file name prefix check
- Remove relation options that are sticked to absent relations
- Delete mentions detail from objects, as it is derived