### PR TITLE
GO-5021 Fallback to empty template

### DIFF
--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -171,11 +171,7 @@ func (s *service) createTemplate(
 	if err != nil {
 		return
 	}
-	id, resultDetails, err = s.CreateSmartBlockFromStateInSpace(ctx, space, []domain.TypeKey{req.ObjectTypeKey}, createState)
-	if e := s.templateService.SetDefaultTemplateInType(ctx, target, id); e != nil {
-		log.Errorf("failed to set defaultTemplateId to type: %v", e)
-	}
-	return
+	return s.CreateSmartBlockFromStateInSpace(ctx, space, []domain.TypeKey{req.ObjectTypeKey}, createState)
 }
 
 func (s *service) createCommonObject(

--- a/core/block/object/objectcreator/creator_test.go
+++ b/core/block/object/objectcreator/creator_test.go
@@ -71,11 +71,6 @@ func TestService_CreateObject(t *testing.T) {
 			st.SetDetails(req.Details)
 			return st, nil
 		})
-		f.templateService.EXPECT().SetDefaultTemplateInType(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, typeId string, templateId string) error {
-			assert.Equal(t, "test", templateId)
-			assert.Equal(t, bundle.TypeKeyTask.URL(), typeId)
-			return nil
-		})
 
 		f.objectStore.AddObjects(t, spaceId, []objectstore.TestObject{
 			{

--- a/core/block/template/mock_template/mock_Service.go
+++ b/core/block/template/mock_template/mock_Service.go
@@ -275,54 +275,6 @@ func (_c *MockService_ObjectApplyTemplate_Call) RunAndReturn(run func(string, st
 	return _c
 }
 
-// SetDefaultTemplateInType provides a mock function with given fields: ctx, typeId, templateId
-func (_m *MockService) SetDefaultTemplateInType(ctx context.Context, typeId string, templateId string) error {
-	ret := _m.Called(ctx, typeId, templateId)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetDefaultTemplateInType")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, typeId, templateId)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockService_SetDefaultTemplateInType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDefaultTemplateInType'
-type MockService_SetDefaultTemplateInType_Call struct {
-	*mock.Call
-}
-
-// SetDefaultTemplateInType is a helper method to define mock.On call
-//   - ctx context.Context
-//   - typeId string
-//   - templateId string
-func (_e *MockService_Expecter) SetDefaultTemplateInType(ctx interface{}, typeId interface{}, templateId interface{}) *MockService_SetDefaultTemplateInType_Call {
-	return &MockService_SetDefaultTemplateInType_Call{Call: _e.mock.On("SetDefaultTemplateInType", ctx, typeId, templateId)}
-}
-
-func (_c *MockService_SetDefaultTemplateInType_Call) Run(run func(ctx context.Context, typeId string, templateId string)) *MockService_SetDefaultTemplateInType_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MockService_SetDefaultTemplateInType_Call) Return(_a0 error) *MockService_SetDefaultTemplateInType_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockService_SetDefaultTemplateInType_Call) RunAndReturn(run func(context.Context, string, string) error) *MockService_SetDefaultTemplateInType_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // TemplateClone provides a mock function with given fields: spaceId, id
 func (_m *MockService) TemplateClone(spaceId string, id string) (string, error) {
 	ret := _m.Called(spaceId, id)

--- a/core/block/template/service.go
+++ b/core/block/template/service.go
@@ -38,7 +38,5 @@ type Service interface {
 
 	TemplateExportAll(ctx context.Context, path string) (string, error)
 
-	SetDefaultTemplateInType(ctx context.Context, typeId, templateId string) error
-
 	app.Component
 }

--- a/core/block/template/templateimpl/impl.go
+++ b/core/block/template/templateimpl/impl.go
@@ -36,10 +36,8 @@ import (
 )
 
 const (
-	CName                = "template"
-	BlankTemplateId      = "blank"
-	DefaultTemplateId    = "default"
-	LastEditedTemplateId = "lastEdited"
+	CName           = "template"
+	blankTemplateId = "blank"
 )
 
 var (
@@ -84,8 +82,7 @@ func (s *service) Init(a *app.App) error {
 }
 
 // CreateTemplateStateWithDetails creates clone of template object state with empty localDetails and updated objectTypes.
-// If withTemplateValidation=true, templateId is queried in store. If template is empty or not found, last edited template is taken.
-// Blank template is created in case template object is deleted or blank/empty templateId is provided
+// If withTemplateValidation=true, templateId is queried in store. If template is empty or not found, empty template is used
 func (s *service) CreateTemplateStateWithDetails(req templateSvc.CreateTemplateRequest) (targetState *state.State, err error) {
 	if validationErr := req.IsValid(); validationErr != nil {
 		return nil, fmt.Errorf("create template request validation error: %s", validationErr.Error())
@@ -98,7 +95,7 @@ func (s *service) CreateTemplateStateWithDetails(req templateSvc.CreateTemplateR
 		}
 	}
 	switch req.TemplateId {
-	case "", BlankTemplateId:
+	case "", blankTemplateId:
 		targetState = s.createBlankTemplateState(domain.FullID{SpaceID: req.SpaceId, ObjectID: req.TypeId}, req.Layout)
 	default:
 		targetState, err = s.createCustomTemplateState(req.TemplateId)
@@ -112,23 +109,8 @@ func (s *service) CreateTemplateStateWithDetails(req templateSvc.CreateTemplateR
 }
 
 func (s *service) resolveValidTemplateId(spaceId, templateId, typeId string) (string, error) {
-	switch templateId {
-	case BlankTemplateId:
-		return BlankTemplateId, nil
-	case DefaultTemplateId:
-		return s.getDefaultTemplateId(spaceId, typeId)
-	case LastEditedTemplateId:
-		return s.getLastEditedTemplateId(spaceId, typeId)
-	case "":
-		defaultTemplateId, err := s.getDefaultTemplateId(spaceId, typeId)
-		if err == nil && defaultTemplateId != "" {
-			return defaultTemplateId, nil
-		}
-		lastEditedTemplateId, err := s.getLastEditedTemplateId(spaceId, typeId)
-		if err == nil && lastEditedTemplateId != "" {
-			return lastEditedTemplateId, nil
-		}
-		return BlankTemplateId, nil
+	if templateId == "" {
+		return "", nil
 	}
 
 	records, err := s.queryTemplatesByType(spaceId, typeId)
@@ -137,52 +119,19 @@ func (s *service) resolveValidTemplateId(spaceId, templateId, typeId string) (st
 	}
 
 	if len(records) == 0 {
-		// if no templates presented, we should create new object with blank template
-		return BlankTemplateId, nil
+		// if no templates presented, we should use empty template
+		return "", nil
 	}
 
-	defaultTemplateId, err := s.getDefaultTemplateId(spaceId, typeId)
-	if err != nil {
-		defaultTemplateId = ""
-	}
-
-	var defaultTemplateIsValid bool
 	for _, record := range records {
 		recordId := record.Details.GetString(bundle.RelationKeyId)
 		if recordId == templateId {
 			return templateId, nil
 		}
-		if !defaultTemplateIsValid && defaultTemplateId != "" && recordId == defaultTemplateId {
-			defaultTemplateIsValid = true
-		}
 	}
 
-	// if requested templateId was not found in store, we should use default template
-	if defaultTemplateIsValid {
-		return defaultTemplateId, nil
-	}
-
-	// if default template is not set or not valid, we should use last edited template
-	return records[0].Details.GetString(bundle.RelationKeyId), nil
-}
-
-func (s *service) getDefaultTemplateId(spaceId, typeId string) (string, error) {
-	details, err := s.store.SpaceIndex(spaceId).GetDetails(typeId)
-	if err != nil {
-		return "", fmt.Errorf("failed to get details of type object from store: %w", err)
-	}
-	return details.GetString(bundle.RelationKeyDefaultTemplateId), nil
-}
-
-func (s *service) getLastEditedTemplateId(spaceId, typeId string) (string, error) {
-	records, err := s.queryTemplatesByType(spaceId, typeId)
-	if err != nil {
-		return "", fmt.Errorf("failed to query templates: %w", err)
-	}
-	if len(records) == 0 {
-		return "", nil
-	}
-	return records[0].Details.GetString(bundle.RelationKeyId), nil
+	// if requested templateId was not found in store, we should use empty template
+	return "", nil
 }
 
 // queryTemplatesByType queries templates by particular type sorted by lastModifiedDate
@@ -484,7 +433,7 @@ func (s *service) SetDefaultTemplateInType(ctx context.Context, typeId, template
 }
 
 func (s *service) createBlankTemplateState(typeId domain.FullID, layout model.ObjectTypeLayout) (st *state.State) {
-	st = state.NewDoc(BlankTemplateId, nil).NewState()
+	st = state.NewDoc(blankTemplateId, nil).NewState()
 	template.InitTemplate(st, template.WithEmpty,
 		template.WithFeaturedRelationsBlock,
 		template.WithDetail(bundle.RelationKeyTag, domain.StringList(nil)),

--- a/core/block/template/templateimpl/impl_test.go
+++ b/core/block/template/templateimpl/impl_test.go
@@ -127,7 +127,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 		assert.Equal(t, st.Get(template.TitleBlockId).Model().GetText().Text, templateName)
 	})
 
-	for templateIndex, templateName := range []string{templateName, "", BlankTemplateId} {
+	for templateIndex, templateName := range []string{templateName, "", blankTemplateId} {
 		for addedDetail, expected := range map[string][]string{
 			"custom": {"custom", "custom", "custom"},
 			"":       {templateName, "", ""},
@@ -155,7 +155,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 
 	for _, testCase := range [][]string{
 		{"templateId is empty", ""},
-		{"templateId is blank", BlankTemplateId},
+		{"templateId is blank", blankTemplateId},
 		{"target template is deleted", deletedTemplateId},
 		{"target template is archived", archivedTemplateId},
 	} {
@@ -169,7 +169,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 
 			// then
 			assert.NoError(t, err)
-			assert.Equal(t, BlankTemplateId, st.RootId())
+			assert.Equal(t, blankTemplateId, st.RootId())
 			assert.True(t, st.Details().Has(bundle.RelationKeyTag))
 		})
 	}
@@ -213,7 +213,7 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 			s := service{converter: converter.NewLayoutConverter()}
 
 			// when
-			st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{TemplateId: BlankTemplateId, Layout: layout})
+			st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{TemplateId: blankTemplateId, Layout: layout})
 
 			// then
 			assert.NoError(t, err)
@@ -253,7 +253,7 @@ func TestCreateTemplateStateFromSmartBlock(t *testing.T) {
 		st := s.CreateTemplateStateFromSmartBlock(nil, templateSvc.CreateTemplateRequest{Layout: model.ObjectType_todo})
 
 		// then
-		assert.Equal(t, BlankTemplateId, st.RootId())
+		assert.Equal(t, blankTemplateId, st.RootId())
 		assert.True(t, st.Details().Has(bundle.RelationKeyTag))
 	})
 
@@ -277,8 +277,6 @@ func TestService_resolveValidTemplateId(t *testing.T) {
 		templateId1 = "template1"
 		templateId2 = "template2"
 		templateId3 = "template3"
-		templateIdP = "projectTemplate"
-		now         = time.Now().Unix()
 	)
 
 	store := objectstore.NewStoreFixture(t)
@@ -287,29 +285,17 @@ func TestService_resolveValidTemplateId(t *testing.T) {
 			bundle.RelationKeyId:               domain.String(templateId1),
 			bundle.RelationKeyType:             domain.String(bundle.TypeKeyTemplate.URL()),
 			bundle.RelationKeyTargetObjectType: domain.String(bundle.TypeKeyTask.URL()),
-			bundle.RelationKeyLastModifiedDate: domain.Int64(now),
 		},
 		{
 			bundle.RelationKeyId:               domain.String(templateId2),
 			bundle.RelationKeyType:             domain.String(bundle.TypeKeyTemplate.URL()),
 			bundle.RelationKeyTargetObjectType: domain.String(bundle.TypeKeyTask.URL()),
-			bundle.RelationKeyLastModifiedDate: domain.Int64(now - 60),
 		},
 		{
 			bundle.RelationKeyId:               domain.String(templateId3),
 			bundle.RelationKeyType:             domain.String(bundle.TypeKeyTemplate.URL()),
 			bundle.RelationKeyTargetObjectType: domain.String(bundle.TypeKeyTask.URL()),
-			bundle.RelationKeyLastModifiedDate: domain.Int64(now - 120),
 			bundle.RelationKeyIsDeleted:        domain.Bool(true),
-		},
-		{
-			bundle.RelationKeyId:                domain.String(bundle.TypeKeyTask.URL()),
-			bundle.RelationKeyDefaultTemplateId: domain.String(templateId2),
-		},
-		{
-			bundle.RelationKeyId:               domain.String(templateIdP),
-			bundle.RelationKeyType:             domain.String(bundle.TypeKeyTemplate.URL()),
-			bundle.RelationKeyTargetObjectType: domain.String(bundle.TypeKeyProject.URL()),
 		},
 	})
 
@@ -332,14 +318,10 @@ func TestService_resolveValidTemplateId(t *testing.T) {
 		expectedTemplateId  string
 	}{
 		{"requested template is valid", bundle.TypeKeyTask, templateId2, templateId2},
-		{"requested template is invalid", bundle.TypeKeyTask, "invalid", templateId2},
-		{"requested template is deleted", bundle.TypeKeyTask, templateId3, templateId2},
-		{"requested template is default", bundle.TypeKeyTask, DefaultTemplateId, templateId2},
-		{"requested template is lastEdited", bundle.TypeKeyTask, LastEditedTemplateId, templateId1},
-		{"requested template is empty", bundle.TypeKeyTask, "", templateId2},
-		{"fallback to lastEdited if no default", bundle.TypeKeyProject, "", templateIdP},
-		{"requested template is blank", bundle.TypeKeyTask, BlankTemplateId, BlankTemplateId},
-		{"no valid template exists", bundle.TypeKeyBook, "templateId", BlankTemplateId},
+		{"requested template is invalid", bundle.TypeKeyTask, "invalid", ""},
+		{"requested template is deleted", bundle.TypeKeyTask, templateId3, ""},
+		{"requested template is empty", bundle.TypeKeyTask, "", ""},
+		{"no valid template exists", bundle.TypeKeyBook, "templateId", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// when


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5021/default-template-logic-change

We should fallback to empty template:
- if empty templateId is provided
- if template could not be found
- if template marked as default is deleted