### PR TITLE
GO-4961: fix backlinks export

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -162,6 +162,7 @@ type exportContext struct {
 	path             string
 	linkStateFilters *state.Filters
 	isLinkProcess    bool
+	includeBackLinks bool
 
 	*export
 }
@@ -179,6 +180,7 @@ func newExportContext(e *export, req pb.RpcObjectListExportRequest) *exportConte
 		reqIds:           req.ObjectIds,
 		zip:              req.Zip,
 		linkStateFilters: pbFiltersToState(req.LinksStateFilters),
+		includeBackLinks: req.IncludeBacklinks,
 		export:           e,
 	}
 	return ec
@@ -197,6 +199,7 @@ func (e *exportContext) copy() *exportContext {
 		export:           e.export,
 		isLinkProcess:    e.isLinkProcess,
 		linkStateFilters: e.linkStateFilters,
+		includeBackLinks: e.includeBackLinks,
 	}
 }
 
@@ -855,6 +858,7 @@ func (e *exportContext) addNestedObject(id string, nestedDocs map[string]*Doc) {
 			Details:                  true,
 			Collection:               true,
 			NoHiddenBundledRelations: true,
+			NoBackLinks:              !e.includeBackLinks,
 		})
 		return nil
 	})

--- a/core/block/object/objectlink/dependent_objects.go
+++ b/core/block/object/objectlink/dependent_objects.go
@@ -48,7 +48,8 @@ type Flags struct {
 	NoSystemRelations,
 	NoHiddenBundledRelations,
 	NoImages,
-	RoundDateIdsToDay bool
+	RoundDateIdsToDay,
+	NoBackLinks bool
 }
 
 func DependentObjectIDs(s *state.State, converter KeyToIDConverter, flags Flags) (ids []string) {
@@ -180,6 +181,10 @@ func collectIdsFromDetail(rel *model.RelationLink, det *domain.Details, flags Fl
 		if r, err := bundle.GetRelation(domain.RelationKey(rel.Key)); err == nil && r.Hidden {
 			return
 		}
+	}
+
+	if rel.Key == bundle.RelationKeyBacklinks.String() && flags.NoBackLinks {
+		return
 	}
 
 	// handle corner cases first for specific formats

--- a/core/block/object/objectlink/dependent_objects_test.go
+++ b/core/block/object/objectlink/dependent_objects_test.go
@@ -224,9 +224,26 @@ func TestState_DepSmartIdsLinksAndRelations(t *testing.T) {
 		assert.Len(t, objectIDs, 15) // 11 links + 4 relations
 	})
 
-	t.Run("date object ids are rounded to day", func(t *testing.T) {
-		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, RoundDateIdsToDay: true})
-		assert.Len(t, objectIDs, 10)
+	t.Run("save backlinks", func(t *testing.T) {
+		st := stateWithLinks.Copy()
+		st.SetDetail(bundle.RelationKeyBacklinks, domain.StringList([]string{"link1"}))
+		st.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyBacklinks.String(),
+			Format: model.RelationFormat_object,
+		})
+		objectIDs := DependentObjectIDs(st, converter, Flags{Details: true})
+		assert.Len(t, objectIDs, 1)
+		assert.Contains(t, objectIDs, "link1")
+	})
+	t.Run("skip backlinks", func(t *testing.T) {
+		st := stateWithLinks.Copy()
+		st.SetDetail(bundle.RelationKeyBacklinks, domain.StringList([]string{"link1"}))
+		st.AddRelationLinks(&model.RelationLink{
+			Key:    bundle.RelationKeyBacklinks.String(),
+			Format: model.RelationFormat_object,
+		})
+		objectIDs := DependentObjectIDs(st, converter, Flags{Details: true, NoBackLinks: true})
+		assert.Len(t, objectIDs, 0)
 	})
 }
 
@@ -317,6 +334,10 @@ func TestState_DepSmartIdsLinksDetailsAndRelations(t *testing.T) {
 	t.Run("blocks option and relations option are turned on: get ids from blocks and relations", func(t *testing.T) {
 		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, Relations: true})
 		assert.Len(t, objectIDs, 9) // 4 links + 5 relations
+	})
+	t.Run("blocks, relations and details option are turned on: get ids from blocks, relations and details", func(t *testing.T) {
+		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, Relations: true, Details: true})
+		assert.Len(t, objectIDs, 14) // 4 links + 5 relations + 3 options + 1 fileID + 1 date
 	})
 	t.Run("blocks, relations and details option are turned on: get ids from blocks, relations and details", func(t *testing.T) {
 		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, Relations: true, Details: true})

--- a/core/block/object/objectlink/dependent_objects_test.go
+++ b/core/block/object/objectlink/dependent_objects_test.go
@@ -339,10 +339,6 @@ func TestState_DepSmartIdsLinksDetailsAndRelations(t *testing.T) {
 		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, Relations: true, Details: true})
 		assert.Len(t, objectIDs, 14) // 4 links + 5 relations + 3 options + 1 fileID + 1 date
 	})
-	t.Run("blocks, relations and details option are turned on: get ids from blocks, relations and details", func(t *testing.T) {
-		objectIDs := DependentObjectIDs(stateWithLinks, converter, Flags{Blocks: true, Relations: true, Details: true})
-		assert.Len(t, objectIDs, 14) // 4 links + 5 relations + 3 options + 1 fileID + 1 date
-	})
 }
 
 func TestState_DepSmartIdsLinksCreatorModifierWorkspace(t *testing.T) {

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -122,15 +122,16 @@ func uniqName() string {
 func (s *service) exportToDir(ctx context.Context, spaceId, pageId string) (dirEntries []fs.DirEntry, exportPath string, err error) {
 	tempDir := os.TempDir()
 	exportPath, _, err = s.exportService.Export(ctx, pb.RpcObjectListExportRequest{
-		SpaceId:       spaceId,
-		Format:        model.Export_Protobuf,
-		IncludeFiles:  true,
-		IsJson:        false,
-		Zip:           false,
-		Path:          tempDir,
-		ObjectIds:     []string{pageId},
-		NoProgress:    true,
-		IncludeNested: true,
+		SpaceId:          spaceId,
+		Format:           model.Export_Protobuf,
+		IncludeFiles:     true,
+		IsJson:           false,
+		Zip:              false,
+		Path:             tempDir,
+		ObjectIds:        []string{pageId},
+		NoProgress:       true,
+		IncludeNested:    true,
+		IncludeBacklinks: true,
 		LinksStateFilters: &pb.RpcObjectListExportStateFilters{
 			RelationsWhiteList: relationsWhiteListToPbModel(),
 			RemoveBlocks:       true,

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -15572,6 +15572,7 @@ Deletes the object, keys from the local store and unsubscribe from remote change
 | includeArchived | [bool](#bool) |  | for migration |
 | noProgress | [bool](#bool) |  | for integrations like raycast and web publishing |
 | linksStateFilters | [Rpc.Object.ListExport.StateFilters](#anytype-Rpc-Object-ListExport-StateFilters) |  |  |
+| includeBacklinks | [bool](#bool) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -2783,6 +2783,7 @@ message Rpc {
                 // for integrations like raycast and web publishing
                 bool noProgress = 11;
                 StateFilters linksStateFilters = 12;
+                bool includeBacklinks = 13;
             }
             message StateFilters {
                 repeated RelationsWhiteList relationsWhiteList = 1;


### PR DESCRIPTION
1. Add new parameter `includeBacklinks` in export
2. Add new parameter in `DependentObjectIds` function - NoBacklinks. If true, we will skip it
3. For regular export we ignore backlinks 