### PR TITLE
GO-6278 Make new types first

### DIFF
--- a/core/block/editor/order/order.go
+++ b/core/block/editor/order/order.go
@@ -87,3 +87,7 @@ func (s *orderSettable) UnsetOrder() error {
 func (s *orderSettable) GetOrder() string {
 	return s.Details().GetString(s.orderKey)
 }
+
+func GetSmallestOrder(currentSmallestOrder string) string {
+	return lx.Prev(currentSmallestOrder)
+}

--- a/core/block/object/objectcreator/object_type.go
+++ b/core/block/object/objectcreator/object_type.go
@@ -52,6 +52,7 @@ func (s *service) createObjectType(ctx context.Context, space clientspace.Space,
 
 	object.SetString(bundle.RelationKeyId, id)
 	object.SetInt64(bundle.RelationKeyLayout, int64(model.ObjectType_objectType))
+	object.SetInt64(bundle.RelationKeyLastUsedDate, time.Now().Unix())
 
 	createState := state.NewDocWithUniqueKey("", nil, uniqueKey).(*state.State)
 	createState.SetDetails(object)

--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -265,6 +265,11 @@ func (b *queryBuilder) extractOrder(sorts []SortRequest) SetOrder {
 				format = sort.Format
 			}
 
+			disableCollator := sort.NoCollate
+			if sort.RelationKey == bundle.RelationKeyOrderId {
+				disableCollator = true
+			}
+
 			keyOrder := &KeyOrder{
 				SpaceID:         b.spaceId,
 				Key:             sort.RelationKey,
@@ -275,7 +280,7 @@ func (b *queryBuilder) extractOrder(sorts []SortRequest) SetOrder {
 				Store:           b.objectStore,
 				arena:           b.arena,
 				collatorBuffer:  b.collatorBuffer,
-				disableCollator: sort.NoCollate,
+				disableCollator: disableCollator,
 			}
 			order = b.appendCustomOrder(sort, order, keyOrder)
 		}


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6278/ensure-that-widget-for-the-newly-created-type-is-positioned-at-top-of

We should set current time to lastUsedDate to sort new type as first, if no custom order is set