### PR TITLE
GO-4586 Unify date object ids in links

### DIFF
--- a/core/block/editor/smartblock/links.go
+++ b/core/block/editor/smartblock/links.go
@@ -32,6 +32,7 @@ func (sb *smartBlock) injectLinksDetails(s *state.State) {
 		NoSystemRelations:        true,
 		NoHiddenBundledRelations: true,
 		NoImages:                 true,
+		UnifyDateObjectIds:       true,
 	})
 	links = slice.RemoveMut(links, sb.Id())
 	s.SetLocalDetail(bundle.RelationKeyLinks.String(), pbtypes.StringList(links))

--- a/core/block/editor/smartblock/links.go
+++ b/core/block/editor/smartblock/links.go
@@ -32,7 +32,7 @@ func (sb *smartBlock) injectLinksDetails(s *state.State) {
 		NoSystemRelations:        true,
 		NoHiddenBundledRelations: true,
 		NoImages:                 true,
-		UnifyDateObjectIds:       true,
+		RoundDateIdsToDay:        true,
 	})
 	links = slice.RemoveMut(links, sb.Id())
 	s.SetLocalDetail(bundle.RelationKeyLinks.String(), pbtypes.StringList(links))

--- a/core/block/object/objectlink/dependent_objects.go
+++ b/core/block/object/objectlink/dependent_objects.go
@@ -41,7 +41,8 @@ type Flags struct {
 	DataviewBlockOnlyTarget,
 	NoSystemRelations,
 	NoHiddenBundledRelations,
-	NoImages bool
+	NoImages,
+	UnifyDateObjectIds bool
 }
 
 func DependentObjectIDs(s *state.State, converter KeyToIDConverter, flags Flags) (ids []string) {
@@ -77,6 +78,10 @@ func DependentObjectIDs(s *state.State, converter KeyToIDConverter, flags Flags)
 
 	if flags.Collection {
 		ids = append(ids, s.GetStoreSlice(template.CollectionStoreKey)...)
+	}
+
+	if flags.UnifyDateObjectIds {
+		ids = unifyDateObjectIds(ids)
 	}
 
 	ids = lo.Uniq(ids)
@@ -197,5 +202,18 @@ func collectIdsFromDetail(rel *model.RelationLink, det *types.Struct, flags Flag
 		}
 	}
 
+	return ids
+}
+
+// unifyDateObjectIds turns all date object ids into ids with no time included
+func unifyDateObjectIds(ids []string) []string {
+	for i, id := range ids {
+		dateObject, err := dateutil.BuildDateObjectFromId(id)
+		if err != nil {
+			continue
+		}
+
+		ids[i] = dateutil.NewDateObject(dateObject.Time(), false).Id()
+	}
 	return ids
 }

--- a/core/block/object/objectlink/dependent_objects.go
+++ b/core/block/object/objectlink/dependent_objects.go
@@ -42,7 +42,7 @@ type Flags struct {
 	NoSystemRelations,
 	NoHiddenBundledRelations,
 	NoImages,
-	UnifyDateObjectIds bool
+	RoundDateIdsToDay bool
 }
 
 func DependentObjectIDs(s *state.State, converter KeyToIDConverter, flags Flags) (ids []string) {
@@ -80,8 +80,8 @@ func DependentObjectIDs(s *state.State, converter KeyToIDConverter, flags Flags)
 		ids = append(ids, s.GetStoreSlice(template.CollectionStoreKey)...)
 	}
 
-	if flags.UnifyDateObjectIds {
-		ids = unifyDateObjectIds(ids)
+	if flags.RoundDateIdsToDay {
+		ids = roundDateIds(ids)
 	}
 
 	ids = lo.Uniq(ids)
@@ -205,8 +205,8 @@ func collectIdsFromDetail(rel *model.RelationLink, det *types.Struct, flags Flag
 	return ids
 }
 
-// unifyDateObjectIds turns all date object ids into ids with no time included
-func unifyDateObjectIds(ids []string) []string {
+// roundDateIds turns all date object ids into ids with no time included
+func roundDateIds(ids []string) []string {
 	for i, id := range ids {
 		dateObject, err := dateutil.BuildDateObjectFromId(id)
 		if err != nil {

--- a/core/block/object/objectlink/dependent_objects_test.go
+++ b/core/block/object/objectlink/dependent_objects_test.go
@@ -212,8 +212,8 @@ func TestState_DepSmartIdsLinksAndRelations(t *testing.T) {
 		assert.Len(t, objectIDs, 15) // 11 links + 4 relations
 	})
 
-	t.Run("date object ids are unified", func(t *testing.T) {
-		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, UnifyDateObjectIds: true})
+	t.Run("date object ids are rounded to day", func(t *testing.T) {
+		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, RoundDateIdsToDay: true})
 		assert.Len(t, objectIDs, 10)
 	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4586/do-not-generate-long-ids

Object could contain multiple limks/mentions of date objects pointing to the same day. 
However **links** relation should contain only single link to date object of the single day