### PR TITLE
GO-5462 Remove TypeChange restriction from collection

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -373,6 +373,9 @@ func (bs *basic) getLayoutForType(objectTypeKey domain.TypeKey) (model.ObjectTyp
 
 func (bs *basic) SetLayoutInState(s *state.State, toLayout model.ObjectTypeLayout, ignoreRestriction bool) (err error) {
 	fromLayout, _ := s.Layout()
+	if fromLayout == toLayout {
+		return nil
+	}
 
 	if !ignoreRestriction {
 		if err = bs.Restrictions().Object.Check(model.Restrictions_LayoutChange); errors.Is(err, restriction.ErrRestricted) {

--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -72,11 +72,15 @@ var (
 	}
 
 	objectRestrictionsByLayout = map[model.ObjectTypeLayout]ObjectRestrictions{
-		model.ObjectType_basic:      {},
-		model.ObjectType_profile:    {},
-		model.ObjectType_todo:       {},
-		model.ObjectType_set:        objRestrictEdit,
-		model.ObjectType_collection: objRestrictEdit,
+		model.ObjectType_basic:   {},
+		model.ObjectType_profile: {},
+		model.ObjectType_todo:    {},
+		model.ObjectType_set:     objRestrictEdit,
+		model.ObjectType_collection: {
+			model.Restrictions_Blocks,
+			model.Restrictions_LayoutChange,
+			model.Restrictions_Publish,
+		},
 		model.ObjectType_objectType: objRestrictEditAndTemplate,
 		model.ObjectType_relation:   objRestrictEditAndTemplate,
 		model.ObjectType_file:       objRestrictEditAndDuplicate,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5462/[later]-provide-change-type-function-for-the-collections-as-we-do-for

We should allow changing type of objects with collection layout to type with recommendedLayout=collection