### PR TITLE
GO-4419 Fix panic on set template creation

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -427,7 +427,7 @@ func (bs *basic) SetLayoutInState(s *state.State, toLayout model.ObjectTypeLayou
 
 	fromLayout, _ := s.Layout()
 	s.SetDetail(bundle.RelationKeyLayout.String(), pbtypes.Int64(int64(toLayout)))
-	if err = bs.layoutConverter.Convert(bs.Space(), s, fromLayout, toLayout); err != nil {
+	if err = bs.layoutConverter.Convert(s, fromLayout, toLayout); err != nil {
 		return fmt.Errorf("convert layout: %w", err)
 	}
 	return nil

--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -1,14 +1,12 @@
 package converter
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/anyproto/any-sync/app"
 	"golang.org/x/exp/slices"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/dataview"
-	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
 	"github.com/anyproto/anytype-heart/core/block/simple"
@@ -23,10 +21,8 @@ import (
 	"github.com/anyproto/anytype-heart/util/slice"
 )
 
-const DefaultSetSource = bundle.TypeKeyPage
-
 type LayoutConverter interface {
-	Convert(space smartblock.Space, st *state.State, fromLayout, toLayout model.ObjectTypeLayout) error
+	Convert(st *state.State, fromLayout, toLayout model.ObjectTypeLayout) error
 	app.Component
 }
 
@@ -49,7 +45,7 @@ func (c *layoutConverter) Name() string {
 	return "layout-converter"
 }
 
-func (c *layoutConverter) Convert(space smartblock.Space, st *state.State, fromLayout, toLayout model.ObjectTypeLayout) error {
+func (c *layoutConverter) Convert(st *state.State, fromLayout, toLayout model.ObjectTypeLayout) error {
 	if fromLayout == toLayout {
 		return nil
 	}
@@ -72,10 +68,10 @@ func (c *layoutConverter) Convert(space smartblock.Space, st *state.State, fromL
 	}
 
 	if fromLayout == model.ObjectType_note && toLayout == model.ObjectType_set {
-		return c.fromNoteToSet(space, st)
+		return c.fromNoteToSet(st)
 	}
 	if toLayout == model.ObjectType_set {
-		return c.fromAnyToSet(space, st)
+		return c.fromAnyToSet(st)
 	}
 
 	if toLayout == model.ObjectType_note {
@@ -127,7 +123,7 @@ func (c *layoutConverter) fromAnyToTodo(st *state.State) error {
 	return nil
 }
 
-func (c *layoutConverter) fromNoteToSet(space smartblock.Space, st *state.State) error {
+func (c *layoutConverter) fromNoteToSet(st *state.State) error {
 	if err := c.fromNoteToAny(st); err != nil {
 		return err
 	}
@@ -135,25 +131,14 @@ func (c *layoutConverter) fromNoteToSet(space smartblock.Space, st *state.State)
 	template.InitTemplate(st,
 		template.WithTitle,
 	)
-	err2 := c.fromAnyToSet(space, st)
-	if err2 != nil {
-		return err2
-	}
-	return nil
+	return c.fromAnyToSet(st)
 }
 
-func (c *layoutConverter) fromAnyToSet(space smartblock.Space, st *state.State) error {
+func (c *layoutConverter) fromAnyToSet(st *state.State) error {
 	source := pbtypes.GetStringList(st.Details(), bundle.RelationKeySetOf.String())
-	if len(source) == 0 && space != nil {
-		defaultTypeID, err := space.GetTypeIdByKey(context.Background(), DefaultSetSource)
-		if err != nil {
-			return fmt.Errorf("get default type id: %w", err)
-		}
-		source = []string{defaultTypeID}
-	}
 	addFeaturedRelationSetOf(st)
 
-	dvBlock, err := dataview.BlockBySource(c.objectStore.SpaceIndex(space.Id()), source)
+	dvBlock, err := dataview.BlockBySource(c.objectStore.SpaceIndex(st.SpaceID()), source)
 	if err != nil {
 		return err
 	}

--- a/core/block/editor/converter/layout_test.go
+++ b/core/block/editor/converter/layout_test.go
@@ -1,0 +1,68 @@
+package converter
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/editor/template"
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+const (
+	root    = "root"
+	spaceId = "space"
+)
+
+func TestLayoutConverter_Convert(t *testing.T) {
+	store := objectstore.NewStoreFixture(t)
+	store.AddObjects(t, spaceId, []spaceindex.TestObject{{
+		bundle.RelationKeyId:        pbtypes.String(bundle.TypeKeyTask.URL()),
+		bundle.RelationKeySpaceId:   pbtypes.String(spaceId),
+		bundle.RelationKeyUniqueKey: pbtypes.String(bundle.TypeKeyTask.URL()),
+	}})
+
+	for _, from := range []model.ObjectTypeLayout{
+		model.ObjectType_basic,
+		model.ObjectType_note,
+		model.ObjectType_todo,
+		model.ObjectType_collection,
+		model.ObjectType_tag,
+	} {
+		t.Run(fmt.Sprintf("convert from %s to set", from.String()), func(t *testing.T) {
+			// given
+			st := state.NewDoc(root, map[string]simple.Block{
+				root: simple.New(&model.Block{Id: root, ChildrenIds: []string{}}),
+			}).NewState()
+			st.SetDetails(&types.Struct{
+				Fields: map[string]*types.Value{
+					bundle.RelationKeySpaceId.String(): pbtypes.String(spaceId),
+					bundle.RelationKeySetOf.String():   pbtypes.StringList([]string{bundle.TypeKeyTask.URL()}),
+				},
+			})
+
+			lc := layoutConverter{objectStore: store}
+
+			// when
+			err := lc.Convert(st, from, model.ObjectType_set)
+
+			// then
+			assert.NoError(t, err)
+			dvb := st.Get(template.DataviewBlockId)
+			assert.NotNil(t, dvb)
+			dv := dvb.Model().GetDataview()
+			require.NotNil(t, dv)
+			assert.NotEmpty(t, dv.Views)
+			assert.NotEmpty(t, dv.RelationLinks)
+		})
+	}
+}

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -339,7 +339,7 @@ func (s *service) createBlankTemplateState(layout model.ObjectTypeLayout) (st *s
 		template.WithDetail(bundle.RelationKeyTag, pbtypes.StringList(nil)),
 		template.WithTitle,
 	)
-	_ = s.converter.Convert(nil, st, model.ObjectType_basic, layout)
+	_ = s.converter.Convert(st, model.ObjectType_basic, layout)
 	return
 }
 

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -339,7 +339,9 @@ func (s *service) createBlankTemplateState(layout model.ObjectTypeLayout) (st *s
 		template.WithDetail(bundle.RelationKeyTag, pbtypes.StringList(nil)),
 		template.WithTitle,
 	)
-	_ = s.converter.Convert(st, model.ObjectType_basic, layout)
+	if err := s.converter.Convert(st, model.ObjectType_basic, layout); err != nil {
+		log.Errorf("failed to set '%s' layout to blank template: %v", layout.String(), err)
+	}
 	return
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4419/templates-for-setscollections

Layout converter asked space as a parameter in Convert just to get the id of Page object type to substitute is as default source in new set. It seems this logic is redundant, as all three clients render sets without source normally. Users are immediately headed to source choose on set object openning