### PR TITLE
GO-5624 Apply style to children blocks

### DIFF
--- a/core/block/editor/stext/text.go
+++ b/core/block/editor/stext/text.go
@@ -393,36 +393,6 @@ func (t *textImpl) TurnInto(ctx session.Context, style model.BlockContentTextSty
 		}
 	}
 
-	onlyParents := func(ids []string) (parents []string) {
-		var childrenIds []string
-		for _, id := range ids {
-			if b := s.Pick(id); b != nil {
-				childrenIds = append(childrenIds, b.Model().ChildrenIds...)
-			}
-		}
-		parents = ids[:0]
-		for _, id := range ids {
-			if slice.FindPos(childrenIds, id) == -1 {
-				parents = append(parents, id)
-			}
-		}
-		return
-	}
-
-	switch style {
-	case model.BlockContentText_Toggle,
-		model.BlockContentText_Checkbox,
-		model.BlockContentText_Marked,
-		model.BlockContentText_Numbered,
-		model.BlockContentText_Header1,
-		model.BlockContentText_Header2,
-		model.BlockContentText_Header3,
-		model.BlockContentText_Code,
-		model.BlockContentText_Callout,
-		model.BlockContentText_Quote:
-		ids = onlyParents(ids)
-	}
-
 	for _, id := range ids {
 		var textBlock text.Block
 		var ok bool

--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -495,7 +495,7 @@ func TestTextImpl_TurnInto(t *testing.T) {
 		assert.Equal(t, model.BlockContentText_Header4, sb.Doc.Pick("1").Model().GetText().Style)
 		assert.Equal(t, model.BlockContentText_Header4, sb.Doc.Pick("1").Model().GetText().Style)
 	})
-	t.Run("apply only for parents", func(t *testing.T) {
+	t.Run("apply both for parents and children", func(t *testing.T) {
 		ctx := session.NewContext()
 		sb := smarttest.New("test")
 		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2"}})).
@@ -508,8 +508,8 @@ func TestTextImpl_TurnInto(t *testing.T) {
 		require.NoError(t, tb.TurnInto(ctx, model.BlockContentText_Checkbox, "1", "1.1", "2", "2.2"))
 		assert.Equal(t, model.BlockContentText_Checkbox, sb.Doc.Pick("1").Model().GetText().Style)
 		assert.Equal(t, model.BlockContentText_Checkbox, sb.Doc.Pick("1").Model().GetText().Style)
-		assert.NotEqual(t, model.BlockContentText_Checkbox, sb.Doc.Pick("1.1").Model().GetText().Style)
-		assert.NotEqual(t, model.BlockContentText_Checkbox, sb.Doc.Pick("2.2").Model().GetText().Style)
+		assert.Equal(t, model.BlockContentText_Checkbox, sb.Doc.Pick("1.1").Model().GetText().Style)
+		assert.Equal(t, model.BlockContentText_Checkbox, sb.Doc.Pick("2.2").Model().GetText().Style)
 	})
 	t.Run("move children up", func(t *testing.T) {
 		sb := smarttest.New("test")
@@ -523,8 +523,8 @@ func TestTextImpl_TurnInto(t *testing.T) {
 		require.NoError(t, tb.TurnInto(nil, model.BlockContentText_Code, "1", "1.1", "2", "2.2"))
 		assert.Equal(t, model.BlockContentText_Code, sb.Doc.Pick("1").Model().GetText().Style)
 		assert.Equal(t, model.BlockContentText_Code, sb.Doc.Pick("2").Model().GetText().Style)
-		assert.Equal(t, model.BlockContentText_Paragraph, sb.Doc.Pick("1.1").Model().GetText().Style)
-		assert.Equal(t, model.BlockContentText_Paragraph, sb.Doc.Pick("2.2").Model().GetText().Style)
+		assert.Equal(t, model.BlockContentText_Code, sb.Doc.Pick("1.1").Model().GetText().Style)
+		assert.Equal(t, model.BlockContentText_Code, sb.Doc.Pick("2.2").Model().GetText().Style)
 		assert.Equal(t, []string{"1", "1.1", "2", "2.2"}, sb.Doc.Pick("test").Model().ChildrenIds)
 	})
 	t.Run("turn link into text", func(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5624/changing-bullets-to-checkboxes-in-bulk-doesnt-change-whole-selection

We should apply style to all blocks