### PR TITLE
GO-4587 ObjectSearch should return dates by ids

### DIFF
--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -18,38 +18,18 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/space"
 	"github.com/anyproto/anytype-heart/util/dateutil"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
-func EnrichRecordsWithDateSuggestion(
+func EnrichRecordsWithDateSuggestions(
 	ctx context.Context,
 	records []database.Record,
 	req *pb.RpcObjectSearchRequest,
 	store objectstore.ObjectStore,
 	spaceService space.Service,
 ) ([]database.Record, error) {
-	dt := suggestDateForSearch(time.Now(), req.FullText)
-	if dt.IsZero() {
-		return records, nil
-	}
-
-	isDay := dt.Hour() == 0 && dt.Minute() == 0 && dt.Second() == 0
-	id := dateutil.NewDateObject(dt, !isDay).Id()
-
-	// Don't duplicate search suggestions
-	var found bool
-	for _, r := range records {
-		if r.Details == nil || r.Details.Fields == nil {
-			continue
-		}
-		if v, ok := r.Details.Fields[bundle.RelationKeyId.String()]; ok {
-			if v.GetStringValue() == id {
-				found = true
-				break
-			}
-		}
-
-	}
-	if found {
+	ids := suggestDateObjectIds(req)
+	if ids == nil {
 		return records, nil
 	}
 
@@ -58,15 +38,49 @@ func EnrichRecordsWithDateSuggestion(
 		return nil, fmt.Errorf("get space: %w", err)
 	}
 
-	rec, err := makeSuggestedDateRecord(spc, id)
-	if err != nil {
-		return nil, fmt.Errorf("make date record: %w", err)
+	for _, id := range ids {
+		if isRecordDuplicated(records, id) {
+			continue
+		}
+
+		rec, err := makeSuggestedDateRecord(ctx, spc, id)
+		if err != nil {
+			return nil, fmt.Errorf("make date record: %w", err)
+		}
+
+		f, _ := database.MakeFilters(req.Filters, store.SpaceIndex(req.SpaceId)) //nolint:errcheck
+		if f.FilterObject(rec.Details) {
+			records = append([]database.Record{rec}, records...)
+		}
 	}
-	f, _ := database.MakeFilters(req.Filters, store.SpaceIndex(req.SpaceId)) //nolint:errcheck
-	if f.FilterObject(rec.Details) {
-		return append([]database.Record{rec}, records...), nil
-	}
+
 	return records, nil
+}
+
+// suggestDateObjectIds suggests date object ids based on two fields:
+// - fullText - if naturalDate successfully parses text into date, resulting date object id is returned
+// - filter with key id
+func suggestDateObjectIds(req *pb.RpcObjectSearchRequest) []string {
+	dt := suggestDateForSearch(time.Now(), req.FullText)
+	if !dt.IsZero() {
+		isDay := dt.Hour() == 0 && dt.Minute() == 0 && dt.Second() == 0
+		return []string{dateutil.NewDateObject(dt, !isDay).Id()}
+	}
+
+	for _, filter := range req.Filters {
+		if filter.RelationKey == bundle.RelationKeyId.String() {
+			list := pbtypes.GetStringListValue(filter.Value)
+			var dateObjectIds []string
+			for _, id := range list {
+				if _, err := dateutil.BuildDateObjectFromId(id); err == nil {
+					dateObjectIds = append(dateObjectIds, id)
+				}
+			}
+			return dateObjectIds
+		}
+	}
+
+	return nil
 }
 
 func suggestDateForSearch(now time.Time, raw string) time.Time {
@@ -129,8 +143,23 @@ func suggestDateForSearch(now time.Time, raw string) time.Time {
 	return t
 }
 
-func makeSuggestedDateRecord(spc source.Space, id string) (database.Record, error) {
-	typeId, err := spc.GetTypeIdByKey(context.Background(), bundle.TypeKeyDate)
+func isRecordDuplicated(records []database.Record, id string) bool {
+	for _, r := range records {
+		if r.Details == nil || r.Details.Fields == nil {
+			continue
+		}
+		if v, ok := r.Details.Fields[bundle.RelationKeyId.String()]; ok {
+			if v.GetStringValue() == id {
+				return true
+			}
+		}
+
+	}
+	return false
+}
+
+func makeSuggestedDateRecord(ctx context.Context, spc source.Space, id string) (database.Record, error) {
+	typeId, err := spc.GetTypeIdByKey(ctx, bundle.TypeKeyDate)
 	if err != nil {
 		return database.Record{}, fmt.Errorf("failed to find Date type to build Date object: %w", err)
 	}

--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -29,7 +29,7 @@ func EnrichRecordsWithDateSuggestions(
 	spaceService space.Service,
 ) ([]database.Record, error) {
 	ids := suggestDateObjectIds(req)
-	if ids == nil {
+	if len(ids) == 0 {
 		return records, nil
 	}
 
@@ -39,7 +39,7 @@ func EnrichRecordsWithDateSuggestions(
 	}
 
 	for _, id := range ids {
-		if isRecordDuplicated(records, id) {
+		if recordsHasId(records, id) {
 			continue
 		}
 
@@ -143,7 +143,7 @@ func suggestDateForSearch(now time.Time, raw string) time.Time {
 	return t
 }
 
-func isRecordDuplicated(records []database.Record, id string) bool {
+func recordsHasId(records []database.Record, id string) bool {
 	for _, r := range records {
 		if r.Details == nil || r.Details.Fields == nil {
 			continue

--- a/core/date/suggest_test.go
+++ b/core/date/suggest_test.go
@@ -5,6 +5,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/dateutil"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 func Test_suggestDateForSearch(t *testing.T) {
@@ -63,4 +70,25 @@ func Test_suggestDateForSearch(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSuggestDateObjectIdsFromFilter(t *testing.T) {
+	// given
+	dateObject1 := dateutil.NewDateObject(time.Now(), false)
+	dateObject2 := dateutil.NewDateObject(time.Now().Add(2*time.Hour), true)
+	req := &pb.RpcObjectSearchRequest{
+		Filters: []*model.BlockContentDataviewFilter{{
+			RelationKey: bundle.RelationKeyId.String(),
+			Condition:   model.BlockContentDataviewFilter_In,
+			Value:       pbtypes.StringList([]string{dateObject1.Id(), "plainObj1", "planObj2", dateObject2.Id()}),
+		}},
+	}
+
+	// when
+	ids := suggestDateObjectIds(req)
+
+	// then
+	require.Len(t, ids, 2)
+	assert.Equal(t, dateObject1.Id(), ids[0])
+	assert.Equal(t, dateObject2.Id(), ids[1])
 }

--- a/core/object.go
+++ b/core/object.go
@@ -102,7 +102,7 @@ func (mw *Middleware) ObjectSearch(cctx context.Context, req *pb.RpcObjectSearch
 
 	// Add dates only to the first page of search results
 	if req.Offset == 0 {
-		records, err = date.EnrichRecordsWithDateSuggestion(cctx, records, req, ds, getService[space.Service](mw))
+		records, err = date.EnrichRecordsWithDateSuggestions(cctx, records, req, ds, getService[space.Service](mw))
 		if err != nil {
 			return response(pb.RpcObjectSearchResponseError_UNKNOWN_ERROR, nil, err)
 		}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4587/objectsearch-by-ids-should-return-date-objects

If ObjectSearch request includes filters by id and values are date object ids, than response should be enriched with date objects' details