### PR TITLE
GO-4886: add joinSpace param in PublishState pb model

### DIFF
--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -192,7 +192,7 @@ func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, u
 
 func (s *service) applyInviteLink(ctx context.Context, spc clientspace.Space, snapshot *PublishingUberSnapshot, joinSpace bool) error {
 	inviteLink, err := s.extractInviteLink(ctx, spc.Id(), joinSpace, spc.IsPersonal())
-	if err != nil && errors.Is(err, ErrLimitExceeded) {
+	if err != nil && errors.Is(err, inviteservice.ErrInviteNotExists) {
 		return nil
 	}
 	if err != nil {

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -59,8 +59,9 @@ type PublishingUberSnapshotMeta struct {
 	InviteLink string `json:"inviteLink,omitempty"`
 }
 
-type Heads struct {
-	Heads []string `json:"heads"`
+type Version struct {
+	Heads     []string `json:"heads"`
+	JoinSpace bool     `json:"joinSpace"`
 }
 
 // Contains all publishing .pb files
@@ -177,7 +178,7 @@ func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, u
 		return err
 	}
 
-	version, err := s.evaluateDocumentVersion(spc, pageId)
+	version, err := s.evaluateDocumentVersion(spc, pageId, joinSpace)
 	if err != nil {
 		return err
 	}
@@ -191,6 +192,9 @@ func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, u
 
 func (s *service) applyInviteLink(ctx context.Context, spc clientspace.Space, snapshot *PublishingUberSnapshot, joinSpace bool) error {
 	inviteLink, err := s.extractInviteLink(ctx, spc.Id(), joinSpace, spc.IsPersonal())
+	if err != nil && errors.Is(err, ErrLimitExceeded) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -356,7 +360,7 @@ func (s *service) extractInviteLink(ctx context.Context, spaceId string, joinSpa
 	return inviteLink, nil
 }
 
-func (s *service) evaluateDocumentVersion(spc clientspace.Space, pageId string) (string, error) {
+func (s *service) evaluateDocumentVersion(spc clientspace.Space, pageId string, joinSpace bool) (string, error) {
 	treeStorage, err := spc.Storage().TreeStorage(pageId)
 	if err != nil {
 		return "", err
@@ -366,7 +370,7 @@ func (s *service) evaluateDocumentVersion(spc clientspace.Space, pageId string) 
 		return "", err
 	}
 	slices.Sort(heads)
-	h := &Heads{Heads: heads}
+	h := &Version{Heads: heads, JoinSpace: joinSpace}
 	jsonData, err := json.Marshal(h)
 	if err != nil {
 		return "", err
@@ -423,6 +427,7 @@ func (s *service) PublishList(ctx context.Context, spaceId string) ([]*pb.RpcPub
 	}
 	pbPublishes := make([]*pb.RpcPublishingPublishState, 0, len(publishes))
 	for _, publish := range publishes {
+		version := s.retrieveVersion(publish)
 		pbPublishes = append(pbPublishes, &pb.RpcPublishingPublishState{
 			SpaceId:   publish.SpaceId,
 			ObjectId:  publish.ObjectId,
@@ -431,9 +436,19 @@ func (s *service) PublishList(ctx context.Context, spaceId string) ([]*pb.RpcPub
 			Version:   publish.Version,
 			Timestamp: publish.Timestamp,
 			Size_:     publish.Size_,
+			JoinSpace: version.JoinSpace,
 		})
 	}
 	return pbPublishes, nil
+}
+
+func (s *service) retrieveVersion(publish *publishapi.Publish) *Version {
+	version := &Version{}
+	err := json.Unmarshal([]byte(publish.Version), version)
+	if err != nil {
+		log.Error("failed to unmarshal publish version", zap.Error(err))
+	}
+	return version
 }
 
 func (s *service) ResolveUri(ctx context.Context, uri string) (*pb.RpcPublishingPublishState, error) {
@@ -441,6 +456,7 @@ func (s *service) ResolveUri(ctx context.Context, uri string) (*pb.RpcPublishing
 	if err != nil {
 		return nil, err
 	}
+	version := s.retrieveVersion(publish)
 	return &pb.RpcPublishingPublishState{
 		SpaceId:   publish.SpaceId,
 		ObjectId:  publish.ObjectId,
@@ -449,6 +465,7 @@ func (s *service) ResolveUri(ctx context.Context, uri string) (*pb.RpcPublishing
 		Version:   publish.Version,
 		Timestamp: publish.Timestamp,
 		Size_:     publish.Size_,
+		JoinSpace: version.JoinSpace,
 	}, nil
 }
 
@@ -457,6 +474,7 @@ func (s *service) GetStatus(ctx context.Context, spaceId string, objectId string
 	if err != nil {
 		return nil, err
 	}
+	version := s.retrieveVersion(status)
 	return &pb.RpcPublishingPublishState{
 		SpaceId:   status.SpaceId,
 		ObjectId:  status.ObjectId,
@@ -465,5 +483,6 @@ func (s *service) GetStatus(ctx context.Context, spaceId string, objectId string
 		Version:   status.Version,
 		Timestamp: status.Timestamp,
 		Size_:     status.Size_,
+		JoinSpace: version.JoinSpace,
 	}, nil
 }

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -192,9 +192,6 @@ func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, u
 
 func (s *service) applyInviteLink(ctx context.Context, spc clientspace.Space, snapshot *PublishingUberSnapshot, joinSpace bool) error {
 	inviteLink, err := s.extractInviteLink(ctx, spc.Id(), joinSpace, spc.IsPersonal())
-	if err != nil && errors.Is(err, inviteservice.ErrInviteNotExists) {
-		return nil
-	}
 	if err != nil {
 		return err
 	}

--- a/core/publish/service_test.go
+++ b/core/publish/service_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/inviteservice"
 	"github.com/anyproto/anytype-heart/core/inviteservice/mock_inviteservice"
 	"github.com/anyproto/anytype-heart/core/notifications/mock_notifications"
+	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
@@ -63,6 +64,7 @@ type mockPublishClient struct {
 	expectedInvite  string
 	expectedObject  string
 	expectedPbFiles map[string]struct{}
+	expectedResult  []*publishapi.Publish
 }
 
 func (m *mockPublishClient) Init(a *app.App) (err error) {
@@ -78,7 +80,7 @@ func (m *mockPublishClient) ResolveUri(ctx context.Context, uri string) (publish
 }
 
 func (m *mockPublishClient) GetPublishStatus(ctx context.Context, spaceId, objectId string) (publish *publishapi.Publish, err error) {
-	return
+	return m.expectedResult[0], nil
 }
 
 func (m *mockPublishClient) Publish(ctx context.Context, req *publishapi.PublishRequest) (uploadUrl string, err error) {
@@ -91,7 +93,7 @@ func (m *mockPublishClient) UnPublish(ctx context.Context, req *publishapi.UnPub
 }
 
 func (m *mockPublishClient) ListPublishes(ctx context.Context, spaceId string) (publishes []*publishapi.Publish, err error) {
-	return
+	return m.expectedResult, nil
 }
 
 func (m *mockPublishClient) UploadDir(ctx context.Context, uploadUrl, dir string) (err error) {
@@ -165,7 +167,7 @@ func TestPublish(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, expected, publish.Url)
-		assert.Equal(t, "{\"heads\":[\"heads\"]}", publishClient.expectedRequest.Version)
+		assert.Equal(t, "{\"heads\":[\"heads\"],\"joinSpace\":false}", publishClient.expectedRequest.Version)
 		assert.Equal(t, objectId, publishClient.expectedRequest.ObjectId)
 		assert.Equal(t, spaceId, publishClient.expectedRequest.SpaceId)
 		assert.Equal(t, expectedUri, publishClient.expectedRequest.Uri)
@@ -219,7 +221,7 @@ func TestPublish(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, expected, publish.Url)
-		assert.Equal(t, "{\"heads\":[\"heads\"]}", publishClient.expectedRequest.Version)
+		assert.Equal(t, "{\"heads\":[\"heads\"],\"joinSpace\":true}", publishClient.expectedRequest.Version)
 		assert.Equal(t, objectId, publishClient.expectedRequest.ObjectId)
 		assert.Equal(t, spaceId, publishClient.expectedRequest.SpaceId)
 		assert.Equal(t, expectedUri, publishClient.expectedRequest.Uri)
@@ -266,7 +268,7 @@ func TestPublish(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, expected, publish.Url)
-		assert.Equal(t, "{\"heads\":[\"heads\"]}", publishClient.expectedRequest.Version)
+		assert.Equal(t, "{\"heads\":[\"heads\"],\"joinSpace\":true}", publishClient.expectedRequest.Version)
 		assert.Equal(t, objectId, publishClient.expectedRequest.ObjectId)
 		assert.Equal(t, spaceId, publishClient.expectedRequest.SpaceId)
 		assert.Equal(t, expectedUri, publishClient.expectedRequest.Uri)
@@ -324,7 +326,7 @@ func TestPublish(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, expectedUrl, publish.Url)
-		assert.Equal(t, "{\"heads\":[\"heads\"]}", publishClient.expectedRequest.Version)
+		assert.Equal(t, "{\"heads\":[\"heads\"],\"joinSpace\":true}", publishClient.expectedRequest.Version)
 		assert.Equal(t, objectId, publishClient.expectedRequest.ObjectId)
 		assert.Equal(t, spaceId, publishClient.expectedRequest.SpaceId)
 		assert.Equal(t, expectedUri, publishClient.expectedRequest.Uri)
@@ -369,7 +371,7 @@ func TestPublish(t *testing.T) {
 		// then
 		assert.Error(t, err)
 		assert.Equal(t, "", publish.Url)
-		assert.Equal(t, "{\"heads\":[\"heads\"]}", publishClient.expectedRequest.Version)
+		assert.Equal(t, "{\"heads\":[\"heads\"],\"joinSpace\":true}", publishClient.expectedRequest.Version)
 		assert.Equal(t, objectId, publishClient.expectedRequest.ObjectId)
 		assert.Equal(t, spaceId, publishClient.expectedRequest.SpaceId)
 		assert.Equal(t, expectedUri, publishClient.expectedRequest.Uri)
@@ -448,6 +450,75 @@ func TestPublish(t *testing.T) {
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, ErrLimitExceeded)
 		assert.Equal(t, "", publish.Url)
+	})
+}
+
+func TestService_PublishList(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		publishClientService := &mockPublishClient{
+			t: t,
+			expectedResult: []*publishapi.Publish{
+				{
+					SpaceId:  spaceId,
+					ObjectId: objectId,
+					Uri:      "test",
+					Version:  "{\"heads\":[\"heads\"],\"joinSpace\":true}",
+				},
+			},
+		}
+		svc := &service{
+			publishClientService: publishClientService,
+		}
+
+		// when
+		publishes, err := svc.PublishList(context.Background(), spaceId)
+
+		// then
+		expectedModel := &pb.RpcPublishingPublishState{
+			SpaceId:   spaceId,
+			ObjectId:  objectId,
+			Uri:       "test",
+			Version:   "{\"heads\":[\"heads\"],\"joinSpace\":true}",
+			JoinSpace: true,
+		}
+		assert.NoError(t, err)
+		assert.Len(t, publishes, 1)
+		assert.Equal(t, expectedModel, publishes[0])
+	})
+}
+
+func TestService_GetStatus(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		publishClientService := &mockPublishClient{
+			t: t,
+			expectedResult: []*publishapi.Publish{
+				{
+					SpaceId:  spaceId,
+					ObjectId: objectId,
+					Uri:      "test",
+					Version:  "{\"heads\":[\"heads\"],\"joinSpace\":false}",
+				},
+			},
+		}
+		svc := &service{
+			publishClientService: publishClientService,
+		}
+
+		// when
+		publish, err := svc.GetStatus(context.Background(), spaceId, objectId)
+
+		// then
+		expectedModel := &pb.RpcPublishingPublishState{
+			SpaceId:   spaceId,
+			ObjectId:  objectId,
+			Uri:       "test",
+			Version:   "{\"heads\":[\"heads\"],\"joinSpace\":false}",
+			JoinSpace: false,
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, expectedModel, publish)
 	})
 }
 

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -18210,6 +18210,7 @@ Available undo/redo operations
 | version | [string](#string) |  |  |
 | timestamp | [int64](#int64) |  |  |
 | size | [int64](#int64) |  |  |
+| joinSpace | [bool](#bool) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -1374,6 +1374,7 @@ message Rpc {
             string version = 5;
             int64 timestamp = 6;
             int64 size = 7;
+            bool joinSpace = 8;
         }
 
         message Create {


### PR DESCRIPTION
1. Save `joinSpace` in `Version` field for server
2. Add new parameter in middleware pb model `PublishingState`
3. Retrieve `joinSpace` parameter from version and save it in pb model for client