### PR TITLE
GO-4945: Bug: not all published pages are shown in "My Sites" settings

### DIFF
--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/anyproto/anytype-publish-server/publishclient/publishapi"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/inviteservice"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space"
 	"github.com/anyproto/anytype-heart/space/clientspace"
@@ -88,6 +90,7 @@ type service struct {
 	publishClientService publishclient.Client
 	identityService      identity.Service
 	inviteService        inviteservice.InviteService
+	objectStore          objectstore.ObjectStore
 }
 
 func New() Service {
@@ -100,6 +103,7 @@ func (s *service) Init(a *app.App) error {
 	s.publishClientService = app.MustComponent[publishclient.Client](a)
 	s.identityService = app.MustComponent[identity.Service](a)
 	s.inviteService = app.MustComponent[inviteservice.InviteService](a)
+	s.objectStore = app.MustComponent[objectstore.ObjectStore](a)
 	return nil
 }
 
@@ -431,6 +435,7 @@ func (s *service) PublishList(ctx context.Context, spaceId string) ([]*pb.RpcPub
 	pbPublishes := make([]*pb.RpcPublishingPublishState, 0, len(publishes))
 	for _, publish := range publishes {
 		version := s.retrieveVersion(publish)
+		details := s.retrieveObjectDetails(publish)
 		pbPublishes = append(pbPublishes, &pb.RpcPublishingPublishState{
 			SpaceId:   publish.SpaceId,
 			ObjectId:  publish.ObjectId,
@@ -440,9 +445,24 @@ func (s *service) PublishList(ctx context.Context, spaceId string) ([]*pb.RpcPub
 			Timestamp: publish.Timestamp,
 			Size_:     publish.Size_,
 			JoinSpace: version.JoinSpace,
+			Details:   details,
 		})
 	}
 	return pbPublishes, nil
+}
+
+func (s *service) retrieveObjectDetails(publish *publishapi.Publish) *types.Struct {
+	records, err := s.objectStore.SpaceIndex(publish.SpaceId).QueryByIds([]string{publish.ObjectId})
+	if err != nil {
+		log.Error("failed to extract object details", zap.Error(err))
+		return nil
+	}
+	if len(records) == 0 {
+		log.Error("details weren't found in store")
+		return nil
+	}
+	details := records[0].Details
+	return details.ToProto()
 }
 
 func (s *service) retrieveVersion(publish *publishapi.Publish) *Version {

--- a/core/publish/service_test.go
+++ b/core/publish/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
 	"github.com/anyproto/any-sync/consensus/consensusproto"
 	"github.com/anyproto/anytype-publish-server/publishclient/publishapi"
+	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/anyproto/anytype-heart/core/anytype/account/mock_account"
@@ -47,12 +48,14 @@ import (
 	"github.com/anyproto/anytype-heart/space/mock_space"
 	"github.com/anyproto/anytype-heart/space/spacecore/typeprovider/mock_typeprovider"
 	"github.com/anyproto/anytype-heart/tests/testutil"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 const (
-	spaceId  = "spaceId"
-	objectId = "objectId"
-	id       = "identity"
+	spaceId    = "spaceId"
+	objectId   = "objectId"
+	id         = "identity"
+	objectName = "test"
 )
 
 type mockPublishClient struct {
@@ -453,41 +456,6 @@ func TestPublish(t *testing.T) {
 	})
 }
 
-func TestService_PublishList(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		// given
-		publishClientService := &mockPublishClient{
-			t: t,
-			expectedResult: []*publishapi.Publish{
-				{
-					SpaceId:  spaceId,
-					ObjectId: objectId,
-					Uri:      "test",
-					Version:  "{\"heads\":[\"heads\"],\"joinSpace\":true}",
-				},
-			},
-		}
-		svc := &service{
-			publishClientService: publishClientService,
-		}
-
-		// when
-		publishes, err := svc.PublishList(context.Background(), spaceId)
-
-		// then
-		expectedModel := &pb.RpcPublishingPublishState{
-			SpaceId:   spaceId,
-			ObjectId:  objectId,
-			Uri:       "test",
-			Version:   "{\"heads\":[\"heads\"],\"joinSpace\":true}",
-			JoinSpace: true,
-		}
-		assert.NoError(t, err)
-		assert.Len(t, publishes, 1)
-		assert.Equal(t, expectedModel, publishes[0])
-	})
-}
-
 func TestService_GetStatus(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		// given
@@ -516,6 +484,176 @@ func TestService_GetStatus(t *testing.T) {
 			Uri:       "test",
 			Version:   "{\"heads\":[\"heads\"],\"joinSpace\":false}",
 			JoinSpace: false,
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, expectedModel, publish)
+	})
+}
+
+func TestService_PublishingList(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// given
+		publishClientService := &mockPublishClient{
+			t: t,
+			expectedResult: []*publishapi.Publish{
+				{
+					SpaceId:  spaceId,
+					ObjectId: objectId,
+					Uri:      objectName,
+					Version:  "{\"heads\":[\"heads\"],\"joinSpace\":true}",
+				},
+			},
+		}
+		svc := &service{
+			objectStore:          objectstore.NewStoreFixture(t),
+			publishClientService: publishClientService,
+		}
+
+		// when
+		publishes, err := svc.PublishList(context.Background(), spaceId)
+
+		// then
+		expectedModel := &pb.RpcPublishingPublishState{
+			SpaceId:   spaceId,
+			ObjectId:  objectId,
+			Uri:       objectName,
+			Version:   "{\"heads\":[\"heads\"],\"joinSpace\":true}",
+			JoinSpace: true,
+		}
+		assert.NoError(t, err)
+		assert.Len(t, publishes, 1)
+		assert.Equal(t, expectedModel, publishes[0])
+	})
+
+	space1Id := "spaceId1"
+	object1Id := "objectId1"
+	name1 := "test1"
+	t.Run("extract from all spaces", func(t *testing.T) {
+		// given
+		publishClientService := &mockPublishClient{
+			t: t,
+			expectedResult: []*publishapi.Publish{
+				{
+					SpaceId:  spaceId,
+					ObjectId: objectId,
+					Uri:      objectName,
+					Version:  "{\"heads\":[\"heads\"],\"joinSpace\":false}",
+				},
+				{
+					SpaceId:  space1Id,
+					ObjectId: object1Id,
+					Uri:      name1,
+					Version:  "{\"heads\":[\"heads1\"],\"joinSpace\":false}",
+				},
+			},
+		}
+		storeFixture := objectstore.NewStoreFixture(t)
+
+		storeFixture.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:   domain.String(objectId),
+				bundle.RelationKeyName: domain.String(objectName),
+			},
+		})
+		storeFixture.AddObjects(t, space1Id, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:   domain.String(object1Id),
+				bundle.RelationKeyName: domain.String(name1),
+			},
+		})
+
+		svc := &service{
+			publishClientService: publishClientService,
+			objectStore:          storeFixture,
+		}
+
+		// when
+		publish, err := svc.PublishList(context.Background(), "")
+
+		// then
+		expectedModel := []*pb.RpcPublishingPublishState{
+			{
+				SpaceId:   spaceId,
+				ObjectId:  objectId,
+				Uri:       objectName,
+				Version:   "{\"heads\":[\"heads\"],\"joinSpace\":false}",
+				JoinSpace: false,
+				Details: &types.Struct{Fields: map[string]*types.Value{
+					bundle.RelationKeyId.String():   pbtypes.String(objectId),
+					bundle.RelationKeyName.String(): pbtypes.String(objectName),
+				}},
+			},
+			{
+				SpaceId:   space1Id,
+				ObjectId:  object1Id,
+				Uri:       name1,
+				Version:   "{\"heads\":[\"heads1\"],\"joinSpace\":false}",
+				JoinSpace: false,
+				Details: &types.Struct{Fields: map[string]*types.Value{
+					bundle.RelationKeyId.String():   pbtypes.String(object1Id),
+					bundle.RelationKeyName.String(): pbtypes.String(name1),
+				}},
+			},
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, expectedModel, publish)
+	})
+	t.Run("details empty", func(t *testing.T) {
+		// given
+		publishClientService := &mockPublishClient{
+			t: t,
+			expectedResult: []*publishapi.Publish{
+				{
+					SpaceId:  spaceId,
+					ObjectId: objectId,
+					Uri:      objectName,
+					Version:  "{\"heads\":[\"heads\"],\"joinSpace\":false}",
+				},
+				{
+					SpaceId:  space1Id,
+					ObjectId: object1Id,
+					Uri:      name1,
+					Version:  "{\"heads\":[\"heads1\"],\"joinSpace\":false}",
+				},
+			},
+		}
+		storeFixture := objectstore.NewStoreFixture(t)
+
+		storeFixture.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:   domain.String(objectId),
+				bundle.RelationKeyName: domain.String(objectName),
+			},
+		})
+
+		svc := &service{
+			publishClientService: publishClientService,
+			objectStore:          storeFixture,
+		}
+
+		// when
+		publish, err := svc.PublishList(context.Background(), "")
+
+		// then
+		expectedModel := []*pb.RpcPublishingPublishState{
+			{
+				SpaceId:   spaceId,
+				ObjectId:  objectId,
+				Uri:       objectName,
+				Version:   "{\"heads\":[\"heads\"],\"joinSpace\":false}",
+				JoinSpace: false,
+				Details: &types.Struct{Fields: map[string]*types.Value{
+					bundle.RelationKeyId.String():   pbtypes.String(objectId),
+					bundle.RelationKeyName.String(): pbtypes.String(objectName),
+				}},
+			},
+			{
+				SpaceId:   space1Id,
+				ObjectId:  object1Id,
+				Uri:       name1,
+				Version:   "{\"heads\":[\"heads1\"],\"joinSpace\":false}",
+				JoinSpace: false,
+			},
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, expectedModel, publish)

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -18315,6 +18315,7 @@ Available undo/redo operations
 | timestamp | [int64](#int64) |  |  |
 | size | [int64](#int64) |  |  |
 | joinSpace | [bool](#bool) |  |  |
+| details | [google.protobuf.Struct](#google-protobuf-Struct) |  |  |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -1400,6 +1400,7 @@ message Rpc {
             int64 timestamp = 6;
             int64 size = 7;
             bool joinSpace = 8;
+            google.protobuf.Struct details = 9;
         }
 
         message Create {


### PR DESCRIPTION
1. Add new parameter in `PublishState` model - details
2. Save details from objects store for each published objects in this field during `PublishingList` call. So clients can retrieve objects information from these details

https://linear.app/anytype/issue/GO-4945/bug-not-all-published-pages-are-shown-in-my-sites-settings