### PR TITLE
GO-4762 Fix template picker + Layout propagation

### DIFF
--- a/core/block/collection/service.go
+++ b/core/block/collection/service.go
@@ -160,7 +160,7 @@ func (s *Service) SubscribeForCollection(collectionID string, subscriptionID str
 
 		initialObjectIDs = st.GetStoreSlice(template.CollectionStoreKey)
 		return nil
-	})
+	}, smartblock.KeepInternalFlags)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/block/editor/smartblock/detailsinject.go
+++ b/core/block/editor/smartblock/detailsinject.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/anyproto/any-sync/app/ocache"
 
@@ -282,6 +283,12 @@ func (sb *smartBlock) changeResolvedLayoutForObjects(msgs []simple.EventMessage,
 		return nil
 	}
 
+	// nolint:gosec
+	if !isLayoutChangeApplicable(model.ObjectTypeLayout(layout)) {
+		// if layout change is not applicable, then it is init of some system type
+		return nil
+	}
+
 	index := sb.objectStore.SpaceIndex(sb.SpaceID())
 	records, err := index.Query(database.Query{Filters: []database.FilterRequest{
 		{
@@ -379,4 +386,14 @@ func getLayoutFromMessages(msgs []simple.EventMessage) (layout int64, found bool
 		}
 	}
 	return 0, false
+}
+
+func isLayoutChangeApplicable(layout model.ObjectTypeLayout) bool {
+	return slices.Contains([]model.ObjectTypeLayout{
+		model.ObjectType_basic,
+		model.ObjectType_todo,
+		model.ObjectType_profile,
+		model.ObjectType_note,
+		model.ObjectType_collection,
+	}, layout)
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4762/template-picker-during-the-collection-creation-doesnt-work

- preserve internalFlags on collection subscription
- fix layout setting for Relation object type