### PR TITLE
GO-1173 Fix alpha sort in tables

### DIFF
--- a/core/block/editor/table/editor.go
+++ b/core/block/editor/table/editor.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 
 	"github.com/globalsign/mgo/bson"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
@@ -630,8 +632,9 @@ func (t *editor) Sort(s *state.State, req pb.RpcBlockTableSortRequest) error {
 
 	rows := s.Get(tb.Rows().Id)
 	sorter := tableSorter{
-		rowIDs: make([]string, 0, len(rows.Model().ChildrenIds)),
-		values: make([]string, len(rows.Model().ChildrenIds)),
+		rowIDs:   make([]string, 0, len(rows.Model().ChildrenIds)),
+		values:   make([]string, len(rows.Model().ChildrenIds)),
+		collator: collate.New(language.Und),
 	}
 
 	var headers []string

--- a/core/block/editor/table/editor_test.go
+++ b/core/block/editor/table/editor_test.go
@@ -1832,6 +1832,33 @@ func TestSort(t *testing.T) {
 					"row3": {IsHeader: true},
 				})),
 		},
+		{
+			name: "alphabetical order",
+			source: mkTestTable([]string{"col1", "col2"}, []string{"row1", "row2", "row3"},
+				[][]string{
+					{"row1-col1", "row1-col2"},
+					{"row2-col1", "row2-col2"},
+					{"row3-col1", "row3-col2"},
+				}, withBlockContents(map[string]*model.Block{
+					"row1-col2": mkTextBlock("João"),
+					"row2-col2": mkTextBlock("joz"),
+					"row3-col2": mkTextBlock("Joao"),
+				})),
+			req: pb.RpcBlockTableSortRequest{
+				ColumnId: "col2",
+				Type:     model.BlockContentDataviewSort_Asc,
+			},
+			want: mkTestTable([]string{"col1", "col2"}, []string{"row3", "row1", "row2"},
+				[][]string{
+					{"row1-col1", "row1-col2"},
+					{"row2-col1", "row2-col2"},
+					{"row3-col1", "row3-col2"},
+				}, withBlockContents(map[string]*model.Block{
+					"row3-col2": mkTextBlock("Joao"),
+					"row1-col2": mkTextBlock("João"),
+					"row2-col2": mkTextBlock("joz"),
+				})),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			tb := editor{}

--- a/core/block/editor/table/table.go
+++ b/core/block/editor/table/table.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"golang.org/x/text/collate"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/simple"
@@ -26,8 +27,9 @@ var (
 )
 
 type tableSorter struct {
-	rowIDs []string
-	values []string
+	rowIDs   []string
+	values   []string
+	collator *collate.Collator
 }
 
 func (t tableSorter) Len() int {
@@ -35,7 +37,7 @@ func (t tableSorter) Len() int {
 }
 
 func (t tableSorter) Less(i, j int) bool {
-	return strings.ToLower(t.values[i]) < strings.ToLower(t.values[j])
+	return t.collator.CompareString(strings.ToLower(t.values[i]), strings.ToLower(t.values[j])) < 0
 }
 
 func (t tableSorter) Swap(i, j int) {

--- a/core/block/editor/table/table.go
+++ b/core/block/editor/table/table.go
@@ -40,24 +40,24 @@ func (t tableSorter) Len() int {
 func (t tableSorter) Less(i, j int) bool {
 	valI := strings.TrimSpace(t.values[i])
 	valJ := strings.TrimSpace(t.values[j])
-	
+
 	// Try to parse both values as numbers
 	numI, errI := strconv.ParseFloat(valI, 64)
 	numJ, errJ := strconv.ParseFloat(valJ, 64)
-	
+
 	// If both values are valid numbers, compare numerically
 	if errI == nil && errJ == nil {
 		return numI < numJ
 	}
-	
+
 	// If only one is a number, numbers come before strings
-	if errI == nil && errJ != nil {
+	if errI == nil {
 		return true
 	}
-	if errI != nil && errJ == nil {
+	if errJ == nil {
 		return false
 	}
-	
+
 	// Both are strings, use collator for text comparison
 	return t.collator.CompareString(strings.ToLower(valI), strings.ToLower(valJ)) < 0
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-1173/sort-table-alphabetically-accents-show-up-after-z

Introduce strings sort with collator that helps to order words with special characters like João