### PR TITLE
GO-5959: Fix install-linter for golanci-lint v2

### DIFF
--- a/makefiles/linter.mk
+++ b/makefiles/linter.mk
@@ -1,6 +1,6 @@
 install-linter:
 	@go install github.com/daixiang0/gci@latest
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 run-linter:
 ifdef GOLANGCI_LINT_BRANCH

--- a/makefiles/vars.mk
+++ b/makefiles/vars.mk
@@ -7,7 +7,7 @@ TANTIVY_GO_PATH ?= ../tantivy-go
 BUILD_FLAGS ?=
 TANTIVY_VERSION := $(shell cat go.mod | grep github.com/anyproto/tantivy-go | cut -d' ' -f2)
 
-export GOLANGCI_LINT_VERSION=2.1.6
+export GOLANGCI_LINT_VERSION=v2.2.1
 export CGO_CFLAGS=-Wno-deprecated-non-prototype -Wno-unknown-warning-option -Wno-deprecated-declarations -Wno-xor-used-as-pow -Wno-single-bit-bitfield-constant-conversion
 
 


### PR DESCRIPTION
After migrating to v2, the `make install-linter` command failed due to an incorrect module path and version tag:

```
make install-linter
go: github.com/golangci/golangci-lint/cmd/golangci-lint@v2.2.1: github.com/golangci/golangci-lint/cmd/golangci-lint@v2.2.1: invalid version: unknown revision cmd/golangci-lint/v2.2.1
make: *** [install-linter] Error 1
```
