### PR TITLE
GO-2214 Fix linkpreview counter opts

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -49,8 +49,8 @@ var (
 	})
 	LinkPreviewStatusCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "anytype",
-		Subsystem: "linkpreview",
-		Name:      "http_status_total",
+		Subsystem: "mw",
+		Name:      "link_preview_non_ok_status_total",
 		Help:      "Total count of HTTP status codes from LinkPreview URL fetches",
 	}, []string{"status_code", "status_class"})
 )


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-2214/bookmarks-add-metrics-for-blocked-requests

We need to set mw as subsystem for linkpreviewstatus counter