### PR TITLE
GO-5424 Do migration for empty rec layout on import

### DIFF
--- a/core/block/editor/objecttype.go
+++ b/core/block/editor/objecttype.go
@@ -99,6 +99,7 @@ func (ot *ObjectType) CreationStateMigration(ctx *smartblock.InitContext) migrat
 				template.WithObjectTypes(ctx.State.ObjectTypeKeys()),
 				template.WithTitle,
 				template.WithLayout(model.ObjectType_objectType),
+				template.WithDetail(bundle.RelationKeyRecommendedLayout, domain.Int64(model.ObjectType_basic)),
 			}
 			templates = append(templates, ot.dataviewTemplates()...)
 

--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -374,6 +374,9 @@ func (oc *ObjectCreator) resetState(newID string, st *state.State) *domain.Detai
 			// we use revision for bundled objects like relations and object types
 			return nil
 		}
+		if st.ObjectTypeKey() == bundle.TypeKeyObjectType {
+			template.InitTemplate(st, template.WithDetail(bundle.RelationKeyRecommendedLayout, domain.Int64(model.ObjectType_basic)))
+		}
 		err := history.ResetToVersion(b, st)
 		if err != nil {
 			log.With(zap.String("object id", newID)).Errorf("failed to set state %s: %s", newID, err)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5424/do-a-migration-when-types-recommended-layout-is-missing

We should set default value **basic** for recommendedLayout detail on types import both for new and already installed types