### PR TITLE
GO-5451 Unset isReadonly on restrictions change

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1277,11 +1277,11 @@ func (sb *smartBlock) setRestrictionsDetail(s *state.State) {
 
 	s.SetLocalDetail(bundle.RelationKeyRestrictions, sb.Restrictions().Object.ToValue())
 
-	// todo: verify this logic with clients
 	if sb.Restrictions().Object.Check(model.Restrictions_Details) != nil &&
 		sb.Restrictions().Object.Check(model.Restrictions_Blocks) != nil {
-
 		s.SetDetailAndBundledRelation(bundle.RelationKeyIsReadonly, domain.Bool(true))
+	} else if s.LocalDetails().GetBool(bundle.RelationKeyIsReadonly) {
+		s.SetDetailAndBundledRelation(bundle.RelationKeyIsReadonly, domain.Bool(false))
 	}
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5451/after-migration-not-all-types-are-displayed-in-the-existing-object-in

We should unset isReadonly relation in case Delete or Blocks restriction was removed from object