### PR TITLE
GO-5612: Refactor loading, make sure that setLoadErr is set when not

### DIFF
--- a/space/internal/components/spaceloader/loadingspace.go
+++ b/space/internal/components/spaceloader/loadingspace.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/anyproto/any-sync/app/logger"
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
-	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/space/clientspace"
@@ -73,11 +72,13 @@ func (ls *loadingSpace) setLoadErr(err error) {
 func (ls *loadingSpace) loadRetry(ctx context.Context) {
 	defer func() {
 		if err := ls.spaceServiceProvider.onLoad(ls.space, ls.getLoadErr()); err != nil {
-			log.WarnCtx(ctx, "space onLoad error", zap.Error(err))
+			log.WarnCtx(ctx, "space onLoad error", zap.Error(err), zap.Error(ls.getLoadErr()))
 		}
 		close(ls.loadCh)
 	}()
-	if ls.load(ctx) {
+	shouldRetry, err := ls.load(ctx)
+	if !shouldRetry {
+		ls.setLoadErr(err)
 		return
 	}
 	timeout := 1 * time.Second
@@ -87,7 +88,9 @@ func (ls *loadingSpace) loadRetry(ctx context.Context) {
 			ls.setLoadErr(ctx.Err())
 			return
 		case <-time.After(timeout):
-			if ls.load(ctx) {
+			shouldRetry, err := ls.load(ctx)
+			if !shouldRetry {
+				ls.setLoadErr(err)
 				return
 			}
 		}
@@ -98,47 +101,25 @@ func (ls *loadingSpace) loadRetry(ctx context.Context) {
 	}
 }
 
-func (ls *loadingSpace) load(ctx context.Context) (notRetryable bool) {
+func (ls *loadingSpace) load(ctx context.Context) (ok bool, err error) {
 	sp, err := ls.spaceServiceProvider.open(ctx)
-	if errors.Is(err, spacesyncproto.ErrSpaceMissing) {
-		log.WarnCtx(ctx, "space load: space is missing", zap.String("spaceId", ls.ID), zap.Bool("notRetryable", ls.disableRemoteLoad), zap.Error(err))
-		return ls.disableRemoteLoad
-	}
-	if err == nil {
-		err = sp.WaitMandatoryObjects(ctx)
-		if err != nil {
-			notRetryable = errors.Is(err, objecttree.ErrHasInvalidChanges)
-			log.WarnCtx(ctx, "space load: mandatory objects error", zap.String("spaceId", ls.ID), zap.Error(err), zap.Bool("notRetryable", ls.disableRemoteLoad || notRetryable))
-			return ls.disableRemoteLoad || notRetryable
-		}
-	}
 	if err != nil {
-		if sp != nil {
-			closeErr := sp.Close(ctx)
-			if closeErr != nil {
-				log.WarnCtx(ctx, "space close error", zap.Error(closeErr))
-			}
-		}
-		ls.setLoadErr(err)
-		if errors.Is(err, context.Canceled) {
-			log.WarnCtx(ctx, "space load: error: context bug", zap.String("spaceId", ls.ID), zap.Error(err), zap.Bool("notRetryable", ls.disableRemoteLoad))
-			// hotfix for drpc bug
-			// todo: remove after https://github.com/anyproto/any-sync/pull/448 got integrated
-			return ls.disableRemoteLoad
-		}
-		log.WarnCtx(ctx, "space load: error", zap.String("spaceId", ls.ID), zap.Error(err), zap.Bool("notRetryable", true))
-	} else {
-		if ls.latestAclHeadId != "" && !ls.disableRemoteLoad {
-			acl := sp.CommonSpace().Acl()
-			acl.RLock()
-			defer acl.RUnlock()
-			_, err := acl.Get(ls.latestAclHeadId)
-			if err != nil {
-				log.WarnCtx(ctx, "space load: acl head not found", zap.String("spaceId", ls.ID), zap.String("aclHeadId", ls.latestAclHeadId), zap.Error(err), zap.Bool("notRetryable", false))
-				return false
-			}
-		}
-		ls.space = sp
+		return ls.disableRemoteLoad, err
 	}
-	return true
+	err = sp.WaitMandatoryObjects(ctx)
+	if err != nil {
+		notRetryable := errors.Is(err, objecttree.ErrHasInvalidChanges) || ls.disableRemoteLoad
+		return notRetryable, err
+	}
+	if ls.latestAclHeadId != "" && !ls.disableRemoteLoad {
+		acl := sp.CommonSpace().Acl()
+		acl.RLock()
+		defer acl.RUnlock()
+		_, err := acl.Get(ls.latestAclHeadId)
+		if err != nil {
+			return false, err
+		}
+	}
+	ls.space = sp
+	return true, nil
 }

--- a/space/internal/components/spaceloader/loadingspace.go
+++ b/space/internal/components/spaceloader/loadingspace.go
@@ -76,8 +76,8 @@ func (ls *loadingSpace) loadRetry(ctx context.Context) {
 		}
 		close(ls.loadCh)
 	}()
-	shouldRetry, err := ls.load(ctx)
-	if !shouldRetry {
+	shouldReturn, err := ls.load(ctx)
+	if shouldReturn {
 		ls.setLoadErr(err)
 		return
 	}
@@ -88,8 +88,8 @@ func (ls *loadingSpace) loadRetry(ctx context.Context) {
 			ls.setLoadErr(ctx.Err())
 			return
 		case <-time.After(timeout):
-			shouldRetry, err := ls.load(ctx)
-			if !shouldRetry {
+			shouldReturn, err := ls.load(ctx)
+			if shouldReturn {
 				ls.setLoadErr(err)
 				return
 			}


### PR DESCRIPTION
…etrying

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
