### PR TITLE
GO-6175 Preserve style on block merge

### DIFF
--- a/core/block/simple/text/text.go
+++ b/core/block/simple/text/text.go
@@ -607,7 +607,7 @@ func (t *Text) Merge(b simple.Block, opts ...MergeOption) error {
 
 	text, ok := b.(*Text)
 
-	if !o.dontSetStyle && t.content != nil && t.content.Text == "" {
+	if !o.dontSetStyle && t.content != nil && t.content.Text == "" && t.content.Style == 0 {
 		t.SetStyle(text.content.Style)
 		t.BackgroundColor = text.BackgroundColor
 	}

--- a/core/block/simple/text/text_test.go
+++ b/core/block/simple/text/text_test.go
@@ -331,6 +331,67 @@ func TestText_Merge(t *testing.T) {
 		assert.Equal(t, mergeTo.content.Style, model.BlockContentText_Header1)
 		assert.Equal(t, mergeTo.BackgroundColor, "grey")
 	})
+
+	t.Run("preserve style of block with text", func(t *testing.T) {
+		// given
+		mergeTo := NewText(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Text: "Two",
+				},
+			},
+		}).(*Text)
+
+		mergeFrom := NewText(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Text:  "One",
+					Style: model.BlockContentText_Header1,
+				},
+			},
+		}).(*Text)
+		mergeFrom.BackgroundColor = "grey"
+
+		// when
+		err := mergeTo.Merge(mergeFrom)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, model.BlockContentText_Paragraph, mergeTo.content.Style)
+		assert.Empty(t, mergeTo.BackgroundColor)
+		assert.Equal(t, "TwoOne", mergeTo.content.Text)
+	})
+
+	t.Run("preserve style != 0", func(t *testing.T) {
+		// given
+		mergeTo := NewText(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Text:  "",
+					Style: model.BlockContentText_Numbered,
+				},
+			},
+		}).(*Text)
+
+		mergeFrom := NewText(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Text:  "One",
+					Style: model.BlockContentText_Header1,
+				},
+			},
+		}).(*Text)
+		mergeFrom.BackgroundColor = "grey"
+
+		// when
+		err := mergeTo.Merge(mergeFrom)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, model.BlockContentText_Numbered, mergeTo.content.Style)
+		assert.Empty(t, mergeTo.BackgroundColor)
+		assert.Equal(t, "One", mergeTo.content.Text)
+	})
 }
 
 func TestText_SetMarkForAllText(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6175/preserve-the-style-when-merging-empty-blocks

We should preserve non-zero style of a block being merged into even if no text is presented