### PR TITLE
GO-4586 | GO-4590 - Do not generate long date ids + Change date format again

### DIFF
--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -32,7 +32,10 @@ func EnrichRecordsWithDateSuggestion(
 		return records, nil
 	}
 
-	isDay := dt.Hour() == 0 && dt.Minute() == 0 && dt.Second() == 0
+	// TODO: GO-4097 Uncomment it when we will be able to support dates with seconds precision
+	// isDay := dt.Hour() == 0 && dt.Minute() == 0 && dt.Second() == 0
+	isDay := true
+
 	id := dateutil.TimeToDateId(dt, !isDay)
 
 	// Don't duplicate search suggestions

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anyproto/anytype-heart
 
-go 1.23.2
+go 1.22.9
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anyproto/anytype-heart
 
-go 1.22.9
+go 1.23.2
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.4.0

--- a/util/dateutil/util.go
+++ b/util/dateutil/util.go
@@ -10,8 +10,8 @@ import (
 const (
 	shortDateIdLayout   = "2006-01-02"
 	dateIdLayout        = "2006-01-02-15-04-05Z-0700"
-	shortDateNameLayout = "02 Jan 2006"
-	dateNameLayout      = "02 Jan 2006 15:04"
+	shortDateNameLayout = "Mon, Jan 02, 2006"
+	dateNameLayout      = "Mon, Jan 02, 2006 3:04 PM"
 )
 
 type DateObject interface {

--- a/util/dateutil/util_test.go
+++ b/util/dateutil/util_test.go
@@ -17,27 +17,27 @@ func TestNewDateObject(t *testing.T) {
 			{
 				ts:           time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
 				expectedId:   "_date_2024-11-07-12-25-59Z_0000",
-				expectedName: "07 Nov 2024 12:25",
+				expectedName: "Thu, Nov 07, 2024 12:25 PM",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
 				expectedId:   "_date_1998-01-01-00-01-01Z_0000",
-				expectedName: "01 Jan 1998 00:01",
+				expectedName: "Thu, Jan 01, 1998 12:01 AM",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
 				expectedId:   "_date_1998-01-01-00-01-01Z_0400",
-				expectedName: "01 Jan 1998 00:01",
+				expectedName: "Thu, Jan 01, 1998 12:01 AM",
 			},
 			{
 				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
 				expectedId:   "_date_2124-12-25-23-34-00Z_0000",
-				expectedName: "25 Dec 2124 23:34",
+				expectedName: "Mon, Dec 25, 2124 11:34 PM",
 			},
 			{
 				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
 				expectedId:   "_date_2124-12-25-23-34-00Z-0200",
-				expectedName: "25 Dec 2124 23:34",
+				expectedName: "Mon, Dec 25, 2124 11:34 PM",
 			},
 		} {
 			do := NewDateObject(tc.ts, true)
@@ -56,27 +56,27 @@ func TestNewDateObject(t *testing.T) {
 			{
 				ts:           time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
 				expectedId:   "_date_2024-11-07",
-				expectedName: "07 Nov 2024",
+				expectedName: "Thu, Nov 07, 2024",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
 				expectedId:   "_date_1998-01-01",
-				expectedName: "01 Jan 1998",
+				expectedName: "Thu, Jan 01, 1998",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
 				expectedId:   "_date_1998-01-01",
-				expectedName: "01 Jan 1998",
+				expectedName: "Thu, Jan 01, 1998",
 			},
 			{
 				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
 				expectedId:   "_date_2124-12-25",
-				expectedName: "25 Dec 2124",
+				expectedName: "Mon, Dec 25, 2124",
 			},
 			{
 				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.FixedZone("UTC", -2*60*60)),
 				expectedId:   "_date_2124-12-25",
-				expectedName: "25 Dec 2124",
+				expectedName: "Mon, Dec 25, 2124",
 			},
 		} {
 			do := NewDateObject(tc.ts, false)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4586/do-not-generate-long-ids
https://linear.app/anytype/issue/GO-4590/support-the-date-format-once-again

- We should not allow to generate second-precision date object ids for now, as old clients could not show these objects correctly
- Change date format to Mon, Dec 25, 2124 11:34 PM