### PR TITLE
GO-5261 | GO-5338 - Exclude Note & Task from system

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -175,8 +175,6 @@ var (
 		bundle.TypeKeySet, bundle.TypeKeyCollection, // lists
 		bundle.TypeKeyFile, bundle.TypeKeyAudio, bundle.TypeKeyVideo, bundle.TypeKeyImage, // files
 	}
-
-	deletableSystemTypes = []domain.TypeKey{bundle.TypeKeyTask, bundle.TypeKeyNote}
 )
 
 func GetRestrictionsBySBType(sbType smartblock.SmartBlockType) []int {
@@ -264,8 +262,6 @@ func getRestrictionsForUniqueKey(uk domain.UniqueKey) (r ObjectRestrictions) {
 		if slices.Contains(bundle.SystemTypes, domain.TypeKey(key)) {
 			if slices.Contains(editableSystemTypes, domain.TypeKey(key)) {
 				r = sysTypesRestrictions
-			} else if slices.Contains(deletableSystemTypes, domain.TypeKey(key)) {
-				r = objRestrictEditAndTemplate
 			} else {
 				r = sysTypesRestrictionsEdit
 			}

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// ForceObjectsReindexCounter reindex thread-based objects
-	ForceObjectsReindexCounter int32 = 17
+	ForceObjectsReindexCounter int32 = 18
 
 	// ForceFilesReindexCounter reindex file objects
 	ForceFilesReindexCounter int32 = 12 //

--- a/pkg/lib/bundle/systemTypes.gen.go
+++ b/pkg/lib/bundle/systemTypes.gen.go
@@ -6,14 +6,12 @@ package bundle
 
 import domain "github.com/anyproto/anytype-heart/core/domain"
 
-const SystemTypesChecksum = "bf5fb329802ba479e21c98306b1bda3226c17c6cae83b280ede6954d9c012185"
+const SystemTypesChecksum = "a1a53bd06364104221da62efd98227afede5c8074dd3a5be71db7c6e24810a26"
 
 // SystemTypes contains types that have some special biz logic depends on them in some objects
 // they shouldn't be removed or edited in any way
 var SystemTypes = append(InternalTypes, []domain.TypeKey{
 	TypeKeyPage,
-	TypeKeyNote,
-	TypeKeyTask,
 	TypeKeyCollection,
 	TypeKeySet,
 	TypeKeyBookmark,

--- a/pkg/lib/bundle/systemTypes.json
+++ b/pkg/lib/bundle/systemTypes.json
@@ -13,8 +13,6 @@
   "date",
   "template",
   "page",
-  "note",
-  "task",
   "collection",
   "set",
   "bookmark",


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5261/[next]-make-type-certain-deletable
https://linear.app/anytype/issue/GO-5338/delete-all-system-descriptions-for-types-and-relations-for-users

- We should exclude Note and Task from system types, so they will not be reinstalled on space start
- Increase reindex counter, so description migration will be run for all bundled types