### PR TITLE
GO-4277 Revise sys objects using bundled info

### DIFF
--- a/space/internal/components/migration/readonlyfixer/relationsfixer.go
+++ b/space/internal/components/migration/readonlyfixer/relationsfixer.go
@@ -31,7 +31,7 @@ func (Migration) Name() string {
 	return MName
 }
 
-func (Migration) Run(ctx context.Context, log logger.CtxLogger, store, _ dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (Migration) Run(ctx context.Context, log logger.CtxLogger, store dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	spaceId := space.Id()
 
 	relations, err := listReadonlyTagAndStatusRelations(store, spaceId)

--- a/space/internal/components/migration/readonlyfixer/relationsfixer_test.go
+++ b/space/internal/components/migration/readonlyfixer/relationsfixer_test.go
@@ -82,7 +82,7 @@ func TestFixReadonlyInRelations(t *testing.T) {
 		).Times(2)
 
 		// when
-		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space1"), nil, spc)
+		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space1"), spc)
 
 		// then
 		assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestFixReadonlyInRelations(t *testing.T) {
 		// sp.EXPECT().Do(mock.Anything, mock.Anything).Times(1).Return(nil)
 
 		// when
-		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space2"), nil, spc)
+		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space2"), spc)
 
 		// then
 		assert.NoError(t, err)
@@ -116,7 +116,7 @@ func TestFixReadonlyInRelations(t *testing.T) {
 		// sp.EXPECT().Do(mock.Anything, mock.Anything).Times(1).Return(nil)
 
 		// when
-		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space3"), nil, spc)
+		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space3"), spc)
 
 		// then
 		assert.NoError(t, err)

--- a/space/internal/components/migration/runner.go
+++ b/space/internal/components/migration/runner.go
@@ -10,7 +10,6 @@ import (
 	"github.com/anyproto/any-sync/app/logger"
 	"go.uber.org/zap"
 
-	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/space/clientspace"
 	"github.com/anyproto/anytype-heart/space/internal/components/dependencies"
@@ -27,7 +26,7 @@ const (
 var log = logger.NewNamed(CName)
 
 type Migration interface {
-	Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error)
+	Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error)
 	Name() string
 }
 
@@ -107,7 +106,7 @@ func (r *Runner) run(migrations ...Migration) (err error) {
 
 	start := time.Now()
 	store := r.store.SpaceIndex(spaceId)
-	marketPlaceStore := r.store.SpaceIndex(addr.AnytypeMarketplaceWorkspace)
+	// marketPlaceStore := r.store.SpaceIndex(addr.AnytypeMarketplaceWorkspace)
 	spent := time.Since(start)
 
 	for _, m := range migrations {
@@ -115,7 +114,7 @@ func (r *Runner) run(migrations ...Migration) (err error) {
 			err = errors.Join(err, e)
 			return
 		}
-		toMigrate, migrated, e := m.Run(r.ctx, log, store, marketPlaceStore, r.spc)
+		toMigrate, migrated, e := m.Run(r.ctx, log, store, r.spc)
 		if e != nil {
 			err = errors.Join(err, wrapError(e, m.Name(), spaceId, migrated, toMigrate))
 			continue

--- a/space/internal/components/migration/runner_test.go
+++ b/space/internal/components/migration/runner_test.go
@@ -158,7 +158,7 @@ func (longSpaceMigration) Name() string {
 	return "long migration"
 }
 
-func (longSpaceMigration) Run(ctx context.Context, _ logger.CtxLogger, _, store dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (longSpaceMigration) Run(ctx context.Context, _ logger.CtxLogger, store dependencies.QueryableStore, space dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	for {
 		if err = space.DoCtx(ctx, "", func(smartblock.SmartBlock) error {
 			// do smth
@@ -175,6 +175,6 @@ func (instantMigration) Name() string {
 	return "instant migration"
 }
 
-func (instantMigration) Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
+func (instantMigration) Run(context.Context, logger.CtxLogger, dependencies.QueryableStore, dependencies.SpaceWithCtx) (toMigrate, migrated int, err error) {
 	return 0, 0, nil
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4277/make-the-list-of-relations-hidden-for-all-objects

SystemObjectReviser should use bundled object as the point of truth, not objects from marketplace store