### PR TITLE
GO-4823 Fixes on hidden recommended relations

### DIFF
--- a/cmd/usecasevalidator/customusage.go
+++ b/cmd/usecasevalidator/customusage.go
@@ -4,8 +4,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
@@ -45,9 +47,12 @@ func collectInfoFromDetails(s *pb.SnapshotWithType, info *useCaseInfo) {
 			cr.isUsed = true
 			info.customTypesAndRelations[k] = cr
 		}
-		values := pbtypes.GetStringListValue(v)
-		for _, val := range values {
-			if k == bundle.RelationKeyRecommendedRelations.String() {
+		if slices.Contains([]domain.RelationKey{
+			bundle.RelationKeyRecommendedRelations, bundle.RelationKeyRecommendedFeaturedRelations,
+			bundle.RelationKeyRecommendedHiddenRelations, bundle.RelationKeyRecommendedFileRelations,
+		}, domain.RelationKey(k)) {
+			values := pbtypes.GetStringListValue(v)
+			for _, val := range values {
 				if key, found := info.relations[val]; found {
 					if cr, foundToo := info.customTypesAndRelations[string(key)]; foundToo {
 						cr.isUsed = true

--- a/cmd/usecasevalidator/validators.go
+++ b/cmd/usecasevalidator/validators.go
@@ -141,11 +141,6 @@ func validateDetails(s *pb.SnapshotWithType, info *useCaseInfo) (err error) {
 					fmt.Println("WARNING: object", id, "is a template with no target type included in the archive, so it will be skipped")
 					return errSkipObject
 				}
-				if k == bundle.RelationKeyRecommendedRelations.String() {
-					// TODO: remove this fix as most of users should obtain version with fixed export of derived objects in GO-2821
-					delete(s.Snapshot.Data.Details.Fields, bundle.RelationKeyRecommendedRelations.String())
-					return nil
-				}
 				err = multierror.Append(err, fmt.Errorf("failed to find target id for detail '%s: %s' of object %s", k, val, id))
 			}
 		}

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -795,7 +796,12 @@ func (e *exportContext) addObjectsAndCollectRecommendedRelations(objectTypes []d
 			if bundle.IsInternalType(key) {
 				continue
 			}
-			recommendedRelations = append(recommendedRelations, objectTypes[i].Details.GetStringList(bundle.RelationKeyRecommendedRelations)...)
+			recommendedRelations = lo.Uniq(slices.Concat(recommendedRelations,
+				objectTypes[i].Details.GetStringList(bundle.RelationKeyRecommendedRelations),
+				objectTypes[i].Details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations),
+				objectTypes[i].Details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations),
+				objectTypes[i].Details.GetStringList(bundle.RelationKeyRecommendedFileRelations),
+			))
 		}
 	}
 	return recommendedRelations, nil

--- a/core/relationutils/recommended_test.go
+++ b/core/relationutils/recommended_test.go
@@ -20,8 +20,9 @@ func (d *mockDeriver) DeriveObjectID(ctx context.Context, key domain.UniqueKey) 
 }
 
 func TestFillRecommendedRelations(t *testing.T) {
-	defaultRecFeatRelIds := buildRelationIds(defaultRecommendedFeaturedRelationKeys)
+	defaultRecFeatRelIds := buildRelationIds(defaultFeaturedRelationKeys)
 	defaultRecRelIds := buildRelationIds(defaultRecommendedRelationKeys)
+	defaultRecHiddenRelIds := buildRelationIds(defaultHiddenRelationKeys)
 
 	for _, tc := range []struct {
 		name     string
@@ -54,7 +55,7 @@ func TestFillRecommendedRelations(t *testing.T) {
 		{
 			"intersect both with featured and system",
 			[]string{bundle.RelationKeyBacklinks.BundledURL(), bundle.RelationKeyAddedDate.BundledURL(), bundle.RelationKeyCreatedDate.BundledURL()},
-			lo.Uniq(append([]string{bundle.RelationKeyAddedDate.URL(), bundle.RelationKeyCreatedDate.URL()}, defaultRecRelIds...)),
+			lo.Uniq(append([]string{bundle.RelationKeyCreatedDate.URL()}, defaultRecRelIds...)),
 		},
 		{
 			"exclude description",
@@ -76,7 +77,8 @@ func TestFillRecommendedRelations(t *testing.T) {
 			assert.False(t, isAlreadyFilled)
 			assert.Equal(t, tc.expected, details.GetStringList(bundle.RelationKeyRecommendedRelations))
 			assert.Equal(t, defaultRecFeatRelIds, details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations))
-			assert.Len(t, keys, len(tc.expected)+3)
+			assert.Equal(t, defaultRecHiddenRelIds, details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations))
+			assert.Len(t, keys, len(tc.expected)+3+8) // 3 featured and 8 hidden
 		})
 	}
 
@@ -135,7 +137,8 @@ func TestFillRecommendedRelations(t *testing.T) {
 			assert.False(t, isAlreadyFilled)
 			assert.Equal(t, tc.expected, details.GetStringList(bundle.RelationKeyRecommendedRelations))
 			assert.Equal(t, defaultRecFeatRelIds, details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations))
-			assert.Len(t, keys, len(tc.expected)+3)
+			assert.Equal(t, defaultRecHiddenRelIds, details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations))
+			assert.Len(t, keys, len(tc.expected)+3+8) // 3 featured and 8 hidden
 		})
 	}
 
@@ -158,17 +161,15 @@ func TestFillRecommendedRelations(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.False(t, isAlreadyFilled)
-		assert.Equal(t, append([]string{
-			bundle.RelationKeyOrigin.URL(),
-			bundle.RelationKeyAddedDate.URL(),
-		}, buildRelationIds(defaultRecommendedRelationKeys)...), details.GetStringList(bundle.RelationKeyRecommendedRelations))
+		assert.Equal(t, buildRelationIds(defaultRecommendedRelationKeys), details.GetStringList(bundle.RelationKeyRecommendedRelations))
 		assert.Equal(t, defaultRecFeatRelIds, details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations))
+		assert.Equal(t, defaultRecHiddenRelIds, details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations))
 		assert.Equal(t, []string{
 			bundle.RelationKeyFileExt.URL(),
 			bundle.RelationKeyCameraIso.URL(),
 			bundle.RelationKeyAperture.URL(),
 		}, details.GetStringList(bundle.RelationKeyRecommendedFileRelations))
-		assert.Len(t, keys, 11)
+		assert.Len(t, keys, 17)
 	})
 }
 

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
@@ -193,6 +193,7 @@ func checkRecommendedRelations(
 		bundle.RelationKeyRecommendedRelations,
 		bundle.RelationKeyRecommendedFeaturedRelations,
 		bundle.RelationKeyRecommendedFileRelations,
+		bundle.RelationKeyRecommendedHiddenRelations,
 	} {
 		localIds := current.GetStringList(key)
 		newIds := details.GetStringList(key)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4823/provide-list-of-fields-to-support-toggle-inside-the-sidebar-and-file

1. Default list of hidden recommended relations for new types should include:

- Last modified date
- Last modified by
- Last opened date
- Added date
- Source
- Source object
- Import Type
- Origin 

2. Include all types of recommended relations to export and to system objects revisor check