### PR TITLE
GO-5108 Do not set restriction detail if not updated

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1415,11 +1415,12 @@ func removeInternalFlags(s *state.State) {
 }
 
 func (sb *smartBlock) setRestrictionsDetail(s *state.State) {
-	rawRestrictions := make([]float64, len(sb.Restrictions().Object))
-	for i, r := range sb.Restrictions().Object {
-		rawRestrictions[i] = float64(r)
+	currentRestrictions := restriction.NewObjectRestrictionsFromValue(s.LocalDetails().Get(bundle.RelationKeyRestrictions))
+	if currentRestrictions.Equal(sb.Restrictions().Object) {
+		return
 	}
-	s.SetLocalDetail(bundle.RelationKeyRestrictions, domain.Float64List(rawRestrictions))
+
+	s.SetLocalDetail(bundle.RelationKeyRestrictions, sb.Restrictions().Object.ToValue())
 
 	// todo: verify this logic with clients
 	if sb.Restrictions().Object.Check(model.Restrictions_Details) != nil &&

--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -3,14 +3,12 @@ package restriction
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/types"
 	"github.com/samber/lo"
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
-	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 var (
@@ -169,6 +167,16 @@ func GetRestrictionsBySBType(sbType smartblock.SmartBlockType) []int {
 
 type ObjectRestrictions []model.RestrictionsObjectRestriction
 
+func NewObjectRestrictionsFromValue(v domain.Value) ObjectRestrictions {
+	raw := v.Int64List()
+	restrictions := make(ObjectRestrictions, len(raw))
+	for i, restriction := range raw {
+		// nolint:gosec
+		restrictions[i] = model.RestrictionsObjectRestriction(restriction)
+	}
+	return restrictions
+}
+
 func (or ObjectRestrictions) Check(cr ...model.RestrictionsObjectRestriction) (err error) {
 	for _, r := range cr {
 		for _, er := range or {
@@ -198,12 +206,12 @@ func (or ObjectRestrictions) Copy() ObjectRestrictions {
 	return obj
 }
 
-func (or ObjectRestrictions) ToPB() *types.Value {
-	var ints = make([]int, len(or))
+func (or ObjectRestrictions) ToValue() domain.Value {
+	var ints = make([]int64, len(or))
 	for i, v := range or {
-		ints[i] = int(v)
+		ints[i] = int64(v)
 	}
-	return pbtypes.IntList(ints...)
+	return domain.Int64List(ints)
 }
 
 func getObjectRestrictions(rh RestrictionHolder) (r ObjectRestrictions) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5108/object-name-disappears-immediately-from-collection-sell

We should not update restrictions detail in smartblock, if it was not actually updated