### PR TITLE
GO-4881 Remove Details restriction from editable types

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -164,7 +164,11 @@ var (
 	}
 )
 
-var editableSystemTypes = []domain.TypeKey{bundle.TypeKeyPage, bundle.TypeKeyTask, bundle.TypeKeyNote}
+var editableSystemTypes = []domain.TypeKey{
+	bundle.TypeKeyPage, bundle.TypeKeyTask, bundle.TypeKeyNote,
+	bundle.TypeKeySet, bundle.TypeKeyCollection, bundle.TypeKeyFile,
+	bundle.TypeKeyAudio, bundle.TypeKeyVideo, bundle.TypeKeyImage,
+}
 
 func GetRestrictionsBySBType(sbType smartblock.SmartBlockType) []int {
 	restrictions := objectRestrictionsBySBType[sbType]


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4881/remove-details-restriction-from-all-editable-types

As recommendedRelation lists are editable for the majority of types, we should remove Details restriction from page-, file- and set-like types