### PR TITLE
Include hidden and file relations when calculating conflicts

### DIFF
--- a/core/block/detailservice/relations.go
+++ b/core/block/detailservice/relations.go
@@ -103,11 +103,12 @@ func (s *service) ObjectTypeListConflictingRelations(spaceId, typeObjectId strin
 		return nil, fmt.Errorf("failed to query object type, expected 1 record")
 	}
 
+	details := records[0].Details
 	allRecommendedRelations := lo.Uniq(slices.Concat(
-		records[0].Details.GetStringList(bundle.RelationKeyRecommendedRelations),
-		records[0].Details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations),
-		records[0].Details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations),
-		records[0].Details.GetStringList(bundle.RelationKeyRecommendedFileRelations),
+		details.GetStringList(bundle.RelationKeyRecommendedRelations),
+		details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations),
+		details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations),
+		details.GetStringList(bundle.RelationKeyRecommendedFileRelations),
 	))
 
 	allRelationKeys := make([]string, 0, len(allRecommendedRelations))

--- a/core/block/detailservice/relations.go
+++ b/core/block/detailservice/relations.go
@@ -103,9 +103,12 @@ func (s *service) ObjectTypeListConflictingRelations(spaceId, typeObjectId strin
 		return nil, fmt.Errorf("failed to query object type, expected 1 record")
 	}
 
-	recommendedRelations := records[0].Details.GetStringList(bundle.RelationKeyRecommendedRelations)
-	recommendedFeaturedRelations := records[0].Details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations)
-	allRecommendedRelations := lo.Uniq(append(recommendedRelations, recommendedFeaturedRelations...))
+	allRecommendedRelations := lo.Uniq(slices.Concat(
+		records[0].Details.GetStringList(bundle.RelationKeyRecommendedRelations),
+		records[0].Details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations),
+		records[0].Details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations),
+		records[0].Details.GetStringList(bundle.RelationKeyRecommendedFileRelations),
+	))
 
 	allRelationKeys := make([]string, 0, len(allRecommendedRelations))
 	err = s.store.SpaceIndex(spaceId).QueryIterate(database.Query{Filters: []database.FilterRequest{

--- a/core/block/detailservice/relations_test.go
+++ b/core/block/detailservice/relations_test.go
@@ -322,6 +322,8 @@ func TestService_ObjectTypeListConflictingRelations(t *testing.T) {
 				bundle.RelationKeyRecommendedRelations: domain.StringList([]string{
 					bundle.RelationKeyAssignee.URL(),
 					bundle.RelationKeyDone.URL(),
+				}),
+				bundle.RelationKeyRecommendedHiddenRelations: domain.StringList([]string{
 					bundle.RelationKeyCreatedDate.URL(),
 				}),
 			},


### PR DESCRIPTION
While evaluating conflicting relations we should take into account all 4 lists of recommended relations