### PR TITLE
GO-5775 Clear sorts and filters on dataview relations update

### DIFF
--- a/core/block/editor/dataview/dataview.go
+++ b/core/block/editor/dataview/dataview.go
@@ -189,18 +189,14 @@ func (d *sdataview) AddRelations(ctx session.Context, blockId string, relationKe
 	}
 }
 
-func (d *sdataview) DeleteRelations(ctx session.Context, blockId string, relationIds []string, showEvent bool) error {
+func (d *sdataview) DeleteRelations(ctx session.Context, blockId string, relationKeys []string, showEvent bool) error {
 	s := d.NewStateCtx(ctx)
 	tb, err := getDataviewBlock(s, blockId)
 	if err != nil {
 		return err
 	}
 
-	for _, id := range relationIds {
-		if err = tb.DeleteRelation(id); err != nil {
-			return err
-		}
-	}
+	tb.DeleteRelations(relationKeys...)
 
 	if showEvent {
 		return d.Apply(s)

--- a/core/block/editor/state/event.go
+++ b/core/block/editor/state/event.go
@@ -187,7 +187,7 @@ func (s *State) applyEvent(ev *pb.EventMessage) (err error) {
 					return err
 				}
 				// MIGRATION: reinterpretation of old changes as new changes
-				f.DeleteRelation(o.BlockDataviewOldRelationDelete.RelationKey)
+				f.DeleteRelations(o.BlockDataviewOldRelationDelete.RelationKey)
 			}
 			return fmt.Errorf("not a dataview block")
 		}); err != nil {
@@ -208,10 +208,7 @@ func (s *State) applyEvent(ev *pb.EventMessage) (err error) {
 	case *pb.EventMessageValueOfBlockDataviewRelationDelete:
 		if err = apply(o.BlockDataviewRelationDelete.Id, func(b simple.Block) error {
 			if f, ok := b.(dataview.Block); ok {
-				for _, key := range o.BlockDataviewRelationDelete.RelationKeys {
-					// todo: implement DeleteRelations?
-					f.DeleteRelation(key)
-				}
+				f.DeleteRelations(o.BlockDataviewRelationDelete.RelationKeys...)
 				return nil
 			}
 			return fmt.Errorf("not a dataview block")

--- a/core/block/simple/dataview/dataview.go
+++ b/core/block/simple/dataview/dataview.go
@@ -3,10 +3,12 @@ package dataview
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/gogo/protobuf/types"
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 
 	"github.com/anyproto/anytype-heart/core/block/simple"
 	"github.com/anyproto/anytype-heart/core/block/simple/base"
@@ -52,7 +54,7 @@ type Block interface {
 	MoveObjectsInView(req *pb.RpcBlockDataviewObjectOrderMoveRequest) error
 
 	AddRelation(relation *model.RelationLink) error
-	DeleteRelation(relationKey string) error
+	DeleteRelations(relationKeys ...string)
 	SetRelations(relationLinks []*model.RelationLink)
 	ListRelationLinks() []*model.RelationLink
 
@@ -120,7 +122,7 @@ func (d *Dataview) ListViews() []*model.BlockContentDataviewView {
 }
 
 // AddView adds a view to the dataview. It doesn't fill any missing field except id
-func (s *Dataview) AddView(view model.BlockContentDataviewView) {
+func (d *Dataview) AddView(view model.BlockContentDataviewView) {
 	if view.Id == "" {
 		view.Id = uuid.New().String()
 	}
@@ -135,11 +137,11 @@ func (s *Dataview) AddView(view model.BlockContentDataviewView) {
 		}
 	}
 
-	s.content.Views = append(s.content.Views, &view)
+	d.content.Views = append(d.content.Views, &view)
 }
 
-func (s *Dataview) GetView(viewId string) (*model.BlockContentDataviewView, error) {
-	for _, view := range s.GetDataview().Views {
+func (d *Dataview) GetView(viewId string) (*model.BlockContentDataviewView, error) {
+	for _, view := range d.GetDataview().Views {
 		if view.Id == viewId {
 			return view, nil
 		}
@@ -148,13 +150,13 @@ func (s *Dataview) GetView(viewId string) (*model.BlockContentDataviewView, erro
 	return nil, fmt.Errorf("view '%s' not found", viewId)
 }
 
-func (s *Dataview) DeleteView(viewID string) error {
+func (d *Dataview) DeleteView(viewID string) error {
 	var found bool
-	for i, v := range s.content.Views {
+	for i, v := range d.content.Views {
 		if v.Id == viewID {
 			found = true
-			s.content.Views[i] = nil
-			s.content.Views = append(s.content.Views[:i], s.content.Views[i+1:]...)
+			d.content.Views[i] = nil
+			d.content.Views = append(d.content.Views[:i], d.content.Views[i+1:]...)
 			break
 		}
 	}
@@ -166,8 +168,8 @@ func (s *Dataview) DeleteView(viewID string) error {
 	return nil
 }
 
-func (s *Dataview) SetView(viewID string, view model.BlockContentDataviewView) error {
-	v, err := s.GetView(viewID)
+func (d *Dataview) SetView(viewID string, view model.BlockContentDataviewView) error {
+	v, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -215,16 +217,16 @@ func (d *Dataview) SetViewFields(viewID string, view *model.BlockContentDataview
 	return nil
 }
 
-func (l *Dataview) FillSmartIds(ids []string) []string {
+func (d *Dataview) FillSmartIds(ids []string) []string {
 	// for _ := range l.content.RelationLinks {
 	// todo: add relationIds from relationLinks
 	// }
 
-	if l.content.TargetObjectId != "" {
-		ids = append(ids, l.content.TargetObjectId)
+	if d.content.TargetObjectId != "" {
+		ids = append(ids, d.content.TargetObjectId)
 	}
 
-	for _, view := range l.content.Views {
+	for _, view := range d.content.Views {
 		if view.DefaultObjectTypeId != "" {
 			ids = append(ids, view.DefaultObjectTypeId)
 		}
@@ -237,15 +239,15 @@ func (l *Dataview) FillSmartIds(ids []string) []string {
 	return ids
 }
 
-func (l *Dataview) MigrateFile(migrateFunc func(oldHash string) (newHash string)) {
-	for _, view := range l.content.Views {
+func (d *Dataview) MigrateFile(migrateFunc func(oldHash string) (newHash string)) {
+	for _, view := range d.content.Views {
 		for _, filter := range view.Filters {
-			l.migrateFilesInFilter(filter, migrateFunc)
+			d.migrateFilesInFilter(filter, migrateFunc)
 		}
 	}
 }
 
-func (l *Dataview) migrateFilesInFilter(filter *model.BlockContentDataviewFilter, migrateFunc func(oldHash string) (newHash string)) {
+func (d *Dataview) migrateFilesInFilter(filter *model.BlockContentDataviewFilter, migrateFunc func(oldHash string) (newHash string)) {
 	if filter.Format != model.RelationFormat_object && filter.Format != model.RelationFormat_file {
 		return
 	}
@@ -297,20 +299,20 @@ func getIdsFromFilters(filters []*model.BlockContentDataviewFilter) (ids []strin
 	return ids
 }
 
-func (l *Dataview) ReplaceLinkIds(replacer func(oldId string) (newId string)) {
-	if l.content.TargetObjectId != "" {
-		l.content.TargetObjectId = replacer(l.content.TargetObjectId)
+func (d *Dataview) ReplaceLinkIds(replacer func(oldId string) (newId string)) {
+	if d.content.TargetObjectId != "" {
+		d.content.TargetObjectId = replacer(d.content.TargetObjectId)
 	}
 	return
 }
 
-func (l *Dataview) HasSmartIds() bool {
-	for _, view := range l.content.Views {
+func (d *Dataview) HasSmartIds() bool {
+	for _, view := range d.content.Views {
 		if view.DefaultObjectTypeId != "" || view.DefaultTemplateId != "" {
 			return true
 		}
 	}
-	return len(l.content.RelationLinks) > 0 || l.content.TargetObjectId != ""
+	return len(d.content.RelationLinks) > 0 || d.content.TargetObjectId != ""
 }
 
 func (d *Dataview) AddRelation(relation *model.RelationLink) error {
@@ -321,39 +323,37 @@ func (d *Dataview) AddRelation(relation *model.RelationLink) error {
 	return nil
 }
 
-func (d *Dataview) DeleteRelation(relationKey string) error {
-	d.content.RelationLinks = pbtypes.RelationLinks(d.content.RelationLinks).Remove(relationKey)
-
-	for _, view := range d.content.Views {
-		var filteredFilters []*model.BlockContentDataviewFilter
-		for _, filter := range view.Filters {
-			if filter.RelationKey != relationKey {
-				filteredFilters = append(filteredFilters, filter)
-			}
-		}
-		view.Filters = filteredFilters
-
-		var filteredSorts []*model.BlockContentDataviewSort
-		for _, sort := range view.Sorts {
-			if sort.RelationKey != relationKey {
-				filteredSorts = append(filteredSorts, sort)
-			}
-		}
-		view.Sorts = filteredSorts
-	}
-	return nil
+func (d *Dataview) DeleteRelations(relationKeys ...string) {
+	d.content.RelationLinks = pbtypes.RelationLinks(d.content.RelationLinks).Remove(relationKeys...)
+	d.removeSortsAndFiltersByKeys(relationKeys...)
 }
 
 func (d *Dataview) SetRelations(relationLinks []*model.RelationLink) {
+	_, removed := pbtypes.RelationLinks(relationLinks).Diff(d.content.RelationLinks)
 	d.content.RelationLinks = relationLinks
+	d.removeSortsAndFiltersByKeys(removed...)
+}
+
+func (d *Dataview) removeSortsAndFiltersByKeys(keys ...string) {
+	if keys == nil {
+		return
+	}
+	for _, view := range d.content.Views {
+		view.Filters = lo.Filter(view.Filters, func(filter *model.BlockContentDataviewFilter, _ int) bool {
+			return !slices.Contains(keys, filter.RelationKey)
+		})
+		view.Sorts = lo.Filter(view.Sorts, func(filter *model.BlockContentDataviewSort, _ int) bool {
+			return !slices.Contains(keys, filter.RelationKey)
+		})
+	}
 }
 
 func (d *Dataview) ListRelationLinks() []*model.RelationLink {
 	return d.content.RelationLinks
 }
 
-func (td *Dataview) ModelToSave() *model.Block {
-	b := pbtypes.CopyBlock(td.Model())
+func (d *Dataview) ModelToSave() *model.Block {
+	b := pbtypes.CopyBlock(d.Model())
 	b.Content.(*model.BlockContentOfDataview).Dataview.Relations = nil
 	b.Content.(*model.BlockContentOfDataview).Dataview.ActiveView = ""
 	return b
@@ -503,26 +503,17 @@ func (d *Dataview) resetObjectOrderForView(viewId string) {
 	}
 }
 
-func (s *Dataview) GetRelation(relationKey string) (*model.Relation, error) {
-	for _, v := range s.content.Relations {
-		if v.Key == relationKey {
-			return v, nil
-		}
-	}
-	return nil, ErrRelationNotFound
-}
-
-func (s *Dataview) UpdateRelationOld(relationKey string, rel model.Relation) error {
+func (d *Dataview) UpdateRelationOld(relationKey string, rel model.Relation) error {
 	var found bool
 	if relationKey != rel.Key {
 		return fmt.Errorf("changing key of existing relation is retricted")
 	}
 
-	for i, v := range s.content.Relations {
+	for i, v := range d.content.Relations {
 		if v.Key == relationKey {
 			found = true
 
-			s.content.Relations[i] = pbtypes.CopyRelation(&rel)
+			d.content.Relations[i] = pbtypes.CopyRelation(&rel)
 			break
 		}
 	}

--- a/core/block/simple/dataview/view_changes.go
+++ b/core/block/simple/dataview/view_changes.go
@@ -215,9 +215,9 @@ func diffViewSorts(a, b *model.BlockContentDataviewView) []*pb.EventBlockDatavie
 		})
 }
 
-func (l *Dataview) ApplyViewUpdate(upd *pb.EventBlockDataviewViewUpdate) {
+func (d *Dataview) ApplyViewUpdate(upd *pb.EventBlockDataviewViewUpdate) {
 	var view *model.BlockContentDataviewView
-	for _, v := range l.content.Views {
+	for _, v := range d.content.Views {
 		if v.Id == upd.ViewId {
 			view = v
 			break
@@ -324,9 +324,9 @@ func diffViewObjectOrder(a, b *model.BlockContentDataviewObjectOrder) []*pb.Even
 	return res
 }
 
-func (l *Dataview) ApplyObjectOrderUpdate(upd *pb.EventBlockDataviewObjectOrderUpdate) {
+func (d *Dataview) ApplyObjectOrderUpdate(upd *pb.EventBlockDataviewObjectOrderUpdate) {
 	var existOrder []string
-	for _, order := range l.Model().GetDataview().ObjectOrders {
+	for _, order := range d.Model().GetDataview().ObjectOrders {
 		if order.ViewId == upd.ViewId && order.GroupId == upd.GroupId {
 			existOrder = order.ObjectIds
 		}
@@ -352,7 +352,7 @@ func (l *Dataview) ApplyObjectOrderUpdate(upd *pb.EventBlockDataviewObjectOrderU
 
 	changedIds := slice.ApplyChanges(existOrder, changes, slice.StringIdentity[string])
 
-	l.SetViewObjectOrder([]*model.BlockContentDataviewObjectOrder{
+	d.SetViewObjectOrder([]*model.BlockContentDataviewObjectOrder{
 		{ViewId: upd.ViewId, GroupId: upd.GroupId, ObjectIds: changedIds},
 	})
 }

--- a/core/block/simple/dataview/views.go
+++ b/core/block/simple/dataview/views.go
@@ -10,10 +10,10 @@ import (
 
 const DefaultViewRelationWidth = 192
 
-func (l *Dataview) AddFilter(viewID string, filter *model.BlockContentDataviewFilter) error {
-	l.resetObjectOrderForView(viewID)
+func (d *Dataview) AddFilter(viewID string, filter *model.BlockContentDataviewFilter) error {
+	d.resetObjectOrderForView(viewID)
 
-	view, err := l.GetView(viewID)
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -21,15 +21,15 @@ func (l *Dataview) AddFilter(viewID string, filter *model.BlockContentDataviewFi
 	if filter.Id == "" {
 		filter.Id = bson.NewObjectId().Hex()
 	}
-	l.setRelationFormat(filter)
+	d.setRelationFormat(filter)
 	view.Filters = append(view.Filters, filter)
 	return nil
 }
 
-func (l *Dataview) RemoveFilters(viewID string, filterIDs []string) error {
-	l.resetObjectOrderForView(viewID)
+func (d *Dataview) RemoveFilters(viewID string, filterIDs []string) error {
+	d.resetObjectOrderForView(viewID)
 
-	view, err := l.GetView(viewID)
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -40,10 +40,10 @@ func (l *Dataview) RemoveFilters(viewID string, filterIDs []string) error {
 	return nil
 }
 
-func (l *Dataview) ReplaceFilter(viewID string, filterID string, filter *model.BlockContentDataviewFilter) error {
-	l.resetObjectOrderForView(viewID)
+func (d *Dataview) ReplaceFilter(viewID string, filterID string, filter *model.BlockContentDataviewFilter) error {
+	d.resetObjectOrderForView(viewID)
 
-	view, err := l.GetView(viewID)
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -52,18 +52,18 @@ func (l *Dataview) ReplaceFilter(viewID string, filterID string, filter *model.B
 		return f.Id == filterID
 	})
 	if idx < 0 {
-		return l.AddFilter(viewID, filter)
+		return d.AddFilter(viewID, filter)
 	}
 
 	filter.Id = filterID
-	l.setRelationFormat(filter)
+	d.setRelationFormat(filter)
 	view.Filters[idx] = filter
 
 	return nil
 }
 
-func (l *Dataview) ReorderFilters(viewID string, ids []string) error {
-	view, err := l.GetView(viewID)
+func (d *Dataview) ReorderFilters(viewID string, ids []string) error {
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -83,10 +83,10 @@ func (l *Dataview) ReorderFilters(viewID string, ids []string) error {
 	return nil
 }
 
-func (l *Dataview) AddSort(viewID string, sort *model.BlockContentDataviewSort) error {
-	l.resetObjectOrderForView(viewID)
+func (d *Dataview) AddSort(viewID string, sort *model.BlockContentDataviewSort) error {
+	d.resetObjectOrderForView(viewID)
 
-	view, err := l.GetView(viewID)
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -99,10 +99,10 @@ func (l *Dataview) AddSort(viewID string, sort *model.BlockContentDataviewSort) 
 	return nil
 }
 
-func (l *Dataview) RemoveSorts(viewID string, ids []string) error {
-	l.resetObjectOrderForView(viewID)
+func (d *Dataview) RemoveSorts(viewID string, ids []string) error {
+	d.resetObjectOrderForView(viewID)
 
-	view, err := l.GetView(viewID)
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -113,10 +113,10 @@ func (l *Dataview) RemoveSorts(viewID string, ids []string) error {
 	return nil
 }
 
-func (l *Dataview) ReplaceSort(viewID string, id string, sort *model.BlockContentDataviewSort) error {
-	l.resetObjectOrderForView(viewID)
+func (d *Dataview) ReplaceSort(viewID string, id string, sort *model.BlockContentDataviewSort) error {
+	d.resetObjectOrderForView(viewID)
 
-	view, err := l.GetView(viewID)
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (l *Dataview) ReplaceSort(viewID string, id string, sort *model.BlockConten
 		return getViewSortID(f) == id
 	})
 	if idx < 0 {
-		return l.AddSort(viewID, sort)
+		return d.AddSort(viewID, sort)
 	}
 
 	view.Sorts[idx] = sort
@@ -133,8 +133,8 @@ func (l *Dataview) ReplaceSort(viewID string, id string, sort *model.BlockConten
 	return nil
 }
 
-func (l *Dataview) ReorderSorts(viewID string, ids []string) error {
-	view, err := l.GetView(viewID)
+func (d *Dataview) ReorderSorts(viewID string, ids []string) error {
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -153,12 +153,12 @@ func (l *Dataview) ReorderSorts(viewID string, ids []string) error {
 	return nil
 }
 
-func (l *Dataview) AddViewRelation(viewID string, relation *model.BlockContentDataviewRelation) error {
-	return l.ReplaceViewRelation(viewID, relation.Key, relation)
+func (d *Dataview) AddViewRelation(viewID string, relation *model.BlockContentDataviewRelation) error {
+	return d.ReplaceViewRelation(viewID, relation.Key, relation)
 }
 
-func (l *Dataview) RemoveViewRelations(viewID string, relationKeys []string) error {
-	view, err := l.GetView(viewID)
+func (d *Dataview) RemoveViewRelations(viewID string, relationKeys []string) error {
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -169,8 +169,8 @@ func (l *Dataview) RemoveViewRelations(viewID string, relationKeys []string) err
 	return nil
 }
 
-func (l *Dataview) ReplaceViewRelation(viewID string, relationKey string, relation *model.BlockContentDataviewRelation) error {
-	view, err := l.GetView(viewID)
+func (d *Dataview) ReplaceViewRelation(viewID string, relationKey string, relation *model.BlockContentDataviewRelation) error {
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -188,8 +188,8 @@ func (l *Dataview) ReplaceViewRelation(viewID string, relationKey string, relati
 	return nil
 }
 
-func (l *Dataview) ReorderViewRelations(viewID string, relationKeys []string) error {
-	view, err := l.GetView(viewID)
+func (d *Dataview) ReorderViewRelations(viewID string, relationKeys []string) error {
+	view, err := d.GetView(viewID)
 	if err != nil {
 		return err
 	}
@@ -215,8 +215,8 @@ func (l *Dataview) ReorderViewRelations(viewID string, relationKeys []string) er
 	return nil
 }
 
-func (l *Dataview) setRelationFormat(filter *model.BlockContentDataviewFilter) {
-	for _, relLink := range l.content.RelationLinks {
+func (d *Dataview) setRelationFormat(filter *model.BlockContentDataviewFilter) {
+	for _, relLink := range d.content.RelationLinks {
 		if relLink.Key == filter.RelationKey {
 			filter.Format = relLink.Format
 		}

--- a/util/pbtypes/relationlink.go
+++ b/util/pbtypes/relationlink.go
@@ -1,6 +1,10 @@
 package pbtypes
 
-import "github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+import (
+	"slices"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
 
 // TODO Add domaain model for link
 type RelationLinks []*model.RelationLink
@@ -27,10 +31,10 @@ func (rl RelationLinks) Append(l *model.RelationLink) RelationLinks {
 	return append(rl, l)
 }
 
-func (rl RelationLinks) Remove(id string) RelationLinks {
+func (rl RelationLinks) Remove(keys ...string) RelationLinks {
 	var n int
 	for _, x := range rl {
-		if x.Key != id {
+		if !slices.Contains(keys, x.Key) {
 			rl[n] = x
 			n++
 		}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5775/the-filter-in-the-set-is-not-reset-after-deleting-the-property

- Check view filters and sorts in case some relations are deleted from dataview and remove them
- Remove Dataview.GetRelation method as it is not used and old
- Rename all Dataview receivers to d