### PR TITLE
GO-5841 Fix spaceUxType migration in workspaces

### DIFF
--- a/core/block/editor/workspaces.go
+++ b/core/block/editor/workspaces.go
@@ -144,14 +144,16 @@ func (w *Workspaces) GetExistingGuestInviteInfo() (fileCid string, fileKey strin
 
 func (w *Workspaces) StateMigrations() migration.Migrations {
 	return migration.MakeMigrations([]migration.Migration{{
-		Version: 1,
+		Version: 2,
 		Proc: func(s *state.State) {
 			spaceUxType, ok := s.Details().TryInt64(bundle.RelationKeySpaceUxType)
 			if !ok {
 				spaceUxType = int64(model.SpaceUxType_Data)
+				s.SetDetail(bundle.RelationKeySpaceUxType, domain.Int64(spaceUxType))
 			} else if spaceUxType == 0 {
 				// convert old spaceUxType 0 to Chat
 				spaceUxType = int64(model.SpaceUxType_Chat)
+				s.SetDetail(bundle.RelationKeySpaceUxType, domain.Int64(spaceUxType))
 			}
 		},
 	}})


### PR DESCRIPTION
## Summary
- Fix spaceUxType migration to properly apply state changes using SetDetail()
- Increment migration version from 1 to 2

## Test plan
- [ ] Verify migration runs successfully on workspaces
- [ ] Confirm spaceUxType values are properly set after migration
- [ ] Check that existing spaces with spaceUxType 0 are converted to Chat type