### PR TITLE
GO-5455 Fix defaultTypeId setting for new lists

### DIFF
--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -363,7 +363,15 @@ func (c *layoutConverter) insertTypeLevelFieldsToDataview(block *model.BlockCont
 	}
 
 	rawViewType := records[0].Details.GetInt64(bundle.RelationKeyDefaultViewType)
-	defaultTypeId := records[0].Details.GetString(bundle.RelationKeyDefaultTypeId)
+	defaultTypeValue := records[0].Details.Get(bundle.RelationKeyDefaultTypeId)
+	defaultTypeId, ok := defaultTypeValue.TryString()
+	if !ok {
+		// some clients put a list of ids to detail, that is normal, because relation has object format
+		list, ok := defaultTypeValue.TryStringList()
+		if ok && len(list) > 0 {
+			defaultTypeId = list[0]
+		}
+	}
 
 	// nolint:gosec
 	viewType := model.BlockContentDataviewViewType(rawViewType)

--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -364,8 +364,8 @@ func (c *layoutConverter) insertTypeLevelFieldsToDataview(block *model.BlockCont
 
 	rawViewType := records[0].Details.GetInt64(bundle.RelationKeyDefaultViewType)
 	defaultTypeIds := records[0].Details.WrapToStringList(bundle.RelationKeyDefaultTypeId)
-	defaultTypeId := ""
-	if len(defaultTypeIds) != 0 {
+	var defaultTypeId string
+	if len(defaultTypeIds) > 0 {
 		defaultTypeId = defaultTypeIds[0]
 	}
 

--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -363,14 +363,10 @@ func (c *layoutConverter) insertTypeLevelFieldsToDataview(block *model.BlockCont
 	}
 
 	rawViewType := records[0].Details.GetInt64(bundle.RelationKeyDefaultViewType)
-	defaultTypeValue := records[0].Details.Get(bundle.RelationKeyDefaultTypeId)
-	defaultTypeId, ok := defaultTypeValue.TryString()
-	if !ok {
-		// some clients put a list of ids to detail, that is normal, because relation has object format
-		list, ok := defaultTypeValue.TryStringList()
-		if ok && len(list) > 0 {
-			defaultTypeId = list[0]
-		}
+	defaultTypeIds := records[0].Details.WrapToStringList(bundle.RelationKeyDefaultTypeId)
+	defaultTypeId := ""
+	if len(defaultTypeIds) != 0 {
+		defaultTypeId = defaultTypeIds[0]
 	}
 
 	// nolint:gosec


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5455/default-object-type-does-not-change-in-the-type-settings

Clients used to set defaultTypeId value as list of strings, so the value was not fetched correctly from anystore