### PR TITLE
GO-5346 Fix convert from Note

### DIFF
--- a/core/block/editor/smartblock/detailsinject.go
+++ b/core/block/editor/smartblock/detailsinject.go
@@ -26,6 +26,7 @@ func (sb *smartBlock) injectLocalDetails(s *state.State) error {
 	keys := bundle.LocalAndDerivedRelationKeys
 
 	localDetailsFromStore := details.CopyOnlyKeys(keys...)
+	localDetailsFromStore.Delete(bundle.RelationKeyResolvedLayout)
 
 	s.InjectLocalDetails(localDetailsFromStore)
 	if p := s.ParentState(); p != nil && !hasPendingLocalDetails {

--- a/core/domain/genericmap.go
+++ b/core/domain/genericmap.go
@@ -250,7 +250,7 @@ func (d *GenericMap[K]) CopyOnlyKeys(keys ...K) *GenericMap[K] {
 	if d == nil {
 		return NewGenericMap[K]()
 	}
-	newData := make(map[K]Value, len(d.data))
+	newData := make(map[K]Value, len(keys))
 	for k, v := range d.data {
 		if slices.Contains(keys, k) {
 			newData[k] = v


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5346/make-possible-to-change-the-note-layout-into-basic-etc

ResolvedLayout used to be inserted to state via UpdatePendingLocalDetails mechanism on smartblock Init, that's why conversion from Note did not work for objects that were not in cache