### PR TITLE
GO-4678 Propagate spaceId to backlinks watcher

### DIFF
--- a/core/block/backlinks/watcher.go
+++ b/core/block/backlinks/watcher.go
@@ -230,11 +230,11 @@ func (w *watcher) updateBackLinksInObject(id string, backlinksUpdate *backLinksU
 		if _, parseErr := dateutil.BuildDateObjectFromId(id); parseErr == nil {
 			return nil
 		}
-		return fmt.Errorf("failed to resolve space id: %v", err)
+		return fmt.Errorf("failed to resolve space id: %w", err)
 	}
 	spc, err := w.spaceService.Get(w.ctx, spaceId)
 	if err != nil {
-		return fmt.Errorf("failed to get space: %v", err)
+		return fmt.Errorf("failed to get space: %w", err)
 	}
 	spaceDerivedIds := spc.DerivedIDs()
 
@@ -288,9 +288,9 @@ func (w *watcher) updateBackLinksInObject(id string, backlinksUpdate *backLinksU
 		// do no do apply, stateAppend send the event and run the index
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to update backlinks: %v", err)
+		return fmt.Errorf("failed to update backlinks: %w", err)
 	}
-	return nil
+	return
 }
 
 func hasSelfLinks(info spaceindex.LinksUpdateInfo) bool {

--- a/core/domain/id.go
+++ b/core/domain/id.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -15,6 +16,8 @@ func (i FullID) IsEmpty() bool {
 }
 
 const ParticipantPrefix = "_participant_"
+
+var ErrParseLongId = errors.New("failed to parse object id")
 
 func NewParticipantId(spaceId, identity string) string {
 	// Replace dots with underscores to avoid issues on Desktop client
@@ -32,4 +35,12 @@ func ParseParticipantId(participantId string) (spaceId string, identity string, 
 	}
 
 	return fmt.Sprintf("%s.%s", parts[2], parts[3]), parts[4], nil
+}
+
+func ParseLongId(id string) (FullID, error) {
+	if id == "" {
+		return FullID{}, ErrParseLongId
+	}
+	// TODO: support spaceId in long ids
+	return FullID{ObjectID: id}, nil
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -175,7 +175,7 @@ func (s *dsObjectStore) Init() error {
 }
 
 type LinksUpdateInfo struct {
-	LinksFromId    string
+	LinksFromId    domain.FullID
 	Added, Removed []string
 }
 

--- a/pkg/lib/localstore/objectstore/spaceindex/submanager.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/submanager.go
@@ -2,6 +2,8 @@ package spaceindex
 
 import (
 	"sync"
+
+	"github.com/anyproto/anytype-heart/core/domain"
 )
 
 type SubscriptionManager struct {
@@ -15,7 +17,7 @@ func (s *SubscriptionManager) SubscribeLinksUpdate(callback func(info LinksUpdat
 	s.lock.Unlock()
 }
 
-func (s *SubscriptionManager) updateObjectLinks(fromId string, added []string, removed []string) {
+func (s *SubscriptionManager) updateObjectLinks(fromId domain.FullID, added []string, removed []string) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	if s.onLinksUpdateCallback != nil && len(added)+len(removed) > 0 {

--- a/pkg/lib/localstore/objectstore/spaceindex/update.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/update.go
@@ -122,7 +122,7 @@ func (s *dsObjectStore) UpdateObjectLinks(ctx context.Context, id string, links 
 		return err
 	}
 
-	s.subManager.updateObjectLinks(id, added, removed)
+	s.subManager.updateObjectLinks(domain.FullID{SpaceID: s.SpaceId(), ObjectID: id}, added, removed)
 
 	return nil
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4678/backlinks-watcher-is-failing-to-resolve-space-id

- Propagate spaceId directly from store
- In case object has link on object from other space, we should parse spaceId from id