### PR TITLE
GO-4762 Preserve template picker on ObjectToCollection

### DIFF
--- a/core/block/collection/service.go
+++ b/core/block/collection/service.go
@@ -220,7 +220,7 @@ func (s *Service) ObjectToCollection(id string) error {
 		sb := b.(smartblock.SmartBlock)
 		s.setDefaultObjectTypeToViews(sb.SpaceID(), st)
 		return b.SetObjectTypesInState(st, []domain.TypeKey{bundle.TypeKeyCollection}, true)
-	})
+	}, smartblock.KeepInternalFlags)
 }
 
 func (s *Service) setDefaultObjectTypeToViews(spaceId string, st *state.State) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4762/template-picker-during-the-collection-creation-doesnt-work

When calling ObjectToCollection we should preserve **editorSelectTemplate** internal flag, so template picker remains 