### PR TITLE
GO-5021 Default template id logic change

### DIFF
--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -56,7 +56,7 @@ type (
 	}
 
 	templateService interface {
-		CreateTemplateStateWithDetails(templateId string, details *domain.Details) (st *state.State, err error)
+		CreateTemplateStateWithDetails(templateId string, details *domain.Details, withTemplateValidation bool) (st *state.State, err error)
 	}
 )
 
@@ -160,7 +160,7 @@ func (s *service) CreateBookmarkObject(
 		objectDetails = rec.Details
 	} else {
 		details.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_bookmark))
-		creationState, err := s.templateService.CreateTemplateStateWithDetails("", details)
+		creationState, err := s.templateService.CreateTemplateStateWithDetails("", details, false)
 		if err != nil {
 			log.Errorf("failed to build state for bookmark: %v", err)
 		}

--- a/core/block/bookmark/bookmark_service_test.go
+++ b/core/block/bookmark/bookmark_service_test.go
@@ -238,7 +238,7 @@ type templateServiceMock struct {
 	t *testing.T
 }
 
-func (m *templateServiceMock) CreateTemplateStateWithDetails(templateId string, details *domain.Details) (st *state.State, err error) {
+func (m *templateServiceMock) CreateTemplateStateWithDetails(templateId string, details *domain.Details, _ bool) (st *state.State, err error) {
 	assert.Empty(m.t, templateId)
 	assert.Equal(m.t, int64(model.ObjectType_bookmark), details.GetInt64(bundle.RelationKeyResolvedLayout))
 	return state.NewDoc("", nil).NewState(), nil

--- a/core/block/delete.go
+++ b/core/block/delete.go
@@ -40,7 +40,7 @@ func (s *Service) DeleteObjectByFullID(id domain.FullID) error {
 		coresb.SmartBlockTypeRelation,
 		coresb.SmartBlockTypeRelationOption,
 		coresb.SmartBlockTypeTemplate:
-		err = s.deleteDerivedObject(id, spc)
+		err = s.deleteDerivedObject(id, sbType, spc)
 	case coresb.SmartBlockTypeSubObject:
 		return fmt.Errorf("subobjects deprecated")
 	case coresb.SmartBlockTypeFileObject:
@@ -64,16 +64,16 @@ func (s *Service) DeleteObjectByFullID(id domain.FullID) error {
 	return nil
 }
 
-func (s *Service) deleteDerivedObject(id domain.FullID, spc clientspace.Space) (err error) {
-	var (
-		relationKey string
-		sbType      coresb.SmartBlockType
-	)
+func (s *Service) deleteDerivedObject(id domain.FullID, sbType coresb.SmartBlockType, spc clientspace.Space) (err error) {
+	var relationKey, targetTypeId string
 	err = spc.Do(id.ObjectID, func(b smartblock.SmartBlock) error {
 		st := b.NewState()
 		st.SetDetailAndBundledRelation(bundle.RelationKeyIsUninstalled, domain.Bool(true))
-		if sbType == coresb.SmartBlockTypeRelation {
+		switch sbType {
+		case coresb.SmartBlockTypeRelation:
 			relationKey = st.Details().GetString(bundle.RelationKeyRelationKey)
+		case coresb.SmartBlockTypeTemplate:
+			targetTypeId = st.Details().GetString(bundle.RelationKeyTargetObjectType)
 		}
 		return b.Apply(st)
 	})
@@ -84,10 +84,14 @@ func (s *Service) deleteDerivedObject(id domain.FullID, spc clientspace.Space) (
 	if err != nil {
 		return fmt.Errorf("on delete: %w", err)
 	}
-	if sbType == coresb.SmartBlockTypeRelation {
-		err := s.deleteRelationOptions(id.SpaceID, relationKey)
-		if err != nil {
+	switch sbType {
+	case coresb.SmartBlockTypeRelation:
+		if err = s.deleteRelationOptions(id.SpaceID, relationKey); err != nil {
 			return fmt.Errorf("failed to delete relation options of deleted relation: %w", err)
+		}
+	case coresb.SmartBlockTypeTemplate:
+		if err = s.resetDefaultTemplateId(id, targetTypeId, spc); err != nil {
+			return fmt.Errorf("failed to reset default template id: %w", err)
 		}
 	}
 	return nil
@@ -118,6 +122,60 @@ func (s *Service) deleteRelationOptions(spaceId string, relationKey string) erro
 		}
 	}
 	return nil
+}
+
+func (s *Service) resetDefaultTemplateId(templateId domain.FullID, typeId string, spc clientspace.Space) error {
+	spaceId := templateId.SpaceID
+	records, err := s.objectStore.SpaceIndex(spaceId).QueryByIds([]string{typeId})
+	if err != nil {
+		return fmt.Errorf("failed to query type object: %w", err)
+	}
+	if len(records) != 1 {
+		return fmt.Errorf("failed to query type object: 1 record expected")
+	}
+	if records[0].Details.GetString(bundle.RelationKeyDefaultTemplateId) != templateId.ObjectID {
+		// template that is about to be deleted was not set as default for type, so we do nothing
+		return nil
+	}
+
+	ctx := context.Background()
+	templateTypeId, err := spc.GetTypeIdByKey(ctx, bundle.TypeKeyTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to derive template type id from space: %w", err)
+	}
+
+	if records, err = s.objectStore.SpaceIndex(spaceId).Query(database.Query{
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyType,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.String(templateTypeId),
+			},
+			{
+				RelationKey: bundle.RelationKeyTargetObjectType,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.String(typeId),
+			},
+		},
+		Sorts: []database.SortRequest{{
+			RelationKey: bundle.RelationKeyLastModifiedDate,
+			Type:        model.BlockContentDataviewSort_Desc,
+		}},
+	}); err != nil {
+		return fmt.Errorf("failed to query templates: %w", err)
+	}
+
+	// in case no templates were found we explicitly set empty default template id to type object
+	newTemplateId := ""
+	if len(records) != 0 {
+		newTemplateId = records[0].Details.GetString(bundle.RelationKeyId)
+	}
+
+	return spc.Do(typeId, func(sb smartblock.SmartBlock) error {
+		st := sb.NewState()
+		st.SetDetail(bundle.RelationKeyDefaultTemplateId, domain.String(newTemplateId))
+		return sb.Apply(st)
+	})
 }
 
 func (s *Service) DeleteObject(objectId string) (err error) {

--- a/core/block/editor/basic/extract_objects.go
+++ b/core/block/editor/basic/extract_objects.go
@@ -22,7 +22,7 @@ type ObjectCreator interface {
 }
 
 type TemplateStateCreator interface {
-	CreateTemplateStateWithDetails(templateId string, details *domain.Details) (*state.State, error)
+	CreateTemplateStateWithDetails(templateId string, details *domain.Details, withTemplateValidation bool) (*state.State, error)
 	CreateTemplateStateFromSmartBlock(sb smartblock.SmartBlock, details *domain.Details) *state.State
 }
 
@@ -86,7 +86,7 @@ func (bs *basic) prepareObjectState(
 		return creator.CreateTemplateStateFromSmartBlock(bs, details), nil
 	}
 
-	return creator.CreateTemplateStateWithDetails(req.TemplateId, details)
+	return creator.CreateTemplateStateWithDetails(req.TemplateId, details, true)
 }
 
 func (bs *basic) prepareTargetObjectDetails(

--- a/core/block/editor/basic/extract_objects_test.go
+++ b/core/block/editor/basic/extract_objects_test.go
@@ -52,7 +52,7 @@ func (tts testTemplateService) AddTemplate(id string, st *state.State) {
 	tts.templates[id] = st
 }
 
-func (tts testTemplateService) CreateTemplateStateWithDetails(id string, details *domain.Details) (st *state.State, err error) {
+func (tts testTemplateService) CreateTemplateStateWithDetails(id string, details *domain.Details, _ bool) (st *state.State, err error) {
 	if id == "" {
 		st = state.NewDoc("", nil).NewState()
 		template.InitTemplate(st, template.WithEmpty,

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -27,6 +27,7 @@ type (
 	templateService interface {
 		CreateTemplateStateWithDetails(templateId string, details *domain.Details) (st *state.State, err error)
 		TemplateCloneInSpace(space clientspace.Space, id string) (templateId string, err error)
+		SetDefaultTemplateInType(ctx context.Context, typeId, templateId string) error
 	}
 
 	bookmarkService interface {
@@ -171,7 +172,11 @@ func (s *service) createTemplate(
 	if err != nil {
 		return
 	}
-	return s.CreateSmartBlockFromStateInSpace(ctx, space, []domain.TypeKey{req.ObjectTypeKey}, createState)
+	id, resultDetails, err = s.CreateSmartBlockFromStateInSpace(ctx, space, []domain.TypeKey{req.ObjectTypeKey}, createState)
+	if e := s.templateService.SetDefaultTemplateInType(ctx, target, id); e != nil {
+		log.Errorf("failed to set defaultTemplateId to type: %v", e)
+	}
+	return
 }
 
 func (s *service) createCommonObject(

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -25,7 +25,7 @@ import (
 
 type (
 	templateService interface {
-		CreateTemplateStateWithDetails(templateId string, details *domain.Details) (st *state.State, err error)
+		CreateTemplateStateWithDetails(templateId string, details *domain.Details, withTemplateValidation bool) (st *state.State, err error)
 		TemplateCloneInSpace(space clientspace.Space, id string) (templateId string, err error)
 		SetDefaultTemplateInType(ctx context.Context, typeId, templateId string) error
 	}
@@ -168,7 +168,7 @@ func (s *service) createTemplate(
 	details.Set(bundle.RelationKeySpaceId, domain.String(space.Id()))
 	details.Set(bundle.RelationKeyType, domain.String(typeId))
 
-	createState, err := s.templateService.CreateTemplateStateWithDetails("", details)
+	createState, err := s.templateService.CreateTemplateStateWithDetails("", details, false)
 	if err != nil {
 		return
 	}
@@ -197,7 +197,7 @@ func (s *service) createCommonObject(
 	details.Set(bundle.RelationKeyType, domain.String(typeId))
 	details.Set(bundle.RelationKeyResolvedLayout, domain.Int64(layout))
 
-	createState, err := s.templateService.CreateTemplateStateWithDetails(req.TemplateId, details)
+	createState, err := s.templateService.CreateTemplateStateWithDetails(req.TemplateId, details, true)
 	if err != nil {
 		return
 	}

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -57,7 +57,7 @@ type testTemplateService struct {
 	templates map[string]*state.State
 }
 
-func (tts *testTemplateService) CreateTemplateStateWithDetails(templateId string, details *domain.Details) (*state.State, error) {
+func (tts *testTemplateService) CreateTemplateStateWithDetails(templateId string, details *domain.Details, withTemplateValidation bool) (*state.State, error) {
 	if tts.templates != nil {
 		if st, found := tts.templates[templateId]; found {
 			return st, nil

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -72,6 +72,10 @@ func (tts *testTemplateService) TemplateCloneInSpace(space clientspace.Space, id
 	return "", nil
 }
 
+func (tts *testTemplateService) SetDefaultTemplateInType(ctx context.Context, typeId, templateId string) error {
+	return nil
+}
+
 func TestService_CreateObject(t *testing.T) {
 	t.Run("template creation", func(t *testing.T) {
 		// given

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -113,7 +113,7 @@ type builtinObjects interface {
 }
 
 type templateService interface {
-	CreateTemplateStateWithDetails(templateId string, details *domain.Details) (*state.State, error)
+	CreateTemplateStateWithDetails(templateId string, details *domain.Details, withTemplateValidation bool) (*state.State, error)
 	CreateTemplateStateFromSmartBlock(sb smartblock.SmartBlock, details *domain.Details) *state.State
 }
 

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/anyproto/anytype-heart/core/block/cache"
+	"github.com/anyproto/anytype-heart/core/block/editor/basic"
 	"github.com/anyproto/anytype-heart/core/block/editor/converter"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
@@ -58,6 +59,8 @@ type Service interface {
 	TemplateClone(spaceId string, id string) (templateId string, err error)
 
 	TemplateExportAll(ctx context.Context, path string) (string, error)
+
+	SetDefaultTemplateInType(ctx context.Context, typeId, templateId string) error
 
 	app.Component
 }
@@ -242,9 +245,24 @@ func (s *service) TemplateCreateFromObject(ctx context.Context, id string) (temp
 		return "", fmt.Errorf("resolve spaceId: %w", err)
 	}
 
-	templateId, _, err = s.creator.CreateSmartBlockFromState(ctx, spaceId, objectTypeKeys, st)
+	spc, err := s.spaceService.Get(ctx, spaceId)
+	if err != nil {
+		return "", fmt.Errorf("get space: %w", err)
+	}
+
+	templateId, _, err = s.creator.CreateSmartBlockFromStateInSpace(ctx, spc, objectTypeKeys, st)
 	if err != nil {
 		return
+	}
+
+	typeId, err2 := spc.GetTypeIdByKey(ctx, objectTypeKeys[0])
+	if err2 != nil {
+		log.Errorf("failed to get typeId: %v", err2)
+		return
+	}
+
+	if err2 = s.SetDefaultTemplateInType(ctx, typeId, templateId); err != nil {
+		log.Errorf("failed to set defaultTemplateId to type: %v", err2)
 	}
 	return
 }
@@ -336,6 +354,23 @@ func (s *service) TemplateExportAll(ctx context.Context, path string) (string, e
 		Zip:       true,
 	})
 	return path, err
+}
+
+// SetDefaultTemplateInType sets defaultTemplateId to type object in case it is empty
+func (s *service) SetDefaultTemplateInType(ctx context.Context, typeId, templateId string) error {
+	return cache.DoContext(s.picker, ctx, typeId, func(sb smartblock.SmartBlock) error {
+		if sb.Details().GetString(bundle.RelationKeyDefaultTemplateId) != "" {
+			return nil
+		}
+		ds := sb.(basic.DetailsSettable)
+		if ds == nil {
+			return fmt.Errorf("cannot set defaultTemplateId as type object does not support DetailsSettable interface")
+		}
+		return ds.SetDetails(nil, []domain.Detail{{
+			Key:   bundle.RelationKeyDefaultTemplateId,
+			Value: domain.String(templateId),
+		}}, false)
+	})
 }
 
 func (s *service) createBlankTemplateState(layout model.ObjectTypeLayout, details *domain.Details) (st *state.State) {

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -133,11 +133,11 @@ func (s *service) resolveValidTemplateId(templateId string, details *domain.Deta
 
 	spc, err := s.spaceService.Get(ctx, spaceId)
 	if err != nil {
-		return "", fmt.Errorf("failed to get space: %v", err)
+		return "", fmt.Errorf("failed to get space: %w", err)
 	}
 	templateTypeId, err := spc.GetTypeIdByKey(ctx, bundle.TypeKeyTemplate)
 	if err != nil {
-		return "", fmt.Errorf("failed to get template type id from space: %v", err)
+		return "", fmt.Errorf("failed to get template type id from space: %w", err)
 	}
 
 	records, err := s.store.SpaceIndex(spaceId).Query(database.Query{
@@ -160,7 +160,7 @@ func (s *service) resolveValidTemplateId(templateId string, details *domain.Deta
 	})
 
 	if err != nil {
-		return "", fmt.Errorf("failed to query templates: %v", err)
+		return "", fmt.Errorf("failed to query templates: %w", err)
 	}
 
 	if len(records) == 0 {

--- a/core/block/template/service_test.go
+++ b/core/block/template/service_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
-	mock_space "github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
+	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
@@ -53,7 +53,7 @@ func (t *testPicker) Init(_ *app.App) error { return nil }
 
 func (t *testPicker) Name() string { return "" }
 
-func NewTemplateTest(templateName, typeKey string) smartblock.SmartBlock {
+func newTemplateTest(templateName, typeKey string) smartblock.SmartBlock {
 	sb := smarttest.New(templateName)
 	details := []domain.Detail{
 		{
@@ -112,7 +112,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 
 	t.Run("empty page name", func(t *testing.T) {
 		// given
-		tmpl := NewTemplateTest(templateName, "")
+		tmpl := newTemplateTest(templateName, "")
 		s := service{picker: &testPicker{sb: tmpl}}
 
 		// when
@@ -132,7 +132,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 			t.Run(fmt.Sprintf("custom page name and description - "+
 				"when template is %s and target detail is %s", templateName, addedDetail), func(t *testing.T) {
 				// given
-				tmpl := NewTemplateTest(templateName, "")
+				tmpl := newTemplateTest(templateName, "")
 				s := service{picker: &testPicker{sb: tmpl}, converter: converter.NewLayoutConverter()}
 				details := domain.NewDetails()
 				details.Set(bundle.RelationKeyName, domain.String(addedDetail))
@@ -158,7 +158,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 	} {
 		t.Run("create blank template in case "+testCase[0], func(t *testing.T) {
 			// given
-			tmpl := NewTemplateTest(testCase[1], "")
+			tmpl := newTemplateTest(testCase[1], "")
 			s := service{picker: &testPicker{sb: tmpl}, converter: converter.NewLayoutConverter()}
 
 			// when
@@ -174,7 +174,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 
 	t.Run("requested smartblock is not a template", func(t *testing.T) {
 		// given
-		tmpl := NewTemplateTest(templateName, "")
+		tmpl := newTemplateTest(templateName, "")
 		tmpl.(*smarttest.SmartTest).Doc.(*state.State).SetObjectTypeKey(bundle.TypeKeyBook)
 		s := service{picker: &testPicker{}}
 
@@ -187,7 +187,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 
 	t.Run("template typeKey is removed", func(t *testing.T) {
 		// given
-		tmpl := NewTemplateTest(templateName, bundle.TypeKeyGoal.String())
+		tmpl := newTemplateTest(templateName, bundle.TypeKeyGoal.String())
 		s := service{picker: &testPicker{sb: tmpl}}
 
 		// when
@@ -263,7 +263,7 @@ func TestCreateTemplateStateFromSmartBlock(t *testing.T) {
 
 	t.Run("create state from template smartblock", func(t *testing.T) {
 		// given
-		tmpl := NewTemplateTest("template", bundle.TypeKeyProject.String())
+		tmpl := newTemplateTest("template", bundle.TypeKeyProject.String())
 		s := service{}
 
 		// when
@@ -380,7 +380,7 @@ func TestBuildTemplateStateFromObject(t *testing.T) {
 
 		obj.SetObjectTypes([]domain.TypeKey{bundle.TypeKeyNote})
 
-		sp := mock_space.NewMockSpace(t)
+		sp := mock_clientspace.NewMockSpace(t)
 		sp.EXPECT().GetTypeIdByKey(mock.Anything, mock.Anything).Times(1).Return(bundle.TypeKeyNote.String(), nil)
 		obj.SetSpace(sp)
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5021/default-template-logic-change

Some changes on default template handling:
1. On new template creation we check defaultTemplateId field of target type. In case it is empty new template is set as default
2. On deletion of some template we check defaultTemplateId value of target type. If we are deleting default template, last edited template is chosen as default. If no templates left for particular type, empty template is set
3. On new object creation we check if requested templateId is valid or not. In case template is empty or could not be found, last edited template of terget type is taken as origin of new object