### PR TITLE
GO-6007 Make non generic titles for preview

### DIFF
--- a/util/linkpreview/linkpreview.go
+++ b/util/linkpreview/linkpreview.go
@@ -7,10 +7,12 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/anyproto/any-sync/app"
 	"github.com/go-shiori/go-readability"
 	"github.com/microcosm-cc/bluemonday"
@@ -38,7 +40,78 @@ const (
 	maxDescriptionSize = 200
 )
 
-var log = logging.Logger("link-preview")
+var (
+	log = logging.Logger("link-preview")
+
+	genericTitles = map[string][]string{
+		"reddit.com": {
+			"Reddit - The heart of the internet",
+			"Reddit - Dive into anything",
+			"Reddit",
+		},
+		"twitter.com": {
+			"Twitter",
+			"X",
+		},
+		"x.com": {
+			"Twitter",
+			"X",
+		},
+		"youtube.com": {
+			"YouTube",
+		},
+		"github.com": {
+			"GitHub",
+		},
+		"stackoverflow.com": {
+			"Stack Overflow",
+		},
+	}
+
+	titleSelectors = map[string][]string{
+		"reddit.com": {
+			"h1[slot='title']",                 // New Reddit
+			"h1._eYtD2XCVieq6emjKBH3m",         // New Reddit class
+			"h1.s1a5i67p-0",                    // New Reddit
+			"p.title a.title",                  // Old Reddit
+			"a.title",                          // Old Reddit
+			"[data-test-id='post-content'] h3", // Mobile/app
+			"shreddit-post h1",                 // Shreddit component
+			"h1[data-testid='post-title']",     // React components
+			"h1:contains('r/')",                // Generic h1 containing subreddit
+		},
+		"twitter.com": {
+			"[data-testid='tweetText']",
+			"[data-testid='tweet'] [lang]",
+			".tweet-text",
+			".js-tweet-text",
+		},
+		"x.com": {
+			"[data-testid='tweetText']",
+			"[data-testid='tweet'] [lang]",
+			".tweet-text",
+			".js-tweet-text",
+		},
+		"youtube.com": {
+			"meta[name='title']",
+			"h1.title yt-formatted-string",
+			"h1.ytd-video-primary-info-renderer",
+			".watch-main-col h1",
+		},
+		"github.com": {
+			"[data-pjax='#repo-content-pjax-container'] h1",
+			".js-issue-title",
+			".gh-header-title",
+			"h1.public strong",
+			"h1 strong a",
+		},
+		"stackoverflow.com": {
+			"h1[data-se-element='title']",
+			".question-hyperlink",
+			"h1 a",
+		},
+	}
+)
 
 type LinkPreview interface {
 	Fetch(ctx context.Context, url string) (linkPreview model.LinkPreview, responseBody []byte, isFile bool, err error)
@@ -81,6 +154,13 @@ func (l *linkPreview) Fetch(ctx context.Context, fetchUrl string) (linkPreview m
 		return model.LinkPreview{}, nil, false, fmt.Errorf("invalid http code %d", resp.StatusCode)
 	}
 	res := l.convertOGToInfo(fetchUrl, og)
+
+	if l.isGenericTitle(res.Title, fetchUrl) {
+		if enhancedTitle := l.extractEnhancedTitle(rt.lastBody, fetchUrl); enhancedTitle != "" {
+			res.Title = enhancedTitle
+		}
+	}
+
 	if len(res.Description) == 0 {
 		res.Description = l.findContent(rt.lastBody)
 	}
@@ -215,4 +295,77 @@ func (l *limitReader) Read(p []byte) (n int, err error) {
 	}
 	l.nTotal += n
 	return
+}
+
+func (l *linkPreview) isGenericTitle(title, fetchUrl string) bool {
+	if title == "" {
+		return true
+	}
+
+	parsedURL, err := url.Parse(fetchUrl)
+	if err != nil {
+		return false
+	}
+
+	hostname := parsedURL.Hostname()
+
+	for domain, titles := range genericTitles {
+		if strings.Contains(hostname, domain) {
+			for _, genericTitle := range titles {
+				if strings.EqualFold(title, genericTitle) || strings.Contains(title, genericTitle) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func (l *linkPreview) extractEnhancedTitle(htmlContent []byte, fetchUrl string) string {
+	if len(htmlContent) == 0 {
+		return ""
+	}
+
+	parsedURL, err := url.Parse(fetchUrl)
+	if err != nil {
+		return ""
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(htmlContent))
+	if err != nil {
+		return ""
+	}
+
+	hostname := parsedURL.Hostname()
+
+	var selectors []string
+	switch {
+	case strings.Contains(hostname, "reddit.com"):
+		selectors = titleSelectors["reddit.com"]
+	case strings.Contains(hostname, "twitter.com") || strings.Contains(hostname, "x.com"):
+		selectors = titleSelectors["twitter.com"]
+	case strings.Contains(hostname, "youtube.com"):
+		selectors = titleSelectors["youtube.com"]
+	case strings.Contains(hostname, "github.com"):
+		selectors = titleSelectors["github.com"]
+	case strings.Contains(hostname, "stackoverflow.com"):
+		selectors = titleSelectors["stackoverflow.com"]
+	default:
+		return ""
+	}
+
+	for _, selector := range selectors {
+		if title := doc.Find(selector).First().Text(); title != "" {
+			title = strings.TrimSpace(title)
+			if len(title) > 100 {
+				title = title[:97] + "..."
+			}
+			if len(title) > 5 {
+				return title
+			}
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6007/reddit-bookmarks-dont-fetch-post-title

All Reddit posts provide single string in their title OG tag, that's why our bookmarks have same name for different Reddit posts.
We should enhance our link preview fetch to grab info from different tags and attributes