### PR TITLE
GO-4608 LayoutWidth relation for layout settings on desktop

### DIFF
--- a/core/block/detailservice/mock_detailservice/mock_Service.go
+++ b/core/block/detailservice/mock_detailservice/mock_Service.go
@@ -372,6 +372,100 @@ func (_c *MockService_ObjectTypeRemoveRelations_Call) RunAndReturn(run func(cont
 	return _c
 }
 
+// ObjectTypeSetFeaturedRelations provides a mock function with given fields: objectTypeId, relationObjectIds
+func (_m *MockService) ObjectTypeSetFeaturedRelations(objectTypeId string, relationObjectIds []string) error {
+	ret := _m.Called(objectTypeId, relationObjectIds)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ObjectTypeSetFeaturedRelations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, []string) error); ok {
+		r0 = rf(objectTypeId, relationObjectIds)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockService_ObjectTypeSetFeaturedRelations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ObjectTypeSetFeaturedRelations'
+type MockService_ObjectTypeSetFeaturedRelations_Call struct {
+	*mock.Call
+}
+
+// ObjectTypeSetFeaturedRelations is a helper method to define mock.On call
+//   - objectTypeId string
+//   - relationObjectIds []string
+func (_e *MockService_Expecter) ObjectTypeSetFeaturedRelations(objectTypeId interface{}, relationObjectIds interface{}) *MockService_ObjectTypeSetFeaturedRelations_Call {
+	return &MockService_ObjectTypeSetFeaturedRelations_Call{Call: _e.mock.On("ObjectTypeSetFeaturedRelations", objectTypeId, relationObjectIds)}
+}
+
+func (_c *MockService_ObjectTypeSetFeaturedRelations_Call) Run(run func(objectTypeId string, relationObjectIds []string)) *MockService_ObjectTypeSetFeaturedRelations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *MockService_ObjectTypeSetFeaturedRelations_Call) Return(_a0 error) *MockService_ObjectTypeSetFeaturedRelations_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockService_ObjectTypeSetFeaturedRelations_Call) RunAndReturn(run func(string, []string) error) *MockService_ObjectTypeSetFeaturedRelations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ObjectTypeSetRelations provides a mock function with given fields: objectTypeId, relationObjectIds
+func (_m *MockService) ObjectTypeSetRelations(objectTypeId string, relationObjectIds []string) error {
+	ret := _m.Called(objectTypeId, relationObjectIds)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ObjectTypeSetRelations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, []string) error); ok {
+		r0 = rf(objectTypeId, relationObjectIds)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockService_ObjectTypeSetRelations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ObjectTypeSetRelations'
+type MockService_ObjectTypeSetRelations_Call struct {
+	*mock.Call
+}
+
+// ObjectTypeSetRelations is a helper method to define mock.On call
+//   - objectTypeId string
+//   - relationObjectIds []string
+func (_e *MockService_Expecter) ObjectTypeSetRelations(objectTypeId interface{}, relationObjectIds interface{}) *MockService_ObjectTypeSetRelations_Call {
+	return &MockService_ObjectTypeSetRelations_Call{Call: _e.mock.On("ObjectTypeSetRelations", objectTypeId, relationObjectIds)}
+}
+
+func (_c *MockService_ObjectTypeSetRelations_Call) Run(run func(objectTypeId string, relationObjectIds []string)) *MockService_ObjectTypeSetRelations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].([]string))
+	})
+	return _c
+}
+
+func (_c *MockService_ObjectTypeSetRelations_Call) Return(_a0 error) *MockService_ObjectTypeSetRelations_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockService_ObjectTypeSetRelations_Call) RunAndReturn(run func(string, []string) error) *MockService_ObjectTypeSetRelations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetDetails provides a mock function with given fields: ctx, objectId, details
 func (_m *MockService) SetDetails(ctx session.Context, objectId string, details []*model.Detail) error {
 	ret := _m.Called(ctx, objectId, details)

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "40664f94553807e45b8ad3ab00ba848505de50bd499545f42673bad8175e135d"
+const RelationChecksum = "7bebaf625f21e63f771279cca7ea7cf876bb06f3c64a5d4083a9f2fe3f824088"
 const (
 	RelationKeyTag                          domain.RelationKey = "tag"
 	RelationKeyCamera                       domain.RelationKey = "camera"
@@ -145,6 +145,7 @@ const (
 	RelationKeyMentions                     domain.RelationKey = "mentions"
 	RelationKeyTimestamp                    domain.RelationKey = "timestamp"
 	RelationKeyRecommendedFeaturedRelations domain.RelationKey = "recommendedFeaturedRelations"
+	RelationKeyLayoutWidth                  domain.RelationKey = "layoutWidth"
 )
 
 var (
@@ -1059,6 +1060,20 @@ var (
 			Key:              "layoutAlign",
 			MaxCount:         1,
 			Name:             "Layout align",
+			ReadOnly:         false,
+			ReadOnlyRelation: true,
+			Scope:            model.Relation_type,
+		},
+		RelationKeyLayoutWidth: {
+
+			DataSource:       model.Relation_details,
+			Description:      "Width of object's layout",
+			Format:           model.RelationFormat_number,
+			Hidden:           true,
+			Id:               "_brlayoutWidth",
+			Key:              "layoutWidth",
+			MaxCount:         1,
+			Name:             "Layout width",
 			ReadOnly:         false,
 			ReadOnlyRelation: true,
 			Scope:            model.Relation_type,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1379,5 +1379,15 @@
     ],
     "readonly": false,
     "source": "details"
+  },
+  {
+    "description": "Width of object's layout",
+    "format": "number",
+    "hidden": true,
+    "key": "layoutWidth",
+    "maxCount": 1,
+    "name": "Layout width",
+    "readonly": false,
+    "source": "details"
   }
 ]

--- a/pkg/lib/bundle/systemRelations.gen.go
+++ b/pkg/lib/bundle/systemRelations.gen.go
@@ -6,7 +6,7 @@ package bundle
 
 import domain "github.com/anyproto/anytype-heart/core/domain"
 
-const SystemRelationsChecksum = "11ca17268a1ec86e67904f9379fba4b70152fe4f6e88db3d046b6a518fe8ccd4"
+const SystemRelationsChecksum = "1e5b0e9052b1eaada03cb90e8703e8bc34b5be7180aa17933afaee74209af65b"
 
 // SystemRelations contains relations that have some special biz logic depends on them in some objects
 // in case EVERY object depend on the relation please add it to RequiredInternalRelations
@@ -83,4 +83,5 @@ var SystemRelations = append(RequiredInternalRelations, []domain.RelationKey{
 	RelationKeyHasChat,
 	RelationKeyTimestamp,
 	RelationKeyRecommendedFeaturedRelations,
+	RelationKeyLayoutWidth,
 }...)

--- a/pkg/lib/bundle/systemRelations.json
+++ b/pkg/lib/bundle/systemRelations.json
@@ -91,5 +91,6 @@
   "chatId",
   "hasChat",
   "timestamp",
-  "recommendedFeaturedRelations"
+  "recommendedFeaturedRelations",
+  "layoutWidth"
 ]


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4608/layout-settings-on-the-object-type-level-or-desktop

LayoutWidth relation will be used by clients to set objects' width