### PR TITLE
GO-4736 markdown exportimport creates a lot of page objects

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -1123,10 +1123,8 @@ func (fn *namer) Get(path, hash, title, ext string) (name string) {
 }
 
 func validType(sbType smartblock.SmartBlockType) bool {
-	return sbType == smartblock.SmartBlockTypeHome ||
-		sbType == smartblock.SmartBlockTypeProfilePage ||
+	return sbType == smartblock.SmartBlockTypeProfilePage ||
 		sbType == smartblock.SmartBlockTypePage ||
-		sbType == smartblock.SmartBlockTypeSubObject ||
 		sbType == smartblock.SmartBlockTypeTemplate ||
 		sbType == smartblock.SmartBlockTypeWorkspace ||
 		sbType == smartblock.SmartBlockTypeWidget ||

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -1067,7 +1067,7 @@ func objectValid(sbType smartblock.SmartBlockType, info *model.ObjectInfo, inclu
 	if info.Id == addr.AnytypeProfileId {
 		return false
 	}
-	if !isProtobuf && !validTypeForNonProtobuf(sbType) && !validLayoutForNonProtobuf(info.Details) {
+	if !isProtobuf && (!validTypeForNonProtobuf(sbType) || !validLayoutForNonProtobuf(info.Details)) {
 		return false
 	}
 	if isProtobuf && !validType(sbType) {


### PR DESCRIPTION
- do not include types/relations in md export
- do not include home object(favorites) in anyblock export. Favorites are handled via isFavorite relation