### PR TITLE
GO-5563 Unset layout on type change

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -350,6 +350,7 @@ func (bs *basic) SetObjectTypesInState(s *state.State, objectTypeKeys []domain.T
 
 	s.SetObjectTypeKeys(objectTypeKeys)
 	removeInternalFlags(s)
+	s.Details().Delete(bundle.RelationKeyLayout)
 
 	toLayout, err := bs.getLayoutForType(objectTypeKeys[0])
 	if err != nil {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5563/changing-type-from-note-to-page-sometimes-does-not-the-correct-line

We should unset layout on type switch, so resolvedLayout would be derived from recommended layout of object type