### PR TITLE
GO-4595 Add restrictions to date

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -149,6 +149,15 @@ var (
 	}
 )
 
+func GetRestrictionsBySBType(sbType smartblock.SmartBlockType) []int {
+	restrictions := objectRestrictionsBySBType[sbType]
+	result := make([]int, len(restrictions))
+	for i, restriction := range restrictions {
+		result[i] = int(restriction)
+	}
+	return result
+}
+
 type ObjectRestrictions []model.RestrictionsObjectRestriction
 
 func (or ObjectRestrictions) Check(cr ...model.RestrictionsObjectRestriction) (err error) {

--- a/core/block/source/date.go
+++ b/core/block/source/date.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
+	"github.com/anyproto/anytype-heart/core/block/restriction"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -60,18 +61,20 @@ func (d *date) getDetails() (*types.Struct, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse date id: %w", err)
 	}
+	restrictions := restriction.GetRestrictionsBySBType(smartblock.SmartBlockTypeDate)
 
 	return &types.Struct{Fields: map[string]*types.Value{
-		bundle.RelationKeyName.String():       pbtypes.String(dateObject.Name()),
-		bundle.RelationKeyId.String():         pbtypes.String(d.id),
-		bundle.RelationKeyType.String():       pbtypes.String(d.typeId),
-		bundle.RelationKeyIsReadonly.String(): pbtypes.Bool(true),
-		bundle.RelationKeyIsArchived.String(): pbtypes.Bool(false),
-		bundle.RelationKeyIsHidden.String():   pbtypes.Bool(false),
-		bundle.RelationKeyLayout.String():     pbtypes.Float64(float64(model.ObjectType_date)),
-		bundle.RelationKeyIconEmoji.String():  pbtypes.String("📅"),
-		bundle.RelationKeySpaceId.String():    pbtypes.String(d.SpaceID()),
-		bundle.RelationKeyTimestamp.String():  pbtypes.Int64(dateObject.Time().Unix()),
+		bundle.RelationKeyName.String():         pbtypes.String(dateObject.Name()),
+		bundle.RelationKeyId.String():           pbtypes.String(d.id),
+		bundle.RelationKeyType.String():         pbtypes.String(d.typeId),
+		bundle.RelationKeyIsReadonly.String():   pbtypes.Bool(true),
+		bundle.RelationKeyIsArchived.String():   pbtypes.Bool(false),
+		bundle.RelationKeyIsHidden.String():     pbtypes.Bool(false),
+		bundle.RelationKeyLayout.String():       pbtypes.Float64(float64(model.ObjectType_date)),
+		bundle.RelationKeyIconEmoji.String():    pbtypes.String("📅"),
+		bundle.RelationKeySpaceId.String():      pbtypes.String(d.SpaceID()),
+		bundle.RelationKeyTimestamp.String():    pbtypes.Int64(dateObject.Time().Unix()),
+		bundle.RelationKeyRestrictions.String(): pbtypes.IntList(restrictions...),
 	}}, nil
 }
 

--- a/core/date/date_test.go
+++ b/core/date/date_test.go
@@ -44,6 +44,7 @@ func TestBuildDetailsFromTimestamp(t *testing.T) {
 			assert.Zero(t, tt.Hour())
 			assert.Zero(t, tt.Minute())
 			assert.Zero(t, tt.Second())
+			assert.Len(t, pbtypes.GetIntList(details, bundle.RelationKeyRestrictions.String()), 8)
 		})
 	}
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4595/remove-menu-items-from-3-dots-in-the-object-widget

It is possible to do certain actions upon date object from 3 dots menu, because restrictions relation is not set to date source