### PR TITLE
GO-5320: Update Import widget structure

### DIFF
--- a/core/block/import/common/collection.go
+++ b/core/block/import/common/collection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/globalsign/mgo/bson"
 	"github.com/google/uuid"
 
 	"github.com/anyproto/anytype-heart/core/block/collection"
@@ -18,12 +19,15 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
+const rootWidget = "rootWidget"
+
 type ImportCollectionSetting struct {
 	collectionName                                      string
 	targetObjects                                       []string
 	icon                                                string
 	fileKeys                                            []*pb.ChangeFileKeys
 	needToAddDate, shouldBeFavorite, shouldAddRelations bool
+	widgetSnapshot                                      *Snapshot
 }
 
 func MakeImportCollectionSetting(
@@ -32,6 +36,7 @@ func MakeImportCollectionSetting(
 	icon string,
 	fileKeys []*pb.ChangeFileKeys,
 	needToAddDate, shouldBeFavorite, shouldAddRelations bool,
+	widgetSnapshot *Snapshot,
 ) *ImportCollectionSetting {
 	return &ImportCollectionSetting{
 		collectionName:     collectionName,
@@ -41,6 +46,7 @@ func MakeImportCollectionSetting(
 		needToAddDate:      needToAddDate,
 		shouldBeFavorite:   shouldBeFavorite,
 		shouldAddRelations: shouldAddRelations,
+		widgetSnapshot:     widgetSnapshot,
 	}
 }
 
@@ -52,7 +58,7 @@ func NewImportCollection(service *collection.Service) *ImportCollection {
 	return &ImportCollection{service: service}
 }
 
-func (r *ImportCollection) MakeImportCollection(req *ImportCollectionSetting) (*Snapshot, error) {
+func (r *ImportCollection) MakeImportCollection(req *ImportCollectionSetting) (*Snapshot, *Snapshot, error) {
 	if req.needToAddDate {
 		importDate := time.Now().Format(time.RFC3339)
 		req.collectionName = fmt.Sprintf("%s %s", req.collectionName, importDate)
@@ -62,20 +68,100 @@ func (r *ImportCollection) MakeImportCollection(req *ImportCollectionSetting) (*
 		Value: model.InternalFlag_collectionDontIndexLinks,
 	}})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if req.shouldAddRelations {
 		err = r.addRelations(st)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
 	detailsStruct = st.CombinedDetails().Merge(detailsStruct)
 	st.UpdateStoreSlice(template.CollectionStoreKey, req.targetObjects)
 
-	return r.getRootCollectionSnapshot(req.collectionName, st, detailsStruct, req.fileKeys), nil
+	rootCollectionSnapshot := r.getRootCollectionSnapshot(req.collectionName, st, detailsStruct, req.fileKeys)
+	widgetSnapshot := r.makeWidgetSnapshot(req, rootCollectionSnapshot)
+	return rootCollectionSnapshot, widgetSnapshot, nil
+}
+
+func (r *ImportCollection) makeWidgetSnapshot(req *ImportCollectionSetting, rootSnapshot *Snapshot) *Snapshot {
+	if req.widgetSnapshot == nil {
+		return r.buildNewWidgetSnapshot(rootSnapshot.Id)
+	}
+	return r.enhanceExistingSnapshot(req.widgetSnapshot, rootSnapshot.Id)
+}
+
+func (r *ImportCollection) buildNewWidgetSnapshot(targetID string) *Snapshot {
+	linkBlock := r.createLinkBlock(targetID)
+	widgetBlock := r.createWidgetBlock(linkBlock.Id)
+	rootBlock := r.createSmartBlock(widgetBlock.Id)
+
+	return &Snapshot{
+		Id:       rootBlock.Id,
+		FileName: rootWidget,
+		Snapshot: &SnapshotModel{
+			SbType: sb.SmartBlockTypeWidget,
+			Data: &StateSnapshot{
+				Blocks:      []*model.Block{rootBlock, widgetBlock, linkBlock},
+				Details:     r.defaultWidgetDetails(),
+				ObjectTypes: []string{bundle.TypeKeyDashboard.String()},
+			},
+		},
+	}
+}
+
+func (r *ImportCollection) enhanceExistingSnapshot(snapshot *Snapshot, targetID string) *Snapshot {
+	linkBlock := r.createLinkBlock(targetID)
+	widgetBlock := r.createWidgetBlock(linkBlock.Id)
+
+	for _, block := range snapshot.Snapshot.Data.Blocks {
+		if block.GetSmartblock() != nil {
+			block.ChildrenIds = append(block.ChildrenIds, widgetBlock.Id)
+		}
+	}
+
+	snapshot.Snapshot.Data.Blocks = append(snapshot.Snapshot.Data.Blocks, linkBlock, widgetBlock)
+	return snapshot
+}
+
+func (r *ImportCollection) createLinkBlock(targetID string) *model.Block {
+	return &model.Block{
+		Id: bson.NewObjectId().Hex(),
+		Content: &model.BlockContentOfLink{
+			Link: &model.BlockContentLink{
+				TargetBlockId: targetID,
+			},
+		},
+	}
+}
+
+func (r *ImportCollection) createWidgetBlock(childID string) *model.Block {
+	return &model.Block{
+		Id:          bson.NewObjectId().Hex(),
+		ChildrenIds: []string{childID},
+		Content: &model.BlockContentOfWidget{
+			Widget: &model.BlockContentWidget{
+				Layout: model.BlockContentWidget_CompactList,
+			},
+		},
+	}
+}
+
+func (r *ImportCollection) createSmartBlock(childID string) *model.Block {
+	return &model.Block{
+		Id:          uuid.New().String(),
+		ChildrenIds: []string{childID},
+		Content:     &model.BlockContentOfSmartblock{Smartblock: &model.BlockContentSmartblock{}},
+	}
+}
+
+func (r *ImportCollection) defaultWidgetDetails() *domain.Details {
+	return domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+		bundle.RelationKeyLayout:   domain.Int64(model.ObjectType_dashboard),
+		bundle.RelationKeyIsHidden: domain.Bool(true),
+	})
 }
 
 func (r *ImportCollection) getRootCollectionSnapshot(

--- a/core/block/import/common/collection.go
+++ b/core/block/import/common/collection.go
@@ -30,23 +30,61 @@ type ImportCollectionSetting struct {
 	widgetSnapshot                                      *Snapshot
 }
 
-func MakeImportCollectionSetting(
-	collectionName string,
-	targetObjects []string,
-	icon string,
-	fileKeys []*pb.ChangeFileKeys,
-	needToAddDate, shouldBeFavorite, shouldAddRelations bool,
-	widgetSnapshot *Snapshot,
-) *ImportCollectionSetting {
-	return &ImportCollectionSetting{
-		collectionName:     collectionName,
-		targetObjects:      targetObjects,
-		icon:               icon,
-		fileKeys:           fileKeys,
-		needToAddDate:      needToAddDate,
-		shouldBeFavorite:   shouldBeFavorite,
-		shouldAddRelations: shouldAddRelations,
-		widgetSnapshot:     widgetSnapshot,
+type ImportCollectionOption func(*ImportCollectionSetting)
+
+func NewImportCollectionSetting(opts ...ImportCollectionOption) *ImportCollectionSetting {
+	s := &ImportCollectionSetting{}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+func WithCollectionName(name string) ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.collectionName = name
+	}
+}
+
+func WithTargetObjects(objs []string) ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.targetObjects = objs
+	}
+}
+
+func WithIcon(icon string) ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.icon = icon
+	}
+}
+
+func WithFileKeys(keys []*pb.ChangeFileKeys) ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.fileKeys = keys
+	}
+}
+
+func WithAddDate() ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.needToAddDate = true
+	}
+}
+
+func WithFavorite() ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.shouldBeFavorite = true
+	}
+}
+
+func WithRelations() ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.shouldAddRelations = true
+	}
+}
+
+func WithWidgetSnapshot(snapshot *Snapshot) ImportCollectionOption {
+	return func(s *ImportCollectionSetting) {
+		s.widgetSnapshot = snapshot
 	}
 }
 

--- a/core/block/import/common/collection_test.go
+++ b/core/block/import/common/collection_test.go
@@ -1,0 +1,92 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/collection"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func TestMakeImportCollection(t *testing.T) {
+	tests := []struct {
+		name              string
+		needToAddDate     bool
+		shouldBeFavorite  bool
+		shouldAddRelation bool
+		widgetSnapshot    bool
+	}{
+		{"all false", false, false, false, false},
+		{"add date", true, false, false, false},
+		{"add favorite", false, true, false, false},
+		{"add relations", false, false, true, false},
+		{"with existing widget snapshot", false, false, false, true},
+		{"all True", true, true, true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			importer := NewImportCollection(collection.New())
+
+			var widget *Snapshot
+			if tt.widgetSnapshot {
+				widget = &Snapshot{
+					Id:       "widget-id",
+					FileName: "existing",
+					Snapshot: &SnapshotModel{
+						Data: &StateSnapshot{
+							Blocks: []*model.Block{
+								{
+									Id:          "root-block",
+									ChildrenIds: []string{},
+									Content: &model.BlockContentOfSmartblock{
+										Smartblock: &model.BlockContentSmartblock{},
+									},
+								},
+							},
+						},
+					},
+				}
+			}
+
+			req := MakeImportCollectionSetting(
+				"My Collection",
+				[]string{"obj1", "obj2"},
+				"icon.png",
+				nil,
+				tt.needToAddDate,
+				tt.shouldBeFavorite,
+				tt.shouldAddRelation,
+				widget,
+			)
+
+			root, widgetSnap, err := importer.MakeImportCollection(req)
+
+			assert.NoError(t, err)
+			assert.NotNil(t, root)
+			assert.NotNil(t, widgetSnap)
+
+			if tt.needToAddDate {
+				assert.Contains(t, root.FileName, time.Now().Format("2006"))
+			} else {
+				assert.Equal(t, "My Collection", root.FileName)
+			}
+
+			if tt.shouldBeFavorite {
+				assert.Equal(t, domain.Bool(true), root.Snapshot.Data.Details.Get(bundle.RelationKeyIsFavorite))
+			} else {
+				assert.Equal(t, domain.Bool(false), root.Snapshot.Data.Details.Get(bundle.RelationKeyIsFavorite))
+			}
+
+			if tt.widgetSnapshot {
+				assert.Equal(t, "existing", widgetSnap.FileName)
+			} else {
+				assert.Equal(t, "rootWidget", widgetSnap.FileName)
+			}
+		})
+	}
+}

--- a/core/block/import/common/collection_test.go
+++ b/core/block/import/common/collection_test.go
@@ -53,16 +53,16 @@ func TestMakeImportCollection(t *testing.T) {
 				}
 			}
 
-			req := MakeImportCollectionSetting(
-				"My Collection",
-				[]string{"obj1", "obj2"},
-				"icon.png",
-				nil,
-				tt.needToAddDate,
-				tt.shouldBeFavorite,
-				tt.shouldAddRelation,
-				widget,
+			req := NewImportCollectionSetting(
+				WithCollectionName("My Collection"),
+				WithTargetObjects([]string{"obj1", "obj2"}),
+				WithIcon("icon.png"),
+				WithWidgetSnapshot(widget),
 			)
+
+			req.needToAddDate = tt.needToAddDate
+			req.shouldBeFavorite = tt.shouldBeFavorite
+			req.shouldAddRelations = tt.shouldAddRelation
 
 			root, widgetSnap, err := importer.MakeImportCollection(req)
 

--- a/core/block/import/csv/converter.go
+++ b/core/block/import/csv/converter.go
@@ -67,8 +67,8 @@ func (c *CSV) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest, 
 		return nil, allErrors
 	}
 	rootCollection := common.NewImportCollection(c.collectionService)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, result.objectIDs, "", nil, true, true, true)
-	rootCol, err := rootCollection.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(rootCollectionName, result.objectIDs, "", nil, true, false, true, nil)
+	rootCol, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		allErrors.Add(err)
 		if req.Mode == pb.RpcObjectImportRequest_ALL_OR_NOTHING {
@@ -79,6 +79,9 @@ func (c *CSV) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest, 
 	if rootCol != nil {
 		result.snapshots = append(result.snapshots, rootCol)
 		rootCollectionID = rootCol.Id
+	}
+	if widgetSnapshot != nil {
+		result.snapshots = append(result.snapshots, widgetSnapshot)
 	}
 	progress.SetTotal(int64(len(result.snapshots)))
 	if allErrors.IsEmpty() {

--- a/core/block/import/csv/converter.go
+++ b/core/block/import/csv/converter.go
@@ -67,7 +67,12 @@ func (c *CSV) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest, 
 		return nil, allErrors
 	}
 	rootCollection := common.NewImportCollection(c.collectionService)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, result.objectIDs, "", nil, true, false, true, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(rootCollectionName),
+		common.WithTargetObjects(result.objectIDs),
+		common.WithAddDate(),
+		common.WithRelations(),
+	)
 	rootCol, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		allErrors.Add(err)

--- a/core/block/import/csv/converter_test.go
+++ b/core/block/import/csv/converter_test.go
@@ -34,7 +34,7 @@ func TestCsv_GetSnapshotsEmptyFile(t *testing.T) {
 	}, p)
 
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 2) // test + root collection
+	assert.Len(t, sn.Snapshots, 3) // test + root collection + root collection widget
 	assert.Contains(t, sn.Snapshots[0].FileName, "test.csv")
 	assert.Len(t, pbtypes.GetStringList(sn.Snapshots[0].Snapshot.Data.Collections, template.CollectionStoreKey), 0)
 	assert.NotEmpty(t, sn.Snapshots[1].Snapshot.Data.ObjectTypes) // empty collection
@@ -63,21 +63,31 @@ func TestCsv_GetSnapshots(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 6) // Journal.csv + root collection + 2 objects in Journal.csv + 2 relations (Created, Tags)
+	assert.Len(t, sn.Snapshots, 7) // Journal.csv + root collection + 2 objects in Journal.csv + 2 relations (Created, Tags)
 	assert.Contains(t, sn.Snapshots[0].FileName, "Journal.csv")
 	assert.Len(t, pbtypes.GetStringList(sn.Snapshots[0].Snapshot.Data.Collections, template.CollectionStoreKey), 2) // 2 objects
 
-	var found bool
+	var found, foundWidget bool
+	var rootCollectionId string
 	for _, snapshot := range sn.Snapshots {
 		if strings.Contains(snapshot.FileName, rootCollectionName) {
 			found = true
+			rootCollectionId = snapshot.Id
 			assert.NotEmpty(t, snapshot.Snapshot.Data.ObjectTypes)
 			assert.Equal(t, snapshot.Snapshot.Data.ObjectTypes[0], bundle.TypeKeyCollection.String())
 			assert.Len(t, pbtypes.GetStringList(snapshot.Snapshot.Data.Collections, template.CollectionStoreKey), 1) // only Journal.csv collection
 		}
+		if snapshot.Snapshot.SbType == sb.SmartBlockTypeWidget {
+			foundWidget = true
+			assert.Len(t, snapshot.Snapshot.Data.Blocks, 3)
+			assert.NotNil(t, snapshot.Snapshot.Data.Blocks[1].GetWidget())
+			assert.NotNil(t, snapshot.Snapshot.Data.Blocks[2].GetLink())
+			assert.Equal(t, rootCollectionId, snapshot.Snapshot.Data.Blocks[2].GetLink().GetTargetBlockId())
+		}
 	}
 
 	assert.True(t, found)
+	assert.True(t, foundWidget)
 }
 
 func TestCsv_GetSnapshotsTable(t *testing.T) {
@@ -97,7 +107,7 @@ func TestCsv_GetSnapshotsTable(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 2) // 1 page with table + root collection
+	assert.Len(t, sn.Snapshots, 3) // 1 page with table + root collection + root collection widget
 	assert.Contains(t, sn.Snapshots[0].FileName, "Journal.csv")
 
 	var found bool
@@ -127,7 +137,7 @@ func TestCsv_GetSnapshotsTableUseFirstColumnForRelationsOn(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 2) // 1 page with table + root collection
+	assert.Len(t, sn.Snapshots, 3) // 1 page with table + root collection + root collection widget
 	assert.Contains(t, sn.Snapshots[0].FileName, "Journal.csv")
 
 	var rowsID []string
@@ -167,7 +177,7 @@ func TestCsv_GetSnapshotsSemiColon(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 16) // 8 objects + root collection + semicolon collection + 5 relations
+	assert.Len(t, sn.Snapshots, 17) // 8 objects + root collection + semicolon collection + 5 relations + root collection widget
 	assert.Contains(t, sn.Snapshots[0].FileName, "semicolon.csv")
 	assert.Len(t, pbtypes.GetStringList(sn.Snapshots[0].Snapshot.Data.Collections, template.CollectionStoreKey), 8)
 	assert.Equal(t, sn.Snapshots[0].Snapshot.Data.ObjectTypes[0], bundle.TypeKeyCollection.String())
@@ -192,7 +202,7 @@ func TestCsv_GetSnapshotsTranspose(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 4) // 2 object + root collection + transpose collection + 1 relations
+		assert.Len(t, sn.Snapshots, 5) // 2 object + root collection + transpose collection + 1 relations + root collection widget
 
 		for _, snapshot := range sn.Snapshots {
 			if snapshot.Snapshot.SbType == sb.SmartBlockTypeRelation {
@@ -236,7 +246,7 @@ func TestCsv_GetSnapshotsTranspose(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 4)
+		assert.Len(t, sn.Snapshots, 5)
 
 		for _, snapshot := range sn.Snapshots {
 			if snapshot.Snapshot.SbType == sb.SmartBlockTypeRelation {
@@ -265,7 +275,7 @@ func TestCsv_GetSnapshotsTransposeUseFirstRowForRelationsOff(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 5) // 2 object + root collection + transpose collection + 1 relations
+	assert.Len(t, sn.Snapshots, 6) // 2 object + root collection + transpose collection + 1 relations + root collection widget
 
 	for _, snapshot := range sn.Snapshots {
 		if snapshot.Snapshot.SbType == sb.SmartBlockTypeRelation {
@@ -292,7 +302,7 @@ func TestCsv_GetSnapshotsUseFirstColumnForRelationsOn(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 6) // Journal.csv collection, root collection + 2 objects in Journal.csv + 2 relations (Created, Tags)
+	assert.Len(t, sn.Snapshots, 7) // Journal.csv collection, root collection + 2 objects in Journal.csv + 2 relations (Created, Tags) + root collection widget
 
 	var rowsObjects []*common.Snapshot
 	for _, snapshot := range sn.Snapshots {
@@ -303,7 +313,7 @@ func TestCsv_GetSnapshotsUseFirstColumnForRelationsOn(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, rowsObjects, 2)
+	assert.Len(t, rowsObjects, 3)
 
 	want := [][]string{
 		{"Hawaii Vacation", "July 13, 2022 8:54 AM", "Special Event"},
@@ -338,7 +348,7 @@ func TestCsv_GetSnapshotsUseFirstColumnForRelationsOff(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, sn)
-	assert.Len(t, sn.Snapshots, 7) // Journal.csv collection, root collection + 3 objects in Journal.csv + 2 relations (Created, Tags)
+	assert.Len(t, sn.Snapshots, 8) // Journal.csv collection, root collection + 3 objects in Journal.csv + 2 relations (Created, Tags) + root collection widget
 
 	var objects []*common.Snapshot
 	for _, snapshot := range sn.Snapshots {
@@ -349,7 +359,7 @@ func TestCsv_GetSnapshotsUseFirstColumnForRelationsOff(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, objects, 3) // first row is also an object
+	assert.Len(t, objects, 4) // first row is also an object
 
 	want := [][]string{
 		{"Name", "Created", "Tags"},
@@ -514,7 +524,7 @@ func TestCsv_GetSnapshots1000RowsFile(t *testing.T) {
 	var objects []*common.Snapshot
 	for _, snapshot := range sn.Snapshots {
 		// only objects created from rows
-		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation &&
+		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation && snapshot.Snapshot.SbType != sb.SmartBlockTypeWidget &&
 			!lo.Contains(snapshot.Snapshot.Data.ObjectTypes, bundle.TypeKeyCollection.String()) {
 			objects = append(objects, snapshot)
 		}
@@ -540,7 +550,7 @@ func TestCsv_GetSnapshots1000RowsFile(t *testing.T) {
 	objects = []*common.Snapshot{}
 	for _, snapshot := range sn.Snapshots {
 		// only objects created from rows
-		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation &&
+		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation && snapshot.Snapshot.SbType != sb.SmartBlockTypeWidget &&
 			!lo.Contains(snapshot.Snapshot.Data.ObjectTypes, bundle.TypeKeyCollection.String()) {
 			objects = append(objects, snapshot)
 		}
@@ -663,7 +673,7 @@ func TestCsv_GetSnapshots10Relations(t *testing.T) {
 	var objects []*common.Snapshot
 	for _, snapshot := range sn.Snapshots {
 		// only objects created from rows
-		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation &&
+		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation && snapshot.Snapshot.SbType != sb.SmartBlockTypeWidget &&
 			!lo.Contains(snapshot.Snapshot.Data.ObjectTypes, bundle.TypeKeyCollection.String()) {
 			objects = append(objects, snapshot)
 		}
@@ -694,7 +704,7 @@ func TestCsv_GetSnapshots10Relations(t *testing.T) {
 	objects = []*common.Snapshot{}
 	for _, snapshot := range sn.Snapshots {
 		// only objects created from rows
-		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation &&
+		if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation && snapshot.Snapshot.SbType != sb.SmartBlockTypeWidget &&
 			!lo.Contains(snapshot.Snapshot.Data.ObjectTypes, bundle.TypeKeyCollection.String()) {
 			objects = append(objects, snapshot)
 		}
@@ -738,7 +748,7 @@ func TestCsv_GetSnapshotsTableModeDifferentColumnsNumber(t *testing.T) {
 				objects = append(objects, snapshot)
 			}
 		}
-		assert.Len(t, objects, 1)
+		assert.Len(t, objects, 2)
 		assert.Equal(t, objects[0].Snapshot.Data.Details.GetString(bundle.RelationKeyName), "differentcolumnnumber")
 		numberOfCSVColumns := lo.CountBy(objects[0].Snapshot.Data.Blocks, func(item *model.Block) bool { return item.GetTableColumn() != nil })
 		assert.Equal(t, 5, numberOfCSVColumns)
@@ -771,7 +781,7 @@ func TestCsv_GetSnapshotsTableModeDifferentColumnsNumber(t *testing.T) {
 		var objects []*common.Snapshot
 		for _, snapshot := range sn.Snapshots {
 			// only objects created from rows
-			if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation &&
+			if snapshot.Snapshot.SbType != sb.SmartBlockTypeRelation && snapshot.Snapshot.SbType != sb.SmartBlockTypeWidget &&
 				!lo.Contains(snapshot.Snapshot.Data.ObjectTypes, bundle.TypeKeyCollection.String()) {
 				objects = append(objects, snapshot)
 			}

--- a/core/block/import/html/converter.go
+++ b/core/block/import/html/converter.go
@@ -66,7 +66,12 @@ func (h *HTML) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest,
 		return nil, allErrors
 	}
 	rootCollection := common.NewImportCollection(h.collectionService)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, targetObjects, "", nil, true, false, true, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(rootCollectionName),
+		common.WithTargetObjects(targetObjects),
+		common.WithAddDate(),
+		common.WithRelations(),
+	)
 	rootCollectionSnapshot, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		allErrors.Add(err)

--- a/core/block/import/html/converter.go
+++ b/core/block/import/html/converter.go
@@ -66,8 +66,8 @@ func (h *HTML) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest,
 		return nil, allErrors
 	}
 	rootCollection := common.NewImportCollection(h.collectionService)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, targetObjects, "", nil, true, true, true)
-	rootCollectionSnapshot, err := rootCollection.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(rootCollectionName, targetObjects, "", nil, true, false, true, nil)
+	rootCollectionSnapshot, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		allErrors.Add(err)
 		if allErrors.ShouldAbortImport(len(path), req.Type) {
@@ -78,6 +78,9 @@ func (h *HTML) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest,
 	if rootCollectionSnapshot != nil {
 		snapshots = append(snapshots, rootCollectionSnapshot)
 		rootCollectionID = rootCollectionSnapshot.Id
+	}
+	if widgetSnapshot != nil {
+		snapshots = append(snapshots, widgetSnapshot)
 	}
 	progress.SetTotal(int64(numberOfStages * len(snapshots)))
 	if allErrors.IsEmpty() {

--- a/core/block/import/html/converter_test.go
+++ b/core/block/import/html/converter_test.go
@@ -44,7 +44,7 @@ func TestHTML_GetSnapshots(t *testing.T) {
 		)
 
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 2)
+		assert.Len(t, sn.Snapshots, 3)
 		assert.Contains(t, sn.Snapshots[0].FileName, "test.html")
 		assert.NotEmpty(t, sn.Snapshots[0].Snapshot.Data.Details.GetString("name"))
 		assert.Equal(t, sn.Snapshots[0].Snapshot.Data.Details.GetString("name"), "test")
@@ -53,6 +53,10 @@ func TestHTML_GetSnapshots(t *testing.T) {
 		assert.NotEmpty(t, sn.Snapshots[1].Snapshot.Data.ObjectTypes)
 		assert.Equal(t, sn.Snapshots[1].Snapshot.Data.ObjectTypes[0], bundle.TypeKeyCollection.String())
 
+		assert.Len(t, sn.Snapshots[2].Snapshot.Data.Blocks, 3)
+		assert.NotNil(t, sn.Snapshots[2].Snapshot.Data.Blocks[1].GetWidget())
+		assert.NotNil(t, sn.Snapshots[2].Snapshot.Data.Blocks[2].GetLink())
+		assert.Equal(t, sn.Snapshots[1].Id, sn.Snapshots[2].Snapshot.Data.Blocks[2].GetLink().GetTargetBlockId())
 		assert.NotEmpty(t, err)
 		assert.True(t, errors.Is(err.GetResultError(model.Import_Html), common.ErrFileImportNoObjectsInDirectory))
 	})

--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -42,6 +42,7 @@ import (
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core"
+	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/filestore"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
@@ -492,6 +493,10 @@ func (i *Import) extractInternalKey(snapshot *common.Snapshot, oldIDToNew map[st
 func (i *Import) addWork(res *common.Response, pool *workerpool.WorkerPool) {
 	for _, snapshot := range res.Snapshots {
 		t := creator.NewTask(snapshot, i.oc)
+		if snapshot.Snapshot.SbType == smartblock.SmartBlockTypeWidget {
+			pool.SetFinalizer(t)
+			continue
+		}
 		stop := pool.AddWork(t)
 		if stop {
 			break

--- a/core/block/import/markdown/import.go
+++ b/core/block/import/markdown/import.go
@@ -102,7 +102,12 @@ func (m *Markdown) processFiles(req *pb.RpcObjectImportRequest, progress process
 
 func (m *Markdown) createRootCollection(allSnapshots []*common.Snapshot, allRootObjectsIds []string) ([]*common.Snapshot, string, error) {
 	rootCollection := common.NewImportCollection(m.service)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, allRootObjectsIds, "", nil, true, false, true, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(rootCollectionName),
+		common.WithTargetObjects(allRootObjectsIds),
+		common.WithAddDate(),
+		common.WithRelations(),
+	)
 	rootCol, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, "", err
@@ -427,7 +432,10 @@ func (m *Markdown) createSnapshots(
 
 func (m *Markdown) addCollectionSnapshot(fileName string, file *FileInfo, snapshots []*common.Snapshot) ([]*common.Snapshot, error) {
 	c := common.NewImportCollection(m.service)
-	settings := common.MakeImportCollectionSetting(file.Title, file.CollectionsObjectsIds, "", nil, false, false, false, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(file.Title),
+		common.WithTargetObjects(file.CollectionsObjectsIds),
+	)
 	csvCollection, _, err := c.MakeImportCollection(settings)
 	if err != nil {
 		return nil, err

--- a/core/block/import/markdown/import.go
+++ b/core/block/import/markdown/import.go
@@ -102,8 +102,8 @@ func (m *Markdown) processFiles(req *pb.RpcObjectImportRequest, progress process
 
 func (m *Markdown) createRootCollection(allSnapshots []*common.Snapshot, allRootObjectsIds []string) ([]*common.Snapshot, string, error) {
 	rootCollection := common.NewImportCollection(m.service)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, allRootObjectsIds, "", nil, true, true, true)
-	rootCol, err := rootCollection.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(rootCollectionName, allRootObjectsIds, "", nil, true, false, true, nil)
+	rootCol, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, "", err
 	}
@@ -112,6 +112,9 @@ func (m *Markdown) createRootCollection(allSnapshots []*common.Snapshot, allRoot
 	if rootCol != nil {
 		allSnapshots = append(allSnapshots, rootCol)
 		rootCollectionID = rootCol.Id
+	}
+	if widgetSnapshot != nil {
+		allSnapshots = append(allSnapshots, widgetSnapshot)
 	}
 	return allSnapshots, rootCollectionID, nil
 }
@@ -424,8 +427,8 @@ func (m *Markdown) createSnapshots(
 
 func (m *Markdown) addCollectionSnapshot(fileName string, file *FileInfo, snapshots []*common.Snapshot) ([]*common.Snapshot, error) {
 	c := common.NewImportCollection(m.service)
-	settings := common.MakeImportCollectionSetting(file.Title, file.CollectionsObjectsIds, "", nil, false, false, false)
-	csvCollection, err := c.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(file.Title, file.CollectionsObjectsIds, "", nil, false, false, false, nil)
+	csvCollection, _, err := c.MakeImportCollection(settings)
 	if err != nil {
 		return nil, err
 	}

--- a/core/block/import/markdown/import_test.go
+++ b/core/block/import/markdown/import_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/import/common/test"
 	"github.com/anyproto/anytype-heart/core/block/process"
 	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/tests/blockbuilder"
 )
@@ -37,10 +38,10 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 3)
+		assert.Len(t, sn.Snapshots, 4)
 		var (
-			found     bool
-			subPageId string
+			found, foundWidget bool
+			subPageId          string
 		)
 		for _, snapshot := range sn.Snapshots {
 			if snapshot.FileName == filepath.Join(testDirectory, "test_database", "test.md") {
@@ -54,10 +55,18 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 				assert.NotEmpty(t, snapshot.Snapshot.Data.Collections.Fields["objects"])
 				assert.Len(t, snapshot.Snapshot.Data.Collections.Fields["objects"].GetListValue().GetValues(), 1)
 				assert.Equal(t, subPageId, snapshot.Snapshot.Data.Collections.Fields["objects"].GetListValue().GetValues()[0].GetStringValue())
+			}
+			if snapshot.Snapshot.SbType == smartblock.SmartBlockTypeWidget {
+				foundWidget = true
+				assert.Len(t, snapshot.Snapshot.Data.Blocks, 3)
+				assert.NotNil(t, snapshot.Snapshot.Data.Blocks[1].GetWidget())
+				assert.NotNil(t, snapshot.Snapshot.Data.Blocks[2].GetLink())
+				assert.NotEmpty(t, snapshot.Snapshot.Data.Blocks[2].GetLink().GetTargetBlockId())
 				break
 			}
 		}
 		assert.True(t, found)
+		assert.True(t, foundWidget)
 	})
 	t.Run("no object error", func(t *testing.T) {
 		// given
@@ -98,7 +107,7 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 7)
+		assert.Len(t, sn.Snapshots, 8)
 
 		fileNameToObjectId := make(map[string]string, len(sn.Snapshots))
 		for _, snapshot := range sn.Snapshots {
@@ -179,7 +188,7 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 		// then
 		assert.Nil(t, ce)
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 4)
+		assert.Len(t, sn.Snapshots, 5)
 		fileNameToObjectId := make(map[string]string, len(sn.Snapshots))
 		for _, snapshot := range sn.Snapshots {
 			fileNameToObjectId[snapshot.FileName] = snapshot.Id

--- a/core/block/import/notion/api/database/database.go
+++ b/core/block/import/notion/api/database/database.go
@@ -345,18 +345,20 @@ func (ds *Service) AddPagesToCollections(databaseSnapshots []*common.Snapshot, p
 	}
 }
 
-func (ds *Service) AddObjectsToNotionCollection(notionContext *api.NotionImportContext,
+func (ds *Service) AddObjectsToNotionCollection(
+	notionContext *api.NotionImportContext,
 	notionDB []Database,
-	notionPages []page.Page) (*common.Snapshot, error) {
+	notionPages []page.Page,
+) (*common.Snapshot, *common.Snapshot, error) {
 	allObjects := ds.filterObjects(notionContext, notionDB, notionPages)
 
 	rootCollection := common.NewImportCollection(ds.collectionService)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, allObjects, "", nil, true, true, true)
-	rootCol, err := rootCollection.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(rootCollectionName, allObjects, "", nil, true, false, true, nil)
+	rootCol, widget, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return rootCol, nil
+	return rootCol, widget, nil
 }
 
 func (ds *Service) filterObjects(notionContext *api.NotionImportContext,

--- a/core/block/import/notion/api/database/database.go
+++ b/core/block/import/notion/api/database/database.go
@@ -353,7 +353,12 @@ func (ds *Service) AddObjectsToNotionCollection(
 	allObjects := ds.filterObjects(notionContext, notionDB, notionPages)
 
 	rootCollection := common.NewImportCollection(ds.collectionService)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, allObjects, "", nil, true, false, true, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(rootCollectionName),
+		common.WithTargetObjects(allObjects),
+		common.WithAddDate(),
+		common.WithRelations(),
+	)
 	rootCol, widget, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, nil, err

--- a/core/block/import/notion/api/database/database_test.go
+++ b/core/block/import/notion/api/database/database_test.go
@@ -41,7 +41,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -83,7 +83,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -119,7 +119,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -166,7 +166,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -205,7 +205,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -251,7 +251,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -287,7 +287,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, nil)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, notionDB, nil)
 
 		// then
 		assert.Nil(t, err)
@@ -329,7 +329,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
 
 		// then
 		assert.Nil(t, err)
@@ -368,7 +368,7 @@ func TestService_AddObjectsToNotionCollection(t *testing.T) {
 		}
 
 		// when
-		collection, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
+		collection, _, err := service.AddObjectsToNotionCollection(notionImportContext, nil, notionPages)
 
 		// then
 		assert.Nil(t, err)

--- a/core/block/import/notion/converter.go
+++ b/core/block/import/notion/converter.go
@@ -116,7 +116,7 @@ func (n *Notion) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportReques
 
 	n.dbService.AddPagesToCollections(dbs, pages, db, notionImportContext.NotionPageIdsToAnytype, notionImportContext.NotionDatabaseIdsToAnytype)
 
-	rootCollectionSnapshot, err := n.dbService.AddObjectsToNotionCollection(notionImportContext, db, pages)
+	rootCollectionSnapshot, widgetSnapshot, err := n.dbService.AddObjectsToNotionCollection(notionImportContext, db, pages)
 	if err != nil {
 		ce.Add(err)
 		if ce.ShouldAbortImport(0, req.Type) {
@@ -131,6 +131,10 @@ func (n *Notion) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportReques
 	allSnapshots := make([]*common.Snapshot, 0, len(pgs)+len(dbs))
 	allSnapshots = append(allSnapshots, pgs...)
 	allSnapshots = append(allSnapshots, dbs...)
+
+	if widgetSnapshot != nil {
+		allSnapshots = append(allSnapshots, widgetSnapshot)
+	}
 
 	if !ce.IsEmpty() {
 		return &common.Response{Snapshots: allSnapshots, RootCollectionID: rootCollectionID}, ce

--- a/core/block/import/pb/converter_test.go
+++ b/core/block/import/pb/converter_test.go
@@ -50,7 +50,7 @@ func Test_GetSnapshotsSuccess(t *testing.T) {
 	}, process.NewNoOp())
 
 	assert.Nil(t, ce)
-	assert.Len(t, res.Snapshots, 2)
+	assert.Len(t, res.Snapshots, 3)
 
 	assert.Contains(t, res.Snapshots[1].FileName, rootCollectionName)
 	assert.NotEmpty(t, res.Snapshots[1].Snapshot.Data.ObjectTypes)
@@ -159,7 +159,7 @@ func Test_GetSnapshotsFailedToGetSnapshotForTwoFiles(t *testing.T) {
 
 	assert.NotNil(t, ce)
 	assert.NotNil(t, res.Snapshots)
-	assert.Len(t, res.Snapshots, 2)
+	assert.Len(t, res.Snapshots, 3)
 	assert.False(t, ce.IsEmpty())
 }
 
@@ -215,7 +215,7 @@ func Test_GetSnapshotsSkipFileWithoutExtension(t *testing.T) {
 
 	assert.Nil(t, ce)
 	assert.NotNil(t, res.Snapshots)
-	assert.Len(t, res.Snapshots, 2)
+	assert.Len(t, res.Snapshots, 3)
 
 	assert.Equal(t, res.Snapshots[0].FileName, "bafyreig5sd7mlmhindapjuvzc4gnetdbszztb755sa7nflojkljmu56mmi.pb")
 	assert.Contains(t, res.Snapshots[1].FileName, rootCollectionName)

--- a/core/block/import/pb/gallery.go
+++ b/core/block/import/pb/gallery.go
@@ -59,7 +59,14 @@ func (g *GalleryImport) ProvideCollection(snapshots []*common.Snapshot,
 		}
 	}
 	objectsIDs := g.getObjectsIDs(snapshots)
-	settings := common.MakeImportCollectionSetting(collectionName, objectsIDs, icon, fileKeys, false, false, true, widgetSnapshot)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(collectionName),
+		common.WithTargetObjects(objectsIDs),
+		common.WithIcon(icon),
+		common.WithRelations(),
+		common.WithFileKeys(fileKeys),
+		common.WithWidgetSnapshot(widgetSnapshot),
+	)
 	objectsCollection, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, err
@@ -77,7 +84,13 @@ func (g *GalleryImport) getWidgetsCollection(
 	collectionsSnapshots []*common.Snapshot,
 ) ([]*common.Snapshot, *common.Snapshot, error) {
 	widgetCollectionName := collectionName + widgetCollectionPattern
-	settings := common.MakeImportCollectionSetting(widgetCollectionName, widgetObjects, icon, fileKeys, false, false, true, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(widgetCollectionName),
+		common.WithTargetObjects(widgetObjects),
+		common.WithIcon(icon),
+		common.WithRelations(),
+		common.WithFileKeys(fileKeys),
+	)
 	widgetsCollectionSnapshot, widget, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, nil, err

--- a/core/block/import/pb/gallery_test.go
+++ b/core/block/import/pb/gallery_test.go
@@ -28,7 +28,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.NotContains(t, widgetCollectionPattern, collection[0].FileName)
 	})
 	t.Run("CollectionTitle parameter is empty - collection with default name", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.Equal(t, rootCollectionName, collection[0].FileName)
 	})
 	t.Run("CollectionTitle parameter is equal 'test' - collection with name test", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.Equal(t, "test", collection[0].FileName)
 	})
 	t.Run("widget with sets - only objects root collection as we ignore default sets and not create widgets collection", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.NotContains(t, widgetCollectionPattern, collection[0].FileName)
 	})
 	t.Run("default sets and objects in widget - root collection with objects from widget and object root collection are created", func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 2)
+		assert.Len(t, collection, 3)
 		rootCollectionState := state.NewDocFromSnapshot("", collection[0].Snapshot.ToProto()).(*state.State)
 		objectsInCollection := rootCollectionState.GetStoreSlice(template.CollectionStoreKey)
 		assert.Len(t, objectsInCollection, 1)
@@ -241,7 +241,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.NotContains(t, widgetCollectionPattern, collection[0].FileName)
 
 	})
@@ -255,7 +255,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.Empty(t, collection[0].Snapshot.Data.Details.GetString(bundle.RelationKeyIconImage))
 	})
 	t.Run("workspace without icon - root collection without icon", func(t *testing.T) {
@@ -278,7 +278,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.Empty(t, collection[0].Snapshot.Data.Details.GetString(bundle.RelationKeyIconImage))
 	})
 	t.Run("workspace with icon - root collection with icon", func(t *testing.T) {
@@ -303,7 +303,7 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.Equal(t, "icon", collection[0].Snapshot.Data.Details.GetString(bundle.RelationKeyIconImage))
 	})
 	t.Run("if import in new space - not create anything", func(t *testing.T) {
@@ -349,7 +349,35 @@ func TestGalleryImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		assert.NotContains(t, widgetCollectionPattern, collection[0].FileName)
+	})
+	t.Run("widget with collection", func(t *testing.T) {
+		// given
+		p := GalleryImport{}
+		params := &pb.RpcObjectImportRequestPbParams{NoCollection: false}
+
+		// object with widget
+		widgetSnapshot := &common.Snapshot{
+			Id: "widgetID",
+			Snapshot: &common.SnapshotModel{
+				SbType: smartblock.SmartBlockTypeWidget,
+				Data: &common.StateSnapshot{
+					Blocks: []*model.Block{},
+				},
+			},
+		}
+
+		// when
+		collection, err := p.ProvideCollection(nil, widgetSnapshot, nil, params, nil, false)
+
+		// then
+		assert.Nil(t, err)
+		assert.Len(t, collection, 2)
+		assert.Equal(t, smartblock.SmartBlockTypeWidget, collection[1].Snapshot.SbType)
+		assert.Len(t, collection[1].Snapshot.Data.Blocks, 3)
+		assert.NotNil(t, collection[1].Snapshot.Data.Blocks[1].GetWidget())
+		assert.NotNil(t, collection[1].Snapshot.Data.Blocks[2].GetLink())
+		assert.Equal(t, collection[0].Id, collection[1].Snapshot.Data.Blocks[2].GetLink().GetTargetBlockId())
 	})
 }

--- a/core/block/import/pb/space.go
+++ b/core/block/import/pb/space.go
@@ -56,12 +56,12 @@ func (s *SpaceImport) ProvideCollection(snapshots []*common.Snapshot,
 		})
 	}
 	rootCollection := common.NewImportCollection(s.service)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, rootObjects, "", nil, true, true, true)
-	rootCollectionSnapshot, err := rootCollection.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(rootCollectionName, rootObjects, "", nil, true, false, true, widgetSnapshot)
+	rootCollectionSnapshot, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, err
 	}
-	return []*common.Snapshot{rootCollectionSnapshot}, nil
+	return []*common.Snapshot{rootCollectionSnapshot, widgetSnapshot}, nil
 }
 
 func (s *SpaceImport) objectShouldBeSkipped(item *common.Snapshot) bool {

--- a/core/block/import/pb/space.go
+++ b/core/block/import/pb/space.go
@@ -56,7 +56,13 @@ func (s *SpaceImport) ProvideCollection(snapshots []*common.Snapshot,
 		})
 	}
 	rootCollection := common.NewImportCollection(s.service)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, rootObjects, "", nil, true, false, true, widgetSnapshot)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(rootCollectionName),
+		common.WithTargetObjects(rootObjects),
+		common.WithRelations(),
+		common.WithAddDate(),
+		common.WithWidgetSnapshot(widgetSnapshot),
+	)
 	rootCollectionSnapshot, widgetSnapshot, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		return nil, err

--- a/core/block/import/pb/space_test.go
+++ b/core/block/import/pb/space_test.go
@@ -27,7 +27,7 @@ func TestSpaceImport_ProvideCollection(t *testing.T) {
 
 		// then
 		assert.Nil(t, err)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		rootCollectionState := state.NewDocFromSnapshot("", collection[0].Snapshot.ToProto()).(*state.State)
 		objectsInCollection := rootCollectionState.GetStoreSlice(template.CollectionStoreKey)
 		assert.Len(t, objectsInCollection, 0)
@@ -82,7 +82,7 @@ func TestSpaceImport_ProvideCollection(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, collection)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		rootCollectionState := state.NewDocFromSnapshot("", collection[0].Snapshot.ToProto()).(*state.State)
 		objectsInCollection := rootCollectionState.GetStoreSlice(template.CollectionStoreKey)
 		assert.Len(t, objectsInCollection, 3)
@@ -172,7 +172,7 @@ func TestSpaceImport_ProvideCollection(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, collection)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		rootCollectionState := state.NewDocFromSnapshot("", collection[0].Snapshot.ToProto()).(*state.State)
 		objectsInCollection := rootCollectionState.GetStoreSlice(template.CollectionStoreKey)
 		assert.Len(t, objectsInCollection, 1)
@@ -261,7 +261,7 @@ func TestSpaceImport_ProvideCollection(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, collection)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		rootCollectionState := state.NewDocFromSnapshot("", collection[0].Snapshot.ToProto()).(*state.State)
 		objectsInCollection := rootCollectionState.GetStoreSlice(template.CollectionStoreKey)
 		assert.Len(t, objectsInCollection, 1)
@@ -365,9 +365,26 @@ func TestSpaceImport_ProvideCollection(t *testing.T) {
 		// then
 		assert.Nil(t, err)
 		assert.NotNil(t, collection)
-		assert.Len(t, collection, 1)
+		assert.Len(t, collection, 2)
 		rootCollectionState := state.NewDocFromSnapshot("", collection[0].Snapshot.ToProto()).(*state.State)
 		objectsInCollection := rootCollectionState.GetStoreSlice(template.CollectionStoreKey)
 		assert.Equal(t, []string{"newObjectInWidget", "id1", "spaceDashboardId"}, objectsInCollection)
+	})
+	t.Run("widget with collection", func(t *testing.T) {
+		// given
+		p := SpaceImport{}
+		params := &pb.RpcObjectImportRequestPbParams{NoCollection: false}
+
+		// when
+		collection, err := p.ProvideCollection(nil, nil, nil, params, nil, false)
+
+		// then
+		assert.Nil(t, err)
+		assert.Len(t, collection, 2)
+		assert.Equal(t, smartblock2.SmartBlockTypeWidget, collection[1].Snapshot.SbType)
+		assert.Len(t, collection[1].Snapshot.Data.Blocks, 3)
+		assert.NotNil(t, collection[1].Snapshot.Data.Blocks[1].GetWidget())
+		assert.NotNil(t, collection[1].Snapshot.Data.Blocks[2].GetLink())
+		assert.Equal(t, collection[0].Id, collection[1].Snapshot.Data.Blocks[2].GetLink().GetTargetBlockId())
 	})
 }

--- a/core/block/import/txt/converter.go
+++ b/core/block/import/txt/converter.go
@@ -56,7 +56,12 @@ func (t *TXT) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest, 
 		return nil, allErrors
 	}
 	rootCollection := common.NewImportCollection(t.service)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, targetObjects, "", nil, true, false, true, nil)
+	settings := common.NewImportCollectionSetting(
+		common.WithCollectionName(rootCollectionName),
+		common.WithTargetObjects(targetObjects),
+		common.WithRelations(),
+		common.WithAddDate(),
+	)
 	rootCol, widget, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		allErrors.Add(err)

--- a/core/block/import/txt/converter.go
+++ b/core/block/import/txt/converter.go
@@ -56,8 +56,8 @@ func (t *TXT) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest, 
 		return nil, allErrors
 	}
 	rootCollection := common.NewImportCollection(t.service)
-	settings := common.MakeImportCollectionSetting(rootCollectionName, targetObjects, "", nil, true, true, true)
-	rootCol, err := rootCollection.MakeImportCollection(settings)
+	settings := common.MakeImportCollectionSetting(rootCollectionName, targetObjects, "", nil, true, false, true, nil)
+	rootCol, widget, err := rootCollection.MakeImportCollection(settings)
 	if err != nil {
 		allErrors.Add(err)
 		if allErrors.ShouldAbortImport(len(paths), req.Type) {
@@ -68,6 +68,9 @@ func (t *TXT) GetSnapshots(ctx context.Context, req *pb.RpcObjectImportRequest, 
 	if rootCol != nil {
 		snapshots = append(snapshots, rootCol)
 		rootCollectionID = rootCol.Id
+	}
+	if widget != nil {
+		snapshots = append(snapshots, widget)
 	}
 	progress.SetTotal(int64(numberOfStages * len(snapshots)))
 	if allErrors.IsEmpty() {

--- a/core/block/import/txt/converter_test.go
+++ b/core/block/import/txt/converter_test.go
@@ -31,7 +31,7 @@ func TestTXT_GetSnapshots(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.True(t, errors.Is(err.GetResultError(model.Import_Txt), common.ErrFileImportNoObjectsInDirectory))
 		assert.NotNil(t, sn)
-		assert.Len(t, sn.Snapshots, 2)
+		assert.Len(t, sn.Snapshots, 3)
 		assert.Contains(t, sn.Snapshots[0].FileName, "test.txt")
 		assert.Equal(t, sn.Snapshots[0].Snapshot.Data.Details.GetString("name"), "test")
 
@@ -39,6 +39,10 @@ func TestTXT_GetSnapshots(t *testing.T) {
 		assert.NotEmpty(t, sn.Snapshots[1].Snapshot.Data.ObjectTypes)
 		assert.Equal(t, sn.Snapshots[1].Snapshot.Data.ObjectTypes[0], bundle.TypeKeyCollection.String())
 
+		assert.Len(t, sn.Snapshots[2].Snapshot.Data.Blocks, 3)
+		assert.NotNil(t, sn.Snapshots[2].Snapshot.Data.Blocks[1].GetWidget())
+		assert.NotNil(t, sn.Snapshots[2].Snapshot.Data.Blocks[2].GetLink())
+		assert.Equal(t, sn.Snapshots[1].Id, sn.Snapshots[2].Snapshot.Data.Blocks[2].GetLink().GetTargetBlockId())
 		var (
 			found bool
 			text  string


### PR DESCRIPTION
1. Add `SetFinialzer` method in import work pool, so the creation of widget will be after all tasks completed to make sure widget is created from existing object
2. Make widget snapshot or extend the existing one in during root collection creation in `MakeImportCollection`
3. Make root collection unfavorite
4. Refactored `ImportCollectionSetting` to use Option pattern