### PR TITLE
GO-5404 Update initial order by lastUsedDate

### DIFF
--- a/core/block/editor/lastused/lastused.go
+++ b/core/block/editor/lastused/lastused.go
@@ -18,18 +18,32 @@ func SetLastUsedDateForInitialObjectType(id string, details *domain.Details) {
 
 	var priority int64
 	switch id {
-	case bundle.TypeKeyNote.BundledURL():
-		priority = 1
 	case bundle.TypeKeyPage.BundledURL():
-		priority = 2
+		priority = 1
 	case bundle.TypeKeyTask.BundledURL():
+		priority = 2
+	case bundle.TypeKeyCollection.BundledURL():
 		priority = 3
 	case bundle.TypeKeySet.BundledURL():
 		priority = 4
-	case bundle.TypeKeyCollection.BundledURL():
+	case bundle.TypeKeyBookmark.BundledURL():
 		priority = 5
-	default:
+	case bundle.TypeKeyNote.BundledURL():
+		priority = 6
+	case bundle.TypeKeyFile.BundledURL():
 		priority = 7
+	case bundle.TypeKeyImage.BundledURL():
+		priority = 8
+	case bundle.TypeKeyAudio.BundledURL():
+		priority = 9
+	case bundle.TypeKeyVideo.BundledURL():
+		priority = 10
+	case bundle.TypeKeyTemplate.BundledURL():
+		priority = 11
+	case bundle.TypeKeyParticipant.BundledURL():
+		priority = 12
+	default:
+		priority = 13
 	}
 
 	// we do this trick to order crucial Anytype object types by last date

--- a/core/block/editor/lastused/lastused_test.go
+++ b/core/block/editor/lastused/lastused_test.go
@@ -39,10 +39,10 @@ func TestSetLastUsedDateForInitialType(t *testing.T) {
 		}
 
 		// then
-		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyNote.BundledURL()], detailMap[bundle.TypeKeyPage.BundledURL()]))
+		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyPage.BundledURL()], detailMap[bundle.TypeKeyNote.BundledURL()]))
 		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyPage.BundledURL()], detailMap[bundle.TypeKeyTask.BundledURL()]))
 		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyTask.BundledURL()], detailMap[bundle.TypeKeySet.BundledURL()]))
-		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeySet.BundledURL()], detailMap[bundle.TypeKeyCollection.BundledURL()]))
+		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyCollection.BundledURL()], detailMap[bundle.TypeKeySet.BundledURL()]))
 		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyCollection.BundledURL()], detailMap[bundle.TypeKeyAudio.BundledURL()]))
 		assert.True(t, isLastUsedDateGreater(detailMap[bundle.TypeKeyCollection.BundledURL()], detailMap[bundle.TypeKeyDiaryEntry.BundledURL()]))
 	})


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5404/make-the-correct-order-in-the-type-library

On space creation we set different values of lastUsedDate to bundled types, so they will be similarly sorted in all new spaces.
New order of types arrives