### PR TITLE
GO-4574 importing markdown file that contains broken link makes app crash

### DIFF
--- a/core/block/import/markdown/blockconverter.go
+++ b/core/block/import/markdown/blockconverter.go
@@ -125,7 +125,7 @@ func (m *mdConverter) handleSingleMark(block *model.Block, files map[string]*Fil
 		}
 		file.HasInboundLinks = true
 	} else if wholeLineLink {
-		block.Content = m.convertTextToBookmark(txt.Marks.Marks[0].Param)
+		m.convertTextToBookmark(txt.Marks.Marks[0].Param, block)
 	}
 }
 
@@ -154,7 +154,7 @@ func (m *mdConverter) handleSingleLinkMark(block *model.Block, files map[string]
 			return true
 		}
 	} else if m.isWholeLineLink(txt.Text, mark) {
-		block.Content = m.convertTextToBookmark(mark.Param)
+		m.convertTextToBookmark(mark.Param, block)
 		return true
 	}
 	return false
@@ -238,12 +238,12 @@ func (m *mdConverter) convertTextToPageLink(block *model.Block) {
 	}
 }
 
-func (m *mdConverter) convertTextToBookmark(url string) *model.BlockContentOfBookmark {
+func (m *mdConverter) convertTextToBookmark(url string, block *model.Block) {
 	if err := uri.ValidateURI(url); err != nil {
-		return nil
+		return
 	}
 
-	return &model.BlockContentOfBookmark{
+	block.Content = &model.BlockContentOfBookmark{
 		Bookmark: &model.BlockContentBookmark{
 			Url: url,
 		},

--- a/core/block/import/markdown/import_test.go
+++ b/core/block/import/markdown/import_test.go
@@ -146,6 +146,7 @@ func buildExpectedTree(fileNameToObjectId map[string]string, provider *MockTempD
 	testMdPath := filepath.Join("testdata", "test.md")
 	testCsvPath := filepath.Join("testdata", "test.csv")
 	testTxtPath := filepath.Join("testdata", "test.txt")
+	url := "http://example.com/%zz"
 	want := blockbuilder.Root(
 		blockbuilder.ID(rootId),
 		blockbuilder.Children(
@@ -169,6 +170,13 @@ func buildExpectedTree(fileNameToObjectId map[string]string, provider *MockTempD
 					Range: &model.Range{From: 17, To: 22},
 					Type:  model.BlockContentTextMark_Mention,
 					Param: fileNameToObjectId[testCsvPath],
+				},
+			}})),
+			blockbuilder.Text("Should not panic test5", blockbuilder.TextMarks(model.BlockContentTextMarks{Marks: []*model.BlockContentTextMark{
+				{
+					Range: &model.Range{From: 17, To: 22},
+					Type:  model.BlockContentTextMark_Link,
+					Param: url,
 				},
 			}})),
 			blockbuilder.Text("File does not exist with bold mark test1", blockbuilder.TextMarks(model.BlockContentTextMarks{Marks: []*model.BlockContentTextMark{
@@ -215,6 +223,17 @@ func buildExpectedTree(fileNameToObjectId map[string]string, provider *MockTempD
 					Type:  model.BlockContentTextMark_Bold,
 				},
 			}})),
+			blockbuilder.Text("Should not panic test5", blockbuilder.TextMarks(model.BlockContentTextMarks{Marks: []*model.BlockContentTextMark{
+				{
+					Range: &model.Range{From: 17, To: 22},
+					Type:  model.BlockContentTextMark_Link,
+					Param: url,
+				},
+				{
+					Range: &model.Range{From: 17, To: 22},
+					Type:  model.BlockContentTextMark_Bold,
+				},
+			}})),
 			blockbuilder.Bookmark(fileMdPath),
 			blockbuilder.Text("test2", blockbuilder.TextMarks(model.BlockContentTextMarks{Marks: []*model.BlockContentTextMark{
 				{
@@ -233,6 +252,17 @@ func buildExpectedTree(fileNameToObjectId map[string]string, provider *MockTempD
 					Range: &model.Range{From: 0, To: 5},
 					Type:  model.BlockContentTextMark_Mention,
 					Param: fileNameToObjectId[testCsvPath],
+				},
+				{
+					Range: &model.Range{From: 0, To: 5},
+					Type:  model.BlockContentTextMark_Bold,
+				},
+			}})),
+			blockbuilder.Text("test5", blockbuilder.TextMarks(model.BlockContentTextMarks{Marks: []*model.BlockContentTextMark{
+				{
+					Range: &model.Range{From: 0, To: 5},
+					Type:  model.BlockContentTextMark_Link,
+					Param: url,
 				},
 				{
 					Range: &model.Range{From: 0, To: 5},

--- a/core/block/import/markdown/testdata/links.md
+++ b/core/block/import/markdown/testdata/links.md
@@ -6,6 +6,8 @@ Test file block [test3](test.txt)
 
 Test link to csv [test4](test.csv)
 
+Should not panic [test5](http://example.com/%zz)
+
 File does not exist with bold mark **[test1](file.md)**
 
 Test link to page with bold mark **[test2](test.md)**
@@ -14,6 +16,8 @@ Test file block with bold mark **[test3](test.txt)**
 
 Test link to csv with bold mark **[test4](test.csv)**
 
+Should not panic **[test5](http://example.com/%zz)**
+
 **[test1](file.md)**
 
 **[test2](test.md)**
@@ -21,3 +25,5 @@ Test link to csv with bold mark **[test4](test.csv)**
 **[test3](test.txt)**
 
 **[test4](test.csv)**
+
+**[test5](http://example.com/%zz)**


### PR DESCRIPTION
In case of wrong url in markdown link, I returned nil value. That makes block content nil, which is invalid state