### PR TITLE
GO-5487 Fix revision of non system types

### DIFF
--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
@@ -42,6 +42,7 @@ var (
 	}
 
 	customObjectFilterKeys = []domain.RelationKey{
+		bundle.RelationKeyRevision,
 		bundle.RelationKeyIconOption,
 		bundle.RelationKeyIconName,
 		bundle.RelationKeyPluralName,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5487/property-changes-in-object-types-are-not-persistent-changes-are-gone
https://linear.app/anytype/issue/GO-5623/default-task-properties-reset-after-editing-and-restarting-anytype
https://linear.app/anytype/issue/GO-5506/i-cant-customize-the-properties-header-is-this-a-bug
https://linear.app/anytype/issue/GO-5512/type-icon-reverts-to-default
https://linear.app/anytype/issue/GO-5564/hiding-property-does-not-work-on-restart-of-the-anytype-desktop

Revision detail did not use to be updated for non-system bundled types, that's why lists of recommended relations and icon were updated every time on restart