### PR TITLE
GO-6044 Fix relation fetch on dataview operations

### DIFF
--- a/core/block/editor/dataview/dataview.go
+++ b/core/block/editor/dataview/dataview.go
@@ -155,9 +155,9 @@ func (d *sdataview) SetRelations(ctx session.Context, blockId string, relationKe
 	}
 	var links []*model.RelationLink
 	for _, key := range relationKeys {
-		relation, err2 := d.objectStore.FetchRelationByKey(key)
-		if err2 != nil {
-			return err2
+		relation, err := d.objectStore.FetchRelationByKey(key)
+		if err != nil {
+			return fmt.Errorf("failed to find relation '%s': %w", key, err)
 		}
 		links = append(links, relation.RelationLink())
 	}

--- a/pkg/lib/localstore/objectstore/spaceindex/relations.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/relations.go
@@ -40,17 +40,11 @@ func (s *dsObjectStore) FetchRelationByKey(key string) (relation *relationutils.
 	if err != nil {
 		return nil, err
 	}
-	q := database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeyUniqueKey,
-				Value:       domain.String(uk.Marshal()),
-			},
-		},
-	}
-
-	records, err := s.Query(q)
+	records, err := s.QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyUniqueKey,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(uk.Marshal()),
+	}}, 1, 0)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6044/blockdataviewrelationset-code-object-not-found-in-space-index

We should return Relation data from store even if relation object is archived or deleted