### PR TITLE
GO-4810: Make notifications optional in progress bar for export

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -106,39 +106,31 @@ func (e *export) Export(ctx context.Context, req pb.RpcObjectListExportRequest) 
 		Id:      bson.NewObjectId().Hex(),
 		State:   0,
 		Message: &pb.ModelProcessMessageOfExport{Export: &pb.ModelProcessExport{}},
-	}, 4)
+	}, 4, req.NoProgress, e.notificationService)
 	queue.SetMessage("prepare")
 
 	if err = queue.Start(); err != nil {
 		return
 	}
-	defer func() {
-		queue.Stop(err)
-		e.sendNotification(err, req)
-	}()
-
 	exportCtx := newExportContext(e, req)
 	return exportCtx.exportObjects(ctx, queue)
 }
 
-func (e *export) sendNotification(err error, req pb.RpcObjectListExportRequest) {
+func (e *export) finishWithNotification(spaceId string, exportFormat model.ExportFormat, queue process.Queue, err error) {
 	errCode := model.NotificationExport_NULL
 	if err != nil {
 		errCode = model.NotificationExport_UNKNOWN_ERROR
 	}
-	notificationSendErr := e.notificationService.CreateAndSend(&model.Notification{
+	queue.FinishWithNotification(&model.Notification{
 		Id:      uuid.New().String(),
 		Status:  model.Notification_Created,
 		IsLocal: true,
 		Payload: &model.NotificationPayloadOfExport{Export: &model.NotificationExport{
 			ErrorCode:  errCode,
-			ExportType: req.Format,
+			ExportType: exportFormat,
 		}},
-		Space: req.SpaceId,
-	})
-	if notificationSendErr != nil {
-		log.Errorf("failed to send notification: %v", notificationSendErr)
-	}
+		Space: spaceId,
+	}, nil)
 }
 
 type exportContext struct {
@@ -187,11 +179,21 @@ func (e *exportContext) copy() *exportContext {
 }
 
 func (e *exportContext) exportObjects(ctx context.Context, queue process.Queue) (string, int, error) {
-	err := e.docsForExport()
+	var (
+		err  error
+		wr   writer
+		path string
+	)
+	defer func() {
+		e.finishWithNotification(e.spaceId, e.format, queue, err)
+		if err = queue.Finalize(); err != nil {
+			cleanupFile(wr)
+		}
+	}()
+	err = e.docsForExport()
 	if err != nil {
 		return "", 0, err
 	}
-	var wr writer
 	wr, err = e.getWriter()
 	if err != nil {
 		return "", 0, err
@@ -202,7 +204,8 @@ func (e *exportContext) exportObjects(ctx context.Context, queue process.Queue) 
 	}
 	wr.Close()
 	if e.zip {
-		return e.renameZipArchive(wr, succeed)
+		path, succeed, err = e.renameZipArchive(wr, succeed)
+		return path, succeed, err
 	}
 	return wr.Path(), succeed, nil
 }
@@ -248,10 +251,6 @@ func (e *exportContext) exportByFormat(ctx context.Context, wr writer, queue pro
 			return 0, nil
 		}
 		succeed += int(succeedAsync)
-	}
-	if err := queue.Finalize(); err != nil {
-		cleanupFile(wr)
-		return 0, err
 	}
 	return succeed, nil
 }
@@ -304,7 +303,7 @@ func (e *exportContext) renameZipArchive(wr writer, succeed int) (string, int, e
 	err := os.Rename(wr.Path(), zipName)
 	if err != nil {
 		os.Remove(wr.Path())
-		return "", 0, nil
+		return "", 0, err
 	}
 	return zipName, succeed, nil
 }
@@ -1144,6 +1143,9 @@ func validLayoutForNonProtobuf(details *domain.Details) bool {
 }
 
 func cleanupFile(wr writer) {
+	if wr == nil {
+		return
+	}
 	wr.Close()
 	os.Remove(wr.Path())
 }

--- a/core/block/import/importer_test.go
+++ b/core/block/import/importer_test.go
@@ -156,7 +156,7 @@ func Test_ImportSuccess(t *testing.T) {
 	})
 }
 
-func setupProcessService(t *testing.T, notificationProcess process.Notificationable) {
+func setupProcessService(t *testing.T, notificationProcess process.Progress) {
 	s := process.New()
 	a := &app.App{}
 	sender := mock_event.NewMockSender(t)

--- a/core/block/process/notificationprocess.go
+++ b/core/block/process/notificationprocess.go
@@ -21,7 +21,6 @@ type NotificationSender interface {
 }
 
 type Notificationable interface {
-	Progress
 	FinishWithNotification(notification *model.Notification, err error)
 }
 
@@ -33,7 +32,7 @@ type notificationProcess struct {
 	notification *model.Notification
 }
 
-func NewNotificationProcess(processMessage pb.IsModelProcessMessage, notificationService NotificationService) Notificationable {
+func NewNotificationProcess(processMessage pb.IsModelProcessMessage, notificationService NotificationService) Progress {
 	return &notificationProcess{progress: &progress{
 		id:             bson.NewObjectId().Hex(),
 		done:           make(chan struct{}),

--- a/core/block/process/queue.go
+++ b/core/block/process/queue.go
@@ -74,7 +74,6 @@ type queue struct {
 	s                   Service
 	m                   sync.Mutex
 	message             string
-	process             Process
 	noProgress          bool
 	notificationService NotificationService
 	notification        *model.Notification

--- a/core/block/process/queue.go
+++ b/core/block/process/queue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/globalsign/mgo/bson"
 
 	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
 var (
@@ -22,6 +23,7 @@ type Task func()
 
 type Queue interface {
 	Process
+	Notificationable
 	// Start starts the queue and register process in service
 	Start() (err error)
 	// Add adds tasks to queue. Can be called before Start
@@ -36,7 +38,7 @@ type Queue interface {
 	Stop(err error)
 }
 
-func (s *service) NewQueue(info pb.ModelProcess, workers int) Queue {
+func (s *service) NewQueue(info pb.ModelProcess, workers int, noProgress bool, notificationService NotificationService) Queue {
 	if workers <= 0 {
 		workers = 1
 	}
@@ -44,32 +46,38 @@ func (s *service) NewQueue(info pb.ModelProcess, workers int) Queue {
 		info.Id = bson.NewObjectId().Hex()
 	}
 	q := &queue{
-		id:      info.Id,
-		info:    info,
-		state:   pb.ModelProcess_None,
-		msgs:    mb.New(0),
-		done:    make(chan struct{}),
-		cancel:  make(chan struct{}),
-		s:       s,
-		workers: workers,
-		wg:      &sync.WaitGroup{},
+		id:                  info.Id,
+		info:                info,
+		state:               pb.ModelProcess_None,
+		msgs:                mb.New(0),
+		done:                make(chan struct{}),
+		cancel:              make(chan struct{}),
+		s:                   s,
+		workers:             workers,
+		wg:                  &sync.WaitGroup{},
+		noProgress:          noProgress,
+		notificationService: notificationService,
 	}
 	q.wg.Add(workers)
 	return q
 }
 
 type queue struct {
-	id            string
-	info          pb.ModelProcess
-	state         pb.ModelProcessState
-	msgs          *mb.MB
-	wg            *sync.WaitGroup
-	done, cancel  chan struct{}
-	pTotal, pDone int64
-	workers       int
-	s             Service
-	m             sync.Mutex
-	message       string
+	id                  string
+	info                pb.ModelProcess
+	state               pb.ModelProcessState
+	msgs                *mb.MB
+	wg                  *sync.WaitGroup
+	done, cancel        chan struct{}
+	pTotal, pDone       int64
+	workers             int
+	s                   Service
+	m                   sync.Mutex
+	message             string
+	process             Process
+	noProgress          bool
+	notificationService NotificationService
+	notification        *model.Notification
 }
 
 func (p *queue) Id() string {
@@ -85,6 +93,9 @@ func (p *queue) Start() (err error) {
 	p.state = pb.ModelProcess_Running
 	for i := 0; i < p.workers; i++ {
 		go p.worker()
+	}
+	if p.noProgress {
+		return nil
 	}
 	return p.s.Add(p)
 }
@@ -224,6 +235,20 @@ func (p *queue) Stop(err error) {
 	p.wg.Wait()
 	close(p.done)
 	return
+}
+
+func (p *queue) FinishWithNotification(notification *model.Notification, err error) {
+	p.notification = notification
+}
+
+func (p *queue) SendNotification() {
+	if p.notification == nil {
+		return
+	}
+	err := p.notificationService.CreateAndSend(p.notification)
+	if err != nil {
+		log.Errorf("failed to send notification: %v", err)
+	}
 }
 
 func (p *queue) checkRunning(checkStarted bool) (err error) {

--- a/core/block/process/service.go
+++ b/core/block/process/service.go
@@ -33,7 +33,7 @@ type Service interface {
 	// Cancel cancels process by id
 	Cancel(id string) (err error)
 	// NewQueue creates new queue with given workers count
-	NewQueue(info pb.ModelProcess, workers int) Queue
+	NewQueue(info pb.ModelProcess, workers int, noProgress bool, notificationService NotificationService) Queue
 	// Subscribe remove session from the map of disabled sessions
 	Subscribe(token string)
 	// Unsubscribe add session to the map of disabled sessions

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -15451,6 +15451,7 @@ Deletes the object, keys from the local store and unsubscribe from remote change
 | includeFiles | [bool](#bool) |  | include all files |
 | isJson | [bool](#bool) |  | for protobuf export |
 | includeArchived | [bool](#bool) |  | for migration |
+| noProgress | [bool](#bool) |  | for integrations like raycast and web publishing |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -2628,6 +2628,8 @@ message Rpc {
                 bool isJson = 7;
                 // for migration
                 bool includeArchived = 9;
+                // for integrations like raycast and web publishing
+                bool noProgress = 11;
             }
 
             message Response {


### PR DESCRIPTION
1. Add new param in export request noProgress - to turn off progress and notification events.
2. Move logic of sending notifications from export service to queue service - I implemented existing interfaces `Notificationable` and `NotificationSender` (NotificationSender is used in processes service to send notifications)
3.  Remove queue.Stop() call as it doesn't do anything