### PR TITLE
GO-5172 Unset internalFlags instead of deletion

### DIFF
--- a/util/internalflag/flag.go
+++ b/util/internalflag/flag.go
@@ -49,7 +49,7 @@ func (s *Set) Remove(flag model.InternalFlagValue) {
 
 func (s *Set) AddToState(st *state.State) {
 	if len(s.flags) == 0 {
-		st.RemoveDetail(relationKey)
+		st.SetDetailAndBundledRelation(relationKey, domain.Float64List([]float64{}))
 		return
 	}
 	st.SetDetailAndBundledRelation(relationKey, domain.Float64List(s.flags))


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5172/the-title-in-the-template-is-being-deleted

Title in new objects used to be wiped, because internalFlags detail was deleted on title editing.
We have switched it to simple array clear