### PR TITLE
GO-5000 add `ANYTYPE_LOCAL_PUBLISH_DIR` to override publish to server

### DIFF
--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -194,8 +194,16 @@ func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, u
 		return err
 	}
 
-	if err := s.publishToServer(ctx, spaceId, pageId, uri, version, tempPublishDir); err != nil {
-		return err
+	if localPublishDir := os.Getenv("ANYTYPE_LOCAL_PUBLISH_DIR"); localPublishDir != "" {
+		err := os.CopyFS(localPublishDir, os.DirFS(tempPublishDir))
+		if err != nil {
+			log.Error("publishing to local dir error", zap.Error(err))
+			return err
+		}
+	} else {
+		if err := s.publishToServer(ctx, spaceId, pageId, uri, version, tempPublishDir); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Enables local dev publishing flow without publish sever via standalone cli renderer.

usage:

1. set the env var to e.g. renderer/test_snapshots/test-me 
`export ANYTYPE_LOCAL_PUBLISH_DIR=/home/zarkone/anytype/anytype-publish-renderer/test_snapshots/test-me`
Run the client with this env and publish a page. Make sure `test-me` was created with `index.json.gz` inside.

3. in renderer, adjust Makefile SNAPSHOT_PATH accordingly:
 `SNAPSHOT_PATH:=./test_snapshots/test-me`

4. `make render` 
it will create `index.html` in renderer root

5. launch a static web server in renderer root:
```
cd /home/zarkone/anytype/anytype-publish-renderer/
python -m http.server 8011
```

6. Open http://localhost:8011 in browser
