### PR TITLE
GO-4840 Check keys to unset from StructDiff

### DIFF
--- a/core/block/editor/state/event.go
+++ b/core/block/editor/state/event.go
@@ -326,7 +326,7 @@ func StructDiffIntoEventsWithSubIds(
 	filterKeys, keysToUnset []domain.RelationKey,
 	subIds []string,
 ) (msgs []*pb.EventMessage) {
-	if diff.Len() == 0 {
+	if diff.Len() == 0 && len(keysToUnset) == 0 {
 		return nil
 	}
 	var (
@@ -351,10 +351,13 @@ func StructDiffIntoEventsWithSubIds(
 		}))
 	}
 
-	filteredKeys := slices.DeleteFunc(keysToUnset, func(key domain.RelationKey) bool {
-		return !slices.Contains(filterKeys, key)
-	})
-	if len(filteredKeys) > 0 {
+	if len(filterKeys) != 0 {
+		keysToUnset = slices.DeleteFunc(keysToUnset, func(key domain.RelationKey) bool {
+			return !slices.Contains(filterKeys, key)
+		})
+	}
+
+	if len(keysToUnset) > 0 {
 		msgs = append(msgs, event.NewMessage(spaceId, &pb.EventMessageValueOfObjectDetailsUnset{
 			ObjectDetailsUnset: &pb.EventObjectDetailsUnset{
 				Id:     contextId,

--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -620,7 +620,7 @@ func (s *State) apply(spaceId string, fast, one, withLayouts bool) (msgs []simpl
 	}
 	if s.parent != nil && s.details != nil {
 		prev := s.parent.Details()
-		if diff, keysToUnset := domain.StructDiff(prev, s.details); diff != nil {
+		if diff, keysToUnset := domain.StructDiff(prev, s.details); diff != nil || len(keysToUnset) != 0 {
 			action.Details = &undo.Details{Before: prev.Copy(), After: s.details.Copy()}
 			msgs = append(msgs, WrapEventMessages(false, StructDiffIntoEvents(s.SpaceID(), s.RootId(), diff, keysToUnset))...)
 			s.parent.details = s.details
@@ -651,7 +651,7 @@ func (s *State) apply(spaceId string, fast, one, withLayouts bool) (msgs []simpl
 
 	if s.parent != nil && s.localDetails != nil {
 		prev := s.parent.LocalDetails()
-		if diff, keysToUnset := domain.StructDiff(prev, s.localDetails); diff != nil {
+		if diff, keysToUnset := domain.StructDiff(prev, s.localDetails); diff != nil || len(keysToUnset) != 0 {
 			msgs = append(msgs, WrapEventMessages(true, StructDiffIntoEvents(spaceId, s.RootId(), diff, keysToUnset))...)
 			s.parent.localDetails = s.localDetails
 		} else if !s.localDetails.Equal(s.parent.localDetails) {

--- a/core/history/history_test.go
+++ b/core/history/history_test.go
@@ -697,7 +697,7 @@ func TestHistory_DiffVersions(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, changes, 3)
+		assert.Len(t, changes, 4)
 	})
 	t.Run("object diff -local relations changes", func(t *testing.T) {
 		// given

--- a/core/subscription/internalsub_test.go
+++ b/core/subscription/internalsub_test.go
@@ -9,8 +9,8 @@ import (
 	mb2 "github.com/cheggaaa/mb/v3"
 	"github.com/stretchr/testify/require"
 
-	"github.com/anyproto/anytype-heart/core/event"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/event"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4840/set-null-detail-on-objectrelationadd

Check detail keys that are going to be removed. If struct diff is nil, while the list is not empty, we still need to generate event messages