### PR TITLE
GO-4144: Fix NestedFilters in FiltersFromProto

### DIFF
--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -190,6 +190,7 @@ func FiltersFromProto(filters []*model.BlockContentDataviewFilter) []FilterReque
 			QuickOption:      f.QuickOption,
 			Format:           f.Format,
 			IncludeTime:      f.IncludeTime,
+			NestedFilters:    FiltersFromProto(f.NestedFilters),
 		})
 	}
 	return res

--- a/pkg/lib/database/database_test.go
+++ b/pkg/lib/database/database_test.go
@@ -361,3 +361,150 @@ func Test_NewFilters(t *testing.T) {
 		assert.Len(t, filters.FilterObj.(FiltersAnd)[0].(FiltersOr), 2)
 	})
 }
+
+func TestFiltersFromProto(t *testing.T) {
+	t.Run("no filters", func(t *testing.T) {
+		// given
+		var protoFilters []*model.BlockContentDataviewFilter
+
+		// when
+		result := FiltersFromProto(protoFilters)
+
+		// then
+		assert.NotNil(t, result)
+		assert.Len(t, result, 0)
+	})
+
+	t.Run("single filter without nesting", func(t *testing.T) {
+		// given
+		protoFilters := []*model.BlockContentDataviewFilter{
+			{
+				Id:          "filter1",
+				Operator:    model.BlockContentDataviewFilter_No,
+				RelationKey: "relationKey1",
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.String("value1").ToProto(),
+				Format:      model.RelationFormat_shorttext,
+			},
+		}
+
+		// when
+		result := FiltersFromProto(protoFilters)
+
+		// then
+		assert.Len(t, result, 1)
+		assert.Equal(t, "filter1", result[0].Id)
+		assert.Equal(t, domain.RelationKey("relationKey1"), result[0].RelationKey)
+		assert.Equal(t, model.BlockContentDataviewFilter_Equal, result[0].Condition)
+		assert.Equal(t, domain.String("value1"), result[0].Value)
+		assert.Equal(t, model.RelationFormat_shorttext, result[0].Format)
+		assert.Empty(t, result[0].NestedFilters)
+	})
+
+	t.Run("nested filters", func(t *testing.T) {
+		// given
+		protoFilters := []*model.BlockContentDataviewFilter{
+			{
+				Id:       "filter1",
+				Operator: model.BlockContentDataviewFilter_And,
+				NestedFilters: []*model.BlockContentDataviewFilter{
+					{
+						Id:          "nestedFilter1",
+						Operator:    model.BlockContentDataviewFilter_No,
+						RelationKey: "relationKey2",
+						Condition:   model.BlockContentDataviewFilter_NotEqual,
+						Value:       domain.String("value2").ToProto(),
+						Format:      model.RelationFormat_date,
+					},
+					{
+						Id:          "nestedFilter2",
+						Operator:    model.BlockContentDataviewFilter_No,
+						RelationKey: "relationKey3",
+						Condition:   model.BlockContentDataviewFilter_Equal,
+						Value:       domain.String("value3").ToProto(),
+						Format:      model.RelationFormat_status,
+					},
+				},
+			},
+		}
+
+		// when
+		result := FiltersFromProto(protoFilters)
+
+		// then
+		assert.Len(t, result, 1)
+		assert.Equal(t, "filter1", result[0].Id)
+		assert.NotNil(t, result[0].NestedFilters)
+
+		nested := result[0].NestedFilters
+		assert.Len(t, nested, 2)
+		assert.Equal(t, "nestedFilter1", nested[0].Id)
+		assert.Equal(t, domain.RelationKey("relationKey2"), nested[0].RelationKey)
+		assert.Equal(t, model.BlockContentDataviewFilter_NotEqual, nested[0].Condition)
+		assert.Equal(t, domain.String("value2"), nested[0].Value)
+		assert.Equal(t, model.RelationFormat_date, nested[0].Format)
+		assert.Equal(t, "nestedFilter2", nested[1].Id)
+		assert.Equal(t, domain.RelationKey("relationKey3"), nested[1].RelationKey)
+		assert.Equal(t, model.BlockContentDataviewFilter_Equal, nested[1].Condition)
+		assert.Equal(t, domain.String("value3"), nested[1].Value)
+		assert.Equal(t, model.RelationFormat_status, nested[1].Format)
+	})
+
+	t.Run("deeply nested filters", func(t *testing.T) {
+		// given
+		protoFilters := []*model.BlockContentDataviewFilter{
+			{
+				Id:       "filter1",
+				Operator: model.BlockContentDataviewFilter_And,
+				NestedFilters: []*model.BlockContentDataviewFilter{
+					{
+						Id:       "nestedFilter1",
+						Operator: model.BlockContentDataviewFilter_Or,
+						NestedFilters: []*model.BlockContentDataviewFilter{
+							{
+								Id:          "deepNestedFilter1",
+								Operator:    model.BlockContentDataviewFilter_No,
+								RelationKey: "relationKey3",
+								Condition:   model.BlockContentDataviewFilter_Equal,
+								Value:       domain.String("value3").ToProto(),
+								Format:      model.RelationFormat_status,
+							},
+							{
+								Id:          "deepNestedFilter2",
+								Operator:    model.BlockContentDataviewFilter_No,
+								RelationKey: "relationKey4",
+								Condition:   model.BlockContentDataviewFilter_NotEqual,
+								Value:       domain.String("value4").ToProto(),
+								Format:      model.RelationFormat_shorttext,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// when
+		result := FiltersFromProto(protoFilters)
+
+		// then
+		assert.Len(t, result, 1)
+		assert.NotNil(t, result[0].NestedFilters)
+
+		nested := result[0].NestedFilters
+		assert.Len(t, nested, 1)
+
+		deepNested := nested[0].NestedFilters
+		assert.Len(t, deepNested, 2)
+		assert.Equal(t, "deepNestedFilter1", deepNested[0].Id)
+		assert.Equal(t, domain.RelationKey("relationKey3"), deepNested[0].RelationKey)
+		assert.Equal(t, model.BlockContentDataviewFilter_Equal, deepNested[0].Condition)
+		assert.Equal(t, domain.String("value3"), deepNested[0].Value)
+		assert.Equal(t, model.RelationFormat_status, deepNested[0].Format)
+		assert.Equal(t, "deepNestedFilter2", deepNested[1].Id)
+		assert.Equal(t, domain.RelationKey("relationKey4"), deepNested[1].RelationKey)
+		assert.Equal(t, model.BlockContentDataviewFilter_NotEqual, deepNested[1].Condition)
+		assert.Equal(t, domain.String("value4"), deepNested[1].Value)
+		assert.Equal(t, model.RelationFormat_shorttext, deepNested[1].Format)
+
+	})
+}


### PR DESCRIPTION
`ObjectSearch` no longer supported `NestedFilters` due to missing recursion in `FiltersFromProto` after details refactoring. 