### PR TITLE
GO-1558 Unset entries that are removed from sorted sub

### DIFF
--- a/core/subscription/diff.go
+++ b/core/subscription/diff.go
@@ -42,7 +42,7 @@ func (ld *listDiff) reset() {
 	ld.afterIdsM = make(map[string]struct{})
 }
 
-func (ld *listDiff) diff(ctx *opCtx, subId string, keys []domain.RelationKey) (wasAddOrRemove bool, ids []string) {
+func (ld *listDiff) diff(ctx *opCtx, subId string, keys []domain.RelationKey) (wasAddOrRemove bool, added, removed []string) {
 	for _, id := range ld.afterIds {
 		ld.afterIdsM[id] = struct{}{}
 	}
@@ -78,7 +78,7 @@ func (ld *listDiff) diff(ctx *opCtx, subId string, keys []domain.RelationKey) (w
 				isAdd:   isAdd,
 			})
 			if isAdd {
-				ids = append(ids, ld.afterIds[idx])
+				added = append(added, ld.afterIds[idx])
 				wasAddOrRemove = true
 			}
 		}
@@ -89,6 +89,7 @@ func (ld *listDiff) diff(ctx *opCtx, subId string, keys []domain.RelationKey) (w
 					id:    ld.beforeIds[idx],
 					subId: subId,
 				})
+				removed = append(removed, ld.beforeIds[idx])
 				wasAddOrRemove = true
 			}
 		}

--- a/core/subscription/sorted.go
+++ b/core/subscription/sorted.go
@@ -172,8 +172,8 @@ func (s *sortedSub) onChange(ctx *opCtx) {
 		s.compCountBefore = s.compCountAfter
 	}
 
-	wasAddOrRemove, ids := s.diff.diff(ctx, s.id, s.keys)
-	s.ds.depEntriesByEntries(ctx, ids)
+	wasAddOrRemove, added, removed := s.diff.diff(ctx, s.id, s.keys)
+	s.ds.depEntriesByEntries(ctx, added)
 
 	hasChanges := false
 	for _, e := range ctx.entries {
@@ -185,6 +185,12 @@ func (s *sortedSub) onChange(ctx *opCtx) {
 				keys:  s.keys,
 			})
 			hasChanges = true
+		}
+	}
+
+	for _, id := range removed {
+		if e := s.cache.Get(id); e != nil {
+			e.SetSub(s.id, false, false)
 		}
 	}
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-1558/sorting-by-relation-done-work-with-problems

We should set isActive=false for entries that are removed from subscription because of limits