### PR TITLE
Fix - Do not set align for tasks

### DIFF
--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -158,9 +158,6 @@ func (c *layoutConverter) fromAnyToBookmark(st *state.State) error {
 }
 
 func (c *layoutConverter) fromAnyToTodo(st *state.State) error {
-	if err := st.SetAlign(model.Block_AlignLeft); err != nil {
-		return err
-	}
 	template.InitTemplate(st,
 		template.WithTitle,
 		template.WithRelations([]domain.RelationKey{bundle.RelationKeyDone}),


### PR DESCRIPTION
With primitives layoutAlign goes from type, so we need to exclude implicit setting of this detail on layout conversion
