### PR TITLE
GO-4560 Mentions should be 1st in RelationsListWithValue response

### DIFF
--- a/core/block/detailservice/relations.go
+++ b/core/block/detailservice/relations.go
@@ -140,18 +140,19 @@ func generateFilter(value *types.Value) func(v *types.Value) bool {
 
 	// date object section
 
-	ts, _, err := dateutil.ParseDateId(stringValue)
+	dateObject, err := dateutil.BuildDateObjectFromId(stringValue)
 	if err != nil {
 		log.Error("failed to parse Date object id", zap.Error(err))
 		return equalOrHasFilter
 	}
 
-	start := timeutil.CutToDay(ts)
+	start := timeutil.CutToDay(dateObject.Time())
 	end := start.Add(24 * time.Hour)
 	startTimestamp := start.Unix()
 	endTimestamp := end.Unix()
 
-	shortId := dateutil.TimeToDateId(start, false)
+	startDateObject := dateutil.NewDateObject(start, false)
+	shortId := startDateObject.Id()
 
 	// filter for date objects is able to find relations with values between the borders of queried day
 	// - for relations with number format it checks timestamp value is between timestamps of this day midnights

--- a/core/block/detailservice/relations_test.go
+++ b/core/block/detailservice/relations_test.go
@@ -54,12 +54,12 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 			bundle.RelationKeyLastModifiedDate: pbtypes.Int64(now.Add(-1 * time.Minute).Unix()),
 			bundle.RelationKeyIsFavorite:       pbtypes.Bool(true),
 			"daysTillSummer":                   pbtypes.Int64(300),
-			bundle.RelationKeyLinks:            pbtypes.StringList([]string{"obj2", "obj3", dateutil.TimeToDateId(now.Add(-30*time.Minute), true)}),
+			bundle.RelationKeyLinks:            pbtypes.StringList([]string{"obj2", "obj3", dateutil.NewDateObject(now.Add(-30*time.Minute), true).Id()}),
 		},
 		{
 			bundle.RelationKeyId:               pbtypes.String("obj2"),
 			bundle.RelationKeySpaceId:          pbtypes.String(spaceId),
-			bundle.RelationKeyName:             pbtypes.String(dateutil.TimeToDateId(now, true)),
+			bundle.RelationKeyName:             pbtypes.String(dateutil.NewDateObject(now, true).Id()),
 			bundle.RelationKeyCreatedDate:      pbtypes.Int64(now.Add(-24*time.Hour - 5*time.Minute).Unix()),
 			bundle.RelationKeyAddedDate:        pbtypes.Int64(now.Add(-24*time.Hour - 3*time.Minute).Unix()),
 			bundle.RelationKeyLastModifiedDate: pbtypes.Int64(now.Add(-1 * time.Minute).Unix()),
@@ -73,7 +73,7 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 			bundle.RelationKeyLastModifiedDate: pbtypes.Int64(now.Unix()),
 			bundle.RelationKeyIsFavorite:       pbtypes.Bool(true),
 			bundle.RelationKeyCoverX:           pbtypes.Int64(300),
-			bundle.RelationKeyMentions:         pbtypes.StringList([]string{dateutil.TimeToDateId(now, true), dateutil.TimeToDateId(now.Add(-24*time.Hour), true)}),
+			bundle.RelationKeyMentions:         pbtypes.StringList([]string{dateutil.NewDateObject(now, true).Id(), dateutil.NewDateObject(now.Add(-24*time.Hour), true).Id()}),
 		},
 	})
 
@@ -86,7 +86,7 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 	}{
 		{
 			"date object - today",
-			pbtypes.String(dateutil.TimeToDateId(now, true)),
+			pbtypes.String(dateutil.NewDateObject(now, true).Id()),
 			[]*pb.RpcRelationListWithValueResponseResponseItem{
 				{bundle.RelationKeyMentions.String(), 1},
 				{bundle.RelationKeyAddedDate.String(), 1},
@@ -98,7 +98,7 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 		},
 		{
 			"date object - yesterday",
-			pbtypes.String(dateutil.TimeToDateId(now.Add(-24*time.Hour), true)),
+			pbtypes.String(dateutil.NewDateObject(now.Add(-24*time.Hour), true).Id()),
 			[]*pb.RpcRelationListWithValueResponseResponseItem{
 				{bundle.RelationKeyMentions.String(), 1},
 				{bundle.RelationKeyAddedDate.String(), 1},
@@ -123,7 +123,7 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 		},
 		{
 			"string list",
-			pbtypes.StringList([]string{"obj2", "obj3", dateutil.TimeToDateId(now.Add(-30*time.Minute), true)}),
+			pbtypes.StringList([]string{"obj2", "obj3", dateutil.NewDateObject(now.Add(-30*time.Minute), true).Id()}),
 			[]*pb.RpcRelationListWithValueResponseResponseItem{
 				{bundle.RelationKeyLinks.String(), 1},
 			},

--- a/core/block/detailservice/relations_test.go
+++ b/core/block/detailservice/relations_test.go
@@ -88,11 +88,11 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 			"date object - today",
 			pbtypes.String(dateutil.TimeToDateId(now, true)),
 			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyMentions.String(), 1},
 				{bundle.RelationKeyAddedDate.String(), 1},
 				{bundle.RelationKeyCreatedDate.String(), 2},
 				{bundle.RelationKeyLastModifiedDate.String(), 3},
 				{bundle.RelationKeyLinks.String(), 1},
-				{bundle.RelationKeyMentions.String(), 1},
 				{bundle.RelationKeyName.String(), 1},
 			},
 		},
@@ -100,9 +100,9 @@ func TestService_ListRelationsWithValue(t *testing.T) {
 			"date object - yesterday",
 			pbtypes.String(dateutil.TimeToDateId(now.Add(-24*time.Hour), true)),
 			[]*pb.RpcRelationListWithValueResponseResponseItem{
+				{bundle.RelationKeyMentions.String(), 1},
 				{bundle.RelationKeyAddedDate.String(), 1},
 				{bundle.RelationKeyCreatedDate.String(), 1},
-				{bundle.RelationKeyMentions.String(), 1},
 			},
 		},
 		{

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -512,8 +512,8 @@ func (sb *smartBlock) fetchMeta() (details []*model.ObjectViewDetailsSet, err er
 func (sb *smartBlock) partitionIdsBySpace(ids []string) map[string][]string {
 	perSpace := map[string][]string{}
 	for _, id := range ids {
-		if _, _, parseErr := dateutil.ParseDateId(id); parseErr == nil {
-			perSpace[sb.space.Id()] = append(perSpace[sb.space.Id()], id)
+		if dateObject, parseErr := dateutil.BuildDateObjectFromId(id); parseErr == nil {
+			perSpace[sb.space.Id()] = append(perSpace[sb.space.Id()], dateObject.Id())
 			continue
 		}
 

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -512,7 +512,7 @@ func (sb *smartBlock) fetchMeta() (details []*model.ObjectViewDetailsSet, err er
 func (sb *smartBlock) partitionIdsBySpace(ids []string) map[string][]string {
 	perSpace := map[string][]string{}
 	for _, id := range ids {
-		if _, parseErr := dateutil.ParseDateId(id); parseErr == nil {
+		if _, _, parseErr := dateutil.ParseDateId(id); parseErr == nil {
 			perSpace[sb.space.Id()] = append(perSpace[sb.space.Id()], id)
 			continue
 		}

--- a/core/block/import/notion/api/block/textobject.go
+++ b/core/block/import/notion/api/block/textobject.go
@@ -239,7 +239,7 @@ func (t *TextObject) handleDateMention(rt api.RichText,
 	if rt.Mention.Date.End != "" {
 		textDate = rt.Mention.Date.End
 	}
-	date, _, err := dateutil.ParseDateId(textDate)
+	dateObject, err := dateutil.BuildDateObjectFromId(textDate)
 	if err != nil {
 		return nil
 	}
@@ -252,7 +252,7 @@ func (t *TextObject) handleDateMention(rt api.RichText,
 				To:   int32(to),
 			},
 			Type:  model.BlockContentTextMark_Mention,
-			Param: dateutil.TimeToDateId(date, false),
+			Param: dateObject.Id(),
 		},
 	}
 }

--- a/core/block/import/notion/api/block/textobject.go
+++ b/core/block/import/notion/api/block/textobject.go
@@ -239,7 +239,7 @@ func (t *TextObject) handleDateMention(rt api.RichText,
 	if rt.Mention.Date.End != "" {
 		textDate = rt.Mention.Date.End
 	}
-	date, err := dateutil.ParseDateId(textDate)
+	date, _, err := dateutil.ParseDateId(textDate)
 	if err != nil {
 		return nil
 	}

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -3,6 +3,7 @@ package objectcreator
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/gogo/protobuf/types"
@@ -183,11 +184,8 @@ func (s *service) createObjectFromTemplate(
 
 // buildDateObject does not create real date object. It just builds date object details
 func buildDateObject(space clientspace.Space, details *types.Struct) (string, *types.Struct, error) {
-	name := pbtypes.GetString(details, bundle.RelationKeyName.String())
-	id, err := dateutil.DateNameToId(name)
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to build date object, as its name is invalid: %w", err)
-	}
+	ts := pbtypes.GetInt64(details, bundle.RelationKeyTimestamp.String())
+	dateObject := dateutil.NewDateObject(time.Unix(ts, 0), false)
 
 	typeId, err := space.GetTypeIdByKey(context.Background(), bundle.TypeKeyDate)
 	if err != nil {
@@ -196,7 +194,7 @@ func buildDateObject(space clientspace.Space, details *types.Struct) (string, *t
 
 	dateSource := source.NewDate(source.DateSourceParams{
 		Id: domain.FullID{
-			ObjectID: id,
+			ObjectID: dateObject.Id(),
 			SpaceID:  space.Id(),
 		},
 		DateObjectTypeId: typeId,
@@ -208,5 +206,5 @@ func buildDateObject(space clientspace.Space, details *types.Struct) (string, *t
 	}
 
 	details, err = detailsGetter.DetailsFromId()
-	return id, details, err
+	return dateObject.Id(), details, err
 }

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -118,7 +118,7 @@ func TestService_CreateObject(t *testing.T) {
 			return bundle.TypeKeyDate.URL(), nil
 		})
 		ts := time.Now()
-		name := dateutil.TimeToDateName(ts)
+		name := dateutil.TimeToDateName(ts, false)
 
 		// when
 		id, details, err := f.service.CreateObject(context.Background(), spaceId, CreateObjectRequest{

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -118,39 +118,20 @@ func TestService_CreateObject(t *testing.T) {
 			return bundle.TypeKeyDate.URL(), nil
 		})
 		ts := time.Now()
-		name := dateutil.TimeToDateName(ts, false)
+		dateObject := dateutil.NewDateObject(ts, false)
 
 		// when
 		id, details, err := f.service.CreateObject(context.Background(), spaceId, CreateObjectRequest{
 			ObjectTypeKey: bundle.TypeKeyDate,
 			Details: &types.Struct{Fields: map[string]*types.Value{
-				bundle.RelationKeyName.String(): pbtypes.String(name),
+				bundle.RelationKeyTimestamp.String(): pbtypes.Int64(dateObject.Time().Unix()),
 			}},
 		})
 
 		// then
 		assert.NoError(t, err)
-		assert.True(t, strings.HasPrefix(id, dateutil.TimeToDateId(ts, false)))
+		assert.True(t, strings.HasPrefix(id, dateObject.Id()))
 		assert.Equal(t, spaceId, pbtypes.GetString(details, bundle.RelationKeySpaceId.String()))
 		assert.Equal(t, bundle.TypeKeyDate.URL(), pbtypes.GetString(details, bundle.RelationKeyType.String()))
-	})
-
-	t.Run("date object creation - invalid name", func(t *testing.T) {
-		// given
-		f := newFixture(t)
-		f.spaceService.EXPECT().Get(mock.Anything, mock.Anything).Return(f.spc, nil)
-		ts := time.Now()
-		name := ts.Format(time.RFC3339)
-
-		// when
-		_, _, err := f.service.CreateObject(context.Background(), spaceId, CreateObjectRequest{
-			ObjectTypeKey: bundle.TypeKeyDate,
-			Details: &types.Struct{Fields: map[string]*types.Value{
-				bundle.RelationKeyName.String(): pbtypes.String(name),
-			}},
-		})
-
-		// then
-		assert.Error(t, err)
 	})
 }

--- a/core/block/object/objectlink/dependent_objects.go
+++ b/core/block/object/objectlink/dependent_objects.go
@@ -152,7 +152,7 @@ func collectIdsFromDetail(rel *model.RelationLink, det *types.Struct, flags Flag
 		if relInt > 0 {
 			t := time.Unix(relInt, 0)
 			t = t.In(time.Local)
-			ids = append(ids, dateutil.TimeToDateId(t, false))
+			ids = append(ids, dateutil.NewDateObject(t, false).Id())
 		}
 		return
 	}

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -224,7 +224,7 @@ func (s *Service) DoFullId(id domain.FullID, apply func(sb smartblock.SmartBlock
 // resolveFullId resolves missing spaceId
 func (s *Service) resolveFullId(id domain.FullID) domain.FullID {
 	// TODO: GO-4494 - Do not resolve spaceId in case of date object id. This logic should be reviewed
-	if _, parseErr := dateutil.ParseDateId(id.ObjectID); parseErr == nil && id.SpaceID != "" {
+	if _, _, parseErr := dateutil.ParseDateId(id.ObjectID); parseErr == nil && id.SpaceID != "" {
 		return id
 	}
 	// First try to resolve space. It's necessary if client accidentally passes wrong spaceId

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -46,7 +46,6 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space"
-	"github.com/anyproto/anytype-heart/util/dateutil"
 	"github.com/anyproto/anytype-heart/util/internalflag"
 	"github.com/anyproto/anytype-heart/util/mutex"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
@@ -223,8 +222,7 @@ func (s *Service) DoFullId(id domain.FullID, apply func(sb smartblock.SmartBlock
 
 // resolveFullId resolves missing spaceId
 func (s *Service) resolveFullId(id domain.FullID) domain.FullID {
-	// TODO: GO-4494 - Do not resolve spaceId in case of date object id. This logic should be reviewed
-	if _, _, parseErr := dateutil.ParseDateId(id.ObjectID); parseErr == nil && id.SpaceID != "" {
+	if id.SpaceID != "" {
 		return id
 	}
 	// First try to resolve space. It's necessary if client accidentally passes wrong spaceId

--- a/core/block/source/date.go
+++ b/core/block/source/date.go
@@ -56,13 +56,13 @@ func (d *date) Type() smartblock.SmartBlockType {
 }
 
 func (d *date) getDetails() (*types.Struct, error) {
-	t, err := dateutil.ParseDateId(d.id)
+	t, includeTime, err := dateutil.ParseDateId(d.id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse date id: %w", err)
 	}
 
 	return &types.Struct{Fields: map[string]*types.Value{
-		bundle.RelationKeyName.String():       pbtypes.String(dateutil.TimeToDateName(t)),
+		bundle.RelationKeyName.String():       pbtypes.String(dateutil.TimeToDateName(t, includeTime)),
 		bundle.RelationKeyId.String():         pbtypes.String(d.id),
 		bundle.RelationKeyType.String():       pbtypes.String(d.typeId),
 		bundle.RelationKeyIsReadonly.String(): pbtypes.Bool(true),

--- a/core/block/source/date.go
+++ b/core/block/source/date.go
@@ -56,13 +56,13 @@ func (d *date) Type() smartblock.SmartBlockType {
 }
 
 func (d *date) getDetails() (*types.Struct, error) {
-	t, includeTime, err := dateutil.ParseDateId(d.id)
+	dateObject, err := dateutil.BuildDateObjectFromId(d.id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse date id: %w", err)
 	}
 
 	return &types.Struct{Fields: map[string]*types.Value{
-		bundle.RelationKeyName.String():       pbtypes.String(dateutil.TimeToDateName(t, includeTime)),
+		bundle.RelationKeyName.String():       pbtypes.String(dateObject.Name()),
 		bundle.RelationKeyId.String():         pbtypes.String(d.id),
 		bundle.RelationKeyType.String():       pbtypes.String(d.typeId),
 		bundle.RelationKeyIsReadonly.String(): pbtypes.Bool(true),
@@ -71,7 +71,7 @@ func (d *date) getDetails() (*types.Struct, error) {
 		bundle.RelationKeyLayout.String():     pbtypes.Float64(float64(model.ObjectType_date)),
 		bundle.RelationKeyIconEmoji.String():  pbtypes.String("📅"),
 		bundle.RelationKeySpaceId.String():    pbtypes.String(d.SpaceID()),
-		bundle.RelationKeyTimestamp.String():  pbtypes.Int64(t.Unix()),
+		bundle.RelationKeyTimestamp.String():  pbtypes.Int64(dateObject.Time().Unix()),
 	}}, nil
 }
 

--- a/core/date/date_test.go
+++ b/core/date/date_test.go
@@ -38,7 +38,7 @@ func TestBuildDetailsFromTimestamp(t *testing.T) {
 
 			tt := time.Unix(ts, 0)
 			assert.Equal(t, dateutil.TimeToDateId(tt, false), pbtypes.GetString(details, bundle.RelationKeyId.String()))
-			assert.Equal(t, dateutil.TimeToDateName(tt), pbtypes.GetString(details, bundle.RelationKeyName.String()))
+			assert.Equal(t, dateutil.TimeToDateName(tt, false), pbtypes.GetString(details, bundle.RelationKeyName.String()))
 			ts2 := pbtypes.GetInt64(details, bundle.RelationKeyTimestamp.String())
 			tt2 := time.Unix(ts2, 0)
 			assert.Zero(t, tt2.Hour())

--- a/core/date/date_test.go
+++ b/core/date/date_test.go
@@ -36,14 +36,14 @@ func TestBuildDetailsFromTimestamp(t *testing.T) {
 			assert.Equal(t, spaceId, pbtypes.GetString(details, bundle.RelationKeySpaceId.String()))
 			assert.Equal(t, bundle.TypeKeyDate.URL(), pbtypes.GetString(details, bundle.RelationKeyType.String()))
 
-			tt := time.Unix(ts, 0)
-			assert.Equal(t, dateutil.TimeToDateId(tt, false), pbtypes.GetString(details, bundle.RelationKeyId.String()))
-			assert.Equal(t, dateutil.TimeToDateName(tt, false), pbtypes.GetString(details, bundle.RelationKeyName.String()))
+			dateObject := dateutil.NewDateObject(time.Unix(ts, 0), false)
+			assert.Equal(t, dateObject.Id(), pbtypes.GetString(details, bundle.RelationKeyId.String()))
+			assert.Equal(t, dateObject.Name(), pbtypes.GetString(details, bundle.RelationKeyName.String()))
 			ts2 := pbtypes.GetInt64(details, bundle.RelationKeyTimestamp.String())
-			tt2 := time.Unix(ts2, 0)
-			assert.Zero(t, tt2.Hour())
-			assert.Zero(t, tt2.Minute())
-			assert.Zero(t, tt2.Second())
+			tt := time.Unix(ts2, 0)
+			assert.Zero(t, tt.Hour())
+			assert.Zero(t, tt.Minute())
+			assert.Zero(t, tt.Second())
 		})
 	}
 }

--- a/core/date/details.go
+++ b/core/date/details.go
@@ -30,7 +30,7 @@ func BuildDetailsFromTimestamp(
 	dateSource := source.NewDate(source.DateSourceParams{
 		Id: domain.FullID{
 			SpaceID:  spaceId,
-			ObjectID: dateutil.TimeToDateId(time.Unix(timestamp, 0), false),
+			ObjectID: dateutil.NewDateObject(time.Unix(timestamp, 0), false).Id(),
 		},
 		DateObjectTypeId: dateTypeId,
 	})

--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -33,7 +33,7 @@ func EnrichRecordsWithDateSuggestion(
 	}
 
 	isDay := dt.Hour() == 0 && dt.Minute() == 0 && dt.Second() == 0
-	id := dateutil.TimeToDateId(dt, !isDay)
+	id := dateutil.NewDateObject(dt, !isDay).Id()
 
 	// Don't duplicate search suggestions
 	var found bool

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "44f147da7e8233e89bb42533778c305d0735a54238aa2e5ba331a3396145450d"
+const RelationChecksum = "0585cf84a06a32d7fa898e2d07c15cb6e3d0e2b2201fcae6125955df1f51f8f8"
 const (
 	RelationKeyTag                       domain.RelationKey = "tag"
 	RelationKeyCamera                    domain.RelationKey = "camera"
@@ -1012,9 +1012,10 @@ var (
 			Id:               "_brlastUsedDate",
 			Key:              "lastUsedDate",
 			MaxCount:         1,
-			Name:             "Last Used date",
+			Name:             "Last used date",
 			ReadOnly:         true,
 			ReadOnlyRelation: true,
+			Revision:         1,
 			Scope:            model.Relation_type,
 		},
 		RelationKeyLatestAclHeadId: {

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1247,9 +1247,10 @@
     "hidden": true,
     "key": "lastUsedDate",
     "maxCount": 1,
-    "name": "Last Used date",
+    "name": "Last used date",
     "readonly": true,
-    "source": "local"
+    "source": "local",
+    "revision": 1
   },
   {
     "description": "Revision of system object",

--- a/pkg/lib/database/filter.go
+++ b/pkg/lib/database/filter.go
@@ -151,10 +151,10 @@ func makeFilterByCondition(spaceID string, rawFilter *model.BlockContentDataview
 	case model.BlockContentDataviewFilter_In:
 		// hack for queries for relations containing date objects ids with format _date_YYYY-MM-DD-hh-mm-ssZ-zzzz
 		// to find all date object ids of the same day we search by prefix _date_YYYY-MM-DD
-		if ts, _, err := dateutil.ParseDateId(rawFilter.Value.GetStringValue()); err == nil {
+		if dateObject, err := dateutil.BuildDateObjectFromId(rawFilter.Value.GetStringValue()); err == nil {
 			return FilterHasPrefix{
 				Key:    rawFilter.RelationKey,
-				Prefix: dateutil.TimeToDateId(ts, false),
+				Prefix: dateutil.NewDateObject(dateObject.Time(), false).Id(),
 			}, nil
 		}
 		list, err := pbtypes.ValueListWrapper(rawFilter.Value)

--- a/pkg/lib/database/filter.go
+++ b/pkg/lib/database/filter.go
@@ -151,7 +151,7 @@ func makeFilterByCondition(spaceID string, rawFilter *model.BlockContentDataview
 	case model.BlockContentDataviewFilter_In:
 		// hack for queries for relations containing date objects ids with format _date_YYYY-MM-DD-hh-mm-ssZ-zzzz
 		// to find all date object ids of the same day we search by prefix _date_YYYY-MM-DD
-		if ts, err := dateutil.ParseDateId(rawFilter.Value.GetStringValue()); err == nil {
+		if ts, _, err := dateutil.ParseDateId(rawFilter.Value.GetStringValue()); err == nil {
 			return FilterHasPrefix{
 				Key:    rawFilter.RelationKey,
 				Prefix: dateutil.TimeToDateId(ts, false),

--- a/pkg/lib/database/filter_test.go
+++ b/pkg/lib/database/filter_test.go
@@ -939,16 +939,16 @@ func TestFilterHasPrefix_FilterObject(t *testing.T) {
 		now := time.Now()
 		f := FilterHasPrefix{
 			Key:    key,
-			Prefix: dateutil.TimeToDateId(now, false), // _date_YYYY-MM-DD
+			Prefix: dateutil.NewDateObject(now, false).Id(), // _date_YYYY-MM-DD
 		}
 		obj1 := &types.Struct{Fields: map[string]*types.Value{
-			key: pbtypes.StringList([]string{"obj2", dateutil.TimeToDateId(now.Add(30*time.Minute), true), "obj3"}), // _date_YYYY-MM-DD-hh-mm-ssZ-zzzz
+			key: pbtypes.StringList([]string{"obj2", dateutil.NewDateObject(now.Add(30*time.Minute), true).Id(), "obj3"}), // _date_YYYY-MM-DD-hh-mm-ssZ-zzzz
 		}}
 		obj2 := &types.Struct{Fields: map[string]*types.Value{
-			key: pbtypes.StringList([]string{dateutil.TimeToDateId(now.Add(24*time.Hour), true), "obj1", "obj3"}), // same format, but next day
+			key: pbtypes.StringList([]string{dateutil.NewDateObject(now.Add(24*time.Hour), true).Id(), "obj1", "obj3"}), // same format, but next day
 		}}
 		obj3 := &types.Struct{Fields: map[string]*types.Value{
-			key: pbtypes.StringList([]string{"obj2", "obj3", dateutil.TimeToDateId(now.Add(30*time.Minute), true)}), // _date_YYYY-MM-DD
+			key: pbtypes.StringList([]string{"obj2", "obj3", dateutil.NewDateObject(now.Add(30*time.Minute), true).Id()}), // _date_YYYY-MM-DD
 		}}
 		assertFilter(t, f, obj1, true)
 		assertFilter(t, f, obj2, false)

--- a/util/dateutil/util.go
+++ b/util/dateutil/util.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	shortDateIdLayout = "2006-01-02"
-	dateIdLayout      = "2006-01-02-15-04-05Z-0700"
-	dateNameLayout    = "02 Jan 2006"
+	shortDateIdLayout   = "2006-01-02"
+	dateIdLayout        = "2006-01-02-15-04-05Z-0700"
+	shortDateNameLayout = "02 Jan 2006"
+	dateNameLayout      = "02 Jan 2006 15:04"
 )
 
 // TimeToDateId returns date object id. We substitute + with _ in time zone, as + is not supported in object ids on clients
@@ -24,18 +25,22 @@ func TimeToDateId(t time.Time, includeTime bool) string {
 	return addr.DatePrefix + t.Format(shortDateIdLayout)
 }
 
-func ParseDateId(id string) (time.Time, error) {
+func ParseDateId(id string) (t time.Time, includeTime bool, err error) {
 	formatted := strings.TrimPrefix(id, addr.DatePrefix)
 	formatted = strings.Replace(formatted, "_", "+", 1)
-	t, err := time.Parse(dateIdLayout, formatted)
+	t, err = time.Parse(dateIdLayout, formatted)
 	if err == nil {
-		return t, nil
+		return t, true, nil
 	}
-	return time.ParseInLocation(shortDateIdLayout, formatted, time.Local)
+	t, err = time.ParseInLocation(shortDateIdLayout, formatted, time.Local)
+	return t, false, err
 }
 
-func TimeToDateName(t time.Time) string {
-	return t.Format(dateNameLayout)
+func TimeToDateName(t time.Time, includeTime bool) string {
+	if includeTime {
+		return t.Format(dateNameLayout)
+	}
+	return t.Format(shortDateNameLayout)
 }
 
 func DateNameToId(name string) (string, error) {

--- a/util/dateutil/util.go
+++ b/util/dateutil/util.go
@@ -14,44 +14,51 @@ const (
 	dateNameLayout      = "02 Jan 2006 15:04"
 )
 
-// TimeToDateId returns date object id. We substitute + with _ in time zone, as + is not supported in object ids on clients
-// Format with time is _date_YYYY-MM-DD-hh-mm-ssZ-zzzz. Format without time _date_YYYY-MM-DD
-func TimeToDateId(t time.Time, includeTime bool) string {
-	if includeTime {
-		formatted := t.Format(dateIdLayout)
+type DateObject interface {
+	Id() string
+	Name() string
+	Time() time.Time
+}
+
+type dateObject struct {
+	t           time.Time
+	includeTime bool
+}
+
+func NewDateObject(t time.Time, includeTime bool) DateObject {
+	return dateObject{t, includeTime}
+}
+
+func BuildDateObjectFromId(id string) (DateObject, error) {
+	formatted := strings.TrimPrefix(id, addr.DatePrefix)
+	formatted = strings.Replace(formatted, "_", "+", 1)
+	t, err := time.Parse(dateIdLayout, formatted)
+	if err == nil {
+		return dateObject{t, true}, nil
+	}
+	t, err = time.ParseInLocation(shortDateIdLayout, formatted, time.Local)
+	if err == nil {
+		return dateObject{t, false}, nil
+	}
+	return dateObject{}, err
+}
+
+func (do dateObject) Id() string {
+	if do.includeTime {
+		formatted := do.t.Format(dateIdLayout)
 		formatted = strings.Replace(formatted, "+", "_", 1)
 		return addr.DatePrefix + formatted
 	}
-	return addr.DatePrefix + t.Format(shortDateIdLayout)
+	return addr.DatePrefix + do.t.Format(shortDateIdLayout)
 }
 
-func ParseDateId(id string) (t time.Time, includeTime bool, err error) {
-	formatted := strings.TrimPrefix(id, addr.DatePrefix)
-	formatted = strings.Replace(formatted, "_", "+", 1)
-	t, err = time.Parse(dateIdLayout, formatted)
-	if err == nil {
-		return t, true, nil
+func (do dateObject) Name() string {
+	if do.includeTime {
+		return do.t.Format(dateNameLayout)
 	}
-	t, err = time.ParseInLocation(shortDateIdLayout, formatted, time.Local)
-	return t, false, err
+	return do.t.Format(shortDateNameLayout)
 }
 
-func TimeToDateName(t time.Time, includeTime bool) string {
-	if includeTime {
-		return t.Format(dateNameLayout)
-	}
-	return t.Format(shortDateNameLayout)
-}
-
-func DateNameToId(name string) (string, error) {
-	t, err := time.Parse(dateNameLayout, name)
-	if err == nil {
-		return TimeToDateId(t, true), nil
-	}
-
-	t, err = time.Parse(shortDateNameLayout, name)
-	if err != nil {
-		return "", err
-	}
-	return TimeToDateId(t, false), nil
+func (do dateObject) Time() time.Time {
+	return do.t
 }

--- a/util/dateutil/util.go
+++ b/util/dateutil/util.go
@@ -45,6 +45,11 @@ func TimeToDateName(t time.Time, includeTime bool) string {
 
 func DateNameToId(name string) (string, error) {
 	t, err := time.Parse(dateNameLayout, name)
+	if err == nil {
+		return TimeToDateId(t, true), nil
+	}
+
+	t, err = time.Parse(shortDateNameLayout, name)
 	if err != nil {
 		return "", err
 	}

--- a/util/dateutil/util_test.go
+++ b/util/dateutil/util_test.go
@@ -24,12 +24,23 @@ func TestTimeToShortDateId(t *testing.T) {
 }
 
 func TestTimeToDateName(t *testing.T) {
-	assert.Equal(t, "07 Nov 2024", TimeToDateName(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC)))
-	assert.Equal(t, "01 Jan 1998", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC)))
-	assert.Equal(t, "01 Jan 1998", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60))))
-	assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC)))
-	assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60))))
-	assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60))))
+	t.Run("short name", func(t *testing.T) {
+		assert.Equal(t, "07 Nov 2024", TimeToDateName(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC), false))
+		assert.Equal(t, "01 Jan 1998", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC), false))
+		assert.Equal(t, "01 Jan 1998", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)), false))
+		assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC), false))
+		assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), false))
+		assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), false))
+	})
+
+	t.Run("long name", func(t *testing.T) {
+		assert.Equal(t, "07 Nov 2024 12:25", TimeToDateName(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC), true))
+		assert.Equal(t, "01 Jan 1998 00:01", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC), true))
+		assert.Equal(t, "01 Jan 1998 00:01", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)), true))
+		assert.Equal(t, "25 Dec 2124 23:34", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC), true))
+		assert.Equal(t, "25 Dec 2124 23:34", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), true))
+		assert.Equal(t, "25 Dec 2124 23:34", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), true))
+	})
 }
 
 func TestParseDateId(t *testing.T) {
@@ -43,9 +54,10 @@ func TestParseDateId(t *testing.T) {
 			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
 		} {
 			dateId := TimeToDateId(ts, true)
-			ts2, err := ParseDateId(dateId)
+			ts2, includeTime, err := ParseDateId(dateId)
 			assert.NoError(t, err)
 			assert.Equal(t, ts.Unix(), ts2.Unix())
+			assert.True(t, includeTime)
 		}
 	})
 
@@ -59,8 +71,9 @@ func TestParseDateId(t *testing.T) {
 			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
 		} {
 			dateId := TimeToDateId(ts, false)
-			ts2, err := ParseDateId(dateId)
+			ts2, includeTime, err := ParseDateId(dateId)
 			assert.NoError(t, err)
+			assert.False(t, includeTime)
 			assert.Equal(t, ts.Year(), ts2.Year())
 			assert.Equal(t, ts.Month(), ts2.Month())
 			assert.Equal(t, ts.Day(), ts2.Day())
@@ -72,10 +85,10 @@ func TestParseDateId(t *testing.T) {
 	})
 
 	t.Run("wrong format", func(t *testing.T) {
-		_, err := ParseDateId("_date_2024")
+		_, _, err := ParseDateId("_date_2024")
 		assert.Error(t, err)
 
-		_, err = ParseDateId("object1")
+		_, _, err = ParseDateId("object1")
 		assert.Error(t, err)
 	})
 }

--- a/util/dateutil/util_test.go
+++ b/util/dateutil/util_test.go
@@ -92,3 +92,20 @@ func TestParseDateId(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestDateNameToId(t *testing.T) {
+	t.Run("short name", func(t *testing.T) {
+		for _, pair := range []struct {
+			name, id string
+		}{
+			{"21 Nov 2024", "_date_2024-11-21"},
+			{"01 Dec 2124", "_date_2124-12-01"},
+			{"01 Jan 1924", "_date_1924-01-01"},
+		} {
+			id, err := DateNameToId(pair.name)
+			assert.NoError(t, err)
+			assert.Equal(t, pair.id, id)
+		}
+
+	})
+}

--- a/util/dateutil/util_test.go
+++ b/util/dateutil/util_test.go
@@ -7,61 +7,88 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTimeToDateId(t *testing.T) {
-	assert.Equal(t, "_date_2024-11-07-12-25-59Z_0000", TimeToDateId(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC), true))
-	assert.Equal(t, "_date_1998-01-01-00-01-01Z_0000", TimeToDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC), true))
-	assert.Equal(t, "_date_1998-01-01-00-01-01Z_0400", TimeToDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)), true))
-	assert.Equal(t, "_date_2124-12-25-23-34-00Z_0000", TimeToDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC), true))
-	assert.Equal(t, "_date_2124-12-25-23-34-00Z-0200", TimeToDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), true))
-}
-
-func TestTimeToShortDateId(t *testing.T) {
-	assert.Equal(t, "_date_2024-11-07", TimeToDateId(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC), false))
-	assert.Equal(t, "_date_1998-01-01", TimeToDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC), false))
-	assert.Equal(t, "_date_1998-01-01", TimeToDateId(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)), false))
-	assert.Equal(t, "_date_2124-12-25", TimeToDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC), false))
-	assert.Equal(t, "_date_2124-12-25", TimeToDateId(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), false))
-}
-
-func TestTimeToDateName(t *testing.T) {
-	t.Run("short name", func(t *testing.T) {
-		assert.Equal(t, "07 Nov 2024", TimeToDateName(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC), false))
-		assert.Equal(t, "01 Jan 1998", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC), false))
-		assert.Equal(t, "01 Jan 1998", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)), false))
-		assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC), false))
-		assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), false))
-		assert.Equal(t, "25 Dec 2124", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), false))
-	})
-
-	t.Run("long name", func(t *testing.T) {
-		assert.Equal(t, "07 Nov 2024 12:25", TimeToDateName(time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC), true))
-		assert.Equal(t, "01 Jan 1998 00:01", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC), true))
-		assert.Equal(t, "01 Jan 1998 00:01", TimeToDateName(time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)), true))
-		assert.Equal(t, "25 Dec 2124 23:34", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC), true))
-		assert.Equal(t, "25 Dec 2124 23:34", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), true))
-		assert.Equal(t, "25 Dec 2124 23:34", TimeToDateName(time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)), true))
-	})
-}
-
-func TestParseDateId(t *testing.T) {
-	t.Run("long date format", func(t *testing.T) {
-		for _, ts := range []time.Time{
-			time.Date(2024, time.December, 7, 12, 25, 59, 0, time.UTC),
-			time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
-			time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
-			time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
-			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
-			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
+func TestNewDateObject(t *testing.T) {
+	t.Run("include time", func(t *testing.T) {
+		for _, tc := range []struct {
+			ts           time.Time
+			expectedId   string
+			expectedName string
+		}{
+			{
+				ts:           time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
+				expectedId:   "_date_2024-11-07-12-25-59Z_0000",
+				expectedName: "07 Nov 2024 12:25",
+			},
+			{
+				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
+				expectedId:   "_date_1998-01-01-00-01-01Z_0000",
+				expectedName: "01 Jan 1998 00:01",
+			},
+			{
+				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
+				expectedId:   "_date_1998-01-01-00-01-01Z_0400",
+				expectedName: "01 Jan 1998 00:01",
+			},
+			{
+				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
+				expectedId:   "_date_2124-12-25-23-34-00Z_0000",
+				expectedName: "25 Dec 2124 23:34",
+			},
+			{
+				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
+				expectedId:   "_date_2124-12-25-23-34-00Z-0200",
+				expectedName: "25 Dec 2124 23:34",
+			},
 		} {
-			dateId := TimeToDateId(ts, true)
-			ts2, includeTime, err := ParseDateId(dateId)
-			assert.NoError(t, err)
-			assert.Equal(t, ts.Unix(), ts2.Unix())
-			assert.True(t, includeTime)
+			do := NewDateObject(tc.ts, true)
+			assert.Equal(t, tc.expectedId, do.Id())
+			assert.Equal(t, tc.expectedName, do.Name())
+			assert.Equal(t, tc.ts, do.Time())
 		}
 	})
 
-	t.Run("short date format", func(t *testing.T) {
+	t.Run("do not include time", func(t *testing.T) {
+		for _, tc := range []struct {
+			ts           time.Time
+			expectedId   string
+			expectedName string
+		}{
+			{
+				ts:           time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
+				expectedId:   "_date_2024-11-07",
+				expectedName: "07 Nov 2024",
+			},
+			{
+				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
+				expectedId:   "_date_1998-01-01",
+				expectedName: "01 Jan 1998",
+			},
+			{
+				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
+				expectedId:   "_date_1998-01-01",
+				expectedName: "01 Jan 1998",
+			},
+			{
+				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
+				expectedId:   "_date_2124-12-25",
+				expectedName: "25 Dec 2124",
+			},
+			{
+				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
+				expectedId:   "_date_2124-12-25",
+				expectedName: "25 Dec 2124",
+			},
+		} {
+			do := NewDateObject(tc.ts, false)
+			assert.Equal(t, tc.expectedId, do.Id())
+			assert.Equal(t, tc.expectedName, do.Name())
+			assert.Equal(t, tc.ts, do.Time())
+		}
+	})
+}
+
+func TestBuildDateObjectFromId(t *testing.T) {
+	t.Run("date object ids", func(t *testing.T) {
 		for _, ts := range []time.Time{
 			time.Date(2024, time.December, 7, 12, 25, 59, 0, time.UTC),
 			time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
@@ -70,42 +97,26 @@ func TestParseDateId(t *testing.T) {
 			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
 			time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
 		} {
-			dateId := TimeToDateId(ts, false)
-			ts2, includeTime, err := ParseDateId(dateId)
+			withTime1 := NewDateObject(ts, true)
+			withTime2, err := BuildDateObjectFromId(withTime1.Id())
 			assert.NoError(t, err)
-			assert.False(t, includeTime)
-			assert.Equal(t, ts.Year(), ts2.Year())
-			assert.Equal(t, ts.Month(), ts2.Month())
-			assert.Equal(t, ts.Day(), ts2.Day())
-			assert.Zero(t, ts2.Hour())
-			assert.Zero(t, ts2.Minute())
-			assert.Zero(t, ts2.Second())
-			assert.Equal(t, time.Local, ts2.Location())
+			assert.Equal(t, withTime2.Time().Unix(), withTime1.Time().Unix())
+			assert.Equal(t, withTime2.Id(), withTime1.Id())
+
+			withoutTime1 := NewDateObject(ts, true)
+			withoutTime2, err := BuildDateObjectFromId(withoutTime1.Id())
+			assert.NoError(t, err)
+			assert.Equal(t, withoutTime2.Time().Unix(), withoutTime1.Time().Unix())
+			assert.Equal(t, withoutTime2.Id(), withoutTime1.Id())
 		}
 	})
 
 	t.Run("wrong format", func(t *testing.T) {
-		_, _, err := ParseDateId("_date_2024")
+		_, err := BuildDateObjectFromId("_date_2024")
 		assert.Error(t, err)
 
-		_, _, err = ParseDateId("object1")
+		_, err = BuildDateObjectFromId("object1")
 		assert.Error(t, err)
 	})
-}
 
-func TestDateNameToId(t *testing.T) {
-	t.Run("short name", func(t *testing.T) {
-		for _, pair := range []struct {
-			name, id string
-		}{
-			{"21 Nov 2024", "_date_2024-11-21"},
-			{"01 Dec 2124", "_date_2124-12-01"},
-			{"01 Jan 1924", "_date_1924-01-01"},
-		} {
-			id, err := DateNameToId(pair.name)
-			assert.NoError(t, err)
-			assert.Equal(t, pair.id, id)
-		}
-
-	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4560/mentions-should-be-put-on-1st-place-in-relationlistwithvalue-output

- Mentions should appear as first relation in RelationListWithValue output (if presented)
- Rename Last Used date -> Last used date for consistency
- For dates with time included enrich date names with time hh:mm