### PR TITLE
GO-4621 Fix panic on load devices

### DIFF
--- a/core/device/service.go
+++ b/core/device/service.go
@@ -138,7 +138,7 @@ func (d *devices) getDeviceObject(ctx context.Context) (object smartblock.SmartB
 	d.deviceObjectId = id
 	object, err = techSpace.GetObject(ctx, d.deviceObjectId)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get device object: %v", err)
+		return nil, fmt.Errorf("failed to get device object: %w", err)
 	}
 	return
 }

--- a/core/device/service_test.go
+++ b/core/device/service_test.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -220,9 +219,7 @@ func TestService_loadDevices(t *testing.T) {
 
 		deviceObject := &editor.Page{SmartBlock: smarttest.New(deviceObjectId)}
 		mockCache := mock_objectcache.NewMockCache(t)
-		mockCache.EXPECT().GetObject(mock.Anything, deviceObjectId).Return(nil, fmt.Errorf("error"))
 		mockCache.EXPECT().DeriveTreeObject(mock.Anything, mock.Anything).Return(deviceObject, nil)
-		mockCache.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(deviceObjectId, nil)
 		virtualSpace.Cache = mockCache
 
 		// when
@@ -240,6 +237,7 @@ func TestService_loadDevices(t *testing.T) {
 
 		deviceObject := &editor.Page{SmartBlock: smarttest.New(deviceObjectId)}
 		mockCache := mock_objectcache.NewMockCache(t)
+		mockCache.EXPECT().DeriveTreeObject(mock.Anything, mock.Anything).Return(nil, treestorage.ErrTreeExists)
 		mockCache.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(deviceObjectId, nil)
 		mockCache.EXPECT().GetObject(mock.Anything, deviceObjectId).Return(deviceObject, nil)
 		virtualSpace.Cache = mockCache
@@ -259,6 +257,7 @@ func TestService_loadDevices(t *testing.T) {
 
 		deviceObject := &editor.Page{SmartBlock: smarttest.New(deviceObjectId)}
 		mockCache := mock_objectcache.NewMockCache(t)
+		mockCache.EXPECT().DeriveTreeObject(mock.Anything, mock.Anything).Return(nil, treestorage.ErrTreeExists)
 		mockCache.EXPECT().DeriveObjectID(mock.Anything, mock.Anything).Return(deviceObjectId, nil)
 		mockCache.EXPECT().GetObject(mock.Anything, deviceObjectId).Return(deviceObject, nil)
 		virtualSpace.Cache = mockCache


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-4621/loaddevices-panic-synthetic

On loadDevices we used to first fetch device object from space by GetObject and on failure DeriveObject.
Sometimes peers to fetch device object became available between these calls, so that leaded to ErrTreeExists error, that was not catched properly.

GetObject and DeriveObject must be switched. Ctx is provided with PeerFindDeadline=30 secs and ResponsiblePeers key