### PR TITLE
GO-3189: set checkbox relation as false in ObjectRelationAdd command

### DIFF
--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -1701,9 +1701,6 @@ func (s *State) AddRelationLinks(links ...*model.RelationLink) {
 	for _, l := range links {
 		if !relLinks.Has(l.Key) {
 			relLinks = append(relLinks, l)
-			if l.Format == model.RelationFormat_checkbox {
-				s.SetDetail(domain.RelationKey(l.Key), domain.Bool(false))
-			}
 		}
 	}
 	s.relationLinks = relLinks

--- a/core/block/editor/state/state_test.go
+++ b/core/block/editor/state/state_test.go
@@ -2976,43 +2976,4 @@ func TestState_AddRelationLinks(t *testing.T) {
 		assert.True(t, s.GetRelationLinks().Has("existingLink"))
 		assert.Len(t, s.GetRelationLinks(), 1)
 	})
-	t.Run("add checkbox link", func(t *testing.T) {
-		// given
-		s := &State{}
-		checkboxLink := &model.RelationLink{
-			Key:    "checkboxLink",
-			Format: model.RelationFormat_checkbox,
-		}
-
-		// when
-		s.AddRelationLinks(checkboxLink)
-
-		// then
-		relLinks := s.GetRelationLinks()
-		assert.Equal(t, 1, len(relLinks))
-		assert.True(t, relLinks.Has("checkboxLink"))
-		detailValue := s.Details().Get("checkboxLink")
-		assert.Equal(t, domain.Bool(false), detailValue)
-	})
-	t.Run("multi links", func(t *testing.T) {
-		// given
-		s := &State{}
-		link1 := &model.RelationLink{
-			Key:    "link1",
-			Format: model.RelationFormat_shorttext,
-		}
-		link2 := &model.RelationLink{
-			Key:    "link2",
-			Format: model.RelationFormat_checkbox,
-		}
-
-		// when
-		s.AddRelationLinks(link1, link2)
-
-		// then
-		relLinks := s.GetRelationLinks()
-		assert.Equal(t, 2, len(relLinks))
-		assert.True(t, relLinks.Has("link1"))
-		assert.True(t, relLinks.Has("link2"))
-	})
 }

--- a/core/details.go
+++ b/core/details.go
@@ -188,8 +188,7 @@ func (mw *Middleware) ObjectRelationAdd(cctx context.Context, req *pb.RpcObjectR
 			}
 			format, err := mw.extractRelationFormat(current, objectStore, key)
 			if err != nil {
-				current.Set(domain.RelationKey(key), domain.Null())
-				continue
+				log.Errorf("failed to fetch relation from store to get format %s, falling back to basic", err)
 			}
 			switch format {
 			case model.RelationFormat_checkbox:
@@ -217,7 +216,7 @@ func (mw *Middleware) extractRelationFormat(current *domain.Details, objectStore
 	spaceId := current.GetString(bundle.RelationKeySpaceId)
 	relation, err := objectStore.SpaceIndex(spaceId).FetchRelationByKeys(domain.RelationKey(key))
 	if err != nil {
-		return 0, err
+		return model.RelationFormat_longtext, err
 	}
 	var format model.RelationFormat
 	if len(relation) != 0 {

--- a/core/details.go
+++ b/core/details.go
@@ -188,11 +188,13 @@ func (mw *Middleware) ObjectRelationAdd(cctx context.Context, req *pb.RpcObjectR
 			}
 			format, err := mw.extractRelationFormat(current, objectStore, key)
 			if err != nil {
+				current.Set(domain.RelationKey(key), domain.Null())
 				continue
 			}
-			if format == model.RelationFormat_checkbox {
+			switch format {
+			case model.RelationFormat_checkbox:
 				current.Set(domain.RelationKey(key), domain.Bool(false))
-			} else {
+			default:
 				current.Set(domain.RelationKey(key), domain.Null())
 			}
 		}

--- a/core/details.go
+++ b/core/details.go
@@ -7,6 +7,9 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/detailservice"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/internalflag"
 )
 
@@ -177,12 +180,21 @@ func (mw *Middleware) ObjectRelationAdd(cctx context.Context, req *pb.RpcObjectR
 	}
 
 	detailsService := mustService[detailservice.Service](mw)
+	objectStore := mustService[objectstore.ObjectStore](mw)
 	err := detailsService.ModifyDetails(ctx, req.ContextId, func(current *domain.Details) (*domain.Details, error) {
 		for _, key := range req.RelationKeys {
 			if current.Has(domain.RelationKey(key)) {
 				continue
 			}
-			current.Set(domain.RelationKey(key), domain.Null())
+			format, err := mw.extractRelationFormat(current, objectStore, key)
+			if err != nil {
+				continue
+			}
+			if format == model.RelationFormat_checkbox {
+				current.Set(domain.RelationKey(key), domain.Bool(false))
+			} else {
+				current.Set(domain.RelationKey(key), domain.Null())
+			}
 		}
 		return current, nil
 	})
@@ -197,4 +209,17 @@ func (mw *Middleware) ObjectRelationAdd(cctx context.Context, req *pb.RpcObjectR
 		Error: &pb.RpcObjectRelationAddResponseError{},
 		Event: mw.getResponseEvent(ctx),
 	}
+}
+
+func (mw *Middleware) extractRelationFormat(current *domain.Details, objectStore objectstore.ObjectStore, key string) (model.RelationFormat, error) {
+	spaceId := current.GetString(bundle.RelationKeySpaceId)
+	relation, err := objectStore.SpaceIndex(spaceId).FetchRelationByKeys(domain.RelationKey(key))
+	if err != nil {
+		return 0, err
+	}
+	var format model.RelationFormat
+	if len(relation) != 0 {
+		format = relation[0].Format
+	}
+	return format, nil
 }


### PR DESCRIPTION
Decided to rewrite this task as we are removing relation links. So I just set details as false for checkoboxes relations, if we add such relation to object