### PR TITLE
GO-6022 Call LinkPreview on md import before creating bookmark

### DIFF
--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/space"
 	"github.com/anyproto/anytype-heart/util/conc"
+	"github.com/anyproto/anytype-heart/util/linkpreview"
 )
 
 var log = logging.Logger("import")
@@ -105,9 +106,10 @@ func (i *Import) setupConverters(a *app.App) {
 	accountService := app.MustComponent[account.Service](a)
 	collectionService := app.MustComponent[*collection.Service](a)
 	tempDirProvider := app.MustComponent[core.TempDirProvider](a)
+	linkPreview := app.MustComponent[linkpreview.LinkPreview](a)
 
 	converters := []common.Converter{
-		markdown.New(tempDirProvider, collectionService),
+		markdown.New(tempDirProvider, collectionService, linkPreview),
 		notion.New(collectionService),
 		pbc.New(collectionService, accountService, tempDirProvider),
 		web.NewConverter(),

--- a/core/block/import/markdown/blockconverter_test.go
+++ b/core/block/import/markdown/blockconverter_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/import/common/source"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/linkpreview/mock_linkpreview"
 )
 
 type MockTempDir struct{}
@@ -24,7 +25,8 @@ func (m MockTempDir) TempDir() string {
 func Test_processFiles(t *testing.T) {
 	t.Run("imported directory include mov and pdf files - md file has file blocks", func(t *testing.T) {
 		// given
-		converter := newMDConverter(&MockTempDir{})
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+		converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 		pdfFile := filepath.Join("testdata", "test.pdf")
 		_, err := os.Create(pdfFile)
 		assert.Nil(t, err)
@@ -69,7 +71,8 @@ func Test_processFiles(t *testing.T) {
 
 	t.Run("imported directory include without mov and pdf files - no file blocks", func(t *testing.T) {
 		// given
-		converter := newMDConverter(&MockTempDir{})
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+		converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 		workingDir, err := os.Getwd()
 		assert.Nil(t, err)
 		absolutePath := filepath.Join(workingDir, "testdata")
@@ -104,7 +107,8 @@ func Test_processFiles(t *testing.T) {
 
 func TestCreateDirectoryPages_EmptyRootName(t *testing.T) {
 	// Test that empty root directory names fallback to rootCollectionName
-	converter := newMDConverter(&MockTempDir{})
+	mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+	converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 
 	// Create test files
 	files := map[string]*FileInfo{
@@ -134,7 +138,8 @@ func TestCreateDirectoryPages_EmptyRootName(t *testing.T) {
 
 func TestCreateDirectoryPages_SkipHiddenDirectories(t *testing.T) {
 	// Test that directories starting with "." are skipped
-	converter := newMDConverter(&MockTempDir{})
+	mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+	converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 
 	// Create test files including hidden directories
 	files := map[string]*FileInfo{
@@ -195,7 +200,8 @@ func TestCreateDirectoryPages_SkipHiddenDirectories(t *testing.T) {
 
 func TestCreateDirectoryPages_PathImport(t *testing.T) {
 	// Test Example 1: Regular path import
-	converter := newMDConverter(&MockTempDir{})
+	mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+	converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 
 	// Create test files matching Example 1
 	files := map[string]*FileInfo{
@@ -258,7 +264,8 @@ func TestCreateDirectoryPages_PathImport(t *testing.T) {
 
 func TestCreateDirectoryPages_ZipImport(t *testing.T) {
 	// Test Example 2: Zip import with single root directory
-	converter := newMDConverter(&MockTempDir{})
+	mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+	converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 
 	// Create test files matching Example 2
 	files := map[string]*FileInfo{
@@ -326,7 +333,8 @@ func TestCreateDirectoryPages_ZipImport(t *testing.T) {
 
 func TestCreateDirectoryPages_NestedDirectories(t *testing.T) {
 	// Test with nested directory structure
-	converter := newMDConverter(&MockTempDir{})
+	mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+	converter := newMDConverter(&MockTempDir{}, mockLinkPreview)
 
 	// Create test files with nested structure
 	files := map[string]*FileInfo{

--- a/core/block/import/markdown/import.go
+++ b/core/block/import/markdown/import.go
@@ -26,6 +26,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/schema"
 	"github.com/anyproto/anytype-heart/pkg/lib/schema/yaml"
 	"github.com/anyproto/anytype-heart/util/constant"
+	"github.com/anyproto/anytype-heart/util/linkpreview"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
@@ -49,8 +50,8 @@ const (
 	typeIdPrefix       = "import_type_"
 )
 
-func New(tempDirProvider core.TempDirProvider, service *collection.Service) common.Converter {
-	bc := newMDConverter(tempDirProvider)
+func New(tempDirProvider core.TempDirProvider, service *collection.Service, linkPreview linkpreview.LinkPreview) common.Converter {
+	bc := newMDConverter(tempDirProvider, linkPreview)
 	si := NewSchemaImporter()
 	bc.SetSchemaImporter(si)
 

--- a/core/block/import/markdown/import_test.go
+++ b/core/block/import/markdown/import_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
@@ -24,6 +25,7 @@ import (
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/tests/blockbuilder"
+	"github.com/anyproto/anytype-heart/util/linkpreview/mock_linkpreview"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
@@ -69,9 +71,10 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 	t.Run("get snapshots of root collection, csv collection and object", func(t *testing.T) {
 		// given
 		testDirectory := setupTestDirectory(t)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 		// Initialize Markdown properly with required components
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -115,9 +118,10 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 	t.Run("no object error", func(t *testing.T) {
 		// given
 		testDirectory := t.TempDir()
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 		// Initialize Markdown properly with required components
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -141,7 +145,9 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 	t.Run("import file with links", func(t *testing.T) {
 		// given
 		tempDirProvider := &MockTempDir{}
-		converter := newMDConverter(tempDirProvider)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
+		mockLinkPreview.EXPECT().Fetch(mock.Anything, mock.Anything).Return(model.LinkPreview{}, nil, false, nil)
+		converter := newMDConverter(tempDirProvider, mockLinkPreview)
 		schemaImporter := NewSchemaImporter()
 		converter.SetSchemaImporter(schemaImporter)
 		h := &Markdown{
@@ -185,10 +191,11 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 		testDirectory := t.TempDir()
 		zipPath := filepath.Join(testDirectory, "empty.zip")
 		test.CreateEmptyZip(t, zipPath)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		// Initialize Markdown properly with required components
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -233,10 +240,11 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 				NonUTF8: true,
 			},
 		})
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		// Initialize Markdown properly with required components
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -275,9 +283,10 @@ func TestMarkdown_GetSnapshots(t *testing.T) {
 	t.Run("create directory pages", func(t *testing.T) {
 		// given
 		testDirectory := setupHierarchicalTestDirectory(t)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 		// Initialize Markdown properly with required components
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -578,9 +587,10 @@ This is the content of the test document.`
 
 		err := os.WriteFile(yamlMdPath, []byte(yamlContent), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		p := process.NewNoOp()
@@ -750,9 +760,10 @@ category: Work
 		assert.NoError(t, err)
 		err = os.WriteFile(filepath.Join(testDirectory, "file2.md"), []byte(yamlContent2), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		p := process.NewNoOp()
@@ -894,10 +905,11 @@ This document references other documents.`
 		assert.NoError(t, err)
 		err = os.WriteFile(mainDocPath, []byte(mainContent), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		// Create markdown importer with schema that defines object format relations
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 
@@ -1045,9 +1057,10 @@ Main content`, doc1Path) // Include one absolute path
 		assert.NoError(t, err)
 		err = os.WriteFile(mainDocPath, []byte(mainContent), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		h.blockConverter.SetSchemaImporter(h.schemaImporter)
@@ -1163,9 +1176,10 @@ This document is used for snapshot testing of YAML front matter import.`
 
 		err := os.WriteFile(yamlMdPath, []byte(yamlContent), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		p := process.NewNoOp()
@@ -1461,9 +1475,10 @@ This is a collection of important tasks.`
 		assert.NoError(t, err)
 		err = os.WriteFile(collectionPath, []byte(collectionContent), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -1618,9 +1633,10 @@ Testing different path formats.`, task1Path)
 		assert.NoError(t, err)
 		err = os.WriteFile(collectionPath, []byte(collectionContent), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		// Set the schema importer in the block converter
@@ -1693,9 +1709,10 @@ This is the document content.`
 
 		err := os.WriteFile(mdPath, []byte(content), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		h.blockConverter.SetSchemaImporter(h.schemaImporter)
@@ -1809,9 +1826,10 @@ priority: high
 
 		err := os.WriteFile(mdPath, []byte(content), os.ModePerm)
 		assert.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		h.blockConverter.SetSchemaImporter(h.schemaImporter)
@@ -1879,10 +1897,11 @@ func TestMarkdown_ProcessFiles_MultipleSelection(t *testing.T) {
 			err := os.WriteFile(f, []byte("# Test\nContent"), 0644)
 			require.NoError(t, err)
 		}
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		// Test 1: Multiple files in same directory
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		h.blockConverter.SetSchemaImporter(h.schemaImporter)
@@ -1928,9 +1947,10 @@ func TestMarkdown_ProcessFiles_MultipleSelection(t *testing.T) {
 			err := os.WriteFile(f, []byte("# Test\nContent"), 0644)
 			require.NoError(t, err)
 		}
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(),
 		}
 		h.blockConverter.SetSchemaImporter(h.schemaImporter)

--- a/core/block/import/markdown/yamlresolver_test.go
+++ b/core/block/import/markdown/yamlresolver_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/linkpreview/mock_linkpreview"
 )
 
 func TestMarkdown_YAMLConsistentProperties(t *testing.T) {
@@ -65,9 +66,10 @@ Content of document 3.`
 		require.NoError(t, err)
 		err = os.WriteFile(file3Path, []byte(file3Content), os.ModePerm)
 		require.NoError(t, err)
+		mockLinkPreview := mock_linkpreview.NewMockLinkPreview(t)
 
 		h := &Markdown{
-			blockConverter: newMDConverter(&MockTempDir{}),
+			blockConverter: newMDConverter(&MockTempDir{}, mockLinkPreview),
 			schemaImporter: NewSchemaImporter(), // No schemas loaded
 		}
 		p := process.NewNoOp()


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6022/fix-importing-via-markdown-a-link-to-nonexistent-file-creates-a

We should not create bookmark block on markdown import, if link could not be fetched