### PR TITLE
GO-5452 Fix backlinks update

### DIFF
--- a/pkg/lib/localstore/objectstore/spaceindex/update.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/update.go
@@ -250,7 +250,7 @@ func (s *dsObjectStore) getPendingLocalDetails(txn *badger.Txn, key []byte) (*mo
 func (s *dsObjectStore) updateObjectLinks(ctx context.Context, id string, links []string) (added []string, removed []string, err error) {
 	_, err = s.links.UpsertId(ctx, id, query.ModifyFunc(func(arena *anyenc.Arena, val *anyenc.Value) (*anyenc.Value, bool, error) {
 		prev := anyEncArrayToStrings(val.GetArray(linkOutboundField))
-		added, removed = slice.DifferenceRemovedAdded(prev, links)
+		removed, added = slice.DifferenceRemovedAdded(prev, links)
 		val.Set(linkOutboundField, stringsToJsonArray(arena, links))
 		return val, len(added)+len(removed) > 0, nil
 	}))


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5452/objects-are-not-displayed-in-set-when-sorted-by-backlinks

Backlinks were not set on link addition, bacause new link was treated as being removed, not added