### PR TITLE
GO-5020 Inject resolvedLayout on HistoryShow

### DIFF
--- a/core/history/history.go
+++ b/core/history/history.go
@@ -93,7 +93,7 @@ func (h *history) Show(id domain.FullID, versionID string) (bs *model.ObjectView
 	}
 
 	if err = h.injectLocalDetails(s, id, space); err != nil {
-		return nil, nil, fmt.Errorf("failed to inject local details to state: %v", err)
+		return nil, nil, fmt.Errorf("failed to inject local details to state: %w", err)
 	}
 
 	details, err := h.buildDetails(s, space)
@@ -542,6 +542,7 @@ func (h *history) treeWithId(id domain.FullID, versionId string, includeBeforeId
 		return
 	}
 
+	// nolint:gosec
 	sbt = coresb.SmartBlockType(payload.SmartBlockType)
 	return
 }

--- a/core/history/history.go
+++ b/core/history/history.go
@@ -18,7 +18,7 @@ import (
 	"github.com/zeebo/blake3"
 
 	"github.com/anyproto/anytype-heart/core/block/cache"
-	smartblock2 "github.com/anyproto/anytype-heart/core/block/editor/smartblock"
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	history2 "github.com/anyproto/anytype-heart/core/block/history"
 	"github.com/anyproto/anytype-heart/core/block/object/idresolver"
@@ -28,7 +28,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
-	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -92,13 +92,9 @@ func (h *history) Show(id domain.FullID, versionID string) (bs *model.ObjectView
 		return
 	}
 
-	s.SetDetailAndBundledRelation(bundle.RelationKeyId, domain.String(id.ObjectID))
-	s.SetDetailAndBundledRelation(bundle.RelationKeySpaceId, domain.String(id.SpaceID))
-	typeId, err := space.GetTypeIdByKey(context.Background(), s.ObjectTypeKey())
-	if err != nil {
-		return nil, nil, fmt.Errorf("get type id by key: %w", err)
+	if err = h.injectLocalDetails(s, id, space); err != nil {
+		return nil, nil, fmt.Errorf("failed to inject local details to state: %v", err)
 	}
-	s.SetDetailAndBundledRelation(bundle.RelationKeyType, domain.String(typeId))
 
 	details, err := h.buildDetails(s, space)
 	if err != nil {
@@ -521,12 +517,12 @@ func (h *history) SetVersion(id domain.FullID, versionId string) (err error) {
 	if err != nil {
 		return
 	}
-	return cache.Do(h.picker, id.ObjectID, func(sb smartblock2.SmartBlock) error {
+	return cache.Do(h.picker, id.ObjectID, func(sb smartblock.SmartBlock) error {
 		return history2.ResetToVersion(sb, s)
 	})
 }
 
-func (h *history) treeWithId(id domain.FullID, versionId string, includeBeforeId bool) (ht objecttree.HistoryTree, sbt smartblock.SmartBlockType, err error) {
+func (h *history) treeWithId(id domain.FullID, versionId string, includeBeforeId bool) (ht objecttree.HistoryTree, sbt coresb.SmartBlockType, err error) {
 	heads := h.retrieveHeads(versionId)
 	spc, err := h.spaceService.Get(context.Background(), id.SpaceID)
 	if err != nil {
@@ -546,11 +542,13 @@ func (h *history) treeWithId(id domain.FullID, versionId string, includeBeforeId
 		return
 	}
 
-	sbt = smartblock.SmartBlockType(payload.SmartBlockType)
+	sbt = coresb.SmartBlockType(payload.SmartBlockType)
 	return
 }
 
-func (h *history) buildState(id domain.FullID, versionId string) (st *state.State, sbType smartblock.SmartBlockType, ver *pb.RpcHistoryVersion, err error) {
+func (h *history) buildState(id domain.FullID, versionId string) (
+	st *state.State, sbType coresb.SmartBlockType, ver *pb.RpcHistoryVersion, err error,
+) {
 	tree, sbType, err := h.treeWithId(id, versionId, true)
 	if err != nil {
 		return
@@ -575,4 +573,51 @@ func (h *history) buildState(id domain.FullID, versionId string) (st *state.Stat
 		}
 	}
 	return
+}
+
+func (h *history) injectLocalDetails(s *state.State, id domain.FullID, space clientspace.Space) error {
+	s.SetDetailAndBundledRelation(bundle.RelationKeyId, domain.String(id.ObjectID))
+	s.SetDetailAndBundledRelation(bundle.RelationKeySpaceId, domain.String(id.SpaceID))
+	typeId, err := space.GetTypeIdByKey(context.Background(), s.ObjectTypeKey())
+	if err != nil {
+		return fmt.Errorf("get type id by key: %w", err)
+	}
+	s.SetDetailAndBundledRelation(bundle.RelationKeyType, domain.String(typeId))
+
+	rawValue := s.Details().Get(bundle.RelationKeyLayout)
+	if rawValue.Ok() {
+		s.SetDetailAndBundledRelation(bundle.RelationKeyResolvedLayout, rawValue)
+		return nil
+	}
+
+	typeObjectId := s.LocalDetails().GetString(bundle.RelationKeyType)
+	if typeObjectId == "" {
+		if currentValue := s.LocalDetails().Get(bundle.RelationKeyResolvedLayout); currentValue.Ok() {
+			return nil
+		}
+		log.Errorf("failed to find id of object type. Falling back to basic layout")
+		s.SetDetailAndBundledRelation(bundle.RelationKeyResolvedLayout, domain.Int64(int64(model.ObjectType_basic)))
+		return nil
+	}
+
+	if currentValue := s.LocalDetails().Get(bundle.RelationKeyResolvedLayout); currentValue.Ok() {
+		return nil
+	}
+
+	records, err := h.objectStore.SpaceIndex(id.SpaceID).QueryByIds([]string{typeObjectId})
+	if err != nil || len(records) != 1 {
+		log.Errorf("failed to query object %s: %v. Fallback to basic layout", typeObjectId, err)
+		s.SetDetailAndBundledRelation(bundle.RelationKeyResolvedLayout, domain.Int64(int64(model.ObjectType_basic)))
+		return nil
+	}
+	rawValue = records[0].Details.Get(bundle.RelationKeyRecommendedLayout)
+
+	if !rawValue.Ok() {
+		log.Errorf("failed to get recommended layout from details of type. Fallback to basic layout")
+		s.SetDetailAndBundledRelation(bundle.RelationKeyResolvedLayout, domain.Int64(int64(model.ObjectType_basic)))
+		return nil
+	}
+
+	s.SetDetailAndBundledRelation(bundle.RelationKeyResolvedLayout, rawValue)
+	return nil
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5020/version-history-and-resolvedlayout

On HistoryShow we should inject `resolvedLayout` in details of smartblock's ObjectView along with `typeId` and `spaceId`, as all clients rely on `resolvedLayout` value when rendering object