### PR TITLE
GO-5475 Fix duplicated collection widget block on import from gallery

### DIFF
--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -657,12 +657,33 @@ func (s *Service) TableColumnListFill(ctx session.Context, req pb.RpcBlockTableC
 	return err
 }
 
-func (s *Service) CreateWidgetBlock(ctx session.Context, req *pb.RpcBlockCreateWidgetRequest) (string, error) {
+func (s *Service) CreateWidgetBlock(ctx session.Context, req *pb.RpcBlockCreateWidgetRequest, checkDuplicatedTarget bool) (string, error) {
 	var id string
 	err := cache.DoStateCtx(s, ctx, req.ContextId, func(st *state.State, w widget.Widget) error {
+		if checkDuplicatedTarget && widgetHasBlock(st, req.Block) {
+			return nil
+		}
 		var err error
 		id, err = w.CreateBlock(st, req)
 		return err
 	})
 	return id, err
+}
+
+// widgetHasBlock checks if widget has block with same targetBlockId as in provided block
+func widgetHasBlock(st *state.State, block *model.Block) (found bool) {
+	if block == nil || block.GetLink() == nil {
+		return false
+	}
+	targetBlockId := block.GetLink().TargetBlockId
+	_ = st.Iterate(func(b simple.Block) (isContinue bool) {
+		if l := b.Model().GetLink(); l != nil {
+			if l.GetTargetBlockId() == targetBlockId {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
 }

--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -676,6 +676,7 @@ func widgetHasBlock(st *state.State, block *model.Block) (found bool) {
 		return false
 	}
 	targetBlockId := block.GetLink().TargetBlockId
+	// nolint:errcheck
 	_ = st.Iterate(func(b simple.Block) (isContinue bool) {
 		if l := b.Model().GetLink(); l != nil {
 			if l.GetTargetBlockId() == targetBlockId {

--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -119,7 +119,7 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 	}
 
 	if sn.Snapshot.SbType == coresb.SmartBlockTypeWidget {
-		return oc.updateWidgetObject(st)
+		return nil, "", nil
 	}
 
 	st.ModifyLinkedFilesInDetails(func(fileId string) string {
@@ -478,32 +478,6 @@ func (oc *ObjectCreator) mergeCollections(existedObjects []string, st *state.Sta
 	st.UpdateStoreSlice(template.CollectionStoreKey, result)
 }
 
-func (oc *ObjectCreator) updateWidgetObject(st *state.State) (*domain.Details, string, error) {
-	err := cache.DoState(oc.objectGetterDeleter, st.RootId(), func(oldState *state.State, sb smartblock.SmartBlock) error {
-		blocks := st.Blocks()
-		blocksMap := make(map[string]*model.Block, len(blocks))
-		existingWidgetsTargetIDs, err := oc.getExistingWidgetsTargetIDs(oldState)
-		if err != nil {
-			return err
-		}
-		for _, block := range blocks {
-			blocksMap[block.Id] = block
-		}
-		for _, block := range blocks {
-			if widget := block.GetWidget(); widget != nil {
-				if len(block.ChildrenIds) > 0 {
-					err := oc.addWidgetBlock(oldState, block, blocksMap, existingWidgetsTargetIDs)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		}
-		return nil
-	})
-	return nil, "", err
-}
-
 func (oc *ObjectCreator) addWidgetBlock(oldState *state.State,
 	block *model.Block,
 	blocksMap map[string]*model.Block,
@@ -531,20 +505,6 @@ func (oc *ObjectCreator) skipObject(targetID string, existingWidgetsTargetIDs ma
 		}
 	}
 	return false
-}
-
-func (oc *ObjectCreator) getExistingWidgetsTargetIDs(oldState *state.State) (map[string]struct{}, error) {
-	existingWidgetsTargetIDs := make(map[string]struct{}, 0)
-	err := oldState.Iterate(func(b simple.Block) (isContinue bool) {
-		if b.Model().GetLink() != nil {
-			existingWidgetsTargetIDs[b.Model().GetLink().GetTargetBlockId()] = struct{}{}
-		}
-		return true
-	})
-	if err != nil {
-		return nil, err
-	}
-	return existingWidgetsTargetIDs, nil
 }
 
 func (oc *ObjectCreator) updateKeys(st *state.State, oldIDtoNew map[string]string) {

--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -203,7 +203,7 @@ func (i *Import) addRootCollectionWidget(res *ImportResponse, req *ImportRequest
 					TargetBlockId: res.RootCollectionId,
 				}},
 			},
-		})
+		}, true)
 		if err != nil {
 			log.Errorf("failed to create widget from root collection, error: %s", err.Error())
 		}

--- a/core/widget.go
+++ b/core/widget.go
@@ -23,7 +23,7 @@ func (mw *Middleware) BlockCreateWidget(cctx context.Context, req *pb.RpcBlockCr
 		if req.Block != nil {
 			req.Block.Id = ""
 		}
-		id, err = bs.CreateWidgetBlock(ctx, req)
+		id, err = bs.CreateWidgetBlock(ctx, req, false)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5475/2-identical-widgets-are-created-after-installing-an-experience-from

In case of import from gallery we have already added link to collection to widgets, so after import we need to check if such link block already exists in widget object