### PR TITLE
GO-5826 Remove description from recommeneded relations on ObjectSetDetails call

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -110,7 +110,7 @@ func applyDetailUpdates(oldDetails *domain.Details, updates []domain.Detail) *do
 // TODO make no sense?
 func (bs *basic) createDetailUpdate(st *state.State, detail domain.Detail) (domain.Detail, error) {
 	if detail.Value.Ok() {
-		if err := bs.setDetailSpecialCases(st, detail); err != nil {
+		if err := bs.setDetailSpecialCases(st, &detail); err != nil {
 			return domain.Detail{}, fmt.Errorf("special case: %w", err)
 		}
 		if err := bs.addRelationLink(st, detail.Key); err != nil {
@@ -256,7 +256,7 @@ func (bs *basic) validateOptions(rel *relationutils.Relation, v []string) error 
 	return nil
 }
 
-func (bs *basic) setDetailSpecialCases(st *state.State, detail domain.Detail) error {
+func (bs *basic) setDetailSpecialCases(st *state.State, detail *domain.Detail) error {
 	if detail.Key == bundle.RelationKeyType {
 		return fmt.Errorf("can't change object type directly: %w", domain.ErrValidationFailed)
 	}
@@ -276,9 +276,9 @@ func (bs *basic) setDetailSpecialCases(st *state.State, detail domain.Detail) er
 		if err != nil {
 			return nil
 		}
-		slices.DeleteFunc(detail.Value.StringList(), func(s string) bool {
+		detail.Value = domain.StringList(slices.DeleteFunc(detail.Value.StringList(), func(s string) bool {
 			return s == descriptionRelationId
-		})
+		}))
 	}
 
 	return nil

--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -3,6 +3,7 @@ package basic
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
@@ -266,6 +267,20 @@ func (bs *basic) setDetailSpecialCases(st *state.State, detail domain.Detail) er
 		// nolint:gosec
 		return bs.layoutConverter.CheckRecommendedLayoutConversionAllowed(st, model.ObjectTypeLayout(detail.Value.Int64()))
 	}
+	if slices.Contains([]domain.RelationKey{
+		bundle.RelationKeyRecommendedFeaturedRelations,
+		bundle.RelationKeyRecommendedHiddenRelations,
+		bundle.RelationKeyRecommendedRelations,
+	}, detail.Key) {
+		descriptionRelationId, err := bs.Space().DeriveObjectID(nil, domain.MustUniqueKey(coresb.SmartBlockTypeRelation, bundle.RelationKeyDescription.String()))
+		if err != nil {
+			return nil
+		}
+		slices.DeleteFunc(detail.Value.StringList(), func(s string) bool {
+			return s == descriptionRelationId
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5826/description-stuck-in-header-copy

Client somehow set description in featuredRecommendedRelations and user cannot remove it from type