### PR TITLE
GO-4475: Incorrect error code when importing unsuitable files

### DIFF
--- a/core/block/import/common/error.go
+++ b/core/block/import/common/error.go
@@ -123,9 +123,7 @@ func GetImportNotificationErrorCode(err error) model.ImportErrorCode {
 		return model.Import_NULL
 	}
 	switch {
-	case errors.Is(err, ErrNoObjectInIntegration) ||
-		errors.Is(err, ErrFileImportNoObjectsInDirectory) ||
-		errors.Is(err, ErrFileImportNoObjectsInZipArchive): // support existing protocol
+	case errors.Is(err, ErrNoObjectInIntegration):
 		return model.Import_NOTION_NO_OBJECTS_IN_INTEGRATION
 	case errors.Is(err, ErrNotionServerIsUnavailable):
 		return model.Import_NOTION_SERVER_IS_UNAVAILABLE

--- a/core/block/import/common/error_test.go
+++ b/core/block/import/common/error_test.go
@@ -134,7 +134,7 @@ func TestGetImportNotificationErrorCode(t *testing.T) {
 		code := GetImportNotificationErrorCode(err)
 
 		// then
-		assert.Equal(t, model.Import_NOTION_NO_OBJECTS_IN_INTEGRATION, code)
+		assert.Equal(t, model.Import_FILE_IMPORT_NO_OBJECTS_IN_DIRECTORY, code)
 	})
 	t.Run("GetImportNotificationErrorCode - no objects in zip", func(t *testing.T) {
 		// given
@@ -144,7 +144,7 @@ func TestGetImportNotificationErrorCode(t *testing.T) {
 		code := GetImportNotificationErrorCode(err)
 
 		// then
-		assert.Equal(t, model.Import_NOTION_NO_OBJECTS_IN_INTEGRATION, code)
+		assert.Equal(t, model.Import_FILE_IMPORT_NO_OBJECTS_IN_ZIP_ARCHIVE, code)
 	})
 	t.Run("GetImportNotificationErrorCode - not any block format", func(t *testing.T) {
 		// given


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4475/incorrect-error-code-when-importing-unsuitable-files

Remove old check for errors, it was needed to support old protocol. Now protocol is supported, so it should be removed