### PR TITLE
GO-4823 File-specific and hidden recommended relations

### DIFF
--- a/core/block/object/objectcreator/installer.go
+++ b/core/block/object/objectcreator/installer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/editor/lastused"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/relationutils"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
@@ -267,7 +268,7 @@ func (s *service) prepareDetailsForInstallingObject(
 
 	switch uk.SmartblockType() {
 	case coresb.SmartBlockTypeBundledObjectType, coresb.SmartBlockTypeObjectType:
-		relationKeys, isAlreadyFilled, err := fillRecommendedRelations(ctx, spc, details)
+		relationKeys, isAlreadyFilled, err := relationutils.FillRecommendedRelations(ctx, spc, details)
 		if err != nil {
 			return nil, fmt.Errorf("fill recommended relations: %w", err)
 		}

--- a/core/block/object/objectcreator/object_type.go
+++ b/core/block/object/objectcreator/object_type.go
@@ -2,42 +2,16 @@ package objectcreator
 
 import (
 	"context"
-	"errors"
 	"fmt"
-
-	"github.com/samber/lo"
-	"golang.org/x/exp/slices"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/relationutils"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space/clientspace"
-)
-
-var (
-	defaultRecommendedFeaturedRelationKeys = []domain.RelationKey{
-		bundle.RelationKeyType,
-		bundle.RelationKeyTag,
-		bundle.RelationKeyBacklinks,
-	}
-
-	defaultRecommendedRelationKeys = []domain.RelationKey{
-		bundle.RelationKeyCreatedDate,
-		bundle.RelationKeyCreator,
-		bundle.RelationKeyLastModifiedDate,
-		bundle.RelationKeyLastModifiedBy,
-		bundle.RelationKeyLastOpenedDate,
-		bundle.RelationKeyLinks,
-	}
-
-	// relationsToExclude = []domain.RelationKey{
-	// 	bundle.RelationKeyDescription,
-	// }
-
-	errRecommendedRelationsAlreadyFilled = fmt.Errorf("recommended featured relations are already filled")
 )
 
 func (s *service) createObjectType(ctx context.Context, space clientspace.Space, details *domain.Details) (id string, newDetails *domain.Details, err error) {
@@ -55,7 +29,7 @@ func (s *service) createObjectType(ctx context.Context, space clientspace.Space,
 		object.SetInt64(bundle.RelationKeyRecommendedLayout, int64(model.ObjectType_basic))
 	}
 
-	keys, isAlreadyFilled, err := fillRecommendedRelations(ctx, space, object)
+	keys, isAlreadyFilled, err := relationutils.FillRecommendedRelations(ctx, space, object)
 	if err != nil {
 		return "", nil, fmt.Errorf("fill recommended relations: %w", err)
 	}
@@ -82,90 +56,6 @@ func (s *service) createObjectType(ctx context.Context, space clientspace.Space,
 		log.With("spaceID", space.Id(), "objectTypeKey", installingObjectTypeKey).Errorf("error while installing templates: %s", err)
 	}
 	return id, newDetails, nil
-}
-
-// fillRecommendedRelations fills recommendedRelations and recommendedFeaturedRelations based on object's details
-// If these relations are already filled with correct ids, isAlreadyFilled = true is returned
-func fillRecommendedRelations(ctx context.Context, spc clientspace.Space, details *domain.Details) (keys []domain.RelationKey, isAlreadyFilled bool, err error) {
-	keys, err = getRelationKeysFromDetails(details)
-	if err != nil {
-		if errors.Is(err, errRecommendedRelationsAlreadyFilled) {
-			return nil, true, nil
-		}
-		return nil, false, fmt.Errorf("get recommended relation keys: %w", err)
-	}
-
-	// we should include default system recommended relations and exclude default recommended featured relations
-	keys = lo.Uniq(append(keys, defaultRecommendedRelationKeys...))
-	keys = slices.DeleteFunc(keys, func(key domain.RelationKey) bool {
-		return slices.Contains(defaultRecommendedFeaturedRelationKeys, key)
-	})
-
-	relationIds, err := prepareRelationIds(ctx, spc, keys)
-	if err != nil {
-		return nil, false, fmt.Errorf("prepare recommended relation ids: %w", err)
-	}
-	details.SetStringList(bundle.RelationKeyRecommendedRelations, relationIds)
-
-	featuredRelationIds, err := prepareRelationIds(ctx, spc, defaultRecommendedFeaturedRelationKeys)
-	if err != nil {
-		return nil, false, fmt.Errorf("prepare recommended featured relation ids: %w", err)
-	}
-	details.SetStringList(bundle.RelationKeyRecommendedFeaturedRelations, featuredRelationIds)
-
-	return append(keys, defaultRecommendedFeaturedRelationKeys...), false, nil
-}
-
-func getRelationKeysFromDetails(details *domain.Details) ([]domain.RelationKey, error) {
-	bundledRelationIds := details.GetStringList(bundle.RelationKeyRecommendedRelations)
-	if len(bundledRelationIds) == 0 {
-		rawRecommendedLayout := details.GetInt64(bundle.RelationKeyRecommendedLayout)
-		// nolint: gosec
-		recommendedLayout, err := bundle.GetLayout(model.ObjectTypeLayout(rawRecommendedLayout))
-		if err != nil {
-			return nil, fmt.Errorf("invalid recommended layout %d: %w", rawRecommendedLayout, err)
-		}
-		keys := make([]domain.RelationKey, 0, len(recommendedLayout.RequiredRelations))
-		for _, rel := range recommendedLayout.RequiredRelations {
-			keys = append(keys, domain.RelationKey(rel.Key))
-		}
-		return keys, nil
-	}
-
-	keys := make([]domain.RelationKey, 0, len(bundledRelationIds))
-	for i, id := range bundledRelationIds {
-		key, err := bundle.RelationKeyFromID(id)
-		if err == nil {
-			// TODO: use Contains when we have more relations to exclude
-			// if !slices.Contains(relationsToExclude, key) {
-			if key != bundle.RelationKeyDescription {
-				keys = append(keys, key)
-			}
-			continue
-		}
-		if i == 0 {
-			// if we fail to parse 1st bundled relation id, details are already filled with correct ids
-			return nil, errRecommendedRelationsAlreadyFilled
-		}
-		return nil, fmt.Errorf("relation key from id: %w", err)
-	}
-	return keys, nil
-}
-
-func prepareRelationIds(ctx context.Context, space clientspace.Space, relationKeys []domain.RelationKey) ([]string, error) {
-	relationIds := make([]string, 0, len(relationKeys))
-	for _, key := range relationKeys {
-		uk, err := domain.NewUniqueKey(coresb.SmartBlockTypeRelation, key.String())
-		if err != nil {
-			return nil, fmt.Errorf("failed to create unique Key: %w", err)
-		}
-		id, err := space.DeriveObjectID(ctx, uk)
-		if err != nil {
-			return nil, fmt.Errorf("failed to derive object id: %w", err)
-		}
-		relationIds = append(relationIds, id)
-	}
-	return relationIds, nil
 }
 
 func (s *service) installRecommendedRelations(ctx context.Context, space clientspace.Space, relationKeys []domain.RelationKey) error {

--- a/core/relationutils/recommended.go
+++ b/core/relationutils/recommended.go
@@ -1,0 +1,148 @@
+package relationutils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/samber/lo"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+type ObjectIDDeriver interface {
+	DeriveObjectID(ctx context.Context, uniqueKey domain.UniqueKey) (id string, err error)
+}
+
+var (
+	defaultRecommendedFeaturedRelationKeys = []domain.RelationKey{
+		bundle.RelationKeyType,
+		bundle.RelationKeyTag,
+		bundle.RelationKeyBacklinks,
+	}
+
+	defaultRecommendedRelationKeys = []domain.RelationKey{
+		bundle.RelationKeyCreatedDate,
+		bundle.RelationKeyCreator,
+		bundle.RelationKeyLastModifiedDate,
+		bundle.RelationKeyLastModifiedBy,
+		bundle.RelationKeyLastOpenedDate,
+		bundle.RelationKeyLinks,
+	}
+
+	nonFileSpecificRelationKeys = []domain.RelationKey{
+		bundle.RelationKeyAddedDate,
+		bundle.RelationKeyOrigin,
+	}
+
+	errRecommendedRelationsAlreadyFilled = fmt.Errorf("recommended featured relations are already filled")
+)
+
+// FillRecommendedRelations fills recommendedRelations and recommendedFeaturedRelations based on object's details
+// If these relations are already filled with correct ids, isAlreadyFilled = true is returned
+func FillRecommendedRelations(ctx context.Context, deriver ObjectIDDeriver, details *domain.Details) (keys []domain.RelationKey, isAlreadyFilled bool, err error) {
+	keys, err = getRelationKeysFromDetails(details)
+	if err != nil {
+		if errors.Is(err, errRecommendedRelationsAlreadyFilled) {
+			return nil, true, nil
+		}
+		return nil, false, fmt.Errorf("get recommended relation keys: %w", err)
+	}
+
+	if isFileType(details) {
+		// for file types we need to fill separate relation list with file-specific recommended relations
+		fileRecommendedRelationKeys := slices.DeleteFunc(keys, func(key domain.RelationKey) bool {
+			return slices.Contains(nonFileSpecificRelationKeys, key)
+		})
+		fileRelationIds, err := prepareRelationIds(ctx, deriver, fileRecommendedRelationKeys)
+		if err != nil {
+			return nil, false, fmt.Errorf("prepare file recommended relation ids: %w", err)
+		}
+		details.SetStringList(bundle.RelationKeyRecommendedFileRelations, fileRelationIds)
+		keys = nonFileSpecificRelationKeys
+	}
+
+	// we should include default system recommended relations and exclude default recommended featured relations
+	keys = lo.Uniq(append(keys, defaultRecommendedRelationKeys...))
+	keys = slices.DeleteFunc(keys, func(key domain.RelationKey) bool {
+		return slices.Contains(defaultRecommendedFeaturedRelationKeys, key)
+	})
+
+	relationIds, err := prepareRelationIds(ctx, deriver, keys)
+	if err != nil {
+		return nil, false, fmt.Errorf("prepare recommended relation ids: %w", err)
+	}
+	details.SetStringList(bundle.RelationKeyRecommendedRelations, relationIds)
+
+	featuredRelationIds, err := prepareRelationIds(ctx, deriver, defaultRecommendedFeaturedRelationKeys)
+	if err != nil {
+		return nil, false, fmt.Errorf("prepare recommended featured relation ids: %w", err)
+	}
+	details.SetStringList(bundle.RelationKeyRecommendedFeaturedRelations, featuredRelationIds)
+
+	return append(keys, defaultRecommendedFeaturedRelationKeys...), false, nil
+}
+
+func getRelationKeysFromDetails(details *domain.Details) ([]domain.RelationKey, error) {
+	bundledRelationIds := details.GetStringList(bundle.RelationKeyRecommendedRelations)
+	if len(bundledRelationIds) == 0 {
+		rawRecommendedLayout := details.GetInt64(bundle.RelationKeyRecommendedLayout)
+		// nolint: gosec
+		recommendedLayout, err := bundle.GetLayout(model.ObjectTypeLayout(rawRecommendedLayout))
+		if err != nil {
+			return nil, fmt.Errorf("invalid recommended layout %d: %w", rawRecommendedLayout, err)
+		}
+		keys := make([]domain.RelationKey, 0, len(recommendedLayout.RequiredRelations))
+		for _, rel := range recommendedLayout.RequiredRelations {
+			keys = append(keys, domain.RelationKey(rel.Key))
+		}
+		return keys, nil
+	}
+
+	keys := make([]domain.RelationKey, 0, len(bundledRelationIds))
+	for i, id := range bundledRelationIds {
+		key, err := bundle.RelationKeyFromID(id)
+		if err == nil {
+			if key != bundle.RelationKeyDescription {
+				keys = append(keys, key)
+			}
+			continue
+		}
+		if i == 0 {
+			// if we fail to parse 1st bundled relation id, details are already filled with correct ids
+			return nil, errRecommendedRelationsAlreadyFilled
+		}
+		return nil, fmt.Errorf("relation key from id: %w", err)
+	}
+	return keys, nil
+}
+
+func prepareRelationIds(ctx context.Context, deriver ObjectIDDeriver, relationKeys []domain.RelationKey) ([]string, error) {
+	relationIds := make([]string, 0, len(relationKeys))
+	for _, key := range relationKeys {
+		uk, err := domain.NewUniqueKey(coresb.SmartBlockTypeRelation, key.String())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create unique Key: %w", err)
+		}
+		id, err := deriver.DeriveObjectID(ctx, uk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive object id: %w", err)
+		}
+		relationIds = append(relationIds, id)
+	}
+	return relationIds, nil
+}
+
+func isFileType(details *domain.Details) bool {
+	uniqueKey, err := domain.UnmarshalUniqueKey(details.GetString(bundle.RelationKeyUniqueKey))
+	if err != nil {
+		return false
+	}
+	return slices.Contains([]domain.TypeKey{
+		bundle.TypeKeyFile, bundle.TypeKeyImage, bundle.TypeKeyVideo, bundle.TypeKeyAudio,
+	}, domain.TypeKey(uniqueKey.InternalKey()))
+}

--- a/core/relationutils/recommended_test.go
+++ b/core/relationutils/recommended_test.go
@@ -1,4 +1,4 @@
-package objectcreator
+package relationutils
 
 import (
 	"context"
@@ -70,7 +70,7 @@ func TestFillRecommendedRelations(t *testing.T) {
 			})
 
 			// when
-			keys, isAlreadyFilled, err := fillRecommendedRelations(nil, spc, details)
+			keys, isAlreadyFilled, err := FillRecommendedRelations(nil, spc, details)
 
 			// then
 			assert.NoError(t, err)
@@ -90,7 +90,7 @@ func TestFillRecommendedRelations(t *testing.T) {
 		})
 
 		// when
-		keys, isAlreadyFilled, err := fillRecommendedRelations(nil, spc, details)
+		keys, isAlreadyFilled, err := FillRecommendedRelations(nil, spc, details)
 
 		// then
 		assert.NoError(t, err)
@@ -129,7 +129,7 @@ func TestFillRecommendedRelations(t *testing.T) {
 			})
 
 			// when
-			keys, isAlreadyFilled, err := fillRecommendedRelations(nil, spc, details)
+			keys, isAlreadyFilled, err := FillRecommendedRelations(nil, spc, details)
 
 			// then
 			assert.NoError(t, err)
@@ -139,6 +139,35 @@ func TestFillRecommendedRelations(t *testing.T) {
 			assert.Len(t, keys, len(tc.expected)+3)
 		})
 	}
+
+	t.Run("recommendedRelations of file types", func(t *testing.T) {
+		// given
+		details := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyRecommendedRelations: domain.StringList([]string{
+				bundle.RelationKeyOrigin.BundledURL(),
+				bundle.RelationKeyFileExt.BundledURL(),
+				bundle.RelationKeyAddedDate.BundledURL(),
+				bundle.RelationKeyCameraIso.BundledURL(),
+				bundle.RelationKeyAperture.BundledURL(),
+			}),
+			bundle.RelationKeyUniqueKey: domain.String(bundle.TypeKeyImage.URL()),
+		})
+
+		// when
+		keys, isAlreadyFilled, err := FillRecommendedRelations(nil, spc, details)
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, isAlreadyFilled)
+		assert.Equal(t, buildRelationIds(append(nonFileSpecificRelationKeys, defaultRecommendedRelationKeys...)), details.GetStringList(bundle.RelationKeyRecommendedRelations))
+		assert.Equal(t, defaultRecFeatRelIds, details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations))
+		assert.Equal(t, []string{
+			bundle.RelationKeyFileExt.URL(),
+			bundle.RelationKeyCameraIso.URL(),
+			bundle.RelationKeyAperture.URL(),
+		}, details.GetStringList(bundle.RelationKeyRecommendedFileRelations))
+		assert.Len(t, keys, 11)
+	})
 }
 
 func buildRelationIds(keys []domain.RelationKey) []string {

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "edeeae3595f2095e368d8bfe083cccb9b0b1b4ffefb247b3ac7a9bcb39354f02"
+const RelationChecksum = "6bc8ce850001905263ba1ac86611612981e5f0b579701ae5713f2999a2607655"
 const (
 	RelationKeyTag                          domain.RelationKey = "tag"
 	RelationKeyCamera                       domain.RelationKey = "camera"
@@ -149,6 +149,8 @@ const (
 	RelationKeySpaceOrder                   domain.RelationKey = "spaceOrder"
 	RelationKeyDefaultViewType              domain.RelationKey = "defaultViewType"
 	RelationKeyDefaultTypeId                domain.RelationKey = "defaultTypeId"
+	RelationKeyRecommendedHiddenRelations   domain.RelationKey = "recommendedHiddenRelations"
+	RelationKeyRecommendedFileRelations     domain.RelationKey = "recommendedFileRelations"
 )
 
 var (
@@ -1349,6 +1351,34 @@ var (
 			Id:               "_brrecommendedFeaturedRelations",
 			Key:              "recommendedFeaturedRelations",
 			Name:             "Recommended featured relations",
+			ObjectTypes:      []string{TypePrefix + "relation"},
+			ReadOnly:         false,
+			ReadOnlyRelation: true,
+			Scope:            model.Relation_type,
+		},
+		RelationKeyRecommendedFileRelations: {
+
+			DataSource:       model.Relation_details,
+			Description:      "List of recommended file-specific relations",
+			Format:           model.RelationFormat_object,
+			Hidden:           true,
+			Id:               "_brrecommendedFileRelations",
+			Key:              "recommendedFileRelations",
+			Name:             "Recommended file relations",
+			ObjectTypes:      []string{TypePrefix + "relation"},
+			ReadOnly:         false,
+			ReadOnlyRelation: true,
+			Scope:            model.Relation_type,
+		},
+		RelationKeyRecommendedHiddenRelations: {
+
+			DataSource:       model.Relation_details,
+			Description:      "List of recommended relations that are hidden in layout",
+			Format:           model.RelationFormat_object,
+			Hidden:           true,
+			Id:               "_brrecommendedHiddenRelations",
+			Key:              "recommendedHiddenRelations",
+			Name:             "Recommended hidden relations",
 			ObjectTypes:      []string{TypePrefix + "relation"},
 			ReadOnly:         false,
 			ReadOnlyRelation: true,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1419,5 +1419,31 @@
     "name": "Default type id",
     "readonly": false,
     "source": "details"
+  },
+  {
+    "description": "List of recommended relations that are hidden in layout",
+    "format": "object",
+    "hidden": true,
+    "key": "recommendedHiddenRelations",
+    "maxCount": 0,
+    "name": "Recommended hidden relations",
+    "objectTypes": [
+      "relation"
+    ],
+    "readonly": false,
+    "source": "details"
+  },
+  {
+    "description": "List of recommended file-specific relations",
+    "format": "object",
+    "hidden": true,
+    "key": "recommendedFileRelations",
+    "maxCount": 0,
+    "name": "Recommended file relations",
+    "objectTypes": [
+      "relation"
+    ],
+    "readonly": false,
+    "source": "details"
   }
 ]

--- a/pkg/lib/bundle/systemRelations.gen.go
+++ b/pkg/lib/bundle/systemRelations.gen.go
@@ -6,7 +6,7 @@ package bundle
 
 import domain "github.com/anyproto/anytype-heart/core/domain"
 
-const SystemRelationsChecksum = "b8f59cddcb6220ca5830f84ce73f5d6ec098ea13def849b31fc61881d9fe95a7"
+const SystemRelationsChecksum = "f5c89fe0d60b257617b7449f76cb845a01a1703105291f3055e963bef89b3afa"
 
 // SystemRelations contains relations that have some special biz logic depends on them in some objects
 // in case EVERY object depend on the relation please add it to RequiredInternalRelations
@@ -83,6 +83,8 @@ var SystemRelations = append(RequiredInternalRelations, []domain.RelationKey{
 	RelationKeyHasChat,
 	RelationKeyTimestamp,
 	RelationKeyRecommendedFeaturedRelations,
+	RelationKeyRecommendedHiddenRelations,
+	RelationKeyRecommendedFileRelations,
 	RelationKeyLayoutWidth,
 	RelationKeyDefaultViewType,
 	RelationKeyDefaultTypeId,

--- a/pkg/lib/bundle/systemRelations.json
+++ b/pkg/lib/bundle/systemRelations.json
@@ -92,6 +92,8 @@
   "hasChat",
   "timestamp",
   "recommendedFeaturedRelations",
+  "recommendedHiddenRelations",
+  "recommendedFileRelations",
   "layoutWidth",
   "defaultViewType",
   "defaultTypeId"

--- a/pkg/lib/bundle/types.gen.go
+++ b/pkg/lib/bundle/types.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const TypeChecksum = "5458717a4167a70b8a8e3148147e192263a645484359ec155b6856a8996e8ec8"
+const TypeChecksum = "ef6f7320503988b931e7e3dcaff70746c59a7ae2e119aa1d802e185a33def361"
 const (
 	TypePrefix = "_ot"
 )
@@ -54,9 +54,9 @@ var (
 			Layout:                 model.ObjectType_file,
 			Name:                   "Audio",
 			Readonly:               true,
-			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyArtist), MustGetRelationLink(RelationKeyAudioAlbum), MustGetRelationLink(RelationKeyAudioAlbumTrackNumber), MustGetRelationLink(RelationKeyAudioGenre), MustGetRelationLink(RelationKeyAudioLyrics), MustGetRelationLink(RelationKeyReleasedYear), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
+			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyOrigin), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyArtist), MustGetRelationLink(RelationKeyAudioAlbum), MustGetRelationLink(RelationKeyAudioGenre), MustGetRelationLink(RelationKeyReleasedYear), MustGetRelationLink(RelationKeyAudioAlbumTrackNumber), MustGetRelationLink(RelationKeyAudioLyrics)},
 			RestrictObjectCreation: true,
-			Revision:               1,
+			Revision:               2,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "audio",
 		},
@@ -169,9 +169,9 @@ var (
 			Layout:                 model.ObjectType_file,
 			Name:                   "File",
 			Readonly:               true,
-			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
+			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyOrigin), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyFileMimeType)},
 			RestrictObjectCreation: true,
-			Revision:               1,
+			Revision:               2,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "file",
 		},
@@ -193,9 +193,9 @@ var (
 			Layout:                 model.ObjectType_image,
 			Name:                   "Image",
 			Readonly:               true,
-			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyWidthInPixels), MustGetRelationLink(RelationKeyCamera), MustGetRelationLink(RelationKeyHeightInPixels), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyCameraIso), MustGetRelationLink(RelationKeyAperture), MustGetRelationLink(RelationKeyExposure), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFocalRatio), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
+			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyOrigin), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyHeightInPixels), MustGetRelationLink(RelationKeyWidthInPixels), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyCamera), MustGetRelationLink(RelationKeyCameraIso), MustGetRelationLink(RelationKeyAperture), MustGetRelationLink(RelationKeyExposure), MustGetRelationLink(RelationKeyFocalRatio)},
 			RestrictObjectCreation: true,
-			Revision:               1,
+			Revision:               2,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "image",
 		},
@@ -379,9 +379,9 @@ var (
 			Layout:                 model.ObjectType_file,
 			Name:                   "Video",
 			Readonly:               true,
-			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyCamera), MustGetRelationLink(RelationKeyHeightInPixels), MustGetRelationLink(RelationKeyWidthInPixels), MustGetRelationLink(RelationKeyCameraIso), MustGetRelationLink(RelationKeyAperture), MustGetRelationLink(RelationKeyExposure), MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeyOrigin)},
+			RelationLinks:          []*model.RelationLink{MustGetRelationLink(RelationKeyAddedDate), MustGetRelationLink(RelationKeyOrigin), MustGetRelationLink(RelationKeyFileExt), MustGetRelationLink(RelationKeySizeInBytes), MustGetRelationLink(RelationKeyHeightInPixels), MustGetRelationLink(RelationKeyWidthInPixels), MustGetRelationLink(RelationKeyFileMimeType), MustGetRelationLink(RelationKeyCamera), MustGetRelationLink(RelationKeyCameraIso), MustGetRelationLink(RelationKeyAperture), MustGetRelationLink(RelationKeyExposure)},
 			RestrictObjectCreation: true,
-			Revision:               1,
+			Revision:               2,
 			Types:                  []model.SmartBlockType{model.SmartBlockType_File},
 			Url:                    TypePrefix + "video",
 		},

--- a/pkg/lib/bundle/types.json
+++ b/pkg/lib/bundle/types.json
@@ -143,21 +143,21 @@
     "hidden": false,
     "layout": "file",
     "relations": [
+      "addedDate",
+      "origin",
+      "fileExt",
       "sizeInBytes",
-      "fileMimeType",
-      "camera",
       "heightInPixels",
       "widthInPixels",
+      "fileMimeType",
+      "camera",
       "cameraIso",
       "aperture",
-      "exposure",
-      "addedDate",
-      "fileExt",
-      "origin"
+      "exposure"
     ],
     "description": "The recording of moving visual images",
     "restrictObjectCreation": true,
-    "revision": 1
+    "revision": 2
   },
   {
     "id": "dashboard",
@@ -346,22 +346,22 @@
     "hidden": false,
     "layout": "image",
     "relations": [
-      "fileMimeType",
-      "widthInPixels",
-      "camera",
-      "heightInPixels",
+      "addedDate",
+      "origin",
+      "fileExt",
       "sizeInBytes",
+      "heightInPixels",
+      "widthInPixels",
+      "fileMimeType",
+      "camera",
       "cameraIso",
       "aperture",
       "exposure",
-      "addedDate",
-      "focalRatio",
-      "fileExt",
-      "origin"
+      "focalRatio"
     ],
     "description": "A representation of the external form of a person or thing in art",
     "restrictObjectCreation": true,
-    "revision": 1
+    "revision": 2
   },
   {
     "id": "profile",
@@ -388,21 +388,21 @@
     "hidden": false,
     "layout": "file",
     "relations": [
-      "artist",
-      "audioAlbum",
-      "audioAlbumTrackNumber",
-      "audioGenre",
-      "audioLyrics",
-      "releasedYear",
+      "addedDate",
+      "origin",
+      "fileExt",
       "sizeInBytes",
       "fileMimeType",
-      "addedDate",
-      "fileExt",
-      "origin"
+      "artist",
+      "audioAlbum",
+      "audioGenre",
+      "releasedYear",
+      "audioAlbumTrackNumber",
+      "audioLyrics"
     ],
     "description": "Sound when recorded, with ability to reproduce",
     "restrictObjectCreation": true,
-    "revision": 1
+    "revision": 2
   },
   {
     "id": "goal",
@@ -432,15 +432,15 @@
     "hidden": false,
     "layout": "file",
     "relations": [
-      "fileMimeType",
-      "sizeInBytes",
       "addedDate",
+      "origin",
       "fileExt",
-      "origin"
+      "sizeInBytes",
+      "fileMimeType"
     ],
     "description": "Computer resource for recording data in a computer storage device",
     "restrictObjectCreation": true,
-    "revision": 1
+    "revision": 2
   },
   {
     "id": "project",

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
@@ -38,8 +38,10 @@ func TestMigration_Run(t *testing.T) {
 
 		spc := mock_space.NewMockSpace(t)
 		spc.EXPECT().Id().Return("space1").Maybe()
-
 		spc.EXPECT().DoCtx(ctx, "id1", mock.Anything).Return(nil).Times(1)
+		spc.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return key.Marshal(), nil
+		})
 
 		// when
 		migrated, toMigrate, err := fixer.Run(ctx, log, store.SpaceIndex("space1"), spc)
@@ -165,6 +167,9 @@ func TestReviseSystemObject(t *testing.T) {
 		space := mock_space.NewMockSpace(t)
 		space.EXPECT().DoCtx(mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
 		space.EXPECT().Id().Times(1).Return("")
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return key.Marshal(), nil
+		})
 
 		// when
 		toRevise, err := reviseObject(ctx, log, space, rel)
@@ -183,6 +188,9 @@ func TestReviseSystemObject(t *testing.T) {
 		space := mock_space.NewMockSpace(t)
 		space.EXPECT().DoCtx(mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
 		space.EXPECT().Id().Times(1).Return("")
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return key.Marshal(), nil
+		})
 
 		// when
 		toRevise, err := reviseObject(ctx, log, space, rel)
@@ -252,6 +260,9 @@ func TestReviseSystemObject(t *testing.T) {
 		space := mock_space.NewMockSpace(t)
 		space.EXPECT().DoCtx(mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
 		space.EXPECT().Id().Times(1).Return("")
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return key.Marshal(), nil
+		})
 
 		// when
 		toRevise, err := reviseObject(ctx, log, space, rel)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4823/provide-list-of-fields-to-support-toggle-inside-the-sidebar-and-file

- provide **RecommendedHiddenRelations** relation, so clients could remove relations from sidebar, but do not remove them from object type at all
- provide **RecommendedFileRelations** relation, so file-specific relations will be presented in separate list in sidebar
- move FillRecommendedRelations logic to util pkg from creator pkg, so it could be used by other services
- modify recommended relation lists for bundled File, Image, Video and Audio types and increase its revision