### PR TITLE
OPS-611 added concurrent execution logic for perftest and other tasks

### DIFF
--- a/.github/scripts/is_runner_busy.sh
+++ b/.github/scripts/is_runner_busy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# The script checks whether a runner with a specific label is busy
+
+OWNER_REPO=$1
+CHECK_LABELS=$2
+
+if [[ -z $OWNER_REPO ]]; then
+    cat <<EOF 1>&2
+Usage: $0 OWNER/REPO CHECK_LABELS
+
+example: $0 anyproto/test-concurrency "self-hosted ubuntu-latest"
+EOF
+    exit 1
+fi
+
+EXIT_CODE=0
+
+# get current runners id
+# gh api repos/anyproto/test-concurrency/actions/runs --jq '.workflow_runs[] | select(.status!="completed") | {id, name, status, created_at, html_url}'
+for RUN_ID in $(gh api repos/${OWNER_REPO}/actions/runs --jq '.workflow_runs[] | select(.status!="completed") | .id'); do
+    # get runner_name
+    LABELS=$(gh api repos/${OWNER_REPO}/actions/runs/${RUN_ID}/jobs --jq '[.jobs[].labels[]] | unique | .[]')
+    for CHECK_LABEL in $CHECK_LABELS; do
+        if echo "$LABELS" | grep -q "$CHECK_LABEL"; then
+            echo "A run='$RUN_ID' is executing on a runner with LABEL='$CHECK_LABEL' in the repository='$OWNER_REPO'" 1>&2
+            EXIT_CODE=$(( EXIT_CODE + 1 ))
+        else
+            continue
+        fi
+    done
+done
+
+exit $EXIT_CODE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,11 @@ permissions:
 
 
 jobs:
+  wait_for_perftest:
+    uses: ./.github/workflows/reusable_wait_for_perftest.yml
+
   build:
+    needs: wait_for_perftest
     runs-on: ${{ github.event_name == 'push' && 'mac-mini-org-heart' || (github.event.inputs.run-on-runner || 'mac-mini-org-heart') }}
     steps:
       - name: validate agent

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,11 @@ permissions:
   contents: 'write'
 
 jobs:
+  wait_for_perftest:
+    uses: ./.github/workflows/reusable_wait_for_perftest.yml
+
   build:
+    needs: wait_for_perftest
     runs-on: ${{ github.event.inputs.run-on-runner }}
     steps:
       - name: Install Go

--- a/.github/workflows/perftests-grafana.yml
+++ b/.github/workflows/perftests-grafana.yml
@@ -26,7 +26,11 @@ permissions:
 
 
 jobs:
+  wait_for_self_hosted_mac_mini:
+    uses: ./.github/workflows/reusable_wait_for_self_hosted_mac_mini.yml
+
   perftests-grafana:
+    needs: wait_for_self_hosted_mac_mini
     runs-on: ${{ github.event.inputs.run-on-runner || 'mac-mini-org-heart' }}
     steps:
       - name: Install Go

--- a/.github/workflows/perftests.yml
+++ b/.github/workflows/perftests.yml
@@ -31,7 +31,11 @@ permissions:
 
 
 jobs:
+  wait_for_self_hosted_mac_mini:
+    uses: ./.github/workflows/reusable_wait_for_self_hosted_mac_mini.yml
+
   perftests-macos:
+    needs: wait_for_self_hosted_mac_mini
     timeout-minutes: 60
     runs-on: 'mac-mini-org-heart'
     steps:

--- a/.github/workflows/reusable_wait_for_perftest.yml
+++ b/.github/workflows/reusable_wait_for_perftest.yml
@@ -1,0 +1,22 @@
+name: Reusable Workflow wait for perftests to finish
+
+on:
+  workflow_call:
+
+jobs:
+  wait_for_perftest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for perftests to finish
+        run: |
+          while true; do
+            RUNNING=$(gh run list --repo $GITHUB_REPOSITORY --workflow perftests.yml --workflow perftests-grafana.yml --status in_progress --json status --jq 'length')
+            if [[ "$RUNNING" -eq 0 ]]; then
+              echo "perftests is finished, proceeding with build."
+              break
+            fi
+            echo "perftests is still running. Waiting 10 seconds..."
+            sleep 10
+          done
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_wait_for_self_hosted_mac_mini.yml
+++ b/.github/workflows/reusable_wait_for_self_hosted_mac_mini.yml
@@ -1,0 +1,26 @@
+name: Reusable Workflow wait for self-hosted mac mini is free
+
+on:
+  workflow_call:
+
+jobs:
+  wait_for_self_hosted_mac_mini:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Wait for self-hosted runners to be free
+        run: |
+          while true; do
+            if .github/scripts/is_runner_busy.sh $GITHUB_REPOSITORY mac-mini-org-heart; then
+              echo "self-hosted runner 'mac-mini-org-heart' is free"
+              break
+            else
+              echo "self-hosted runner 'mac-mini-org-heart' is busy. waiting 10 seconds..."
+              sleep 10
+              continue
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/reusable_wait_for_perftest.yml
 
   unit-test:
+    needs: wait_for_perftest
     runs-on: ${{ vars.RUNNER_TEST }}
     env:
       GOPRIVATE: github.com/anyproto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ permissions:
   pull-requests: write
 
 jobs:
+  wait_for_perftest:
+    uses: ./.github/workflows/reusable_wait_for_perftest.yml
+
   unit-test:
     runs-on: ${{ vars.RUNNER_TEST }}
     env:


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [x] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
