### PR TITLE
GO-4670 Filter out lasModifiedDate tab

### DIFF
--- a/core/block/object/objectcreator/installer.go
+++ b/core/block/object/objectcreator/installer.go
@@ -257,7 +257,7 @@ func (s *service) prepareDetailsForInstallingObject(
 	details.Fields[bundle.RelationKeyIsReadonly.String()] = pbtypes.Bool(false)
 
 	// we should delete old createdDate as it belongs to source object from marketplace
-	details.Fields[bundle.RelationKeyCreatedDate.String()] = pbtypes.Int64(0)
+	delete(details.Fields, bundle.RelationKeyCreatedDate.String())
 
 	if isNewSpace {
 		lastused.SetLastUsedDateForInitialObjectType(sourceId, details)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4670/filter-out-objects-from-lastmodifieddate-tab

We used to leave createdDate of source objects while adding types and relations to new spaces.
Now createdDate and lastModifiedDate have same value on new space creation, so valueFromRelation filter could be used to filter out lastModifiedDate tab