### PR TITLE
GO-4719: After import I can no longer add an object to a collection

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -345,13 +345,13 @@ func (e *exportContext) queryAndFilterObjectsByRelation(spaceId string, reqIds [
 	const singleBatchCount = 50
 	for j := 0; j < len(reqIds); {
 		if j+singleBatchCount < len(reqIds) {
-			records, err := e.queryObjectsByIds(spaceId, reqIds[j:j+singleBatchCount], relationKey)
+			records, err := e.queryObjectsByRelation(spaceId, reqIds[j:j+singleBatchCount], relationKey)
 			if err != nil {
 				return nil, err
 			}
 			allObjects = append(allObjects, records...)
 		} else {
-			records, err := e.queryObjectsByIds(spaceId, reqIds[j:], relationKey)
+			records, err := e.queryObjectsByRelation(spaceId, reqIds[j:], relationKey)
 			if err != nil {
 				return nil, err
 			}
@@ -362,7 +362,7 @@ func (e *exportContext) queryAndFilterObjectsByRelation(spaceId string, reqIds [
 	return allObjects, nil
 }
 
-func (e *exportContext) queryObjectsByIds(spaceId string, reqIds []string, relationKey domain.RelationKey) ([]database.Record, error) {
+func (e *exportContext) queryObjectsByRelation(spaceId string, reqIds []string, relationKey domain.RelationKey) ([]database.Record, error) {
 	return e.objectStore.SpaceIndex(spaceId).Query(database.Query{
 		Filters: []database.FilterRequest{
 			{
@@ -392,6 +392,12 @@ func (e *exportContext) processNotProtobuf() error {
 }
 
 func (e *exportContext) processProtobuf() error {
+	if !e.includeNested {
+		err := e.addDependentObjectsFromDataview()
+		if err != nil {
+			return err
+		}
+	}
 	ids := listObjectIds(e.docs)
 	if e.includeFiles {
 		err := e.addFileObjects(ids)
@@ -399,6 +405,7 @@ func (e *exportContext) processProtobuf() error {
 			return err
 		}
 	}
+
 	err := e.addDerivedObjects()
 	if err != nil {
 		return err
@@ -411,6 +418,55 @@ func (e *exportContext) processProtobuf() error {
 		}
 	}
 	return nil
+}
+
+func (e *exportContext) addDependentObjectsFromDataview() error {
+	var (
+		viewDependantObjectsIds []string
+		err                     error
+	)
+	for id, details := range e.docs {
+		layout := details.GetInt64(bundle.RelationKeyLayout)
+		if layout == int64(model.ObjectType_collection) {
+			viewDependantObjectsIds, err = e.getViewDependentObjects(id, viewDependantObjectsIds)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	viewDependantObjects, err := e.queryAndFilterObjectsByRelation(e.spaceId, viewDependantObjectsIds, bundle.RelationKeyId)
+	if err != nil {
+		return err
+	}
+	for _, object := range viewDependantObjects {
+		id := object.Details.GetString(bundle.RelationKeyId)
+		e.docs[id] = object.Details
+	}
+	return nil
+}
+
+func (e *exportContext) getViewDependentObjects(id string, viewDependantObjectsIds []string) ([]string, error) {
+	err := cache.Do(e.picker, id, func(sb sb.SmartBlock) error {
+		st := sb.NewState()
+		return st.Iterate(func(b simple.Block) (isContinue bool) {
+			if dv := b.Model().GetDataview(); dv != nil {
+				for _, view := range dv.GetViews() {
+					if view.DefaultObjectTypeId != "" {
+						viewDependantObjectsIds = append(viewDependantObjectsIds, view.DefaultObjectTypeId)
+					}
+					if view.DefaultTemplateId != "" {
+						viewDependantObjectsIds = append(viewDependantObjectsIds, view.DefaultTemplateId)
+					}
+				}
+				return false
+			}
+			return true
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return viewDependantObjectsIds, nil
 }
 
 func (e *exportContext) addFileObjects(ids []string) error {

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -427,8 +427,7 @@ func (e *exportContext) addDependentObjectsFromDataview() error {
 		err                     error
 	)
 	for id, details := range e.docs {
-		layout := details.GetInt64(bundle.RelationKeyLayout)
-		if layout == int64(model.ObjectType_collection) {
+		if isObjectWithDataview(details) {
 			viewDependentObjectsIds, err = e.getViewDependentObjects(id, viewDependentObjectsIds)
 			if err != nil {
 				return err

--- a/core/block/export/export_test.go
+++ b/core/block/export/export_test.go
@@ -1361,6 +1361,243 @@ func Test_docsForExport(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, 5, len(expCtx.docs))
 	})
+	t.Run("add default object type and template from dataview", func(t *testing.T) {
+		// given
+		id := "id"
+
+		storeFixture := objectstore.NewStoreFixture(t)
+		objectTypeId := "objectTypeId"
+		objectTypeUniqueKey, err := domain.NewUniqueKey(smartblock.SmartBlockTypeObjectType, objectTypeId)
+		assert.Nil(t, err)
+
+		defaultObjectTypeId := "defaultObjectTypeId"
+		defaultObjectTypeUniqueKey, err := domain.NewUniqueKey(smartblock.SmartBlockTypeObjectType, objectTypeId)
+		assert.Nil(t, err)
+
+		defaultTemplateId := "defaultTemplateId"
+
+		storeFixture.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:      domain.String(id),
+				bundle.RelationKeyName:    domain.String("name"),
+				bundle.RelationKeySpaceId: domain.String(spaceId),
+				bundle.RelationKeyType:    domain.String(objectTypeId),
+				bundle.RelationKeyLayout:  domain.Int64(int64(model.ObjectType_collection)),
+			},
+			{
+				bundle.RelationKeyId:        domain.String(objectTypeId),
+				bundle.RelationKeyUniqueKey: domain.String(objectTypeUniqueKey.Marshal()),
+				bundle.RelationKeyLayout:    domain.Int64(int64(model.ObjectType_objectType)),
+				bundle.RelationKeySpaceId:   domain.String(spaceId),
+				bundle.RelationKeyType:      domain.String(objectTypeId),
+			},
+			{
+				bundle.RelationKeyId:        domain.String(defaultObjectTypeId),
+				bundle.RelationKeyUniqueKey: domain.String(defaultObjectTypeUniqueKey.Marshal()),
+				bundle.RelationKeyLayout:    domain.Int64(int64(model.ObjectType_objectType)),
+				bundle.RelationKeySpaceId:   domain.String(spaceId),
+				bundle.RelationKeyType:      domain.String(objectTypeId),
+			},
+			{
+				bundle.RelationKeyId:      domain.String(defaultTemplateId),
+				bundle.RelationKeySpaceId: domain.String(spaceId),
+				bundle.RelationKeyType:    domain.String(objectTypeId),
+			},
+		})
+
+		smartBlockTest := smarttest.New("id")
+		doc := smartBlockTest.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(id),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		doc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		})
+
+		doc.Set(simple.New(&model.Block{
+			Id:          "id",
+			ChildrenIds: []string{"blockId"},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}))
+
+		doc.Set(simple.New(&model.Block{
+			Id: "blockId",
+			Content: &model.BlockContentOfDataview{Dataview: &model.BlockContentDataview{
+				Views: []*model.BlockContentDataviewView{
+					{
+						Id:                  "viewId",
+						DefaultObjectTypeId: defaultObjectTypeId,
+					},
+					{
+						Id:                "viewId2",
+						DefaultTemplateId: defaultTemplateId,
+					},
+				},
+			}},
+		}))
+		smartBlockTest.Doc = doc
+
+		objectType := smarttest.New(objectTypeId)
+		objectTypeDoc := objectType.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(objectTypeId),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		objectTypeDoc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		}, &model.RelationLink{
+			Key:    bundle.RelationKeyType.String(),
+			Format: model.RelationFormat_longtext,
+		})
+		objectType.Doc = objectTypeDoc
+
+		defaultObjectType := smarttest.New(defaultObjectTypeId)
+		defaultObjectTypeDoc := objectType.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(defaultObjectTypeId),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		defaultObjectTypeDoc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		}, &model.RelationLink{
+			Key:    bundle.RelationKeyType.String(),
+			Format: model.RelationFormat_longtext,
+		})
+		defaultObjectType.Doc = defaultObjectTypeDoc
+
+		defaultTemplate := smarttest.New(defaultObjectTypeId)
+		defaultTemplateDoc := objectType.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(defaultTemplateId),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		defaultTemplateDoc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		}, &model.RelationLink{
+			Key:    bundle.RelationKeyType.String(),
+			Format: model.RelationFormat_longtext,
+		})
+		defaultTemplate.Doc = defaultTemplateDoc
+
+		objectGetter := mock_cache.NewMockObjectGetter(t)
+
+		objectGetter.EXPECT().GetObject(context.Background(), id).Return(smartBlockTest, nil)
+		objectGetter.EXPECT().GetObject(context.Background(), objectTypeId).Return(objectType, nil)
+		objectGetter.EXPECT().GetObject(context.Background(), defaultObjectTypeId).Return(defaultObjectType, nil)
+		objectGetter.EXPECT().GetObject(context.Background(), defaultTemplateId).Return(defaultTemplate, nil)
+
+		e := &export{
+			objectStore: storeFixture,
+			picker:      objectGetter,
+		}
+
+		expCtx := newExportContext(e, pb.RpcObjectListExportRequest{
+			SpaceId:   spaceId,
+			ObjectIds: []string{"id"},
+			Format:    model.Export_Protobuf,
+		})
+
+		// when
+		err = expCtx.docsForExport()
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, 4, len(expCtx.docs))
+	})
+	t.Run("no default object type and template from dataview", func(t *testing.T) {
+		// given
+		id := "id"
+
+		storeFixture := objectstore.NewStoreFixture(t)
+		objectTypeId := "objectTypeId"
+		objectTypeUniqueKey, err := domain.NewUniqueKey(smartblock.SmartBlockTypeObjectType, objectTypeId)
+		assert.Nil(t, err)
+
+		storeFixture.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:      domain.String(id),
+				bundle.RelationKeyName:    domain.String("name"),
+				bundle.RelationKeySpaceId: domain.String(spaceId),
+				bundle.RelationKeyType:    domain.String(objectTypeId),
+				bundle.RelationKeyLayout:  domain.Int64(int64(model.ObjectType_collection)),
+			},
+			{
+				bundle.RelationKeyId:        domain.String(objectTypeId),
+				bundle.RelationKeyUniqueKey: domain.String(objectTypeUniqueKey.Marshal()),
+				bundle.RelationKeyLayout:    domain.Int64(int64(model.ObjectType_objectType)),
+				bundle.RelationKeySpaceId:   domain.String(spaceId),
+				bundle.RelationKeyType:      domain.String(objectTypeId),
+			},
+		})
+
+		smartBlockTest := smarttest.New("id")
+		doc := smartBlockTest.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(id),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		doc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		})
+
+		doc.Set(simple.New(&model.Block{
+			Id:          "id",
+			ChildrenIds: []string{"blockId"},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}))
+
+		doc.Set(simple.New(&model.Block{
+			Id: "blockId",
+			Content: &model.BlockContentOfDataview{Dataview: &model.BlockContentDataview{
+				Views: []*model.BlockContentDataviewView{
+					{
+						Id: "viewId",
+					},
+					{
+						Id: "viewId2",
+					},
+				},
+			}},
+		}))
+		smartBlockTest.Doc = doc
+
+		objectType := smarttest.New(objectTypeId)
+		objectTypeDoc := objectType.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(objectTypeId),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		objectTypeDoc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		}, &model.RelationLink{
+			Key:    bundle.RelationKeyType.String(),
+			Format: model.RelationFormat_longtext,
+		})
+		objectType.Doc = objectTypeDoc
+
+		objectGetter := mock_cache.NewMockObjectGetter(t)
+		objectGetter.EXPECT().GetObject(context.Background(), id).Return(smartBlockTest, nil)
+		objectGetter.EXPECT().GetObject(context.Background(), objectTypeId).Return(objectType, nil)
+
+		e := &export{
+			objectStore: storeFixture,
+			picker:      objectGetter,
+		}
+
+		expCtx := newExportContext(e, pb.RpcObjectListExportRequest{
+			SpaceId:   spaceId,
+			ObjectIds: []string{"id"},
+			Format:    model.Export_Protobuf,
+		})
+
+		// when
+		err = expCtx.docsForExport()
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(expCtx.docs))
+	})
 }
 
 func Test_provideFileName(t *testing.T) {

--- a/core/block/export/export_test.go
+++ b/core/block/export/export_test.go
@@ -1375,6 +1375,7 @@ func Test_docsForExport(t *testing.T) {
 		assert.Nil(t, err)
 
 		defaultTemplateId := "defaultTemplateId"
+		defaultObjectTypeTemplateId := "defaultObjectTypeTemplateId"
 
 		storeFixture.AddObjects(t, spaceId, []objectstore.TestObject{
 			{
@@ -1402,6 +1403,12 @@ func Test_docsForExport(t *testing.T) {
 				bundle.RelationKeyId:      domain.String(defaultTemplateId),
 				bundle.RelationKeySpaceId: domain.String(spaceId),
 				bundle.RelationKeyType:    domain.String(objectTypeId),
+			},
+			{
+				bundle.RelationKeyId:               domain.String(defaultObjectTypeTemplateId),
+				bundle.RelationKeySpaceId:          domain.String(spaceId),
+				bundle.RelationKeyType:             domain.String(objectTypeId),
+				bundle.RelationKeyTargetObjectType: domain.String(defaultObjectTypeId),
 			},
 		})
 
@@ -1480,12 +1487,27 @@ func Test_docsForExport(t *testing.T) {
 		})
 		defaultTemplate.Doc = defaultTemplateDoc
 
+		defaultObjectTypeTemplate := smarttest.New(defaultObjectTypeTemplateId)
+		defaultObjectTypeTemplateDoc := objectType.NewState().SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(defaultObjectTypeTemplateId),
+			bundle.RelationKeyType: domain.String(objectTypeId),
+		}))
+		defaultObjectTypeTemplateDoc.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyId.String(),
+			Format: model.RelationFormat_longtext,
+		}, &model.RelationLink{
+			Key:    bundle.RelationKeyType.String(),
+			Format: model.RelationFormat_longtext,
+		})
+		defaultObjectTypeTemplate.Doc = defaultObjectTypeTemplateDoc
+
 		objectGetter := mock_cache.NewMockObjectGetter(t)
 
 		objectGetter.EXPECT().GetObject(context.Background(), id).Return(smartBlockTest, nil)
 		objectGetter.EXPECT().GetObject(context.Background(), objectTypeId).Return(objectType, nil)
 		objectGetter.EXPECT().GetObject(context.Background(), defaultObjectTypeId).Return(defaultObjectType, nil)
 		objectGetter.EXPECT().GetObject(context.Background(), defaultTemplateId).Return(defaultTemplate, nil)
+		objectGetter.EXPECT().GetObject(context.Background(), defaultObjectTypeTemplateId).Return(defaultObjectTypeTemplate, nil)
 
 		e := &export{
 			objectStore: storeFixture,
@@ -1503,7 +1525,7 @@ func Test_docsForExport(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Equal(t, 4, len(expCtx.docs))
+		assert.Equal(t, 5, len(expCtx.docs))
 	})
 	t.Run("no default object type and template from dataview", func(t *testing.T) {
 		// given

--- a/core/block/import/common/common.go
+++ b/core/block/import/common/common.go
@@ -93,6 +93,10 @@ func handleDataviewBlock(block simple.Block, oldIDtoNew map[string]string, st *s
 			view.DefaultTemplateId = oldIDtoNew[view.DefaultTemplateId]
 		}
 
+		if view.DefaultObjectTypeId != "" {
+			view.DefaultObjectTypeId = oldIDtoNew[view.DefaultObjectTypeId]
+		}
+
 		updateRelationsInView(view, oldIDtoNew)
 		updateSortsInView(view, oldIDtoNew)
 	}

--- a/core/block/import/common/common_test.go
+++ b/core/block/import/common/common_test.go
@@ -354,4 +354,37 @@ func TestUpdateLinksToObjects(t *testing.T) {
 		assert.Equal(t, "newKey", st.Get("test").Model().GetDataview().GetViews()[0].GetSorts()[0].RelationKey)
 		assert.Equal(t, "key1", st.Get("test").Model().GetDataview().GetViews()[0].GetSorts()[1].RelationKey)
 	})
+	t.Run("update default object type", func(t *testing.T) {
+		// given
+		dataviewBlockId := "test"
+		rootId := "root"
+		newTypeId := "newType"
+		typeId := "type"
+		block := &model.Block{
+			Id: dataviewBlockId,
+			Content: &model.BlockContentOfDataview{Dataview: &model.BlockContentDataview{
+				Views: []*model.BlockContentDataviewView{
+					{
+						Id:                  "id",
+						DefaultObjectTypeId: typeId,
+					},
+				},
+			}},
+		}
+		rootBlock := &model.Block{
+			Id:          rootId,
+			ChildrenIds: []string{dataviewBlockId},
+			Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+		}
+		dataviewSimpleBlock := simple.New(block)
+		rootSimpleBlock := simple.New(rootBlock)
+		st := state.NewDoc(rootId, map[string]simple.Block{dataviewBlockId: dataviewSimpleBlock, rootId: rootSimpleBlock}).(*state.State)
+
+		// when
+		err := UpdateLinksToObjects(st, map[string]string{typeId: newTypeId})
+
+		// then
+		assert.Nil(t, err)
+		assert.Equal(t, newTypeId, st.Get(dataviewBlockId).Model().GetDataview().GetViews()[0].GetDefaultObjectTypeId())
+	})
 }


### PR DESCRIPTION
Add mapping of default object type id to the new one in import, so we get new id of default type in result collection object