### PR TITLE
GO-5017: fix export of unsplash images

### DIFF
--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -1127,7 +1127,7 @@ func (s *State) FileRelationKeys() []domain.RelationKey {
 		}
 		if rel.Key == bundle.RelationKeyCoverId.String() {
 			coverType := s.Details().GetInt64(bundle.RelationKeyCoverType)
-			if (coverType == 1 || coverType == 4) && slice.FindPos(keys, domain.RelationKey(rel.Key)) == -1 {
+			if (coverType == 1 || coverType == 4 || coverType == 5) && slice.FindPos(keys, domain.RelationKey(rel.Key)) == -1 {
 				keys = append(keys, domain.RelationKey(rel.Key))
 			}
 		}

--- a/core/block/editor/state/state_test.go
+++ b/core/block/editor/state/state_test.go
@@ -2943,6 +2943,23 @@ func TestState_FileRelationKeys(t *testing.T) {
 		// then
 		assert.Len(t, keys, 0)
 	})
+	t.Run("unsplash cover", func(t *testing.T) {
+		// given
+		s := &State{
+			relationLinks: pbtypes.RelationLinks{
+				{Key: bundle.RelationKeyCoverId.String()},
+			},
+			details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyCoverType: domain.Int64(5),
+			}),
+		}
+
+		// when
+		keys := s.FileRelationKeys()
+
+		// then
+		assert.Len(t, keys, 1)
+	})
 }
 
 func TestState_AddRelationLinks(t *testing.T) {

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -378,7 +378,7 @@ var (
 		RelationKeyCoverType: {
 
 			DataSource:       model.Relation_details,
-			Description:      "1-image, 2-color, 3-gradient, 4-prebuilt bg image. Value stored in coverId",
+			Description:      "1-image, 2-color, 3-gradient, 4-prebuilt bg image, 5 - unsplash image. Value stored in coverId",
 			Format:           model.RelationFormat_number,
 			Hidden:           true,
 			Id:               "_brcoverType",


### PR DESCRIPTION
Handle unsplash `coverType` (5) in `FileRelationKeys()` function