### PR TITLE
GO-5249: Wrong file permissions on export

### DIFF
--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -63,6 +63,8 @@ const (
 
 	FilesObjects = "filesObjects"
 	Files        = "files"
+
+	defaultFileName = "untitled"
 )
 
 var log = logging.Logger("anytype-mw-export")
@@ -1258,6 +1260,9 @@ func (fn *namer) Get(path, hash, title, ext string) (name string) {
 	title = slug.Make(strings.TrimSuffix(title, ext))
 	name = text.TruncateEllipsized(title, fileLenLimit)
 	name = strings.TrimSuffix(name, text.TruncateEllipsis)
+	if name == "" {
+		name = defaultFileName
+	}
 	var (
 		i = 0
 		b = 36

--- a/core/block/export/writer_test.go
+++ b/core/block/export/writer_test.go
@@ -75,3 +75,22 @@ func TestZipWriter_WriteFile(t *testing.T) {
 	}
 	assert.True(t, found)
 }
+
+func TestZipWriter_Get(t *testing.T) {
+	t.Run("file without name", func(t *testing.T) {
+		// given
+		path, err := ioutil.TempDir("", "")
+		require.NoError(t, err)
+		defer os.RemoveAll(path)
+
+		wr, err := newZipWriter(path, uniqName()+".zip")
+		require.NoError(t, err)
+
+		// when
+		name := wr.Namer().Get(Files, "hash", "", "")
+
+		// then
+		require.NoError(t, wr.Close())
+		assert.Equal(t, filepath.Join(Files, defaultFileName), name)
+	})
+}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5249/wrong-file-permissions-on-export