### PR TITLE
GO-4947 Fix Account layout

### DIFF
--- a/core/block/source/source.go
+++ b/core/block/source/source.go
@@ -191,7 +191,7 @@ func (s *service) newTreeSource(ctx context.Context, space Space, id string, bui
 		fileObjectMigrator: s.fileObjectMigrator,
 	}
 	if sbt == smartblock.SmartBlockTypeChatDerivedObject || sbt == smartblock.SmartBlockTypeAccountObject {
-		return &store{source: src}, nil
+		return &store{source: src, sbType: sbt}, nil
 	}
 
 	return src, nil


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4947/account-object-comes-with-chatderived-layout

Account object from tech space should have Profile layout, not ChatDerived