### PR TITLE
GO-5638 Fix panic on symm key derivation

### DIFF
--- a/core/pushnotification/keys.go
+++ b/core/pushnotification/keys.go
@@ -1,6 +1,8 @@
 package pushnotification
 
 import (
+	"errors"
+
 	"github.com/anyproto/any-sync/util/crypto"
 
 	"github.com/anyproto/anytype-heart/util/privkey"
@@ -20,6 +22,9 @@ func deriveSpaceKey(firstMetadataKey crypto.PrivKey) (crypto.PrivKey, error) {
 }
 
 func deriveSymmetricKey(readKey crypto.SymKey) (crypto.SymKey, error) {
+	if readKey == nil {
+		return nil, errors.New("readKey is nil")
+	}
 	raw, err := readKey.Raw()
 	if err != nil {
 		return nil, err

--- a/space/internal/components/aclobjectmanager/aclobjectmanager.go
+++ b/space/internal/components/aclobjectmanager/aclobjectmanager.go
@@ -259,6 +259,11 @@ func (a *aclObjectManager) processAcl() (err error) {
 	defer a.mx.Unlock()
 	a.lastIndexed = acl.Head().Id
 
+	if aclState.Permissions(aclState.Identity()).NoPermissions() {
+		// no need to push notifications or subscribe on them if space is removing
+		return nil
+	}
+
 	err = a.pushNotificationService.BroadcastKeyUpdate(common.Id(), aclState)
 	if err != nil {
 		return fmt.Errorf("broadcast key update: %w", err)

--- a/space/internal/components/aclobjectmanager/aclobjectmanager.go
+++ b/space/internal/components/aclobjectmanager/aclobjectmanager.go
@@ -259,11 +259,6 @@ func (a *aclObjectManager) processAcl() (err error) {
 	defer a.mx.Unlock()
 	a.lastIndexed = acl.Head().Id
 
-	if aclState.Permissions(aclState.Identity()).NoPermissions() {
-		// no need to push notifications or subscribe on them if space is removing
-		return nil
-	}
-
 	err = a.pushNotificationService.BroadcastKeyUpdate(common.Id(), aclState)
 	if err != nil {
 		return fmt.Errorf("broadcast key update: %w", err)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5638/the-app-crashes-after-remove-member

Symmetric key of ACL current state could be nil