### PR TITLE
GO-4320 Revise createdBy objectTypes

### DIFF
--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "7e14cc433fd3903623ab8f25cfdcfea52317aa59aee7b0925f1ba68afe46c5f5"
+const RelationChecksum = "728a1bc7031c451a7d4f3c9ce4fb0eb1cbad0c01b3bfa5b2efae3d98081d0b2c"
 const (
 	RelationKeyTag                       domain.RelationKey = "tag"
 	RelationKeyCamera                    domain.RelationKey = "camera"
@@ -439,9 +439,10 @@ var (
 			Key:              "creator",
 			MaxCount:         1,
 			Name:             "Created by",
+			ObjectTypes:      []string{TypePrefix + "participant"},
 			ReadOnly:         true,
 			ReadOnlyRelation: true,
-			Revision:         1,
+			Revision:         2,
 			Scope:            model.Relation_type,
 		},
 		RelationKeyDefaultTemplateId: {

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -403,7 +403,10 @@
     "name": "Created by",
     "readonly": true,
     "source": "derived",
-    "revision": 1
+    "revision": 2,
+    "objectTypes": [
+      "participant"
+    ]
   },
   {
     "description": "Recommended layout for new templates and objects of specific objec",

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser_test.go
@@ -305,4 +305,27 @@ func TestReviseSystemObject(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, toRevise)
 	})
+
+	t.Run("relationFormatObjectTypes list is updated", func(t *testing.T) {
+		// given
+		rel := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyRevision:                  domain.Int64(bundle.MustGetRelation(bundle.RelationKeyCreator).Revision - 1),
+			bundle.RelationKeySourceObject:              domain.String("_brcreator"),
+			bundle.RelationKeyUniqueKey:                 domain.String("rel-creator"),
+			bundle.RelationKeyRelationFormatObjectTypes: domain.StringList([]string{}),
+		})
+		space := mock_space.NewMockSpace(t)
+		space.EXPECT().DoCtx(mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
+		space.EXPECT().Id().Times(1).Return("")
+		space.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, key domain.UniqueKey) (string, error) {
+			return addr.RelationKeyToIdPrefix + key.InternalKey(), nil
+		}).Maybe()
+
+		// when
+		toRevise, err := reviseObject(ctx, log, space, rel)
+
+		// then
+		assert.NoError(t, err)
+		assert.True(t, toRevise)
+	})
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4320/the-relation-created-by-should-only-display-the-space-member-type

- refactor relationFormatObjectTypes detail check in SystemObjectReviser
- set Participant as relationFormatObjectType of CreatedBy relation