### PR TITLE
GO-0000: Autogen release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
         with:
           prerelease: ${{ contains(github.ref, '-rc') }}
           fail_on_unmatched_files: true
+          generate_release_notes: true
           files: '.release/*'
 
       # start of notifications in Linear


### PR DESCRIPTION
We publish releases automatically, but we need to hit `Generate release notes` manually each time. Let's get rid of that extra step.

