### PR TITLE
GO-4295 Ignore relations with existing key

### DIFF
--- a/core/block/import/common/objectid/deriveobject_test.go
+++ b/core/block/import/common/objectid/deriveobject_test.go
@@ -73,8 +73,9 @@ func TestDerivedObject_GetIDAndPayload(t *testing.T) {
 			Snapshot: &common.SnapshotModel{
 				Data: &common.StateSnapshot{
 					Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-						bundle.RelationKeyName:           domain.String("name"),
+						bundle.RelationKeyName:           domain.String("IMPORTED NAME"),
 						bundle.RelationKeyRelationFormat: domain.Int64(int64(model.RelationFormat_number)),
+						bundle.RelationKeyRelationKey:    domain.String(bundle.RelationKeyName.String()),
 					}),
 				},
 				SbType: coresb.SmartBlockTypeRelation,
@@ -88,6 +89,7 @@ func TestDerivedObject_GetIDAndPayload(t *testing.T) {
 				bundle.RelationKeyUniqueKey:      domain.String(uniqueKey.Marshal()),
 				bundle.RelationKeyId:             domain.String("oldId"),
 				bundle.RelationKeyName:           domain.String("name"),
+				bundle.RelationKeyRelationKey:    domain.String(bundle.RelationKeyName.String()),
 				bundle.RelationKeyRelationFormat: domain.Int64(int64(model.RelationFormat_number)),
 				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_relation)),
 				bundle.RelationKeySpaceId:        domain.String("spaceId"),

--- a/core/block/import/common/objectid/existingobject.go
+++ b/core/block/import/common/objectid/existingobject.go
@@ -126,14 +126,14 @@ func (e *existingObject) getExistingRelationOption(snapshot *common.Snapshot, sp
 }
 
 func (e *existingObject) getExistingRelation(snapshot *common.Snapshot, spaceID string) string {
-	name := snapshot.Snapshot.Data.Details.GetString(bundle.RelationKeyName)
+	key := snapshot.Snapshot.Data.Details.GetString(bundle.RelationKeyRelationKey)
 	format := snapshot.Snapshot.Data.Details.GetFloat64(bundle.RelationKeyRelationFormat)
 	ids, _, err := e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
 		Filters: []database.FilterRequest{
 			{
 				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeyName,
-				Value:       domain.String(name),
+				RelationKey: bundle.RelationKeyRelationKey,
+				Value:       domain.String(key),
 			},
 			{
 				Condition:   model.BlockContentDataviewFilter_Equal,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4295/multi-select-relation-not-displaying-values-that-are-already-entered

We used to check if imported relation already existed in target space by format+name+layout. However, relationKey detail should be used instead of name, as it could not be modified by user