### PR TITLE
GO-5434 Fix collection on MD import

### DIFF
--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -381,14 +381,6 @@ func (oc *ObjectCreator) resetState(newID string, st *state.State) *domain.Detai
 		if err != nil {
 			log.With(zap.String("object id", newID)).Errorf("failed to set state %s: %s", newID, err)
 		}
-		commonOperations, ok := b.(basic.CommonOperations)
-		if !ok {
-			return nil
-		}
-		err = commonOperations.FeaturedRelationAdd(nil, bundle.RelationKeyType.String())
-		if err != nil {
-			log.With(zap.String("object id", newID)).Errorf("failed to set featuredRelations %s: %s", newID, err)
-		}
 		respDetails = b.CombinedDetails()
 		return nil
 	})


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5434/auto-widget-collection-import-is-created-with-a-conflict

We should not add featuredRelations to collection on markdown import, as now featuredRelations are tuned from Collection type