### PR TITLE
GO-5103 Inject layout in smartblock

### DIFF
--- a/core/block/editor/smartblock/dependencies_test.go
+++ b/core/block/editor/smartblock/dependencies_test.go
@@ -63,6 +63,7 @@ func TestDependenciesSubscription(t *testing.T) {
 			bundle.RelationKeyId:      domain.String(mainObjId),
 			bundle.RelationKeySpaceId: domain.String(testSpaceId),
 			bundle.RelationKeyName:    domain.String("Main object"),
+			bundle.RelationKeyLayout:  domain.Int64(int64(model.ObjectType_todo)),
 		})
 
 		fx.Doc.(*state.State).SetDetails(objDetails)
@@ -79,6 +80,7 @@ func TestDependenciesSubscription(t *testing.T) {
 						bundle.RelationKeyId.String():      pbtypes.String(mainObjId),
 						bundle.RelationKeySpaceId.String(): pbtypes.String(testSpaceId),
 						bundle.RelationKeyName.String():    pbtypes.String("Main object"),
+						bundle.RelationKeyLayout.String():  pbtypes.Int64(int64(model.ObjectType_todo)),
 					},
 				},
 			},

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -312,7 +312,7 @@ func (sb *smartBlock) Type() smartblock.SmartBlockType {
 }
 
 func (sb *smartBlock) ObjectTypeID() string {
-	return sb.Doc.Details().GetString(bundle.RelationKeyType)
+	return sb.Doc.LocalDetails().GetString(bundle.RelationKeyType)
 }
 
 func (sb *smartBlock) Init(ctx *InitContext) (err error) {

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1387,6 +1387,7 @@ func (sb *smartBlock) injectLayout(details *domain.Details) {
 	layout := model.ObjectType_basic // fallback
 	records, err := sb.objectStore.SpaceIndex(sb.SpaceID()).QueryByIds([]string{sb.ObjectTypeID()})
 	if err == nil && len(records) != 0 {
+		// nolint:gosec
 		layout = model.ObjectTypeLayout(records[0].Details.GetInt64(bundle.RelationKeyRecommendedLayout))
 	}
 	details.SetInt64(bundle.RelationKeyLayout, int64(layout))


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5103/inject-layout-in-objectshow-and-indexation

We should inject layout to objects missing this detail, as we are going to get rid of layout in primitives and must support backward compatibility for objects