### PR TITLE
GO-5449 Fallback to layout from bundle info

### DIFF
--- a/core/block/editor/layout/syncer.go
+++ b/core/block/editor/layout/syncer.go
@@ -245,6 +245,7 @@ func (s *syncer) updateResolvedLayout(id string, layout int64, addName, needAppl
 				snippet := details.GetString(bundle.RelationKeySnippet)
 				cutSnippet, _, _ := strings.Cut(snippet, "\n")
 				details.SetString(bundle.RelationKeyName, cutSnippet)
+				details.SetBool(bundle.RelationKeyShouldConvertFromNote, true)
 			}
 			details.Set(bundle.RelationKeyResolvedLayout, domain.Int64(layout))
 			return details, true, nil

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -366,11 +366,11 @@ func (sb *smartBlock) Init(ctx *InitContext) (err error) {
 		source.NewSubObjectsAndProfileLinksMigration(sb.Type(), sb.space, sb.currentParticipantId, sb.spaceIndex).Migrate(ctx.State)
 	}
 
-	sb.resolveLayout(ctx.State)
 	if err = sb.injectLocalDetails(ctx.State); err != nil {
 		return
 	}
 	sb.injectDerivedDetails(ctx.State, sb.SpaceID(), sb.Type())
+	sb.resolveLayout(ctx.State)
 
 	sb.AddHook(sb.sendObjectCloseEvent, HookOnClose, HookOnBlockClose)
 	return

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -366,11 +366,11 @@ func (sb *smartBlock) Init(ctx *InitContext) (err error) {
 		source.NewSubObjectsAndProfileLinksMigration(sb.Type(), sb.space, sb.currentParticipantId, sb.spaceIndex).Migrate(ctx.State)
 	}
 
+	sb.resolveLayout(ctx.State)
 	if err = sb.injectLocalDetails(ctx.State); err != nil {
 		return
 	}
 	sb.injectDerivedDetails(ctx.State, sb.SpaceID(), sb.Type())
-	sb.resolveLayout(ctx.State)
 
 	sb.AddHook(sb.sendObjectCloseEvent, HookOnClose, HookOnBlockClose)
 	return

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "c4effd0b56ce4d007b246e0371064334d9a7acd7dee184669939217848faa938"
+const RelationChecksum = "40f927a64a108c72afa41cb6d5253b460098c188eb5c636bc23198a62ab8cc00"
 const (
 	RelationKeyTag                          domain.RelationKey = "tag"
 	RelationKeyCamera                       domain.RelationKey = "camera"
@@ -160,6 +160,7 @@ const (
 	RelationKeyAutoWidgetTargets            domain.RelationKey = "autoWidgetTargets"
 	RelationKeyAutoWidgetDisabled           domain.RelationKey = "autoWidgetDisabled"
 	RelationKeyPluralName                   domain.RelationKey = "pluralName"
+	RelationKeyShouldConvertFromNote        domain.RelationKey = "shouldConvertFromNote"
 )
 
 var (
@@ -1669,6 +1670,20 @@ var (
 			Key:              "sharedSpacesLimit",
 			MaxCount:         1,
 			Name:             "Shared spaces limit",
+			ReadOnly:         true,
+			ReadOnlyRelation: true,
+			Scope:            model.Relation_type,
+		},
+		RelationKeyShouldConvertFromNote: {
+
+			DataSource:       model.Relation_local,
+			Description:      "Object should be converted from Note",
+			Format:           model.RelationFormat_checkbox,
+			Hidden:           true,
+			Id:               "_brshouldConvertFromNote",
+			Key:              "shouldConvertFromNote",
+			MaxCount:         1,
+			Name:             "Should convert from Note",
 			ReadOnly:         true,
 			ReadOnlyRelation: true,
 			Scope:            model.Relation_type,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1535,5 +1535,15 @@
     "name": "Plural name",
     "readonly": false,
     "source": "details"
+  },
+  {
+    "description": "Object should be converted from Note",
+    "format": "checkbox",
+    "hidden": true,
+    "key": "shouldConvertFromNote",
+    "maxCount": 1,
+    "name": "Should convert from Note",
+    "readonly": true,
+    "source": "local"
   }
 ]


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5449/layout-fallback-on-cold-sync

Fix layout resolution flow:
1. Value from layout detail has highest priority
2. First we should try to resolve layout, and then - inject local details from objectstore
3. If we fail to get details of type object from object store by tyoe id, we need to check if this type is bundled and fallback to layout from bundle info. Key of type must be stored in state
4. Same for templates - we must store 2 keys in store for them: "template" and key for target type