### PR TITLE
GO-5047: Space Member is not displayed in Created by/last modified by

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -859,6 +859,7 @@ func (e *exportContext) addNestedObject(id string, nestedDocs map[string]*Doc) {
 			Collection:               true,
 			NoHiddenBundledRelations: true,
 			NoBackLinks:              !e.includeBackLinks,
+			CreatorModifierWorkspace: true,
 		})
 		return nil
 	})


### PR DESCRIPTION
Use `CreatorModifierWorkspace` for dependent objects, so we can extract participants from according details