### PR TITLE
GO-4232 Add system relations to recommended

### DIFF
--- a/core/block/object/objectcreator/installer_test.go
+++ b/core/block/object/objectcreator/installer_test.go
@@ -1,6 +1,7 @@
 package objectcreator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
@@ -11,6 +12,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/detailservice/mock_detailservice"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
@@ -84,9 +86,10 @@ func TestInstaller_reinstallObject(t *testing.T) {
 	t.Run("reinstall archived object", func(t *testing.T) {
 		// given
 		sourceDetails := &types.Struct{Fields: map[string]*types.Value{
-			bundle.RelationKeyId.String():      pbtypes.String(bundle.TypeKeyProject.BundledURL()),
-			bundle.RelationKeySpaceId.String(): pbtypes.String(addr.AnytypeMarketplaceWorkspace),
-			bundle.RelationKeyName.String():    pbtypes.String(bundle.TypeKeyProject.String()),
+			bundle.RelationKeyId.String():        pbtypes.String(bundle.TypeKeyProject.BundledURL()),
+			bundle.RelationKeySpaceId.String():   pbtypes.String(addr.AnytypeMarketplaceWorkspace),
+			bundle.RelationKeyName.String():      pbtypes.String(bundle.TypeKeyProject.String()),
+			bundle.RelationKeyUniqueKey.String(): pbtypes.String(bundle.TypeKeyProject.URL()),
 		}}
 
 		sourceObject := smarttest.New(bundle.TypeKeyProject.BundledURL())
@@ -121,6 +124,10 @@ func TestInstaller_reinstallObject(t *testing.T) {
 			assert.Equal(t, id, bundle.TypeKeyProject.URL())
 			return apply(archivedObject)
 		})
+		spc.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key domain.UniqueKey) (string, error) {
+			return domain.RelationKey(key.InternalKey()).URL(), nil
+		})
+		spc.EXPECT().IsReadOnly().Return(true)
 
 		archiver := mock_detailservice.NewMockService(t)
 		archiver.EXPECT().SetIsArchived(mock.Anything, mock.Anything).RunAndReturn(func(id string, isArchived bool) error {

--- a/core/block/object/objectcreator/object_type.go
+++ b/core/block/object/objectcreator/object_type.go
@@ -105,7 +105,7 @@ func getRelationKeysFromDetails(details *types.Struct, fromLayout bool) ([]domai
 	var keys []domain.RelationKey
 	if fromLayout {
 		rawRecommendedLayout := pbtypes.GetInt64(details, bundle.RelationKeyRecommendedLayout.String())
-		recommendedLayout, err := bundle.GetLayout(model.ObjectTypeLayout(int32(rawRecommendedLayout)))
+		recommendedLayout, err := bundle.GetLayout(model.ObjectTypeLayout(rawRecommendedLayout))
 		if err != nil {
 			return nil, fmt.Errorf("invalid recommended layout %d: %w", rawRecommendedLayout, err)
 		}

--- a/core/block/object/objectcreator/object_type_test.go
+++ b/core/block/object/objectcreator/object_type_test.go
@@ -1,0 +1,86 @@
+package objectcreator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+func TestService_fillRecommendedRelations(t *testing.T) {
+	s := service{}
+	spc := mock_clientspace.NewMockSpace(t)
+	spc.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, key domain.UniqueKey) (string, error) {
+		return domain.RelationKey(key.InternalKey()).URL(), nil
+	}).Maybe()
+	spc.EXPECT().IsReadOnly().Return(true).Maybe()
+	defaultRecFeatRelIds := buildRelationIds(defaultRecommendedFeaturedRelationKeys)
+	defaultRecRelIds := buildRelationIds(defaultRecommendedRelationKeys)
+
+	for _, tc := range []struct {
+		name     string
+		given    []string
+		expected []string
+	}{
+		{
+			"empty", []string{}, defaultRecRelIds,
+		},
+		{
+			"no intersect",
+			[]string{bundle.RelationKeyAssignee.BundledURL(), bundle.RelationKeyDone.BundledURL()},
+			append([]string{bundle.RelationKeyAssignee.URL(), bundle.RelationKeyDone.URL()}, defaultRecRelIds...),
+		},
+		{
+			"fully intersect with system",
+			[]string{bundle.RelationKeyLinks.BundledURL(), bundle.RelationKeyCreator.BundledURL()},
+			lo.Uniq(append([]string{bundle.RelationKeyLinks.URL(), bundle.RelationKeyCreator.URL()}, defaultRecRelIds...)),
+		},
+		{
+			"partially intersect with system",
+			[]string{bundle.RelationKeyLinks.BundledURL(), bundle.RelationKeyDone.BundledURL()},
+			lo.Uniq(append([]string{bundle.RelationKeyLinks.URL(), bundle.RelationKeyDone.URL()}, defaultRecRelIds...)),
+		},
+		{
+			"intersect with featured",
+			[]string{bundle.RelationKeyType.BundledURL(), bundle.RelationKeyTag.BundledURL(), bundle.RelationKeyIconOption.BundledURL()},
+			append([]string{bundle.RelationKeyIconOption.URL()}, defaultRecRelIds...),
+		},
+		{
+			"intersect both with featured and system",
+			[]string{bundle.RelationKeyBacklinks.BundledURL(), bundle.RelationKeyAddedDate.BundledURL(), bundle.RelationKeyCreatedDate.BundledURL()},
+			lo.Uniq(append([]string{bundle.RelationKeyAddedDate.URL(), bundle.RelationKeyCreatedDate.URL()}, defaultRecRelIds...)),
+		},
+	} {
+		t.Run(fmt.Sprintf("from source: %s", tc.name), func(t *testing.T) {
+			// given
+			details := &types.Struct{Fields: map[string]*types.Value{
+				bundle.RelationKeyRecommendedRelations.String(): pbtypes.StringList(tc.given),
+			}}
+
+			// when
+			err := s.fillRecommendedRelations(nil, spc, details, false)
+
+			// then
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, pbtypes.GetStringList(details, bundle.RelationKeyRecommendedRelations.String()))
+			assert.Equal(t, defaultRecFeatRelIds, pbtypes.GetStringList(details, bundle.RelationKeyRecommendedFeaturedRelations.String()))
+		})
+	}
+}
+
+func buildRelationIds(keys []domain.RelationKey) []string {
+	ids := make([]string, len(keys))
+	for i, rel := range keys {
+		ids[i] = rel.URL()
+	}
+	return ids
+}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4232/add-every-system-relations-to-recommended-relations-to-make-a-list-in

On creation / installation of object types recommendedRelations and recommendedFeaturedRelations are being filled by system relations as well 