### PR TITLE
GO-5402 Fix view relations update

### DIFF
--- a/core/block/dataviewservice/service.go
+++ b/core/block/dataviewservice/service.go
@@ -216,7 +216,7 @@ func (s *service) AddDataviewViewRelation(
 		if err = dv.AddViewRelation(viewId, relation); err != nil {
 			return err
 		}
-		s.syncViewRelationsAndRelationLinks(objectId, viewId, dv)
+		syncViewRelationsAndRelationLinks(viewId, dv)
 		return nil
 	})
 }
@@ -234,7 +234,7 @@ func (s *service) RemoveDataviewViewRelations(
 		if err = dv.RemoveViewRelations(viewId, relationKeys); err != nil {
 			return err
 		}
-		s.syncViewRelationsAndRelationLinks(objectId, viewId, dv)
+		syncViewRelationsAndRelationLinks(viewId, dv)
 		return nil
 	})
 }
@@ -253,7 +253,7 @@ func (s *service) ReplaceDataviewViewRelation(
 		if err = dv.ReplaceViewRelation(viewId, relationKey, relation); err != nil {
 			return err
 		}
-		s.syncViewRelationsAndRelationLinks(objectId, viewId, dv)
+		syncViewRelationsAndRelationLinks(viewId, dv)
 		return nil
 	})
 }
@@ -271,12 +271,12 @@ func (s *service) ReorderDataviewViewRelations(
 		if err = dv.ReorderViewRelations(viewId, relationKeys); err != nil {
 			return err
 		}
-		s.syncViewRelationsAndRelationLinks(objectId, viewId, dv)
+		syncViewRelationsAndRelationLinks(viewId, dv)
 		return nil
 	})
 }
 
-func (s *service) syncViewRelationsAndRelationLinks(objectId, viewId string, dv dvblock.Block) {
+func syncViewRelationsAndRelationLinks(viewId string, dv dvblock.Block) {
 	view, err := dv.GetView(viewId)
 	if err != nil {
 		log.Error("failed to get view", zap.String("viewId", viewId), zap.Error(err))

--- a/core/block/dataviewservice/service_test.go
+++ b/core/block/dataviewservice/service_test.go
@@ -5,48 +5,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/anyproto/anytype-heart/core/block/object/idresolver/mock_idresolver"
 	dvblock "github.com/anyproto/anytype-heart/core/block/simple/dataview"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
-	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
 const (
-	spaceId    = "spc1"
-	objectId   = "obj1"
 	blockId    = "dataview"
 	testViewId = "view1"
 )
 
-type fixture struct {
-	store      *objectstore.StoreFixture
-	idResolver *mock_idresolver.MockResolver
-	*service
-}
-
-func newFixture(t *testing.T) *fixture {
-	store := objectstore.NewStoreFixture(t)
-	idResolver := mock_idresolver.NewMockResolver(t)
-	return &fixture{
-		store:      store,
-		idResolver: idResolver,
-		service: &service{
-			objectStore: store,
-			idResolver:  idResolver,
-		},
-	}
-}
-
 func TestService_syncViewRelationsAndRelationLinks(t *testing.T) {
 	t.Run("relations are synced", func(t *testing.T) {
 		// given
-		fx := newFixture(t)
-		fx.idResolver.EXPECT().ResolveSpaceID(objectId).Return(spaceId, nil)
 		dv := makeDataviewForViewRelationsTest([]*model.RelationLink{
 			{Key: bundle.RelationKeyName.String(), Format: model.RelationFormat_longtext},
 			{Key: bundle.RelationKeyBacklinks.String(), Format: model.RelationFormat_object},
-			// relation links do not include CreatedDate and Type, so they should be inserted using objectStore
+			// relation links do not include CreatedDate and Type, but it is OK!
 		}, []*model.BlockContentDataviewRelation{
 			{Key: bundle.RelationKeyName.String(), IsVisible: true, Width: dvblock.DefaultViewRelationWidth},
 			{Key: bundle.RelationKeyCreatedDate.String(), IsVisible: true, Width: dvblock.DefaultViewRelationWidth},
@@ -57,8 +32,6 @@ func TestService_syncViewRelationsAndRelationLinks(t *testing.T) {
 		want := makeDataviewForViewRelationsTest([]*model.RelationLink{
 			{Key: bundle.RelationKeyName.String(), Format: model.RelationFormat_longtext},
 			{Key: bundle.RelationKeyBacklinks.String(), Format: model.RelationFormat_object},
-			{Key: bundle.RelationKeyCreatedDate.String(), Format: model.RelationFormat_date},
-			{Key: bundle.RelationKeyType.String(), Format: model.RelationFormat_object},
 		}, []*model.BlockContentDataviewRelation{
 			{Key: bundle.RelationKeyName.String(), IsVisible: true, Width: dvblock.DefaultViewRelationWidth},
 			{Key: bundle.RelationKeyCreatedDate.String(), IsVisible: true, Width: dvblock.DefaultViewRelationWidth},
@@ -67,7 +40,7 @@ func TestService_syncViewRelationsAndRelationLinks(t *testing.T) {
 		})
 
 		// when
-		fx.syncViewRelationsAndRelationLinks(objectId, testViewId, dv)
+		syncViewRelationsAndRelationLinks(testViewId, dv)
 
 		// then
 		assert.Equal(t, want, dv)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5402/after-remove-from-type-and-adding-a-new-property-all-properties-are

We should not update RelationLinks of dataview block on view relations update.
Fisrt list contains relations common for all views of dataview, while second contains layout settings for particular views (visibility, width, etc.)