### PR TITLE
GO-5134 Set description to space view

### DIFF
--- a/core/block/editor/spaceview.go
+++ b/core/block/editor/spaceview.go
@@ -257,6 +257,7 @@ var workspaceKeysToCopy = []domain.RelationKey{
 	bundle.RelationKeySpaceDashboardId,
 	bundle.RelationKeyCreatedDate,
 	bundle.RelationKeyChatId,
+	bundle.RelationKeyDescription,
 }
 
 func (s *SpaceView) GetSpaceDescription() (data spaceinfo.SpaceDescription) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5134/description-for-space-view-is-not-saved

Save description to spaceView details on Workspace object update