### PR TITLE
GO-4647 | GO-4635 - Improve dates suggestion in search

### DIFF
--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/block/source"
 	"github.com/anyproto/anytype-heart/core/domain"
-	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space"
 	"github.com/anyproto/anytype-heart/util/dateutil"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
@@ -23,17 +23,18 @@ import (
 
 func EnrichRecordsWithDateSuggestions(
 	ctx context.Context,
+	spaceId, fullText string,
 	records []database.Record,
-	req *pb.RpcObjectSearchRequest,
+	filters []*model.BlockContentDataviewFilter,
 	store objectstore.ObjectStore,
 	spaceService space.Service,
 ) ([]database.Record, error) {
-	ids := suggestDateObjectIds(req)
+	ids := suggestDateObjectIds(fullText, filters)
 	if len(ids) == 0 {
 		return records, nil
 	}
 
-	spc, err := spaceService.Get(ctx, req.SpaceId)
+	spc, err := spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return nil, fmt.Errorf("get space: %w", err)
 	}
@@ -48,7 +49,7 @@ func EnrichRecordsWithDateSuggestions(
 			return nil, fmt.Errorf("make date record: %w", err)
 		}
 
-		f, _ := database.MakeFilters(req.Filters, store.SpaceIndex(req.SpaceId)) //nolint:errcheck
+		f, _ := database.MakeFilters(filters, store.SpaceIndex(spaceId)) //nolint:errcheck
 		if f.FilterObject(rec.Details) {
 			records = append([]database.Record{rec}, records...)
 		}
@@ -60,8 +61,8 @@ func EnrichRecordsWithDateSuggestions(
 // suggestDateObjectIds suggests date object ids based on two fields:
 // - fullText - if naturalDate successfully parses text into date, resulting date object id is returned
 // - filter with key id
-func suggestDateObjectIds(req *pb.RpcObjectSearchRequest) []string {
-	dt := suggestDateForSearch(time.Now(), req.FullText)
+func suggestDateObjectIds(fullText string, filters []*model.BlockContentDataviewFilter) []string {
+	dt := suggestDateForSearch(time.Now(), fullText)
 	if !dt.IsZero() {
 		// TODO: GO-4097 Uncomment it when we will be able to support dates with seconds precision
 		// isDay := dt.Hour() == 0 && dt.Minute() == 0 && dt.Second() == 0
@@ -69,7 +70,7 @@ func suggestDateObjectIds(req *pb.RpcObjectSearchRequest) []string {
 		return []string{dateutil.NewDateObject(dt, !isDay).Id()}
 	}
 
-	for _, filter := range req.Filters {
+	for _, filter := range filters {
 		if filter.RelationKey == bundle.RelationKeyId.String() {
 			list := pbtypes.GetStringListValue(filter.Value)
 			var dateObjectIds []string

--- a/core/date/suggest.go
+++ b/core/date/suggest.go
@@ -26,12 +26,12 @@ var literals []string
 func init() {
 	literals = []string{"today", "now", "yesterday", "tomorrow"}
 
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 7; i++ {
 		literals = append(literals, strings.ToLower(time.Weekday(i).String()))
 	}
 
-	for i := 1; i < 12; i++ {
-		literals = append(literals, strings.ToLower(time.Month(i).String()))
+	for i := 0; i < 12; i++ {
+		literals = append(literals, strings.ToLower(time.Month(i+1).String()))
 	}
 }
 

--- a/core/date/suggest_test.go
+++ b/core/date/suggest_test.go
@@ -34,6 +34,22 @@ func Test_suggestDateForSearch(t *testing.T) {
 			want: time.Date(2022, 5, 18, 0, 0, 0, 0, loc),
 		},
 		{
+			raw:  "toda",
+			want: time.Date(2022, 5, 18, 0, 0, 0, 0, loc),
+		},
+		{
+			raw:  "to",
+			want: time.Date(2022, 5, 18, 0, 0, 0, 0, loc),
+		},
+		{
+			raw:  "yeste",
+			want: time.Date(2022, 5, 17, 0, 0, 0, 0, loc),
+		},
+		{
+			raw:  "NoVem",
+			want: time.Date(2022, 11, 18, 14, 56, 33, 0, loc),
+		},
+		{
 			raw:  "10 days from now",
 			want: time.Date(2022, 5, 28, 14, 56, 33, 0, loc),
 		},

--- a/core/date/suggest_test.go
+++ b/core/date/suggest_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/dateutil"
@@ -76,16 +75,14 @@ func TestSuggestDateObjectIdsFromFilter(t *testing.T) {
 	// given
 	dateObject1 := dateutil.NewDateObject(time.Now(), false)
 	dateObject2 := dateutil.NewDateObject(time.Now().Add(2*time.Hour), true)
-	req := &pb.RpcObjectSearchRequest{
-		Filters: []*model.BlockContentDataviewFilter{{
-			RelationKey: bundle.RelationKeyId.String(),
-			Condition:   model.BlockContentDataviewFilter_In,
-			Value:       pbtypes.StringList([]string{dateObject1.Id(), "plainObj1", "planObj2", dateObject2.Id()}),
-		}},
-	}
+	filters := []*model.BlockContentDataviewFilter{{
+		RelationKey: bundle.RelationKeyId.String(),
+		Condition:   model.BlockContentDataviewFilter_In,
+		Value:       pbtypes.StringList([]string{dateObject1.Id(), "plainObj1", "planObj2", dateObject2.Id()}),
+	}}
 
 	// when
-	ids := suggestDateObjectIds(req)
+	ids := suggestDateObjectIds("", filters)
 
 	// then
 	require.Len(t, ids, 2)

--- a/core/object.go
+++ b/core/object.go
@@ -102,7 +102,7 @@ func (mw *Middleware) ObjectSearch(cctx context.Context, req *pb.RpcObjectSearch
 
 	// Add dates only to the first page of search results
 	if req.Offset == 0 {
-		records, err = date.EnrichRecordsWithDateSuggestions(cctx, records, req, ds, getService[space.Service](mw))
+		records, err = date.EnrichRecordsWithDateSuggestions(cctx, req.SpaceId, req.FullText, records, req.Filters, ds, getService[space.Service](mw))
 		if err != nil {
 			return response(pb.RpcObjectSearchResponseError_UNKNOWN_ERROR, nil, err)
 		}
@@ -143,6 +143,14 @@ func (mw *Middleware) ObjectSearchWithMeta(cctx context.Context, req *pb.RpcObje
 		TextQuery: req.FullText,
 		SpaceId:   req.SpaceId,
 	})
+
+	// Add dates only to the first page of search results
+	if req.Offset == 0 {
+		results, err = date.EnrichRecordsWithDateSuggestions(cctx, req.SpaceId, req.FullText, results, req.Filters, ds, getService[space.Service](mw))
+		if err != nil {
+			return response(pb.RpcObjectSearchWithMetaResponseError_UNKNOWN_ERROR, nil, err)
+		}
+	}
 
 	var resultsModels = make([]*model.SearchResult, 0, len(results))
 	for i, rec := range results {

--- a/util/dateutil/util.go
+++ b/util/dateutil/util.go
@@ -10,8 +10,8 @@ import (
 const (
 	shortDateIdLayout   = "2006-01-02"
 	dateIdLayout        = "2006-01-02-15-04-05Z-0700"
-	shortDateNameLayout = "Mon, Jan 02, 2006"
-	dateNameLayout      = "Mon, Jan 02, 2006 3:04 PM"
+	shortDateNameLayout = "Mon, Jan 2, 2006"
+	dateNameLayout      = "Mon, Jan 2, 2006 3:04 PM"
 )
 
 type DateObject interface {

--- a/util/dateutil/util_test.go
+++ b/util/dateutil/util_test.go
@@ -17,17 +17,17 @@ func TestNewDateObject(t *testing.T) {
 			{
 				ts:           time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
 				expectedId:   "_date_2024-11-07-12-25-59Z_0000",
-				expectedName: "Thu, Nov 07, 2024 12:25 PM",
+				expectedName: "Thu, Nov 7, 2024 12:25 PM",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
 				expectedId:   "_date_1998-01-01-00-01-01Z_0000",
-				expectedName: "Thu, Jan 01, 1998 12:01 AM",
+				expectedName: "Thu, Jan 1, 1998 12:01 AM",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
 				expectedId:   "_date_1998-01-01-00-01-01Z_0400",
-				expectedName: "Thu, Jan 01, 1998 12:01 AM",
+				expectedName: "Thu, Jan 1, 1998 12:01 AM",
 			},
 			{
 				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),
@@ -56,17 +56,17 @@ func TestNewDateObject(t *testing.T) {
 			{
 				ts:           time.Date(2024, time.November, 7, 12, 25, 59, 0, time.UTC),
 				expectedId:   "_date_2024-11-07",
-				expectedName: "Thu, Nov 07, 2024",
+				expectedName: "Thu, Nov 7, 2024",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.UTC),
 				expectedId:   "_date_1998-01-01",
-				expectedName: "Thu, Jan 01, 1998",
+				expectedName: "Thu, Jan 1, 1998",
 			},
 			{
 				ts:           time.Date(1998, time.January, 1, 0, 1, 1, 0, time.FixedZone("UTC", +4*60*60)),
 				expectedId:   "_date_1998-01-01",
-				expectedName: "Thu, Jan 01, 1998",
+				expectedName: "Thu, Jan 1, 1998",
 			},
 			{
 				ts:           time.Date(2124, time.December, 25, 23, 34, 0, 0, time.UTC),


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4647/add-date-to-global-search
https://linear.app/anytype/issue/GO-4635/improve-date-suggestion

- Add date objects to results of ObjectSearchWithMeta as well
- Suggest date objects on prefix
- Substitute Thu, 05 Dec, 2024 -> Thu, 5 Dec, 2024