### PR TITLE
Fix default featured relations order

### DIFF
--- a/core/relationutils/recommended.go
+++ b/core/relationutils/recommended.go
@@ -21,8 +21,8 @@ type ObjectIDDeriver interface {
 var (
 	defaultFeaturedRelationKeys = []domain.RelationKey{
 		bundle.RelationKeyType,
-		bundle.RelationKeyTag,
 		bundle.RelationKeyBacklinks,
+		bundle.RelationKeyTag,
 	}
 
 	defaultSetFeaturedRelationKeys = []domain.RelationKey{

--- a/core/relationutils/recommended.go
+++ b/core/relationutils/recommended.go
@@ -31,6 +31,11 @@ var (
 		bundle.RelationKeyBacklinks,
 	}
 
+	defaultCollectionFeaturedRelationKeys = []domain.RelationKey{
+		bundle.RelationKeyType,
+		bundle.RelationKeyBacklinks,
+	}
+
 	defaultRecommendedRelationKeys = []domain.RelationKey{
 		bundle.RelationKeyCreatedDate,
 		bundle.RelationKeyCreator,
@@ -66,8 +71,11 @@ var (
 )
 
 func DefaultFeaturedRelationKeys(typeKey domain.TypeKey) []domain.RelationKey {
-	if typeKey == bundle.TypeKeySet {
+	switch typeKey {
+	case bundle.TypeKeySet:
 		return defaultSetFeaturedRelationKeys
+	case bundle.TypeKeyCollection:
+		return defaultCollectionFeaturedRelationKeys
 	}
 	return defaultFeaturedRelationKeys
 }

--- a/core/relationutils/recommended.go
+++ b/core/relationutils/recommended.go
@@ -28,7 +28,6 @@ var (
 	defaultSetFeaturedRelationKeys = []domain.RelationKey{
 		bundle.RelationKeyType,
 		bundle.RelationKeySetOf,
-		bundle.RelationKeyTag,
 		bundle.RelationKeyBacklinks,
 	}
 

--- a/core/relationutils/recommended_test.go
+++ b/core/relationutils/recommended_test.go
@@ -187,10 +187,11 @@ func TestFillRecommendedRelations(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.False(t, isAlreadyFilled)
-		assert.Equal(t, buildRelationIds(defaultRecommendedRelationKeys), details.GetStringList(bundle.RelationKeyRecommendedRelations))
+		assert.Equal(t, buildRelationIds(append([]domain.RelationKey{bundle.RelationKeyTag}, defaultRecommendedRelationKeys...)),
+			details.GetStringList(bundle.RelationKeyRecommendedRelations))
 		assert.Equal(t, buildRelationIds(defaultSetFeaturedRelationKeys), details.GetStringList(bundle.RelationKeyRecommendedFeaturedRelations))
 		assert.Equal(t, defaultRecHiddenRelIds, details.GetStringList(bundle.RelationKeyRecommendedHiddenRelations))
-		assert.Len(t, keys, 4+3+3) // 4 featured + 3 sidebar + 3 hidden
+		assert.Len(t, keys, 3+4+3) // 3 featured + 4 sidebar + 3 hidden
 	})
 }
 


### PR DESCRIPTION
Fix default order for featured relations, so most types after migration won't face conflicting layout