### PR TITLE
GO-5923: Fix markdown export after property export changes

### DIFF
--- a/core/export.go
+++ b/core/export.go
@@ -9,7 +9,6 @@ import (
 )
 
 func (mw *Middleware) ObjectListExport(cctx context.Context, req *pb.RpcObjectListExportRequest) *pb.RpcObjectListExportResponse {
-	req.IncludeJsonSchema = true
 	response := func(path string, succeed int, err error) (res *pb.RpcObjectListExportResponse) {
 		res = &pb.RpcObjectListExportResponse{
 			Error: &pb.RpcObjectListExportResponseError{

--- a/docs/proto.md
+++ b/docs/proto.md
@@ -16801,7 +16801,7 @@ Deletes the object, keys from the local store and unsubscribe from remote change
 | linksStateFilters | [Rpc.Object.ListExport.StateFilters](#anytype-Rpc-Object-ListExport-StateFilters) |  |  |
 | includeBacklinks | [bool](#bool) |  |  |
 | includeSpace | [bool](#bool) |  |  |
-| includeJsonSchema | [bool](#bool) |  |  |
+| mdIncludePropertiesAndSchema | [bool](#bool) |  | include properties frontmatter and schema in directory for markdown export |
 
 
 

--- a/pb/protos/commands.proto
+++ b/pb/protos/commands.proto
@@ -3006,7 +3006,8 @@ message Rpc {
                 StateFilters linksStateFilters = 12;
                 bool includeBacklinks = 13;
                 bool includeSpace = 14;
-                bool includeJsonSchema = 15;
+                // include properties frontmatter and schema in directory for markdown export
+                bool mdIncludePropertiesAndSchema = 15;
             }
             message StateFilters {
                 repeated RelationsWhiteList relationsWhiteList = 1;


### PR DESCRIPTION
- Replace `includeJsonSchema` flag with a more descriptive `mdIncludePropertiesAndSchema` flag
- Set `mdIncludePropertiesAndSchema` to false for `ExportSingleInMemory`
- Don't throw error for empty result data in `ExportSingleInMemory`, which occurs during participant export
