### PR TITLE
GO-4502 cleanup empty account folder on cold start

### DIFF
--- a/core/application/account_select.go
+++ b/core/application/account_select.go
@@ -99,6 +99,11 @@ func (s *Service) start(ctx context.Context, id string, rootPath string, disable
 		}
 	}
 
+	defer func() {
+		if repoWasMissing && err != nil {
+			os.RemoveAll(filepath.Join(s.rootPath, id))
+		}
+	}()
 	cfg := anytype.BootstrapConfig(false, os.Getenv("ANYTYPE_STAGING") == "1")
 	if disableLocalNetworkSync {
 		cfg.DontStartLocalNetworkSyncAutomatically = true

--- a/core/application/account_select_test.go
+++ b/core/application/account_select_test.go
@@ -1,0 +1,45 @@
+package application
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/anyproto/anytype-heart/core/event/mock_event"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/core"
+)
+
+func TestService_AccountSelect(t *testing.T) {
+	t.Run("account select finish with error", func(t *testing.T) {
+		// given
+		s := New()
+		dir := t.TempDir()
+		s.SetClientVersion("platform", "1")
+		mnemonic, err := core.WalletGenerateMnemonic(wordCount)
+		assert.NoError(t, err)
+		err = s.setMnemonic(mnemonic)
+		assert.NoError(t, err)
+		account, err := core.WalletAccountAt(mnemonic, 0)
+		assert.NoError(t, err)
+		expectedDir := filepath.Join(dir, account.Identity.GetPublic().Account())
+
+		sender := mock_event.NewMockSender(t)
+		sender.EXPECT().Name().Return("service")
+		ctx := context.Background()
+		sender.EXPECT().Init(mock.Anything).Return(ErrFailedToStartApplication)
+		s.eventSender = sender
+
+		// when
+		_, err = s.AccountSelect(ctx, &pb.RpcAccountSelectRequest{Id: account.Identity.GetPublic().Account(), RootPath: dir})
+
+		// then
+		assert.NotNil(t, err)
+		_, err = os.Stat(expectedDir)
+		assert.True(t, os.IsNotExist(err))
+	})
+}


### PR DESCRIPTION
In case of error during `AccountSelect`, I call `os.RemoveAll` for account directory, so it won't exist