### PR TITLE
GO-2736 Remove custom order on sorts reorder

### DIFF
--- a/core/block/simple/dataview/views.go
+++ b/core/block/simple/dataview/views.go
@@ -134,6 +134,7 @@ func (l *Dataview) ReplaceSort(viewID string, id string, sort *model.BlockConten
 }
 
 func (l *Dataview) ReorderSorts(viewID string, ids []string) error {
+	l.resetObjectOrderForView(viewID)
 	view, err := l.GetView(viewID)
 	if err != nil {
 		return err


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2736/manual-sort-in-collections-interferes-with-regular-sort

Remove custom objects order in views when sorts order chenges