### PR TITLE
GO-3743 Fix md import of code blocks with indentation

### DIFF
--- a/core/converter/md/md.go
+++ b/core/converter/md/md.go
@@ -591,11 +591,11 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 		buf.WriteString("   \n\n")
 		h.renderChildren(buf, in, b)
 	case model.BlockContentText_Code:
-		buf.WriteString("```\n")
+		buf.WriteString("```\n") // nolint:errcheck
 		txt := strings.ReplaceAll(text.Text, "```", "\\`\\`\\`")
 		txt = strings.ReplaceAll(txt, "\n", "\n"+in.indent)
-		buf.WriteString(in.indent + txt)
-		buf.WriteString("\n" + in.indent + "```\n")
+		buf.WriteString(in.indent + txt)            // nolint:errcheck
+		buf.WriteString("\n" + in.indent + "```\n") // nolint:errcheck
 		h.renderChildren(buf, in, b)
 	case model.BlockContentText_Checkbox:
 		if text.Checked {

--- a/core/converter/md/md.go
+++ b/core/converter/md/md.go
@@ -592,8 +592,10 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 		h.renderChildren(buf, in, b)
 	case model.BlockContentText_Code:
 		buf.WriteString("```\n")
-		buf.WriteString(strings.ReplaceAll(text.Text, "```", "\\`\\`\\`"))
-		buf.WriteString("\n```\n")
+		txt := strings.ReplaceAll(text.Text, "```", "\\`\\`\\`")
+		txt = strings.ReplaceAll(txt, "\n", "\n"+in.indent)
+		buf.WriteString(in.indent + txt)
+		buf.WriteString("\n" + in.indent + "```\n")
 		h.renderChildren(buf, in, b)
 	case model.BlockContentText_Checkbox:
 		if text.Checked {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3743/incorrect-indentation-of-nested-code-blocks-in-exported-markdown-files

We must save indents for code blocks on markdown import