### PR TITLE
GO-5461 Include all system relations on store.ListAllRelations

### DIFF
--- a/pkg/lib/localstore/objectstore/spaceindex/relations.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/relations.go
@@ -126,15 +126,26 @@ func (s *dsObjectStore) ListAllRelations() (relations relationutils.Relations, e
 		},
 	}
 
-	relations2, err := s.Query(database.Query{
+	records, err := s.Query(database.Query{
 		Filters: filters,
 	})
 	if err != nil {
 		return
 	}
 
-	for _, rec := range relations2 {
-		relations = append(relations, relationutils.RelationFromDetails(rec.Details))
+	allKeys := make(map[domain.RelationKey]struct{}, len(records))
+	for _, rec := range records {
+		relationModel := relationutils.RelationFromDetails(rec.Details)
+		relations = append(relations, relationModel)
+		allKeys[domain.RelationKey(relationModel.Key)] = struct{}{}
+	}
+
+	for _, key := range bundle.SystemRelations {
+		if _, found := allKeys[key]; found {
+			continue
+		}
+		// we should include system relations if they were not indexed
+		relations = append(relations, &relationutils.Relation{Relation: bundle.MustGetRelation(key)})
 	}
 	return
 }
@@ -170,7 +181,7 @@ func (s *dsObjectStore) GetRelationByKey(key string) (*model.Relation, error) {
 }
 
 func (s *dsObjectStore) GetRelationFormatByKey(key domain.RelationKey) (model.RelationFormat, error) {
-	rel, err := bundle.GetRelation(domain.RelationKey(key))
+	rel, err := bundle.GetRelation(key)
 	if err == nil {
 		return rel.Format, nil
 	}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5461/after-migration-the-graph-displays-the-old-icons-there-is-no-iconname

Graph used to show old icons for types that migrated from older versions.
The problem was in the absence of **globalName** and **iconName** relations in object store, these relations just were not added to space as objects.
The fix adds missing system relations to response of ListAllRelations method