### PR TITLE
GO-6182 Create autowidget when object is created from editor

### DIFF
--- a/core/block.go
+++ b/core/block.go
@@ -61,14 +61,7 @@ func (mw *Middleware) BlockLinkCreateWithObject(cctx context.Context, req *pb.Rp
 	)
 	err := mw.doBlockService(func(bs *block.Service) (err error) {
 		id, targetId, objectDetails, err = bs.CreateLinkToTheNewObject(cctx, ctx, req)
-		if err != nil {
-			return err
-		}
-		typeKey, err := domain.GetTypeKeyFromRawUniqueKey(req.ObjectTypeUniqueKey)
-		if err != nil {
-			return err
-		}
-		return bs.CreateTypeWidgetIfMissing(cctx, req.SpaceId, typeKey)
+		return
 	})
 	if err != nil {
 		return response(pb.RpcBlockLinkCreateWithObjectResponseError_UNKNOWN_ERROR, "", "", nil, err)

--- a/core/block/create.go
+++ b/core/block/create.go
@@ -106,6 +106,11 @@ func (s *Service) CreateLinkToTheNewObject(
 	if err != nil {
 		return
 	}
+
+	if err = s.CreateTypeWidgetIfMissing(ctx, req.SpaceId, objectTypeKey); err != nil {
+		return
+	}
+
 	if req.ContextId == "" {
 		return
 	}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6182/auto-widget-creation-doesnt-work-if-an-object-was-created-from-editor

Create autowidget for object type when object is created from editor