### PR TITLE
GO-4985 Fix bookmark picture upload

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -59,7 +59,6 @@ var (
 		model.Restrictions_LayoutChange,
 		model.Restrictions_TypeChange,
 		model.Restrictions_Template,
-		model.Restrictions_Details,
 		model.Restrictions_Delete,
 		model.Restrictions_Publish,
 	}
@@ -173,9 +172,10 @@ var (
 )
 
 var editableSystemTypes = []domain.TypeKey{
-	bundle.TypeKeyPage, bundle.TypeKeyTask, bundle.TypeKeyNote,
-	bundle.TypeKeySet, bundle.TypeKeyCollection, bundle.TypeKeyFile,
-	bundle.TypeKeyAudio, bundle.TypeKeyVideo, bundle.TypeKeyImage,
+	bundle.TypeKeyPage, bundle.TypeKeyTask, bundle.TypeKeyNote, // pages
+	bundle.TypeKeySet, bundle.TypeKeyCollection, // lists
+	bundle.TypeKeyFile, bundle.TypeKeyAudio, bundle.TypeKeyVideo, bundle.TypeKeyImage, // files
+	bundle.TypeKeyBookmark,
 }
 
 func GetRestrictionsBySBType(sbType smartblock.SmartBlockType) []int {

--- a/core/files/file.go
+++ b/core/files/file.go
@@ -145,6 +145,7 @@ func calculateCommonDetails(
 	det.SetString(bundle.RelationKeyFileId, fileId.String())
 	det.SetBool(bundle.RelationKeyIsReadonly, false)
 	det.SetInt64(bundle.RelationKeyResolvedLayout, int64(layout))
+	det.SetInt64(bundle.RelationKeyLayout, int64(layout))
 	det.SetFloat64(bundle.RelationKeyLastModifiedDate, float64(lastModifiedDate))
 	return det
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4985/cover-by-picture-in-gallery-view-of-sets-by-bookmarks-does-not-work

- fix layout of new images uploaded as bookmark picture
- remove Details restriction from Bookmark type