### PR TITLE
GO-4592 Do not index backlinks for dates

### DIFF
--- a/core/block/backlinks/watcher.go
+++ b/core/block/backlinks/watcher.go
@@ -194,7 +194,7 @@ func (w *watcher) updateAccumulatedBacklinks() {
 }
 
 func shouldIndexBacklinks(ids threads.DerivedSmartblockIds, id string) bool {
-	if _, parseDateErr := dateutil.BuildDateObjectFromId(id); parseDateErr != nil {
+	if _, parseDateErr := dateutil.BuildDateObjectFromId(id); parseDateErr == nil {
 		return false
 	}
 	switch id {

--- a/core/block/backlinks/watcher.go
+++ b/core/block/backlinks/watcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/threads"
 	"github.com/anyproto/anytype-heart/space"
+	"github.com/anyproto/anytype-heart/util/dateutil"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 	"github.com/anyproto/anytype-heart/util/slice"
 )
@@ -193,6 +194,9 @@ func (w *watcher) updateAccumulatedBacklinks() {
 }
 
 func shouldIndexBacklinks(ids threads.DerivedSmartblockIds, id string) bool {
+	if _, parseDateErr := dateutil.BuildDateObjectFromId(id); parseDateErr != nil {
+		return false
+	}
 	switch id {
 	case ids.Workspace, ids.Archive, ids.Home, ids.Widgets, ids.Profile:
 		return false


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4592/objectdetailsunset-event-erases-details-of-date-object-sometimes

ObjectDetailsUnset event was sent to client subscription, because backinks updater called StateAppend for it.
We should not allow backlinks updater change date object details, as even space id could not be resolved correctly for these objects