### PR TITLE
GO-5408 Add Blocks restriction to types

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -54,6 +54,7 @@ var (
 		model.Restrictions_Publish,
 	}
 	sysTypesRestrictions = ObjectRestrictions{
+		model.Restrictions_Blocks,
 		model.Restrictions_LayoutChange,
 		model.Restrictions_TypeChange,
 		model.Restrictions_Template,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5408/blocks-from-the-editor-are-moved-to-the-type-in-the-widget

Add Blocks restriction to types, so DnD to type widget will be prohibited