### PR TITLE
GO-4284 Remove AddRelationKeys method from details

### DIFF
--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -426,7 +426,6 @@ func (bs *basic) AddRelationAndSet(ctx session.Context, req pb.RpcBlockRelationA
 	} else {
 		return fmt.Errorf("unexpected block type: %T (want relation)", b)
 	}
-	s.AddRelationKeys(domain.RelationKey(rel.Key))
 	s.AddRelationLinks(rel.RelationLink())
 	return bs.Apply(s)
 }
@@ -446,7 +445,6 @@ func (bs *basic) FeaturedRelationAdd(ctx session.Context, relations ...string) (
 			frc = append(frc, r)
 			key := domain.RelationKey(r)
 			if !s.HasRelation(key) {
-				s.AddRelationKeys(key)
 				// TODO: GO-4284 remove
 				err = bs.addRelationLink(s, key)
 				if err != nil {

--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -454,7 +454,6 @@ func (cb *clipboard) pasteAny(
 			missingRelationKeys = append(missingRelationKeys, domain.RelationKey(r.Key))
 		}
 	}
-	s.AddRelationKeys(missingRelationKeys...)
 
 	// TODO: GO-4284 remove
 	if len(missingRelationKeys) > 0 {

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -327,16 +327,14 @@ func (sb *smartBlock) Init(ctx *InitContext) (err error) {
 		ctx.State.SetParent(sb.Doc.(*state.State))
 	}
 
+	// TODO: GO-4284 remove
 	injectRequiredRelationLinks := func(s *state.State) {
 		s.AddBundledRelationLinks(bundle.RequiredInternalRelations...)
 		s.AddBundledRelationLinks(ctx.RequiredInternalRelationKeys...)
-		s.AddRelationKeys(bundle.RequiredInternalRelations...)
-		s.AddRelationKeys(ctx.RequiredInternalRelationKeys...)
 	}
 	injectRequiredRelationLinks(ctx.State)
 	injectRequiredRelationLinks(ctx.State.ParentState())
 
-	ctx.State.AddRelationKeys(ctx.RelationKeys...)
 	// TODO: GO-4284 remove
 	if err = sb.AddRelationLinksToState(ctx.State, ctx.RelationKeys...); err != nil {
 		return

--- a/core/block/editor/smartblock/smartblock_test.go
+++ b/core/block/editor/smartblock/smartblock_test.go
@@ -2,7 +2,6 @@ package smartblock
 
 import (
 	"context"
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,13 +36,9 @@ func TestSmartBlock_Init(t *testing.T) {
 	// when
 	initCtx := fx.init(t, []*model.Block{{Id: id}})
 
+	// then
 	require.NotNil(t, initCtx)
 	require.NotNil(t, initCtx.State)
-	keys := initCtx.State.AllRelationKeys()
-	for _, key := range bundle.RequiredInternalRelations {
-		assert.Truef(t, slices.Contains(keys, key), "missing relation %s", key)
-	}
-	// then
 	assert.Equal(t, id, fx.RootId())
 }
 

--- a/core/block/editor/state/details.go
+++ b/core/block/editor/state/details.go
@@ -159,16 +159,6 @@ func (s *State) SetLocalDetail(key domain.RelationKey, value domain.Value) {
 	s.localDetails.Set(key, value)
 }
 
-// AddRelationKeys adds details with null value, if no detail corresponding to key was presented
-func (s *State) AddRelationKeys(keys ...domain.RelationKey) {
-	for _, key := range keys {
-		if s.HasRelation(key) {
-			continue
-		}
-		s.SetDetail(key, domain.Null())
-	}
-}
-
 // details removers
 
 func (s *State) RemoveRelation(keys ...domain.RelationKey) {

--- a/core/block/editor/state/details_test.go
+++ b/core/block/editor/state/details_test.go
@@ -206,37 +206,3 @@ func TestState_AllRelationKeys(t *testing.T) {
 		assert.Len(t, keys, 5)
 	})
 }
-
-func TestState_AddRelationKeys(t *testing.T) {
-	t.Run("add new keys", func(t *testing.T) {
-		// given
-		st := NewDoc("root", nil).NewState()
-		st.AddDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-			// details
-			bundle.RelationKeyCoverType: domain.Int64(1),
-			bundle.RelationKeyName:      domain.String("name"),
-			bundle.RelationKeyAssignee:  domain.String("assignee"),
-			// local details
-			bundle.RelationKeyResolvedLayout: domain.Int64(model.ObjectType_todo),
-			bundle.RelationKeyType:           domain.String(bundle.TypeKeyTask.URL()),
-		}))
-		require.Equal(t, 3, st.details.Len())
-		require.Equal(t, 2, st.localDetails.Len())
-
-		// when
-		st.AddRelationKeys(
-			bundle.RelationKeyPicture, // new detail
-			bundle.RelationKeyName,    // existing detail
-			bundle.RelationKeySpaceId, // new local detail
-			bundle.RelationKeyType,    // existing local detail
-		)
-
-		// then
-		assert.Equal(t, 4, st.details.Len())
-		assert.Equal(t, 3, st.localDetails.Len())
-		assert.Equal(t, domain.Null(), st.details.Get(bundle.RelationKeyPicture))
-		assert.Equal(t, domain.String("name"), st.details.Get(bundle.RelationKeyName))
-		assert.Equal(t, domain.Null(), st.localDetails.Get(bundle.RelationKeySpaceId))
-		assert.Equal(t, domain.Int64(model.ObjectType_todo), st.localDetails.Get(bundle.RelationKeyResolvedLayout))
-	})
-}

--- a/core/block/editor/template/template.go
+++ b/core/block/editor/template/template.go
@@ -80,9 +80,9 @@ var WithNoDuplicateLinks = func() StateTransformer {
 	}
 }
 
+// TODO: GO-4284 remove
 var WithRelations = func(keys []domain.RelationKey) StateTransformer {
 	return func(s *state.State) {
-		s.AddRelationKeys(keys...)
 		s.AddBundledRelationLinks(keys...)
 	}
 }
@@ -600,7 +600,7 @@ var WithBookmarkBlocks = func(s *state.State) {
 
 	for _, k := range bookmarkRelationKeys {
 		if !s.HasRelation(domain.RelationKey(k)) {
-			s.AddRelationKeys(domain.RelationKey(k))
+			// TODO: GO-4284 remove
 			s.AddBundledRelationLinks(domain.RelationKey(k))
 		}
 	}

--- a/core/block/object/objectlink/dependent_objects_test.go
+++ b/core/block/object/objectlink/dependent_objects_test.go
@@ -228,7 +228,12 @@ func TestState_DepSmartIdsLinksAndRelations(t *testing.T) {
 		},
 	}
 	stateWithLinks.AddRelationLinks(relations...)
-	stateWithLinks.AddRelationKeys("relation1", "relation2", "relation3", "relation4")
+	stateWithLinks.AddDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+		"relation1": domain.String("image_with_cute_kitten"),
+		"relation2": domain.String("Important"),
+		"relation3": domain.String("TODO"),
+		"relation4": domain.String("Project"),
+	}))
 	fetcher := setupFetcher(t, relations)
 
 	t.Run("blocks option is turned on: get ids from blocks", func(t *testing.T) {

--- a/core/block/source/sourceimpl/source.go
+++ b/core/block/source/sourceimpl/source.go
@@ -306,7 +306,6 @@ func (s *treeSource) buildState() (doc state.Doc, err error) {
 
 	// we need to have required internal relations for all objects, including system
 	st.AddBundledRelationLinks(bundle.RequiredInternalRelations...)
-	st.AddRelationKeys(bundle.RequiredInternalRelations...)
 	if s.Type() == smartblock.SmartBlockTypePage || s.Type() == smartblock.SmartBlockTypeProfilePage {
 		template.WithRelations([]domain.RelationKey{bundle.RelationKeyBacklinks})(st)
 		template.WithFeaturedRelationsBlock(st)

--- a/core/files/fileobject/fileindex.go
+++ b/core/files/fileobject/fileindex.go
@@ -273,7 +273,6 @@ func (ind *indexer) injectMetadataToState(ctx context.Context, st *state.State, 
 		keys = append(keys, k)
 	}
 	st.AddBundledRelationLinks(keys...)
-	st.AddRelationKeys(keys...)
 
 	details = prevDetails.Merge(details)
 	st.SetDetails(details)

--- a/util/builtintemplate/builtintemplate.go
+++ b/util/builtintemplate/builtintemplate.go
@@ -127,7 +127,6 @@ func (b *builtinTemplate) registerBuiltin(space clientspace.Space, rd io.ReadClo
 			relKey := domain.RelationKey(b.Model().GetRelation().Key)
 			if !st.HasRelation(relKey) {
 				st.AddBundledRelationLinks(relKey)
-				st.AddRelationKeys(relKey)
 			}
 		}
 		return true


### PR DESCRIPTION
As we are going to compeletely remove relation links from object state, clients should rely on recommended relations in types to identify which properies to render. Details should be relation value store, not relation presence store