### PR TITLE
GO-6154 Fix view relation update for new sets

### DIFF
--- a/core/block/simple/dataview/diff.go
+++ b/core/block/simple/dataview/diff.go
@@ -23,8 +23,8 @@ func (d *Dataview) Diff(spaceId string, b simple.Block) (msgs []simple.EventMess
 
 	msgs = d.diffGroupOrders(spaceId, other, msgs)
 	msgs = d.diffObjectOrders(spaceId, other, msgs)
-	msgs = d.diffViews(spaceId, other, msgs)
 	msgs = d.diffRelationLinks(spaceId, other, msgs)
+	msgs = d.diffViews(spaceId, other, msgs)
 	msgs = d.diffSources(spaceId, other, msgs)
 	msgs = d.diffOrderOfViews(spaceId, other, msgs)
 	msgs = d.diffTargetObjectIDs(spaceId, other, msgs)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6154/property-values-are-not-updated-in-the-set-at-the-first-start

We should reorder events in ObjectSetSource response, so first go RelationSet and after ViewUpdate. This way relations in view will get updated properly and rendered on client