### PR TITLE
GO-5848 Add sync events to BlockMoveToExistingObject

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -575,7 +575,7 @@ func (mw *Middleware) BlockListMoveToExistingObject(cctx context.Context, req *p
 		return m
 	}
 	err := mw.doBlockService(func(bs *block.Service) (err error) {
-		return bs.MoveBlocks(*req)
+		return bs.MoveBlocks(ctx, *req)
 	})
 	if err != nil {
 		return response(pb.RpcBlockListMoveToExistingObjectResponseError_UNKNOWN_ERROR, err)

--- a/core/block/cache/cache.go
+++ b/core/block/cache/cache.go
@@ -108,9 +108,9 @@ func DoContextFullID[t any](p ObjectGetter, ctx context.Context, id domain.FullI
 
 // DoState2 picks two blocks and perform an action on them. The order of locks is always the same for two ids.
 // It correctly handles the case when two ids are the same.
-func DoState2[t1, t2 any](s ObjectGetter, firstID, secondID string, f func(*state.State, *state.State, t1, t2) error) error {
+func DoState2[t1, t2 any](s ObjectGetter, ctx session.Context, firstID, secondID string, f func(*state.State, *state.State, t1, t2) error) error {
 	if firstID == secondID {
-		return DoState(s, firstID, func(st *state.State, b t1) error {
+		return DoStateCtx(s, ctx, firstID, func(st *state.State, b t1) error {
 			// Check that b satisfies t2
 			b2, ok := any(b).(t2)
 			if !ok {

--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -543,8 +543,8 @@ type Movable interface {
 	basic.Restrictionable
 }
 
-func (s *Service) MoveBlocks(req pb.RpcBlockListMoveToExistingObjectRequest) error {
-	return cache.DoState2(s, req.ContextId, req.TargetContextId, func(srcState, destState *state.State, sb, tb Movable) error {
+func (s *Service) MoveBlocks(ctx session.Context, req pb.RpcBlockListMoveToExistingObjectRequest) error {
+	return cache.DoState2(s, ctx, req.ContextId, req.TargetContextId, func(srcState, destState *state.State, sb, tb Movable) error {
 		if err := sb.Restrictions().Object.Check(model.Restrictions_Blocks); err != nil {
 			return restriction.ErrRestricted
 		}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-5848/make-events-in-blocklistmovetoexistingobjects-sync-in-response

Make events sync for BlockListMoveToExistingObject