### PR TITLE
GO-5531 Support batch details unset

### DIFF
--- a/core/block/detailservice/service.go
+++ b/core/block/detailservice/service.go
@@ -114,7 +114,7 @@ func (s *service) ModifyDetailsList(req *pb.RpcObjectListModifyDetailValuesReque
 	for _, objectId := range req.ObjectIds {
 		err := s.ModifyDetails(nil, objectId, func(current *domain.Details) (*domain.Details, error) {
 			for _, op := range req.Operations {
-				if !pbtypes.IsNullValue(op.Set) {
+				if pbtypes.IsNullValue(op.Add) && pbtypes.IsNullValue(op.Remove) {
 					// Set operation has higher priority than Add and Remove, because it modifies full value
 					current.Set(domain.RelationKey(op.RelationKey), domain.ValueFromProto(op.Set))
 					continue

--- a/core/block/detailservice/service.go
+++ b/core/block/detailservice/service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/space"
-	"github.com/anyproto/anytype-heart/util/pbtypes"
 	"github.com/anyproto/anytype-heart/util/slice"
 )
 
@@ -114,7 +113,7 @@ func (s *service) ModifyDetailsList(req *pb.RpcObjectListModifyDetailValuesReque
 	for _, objectId := range req.ObjectIds {
 		err := s.ModifyDetails(nil, objectId, func(current *domain.Details) (*domain.Details, error) {
 			for _, op := range req.Operations {
-				if pbtypes.IsNullValue(op.Add) && pbtypes.IsNullValue(op.Remove) {
+				if op.Set != nil {
 					// Set operation has higher priority than Add and Remove, because it modifies full value
 					current.Set(domain.RelationKey(op.RelationKey), domain.ValueFromProto(op.Set))
 					continue


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5531/date-relations-cant-be-cleared-when-doing-a-bulk-edit-of-the-relation

Support batch unset of details 