### PR TITLE
GO-3588 Add restrictions to archived objects

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1262,22 +1262,6 @@ func removeInternalFlags(s *state.State) {
 	}
 }
 
-func (sb *smartBlock) setRestrictionsDetail(s *state.State) {
-	currentRestrictions := restriction.NewObjectRestrictionsFromValue(s.LocalDetails().Get(bundle.RelationKeyRestrictions))
-	if currentRestrictions.Equal(sb.Restrictions().Object) {
-		return
-	}
-
-	s.SetLocalDetail(bundle.RelationKeyRestrictions, sb.Restrictions().Object.ToValue())
-
-	if sb.Restrictions().Object.Check(model.Restrictions_Details) != nil &&
-		sb.Restrictions().Object.Check(model.Restrictions_Blocks) != nil {
-		s.SetDetailAndBundledRelation(bundle.RelationKeyIsReadonly, domain.Bool(true))
-	} else if s.LocalDetails().GetBool(bundle.RelationKeyIsReadonly) {
-		s.SetDetailAndBundledRelation(bundle.RelationKeyIsReadonly, domain.Bool(false))
-	}
-}
-
 func msgsToEvents(msgs []simple.EventMessage) []*pb.EventMessage {
 	events := make([]*pb.EventMessage, len(msgs))
 	for i := range msgs {

--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -182,6 +182,11 @@ func getObjectRestrictions(rh RestrictionHolder) (r ObjectRestrictions) {
 			r = ObjectRestrictions{}
 		}
 	}
+
+	if rh.LocalDetails().GetBool(bundle.RelationKeyIsArchived) {
+		return objRestrictAll.Copy()
+	}
+
 	return
 }
 

--- a/core/block/restriction/object_test.go
+++ b/core/block/restriction/object_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -125,4 +126,19 @@ func TestTemplateRestriction(t *testing.T) {
 		book := givenRestrictionHolder(smartblock.SmartBlockTypePage, bundle.TypeKeyBook)
 		assert.NoError(t, GetRestrictions(book).Object.Check(model.Restrictions_Template))
 	})
+}
+
+func TestArchivedObjectRestrictions(t *testing.T) {
+	archived := &restrictionHolder{
+		localDetails: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyIsArchived: domain.Bool(true),
+		}),
+	}
+
+	rs := GetRestrictions(archived).Object
+	for r := range objRestrictAll {
+		assert.Error(t, rs.Check(r))
+	}
+	assert.NoError(t, rs.Check(model.Restrictions_None))
+	assert.NoError(t, rs.Check(model.Restrictions_CreateObjectOfThisType))
 }

--- a/core/block/restriction/restrictions.go
+++ b/core/block/restriction/restrictions.go
@@ -14,6 +14,7 @@ type RestrictionHolder interface {
 	Type() smartblock.SmartBlockType
 	Layout() (model.ObjectTypeLayout, bool)
 	UniqueKey() domain.UniqueKey
+	LocalDetails() *domain.Details
 }
 
 func GetRestrictions(rh RestrictionHolder) (r Restrictions) {

--- a/core/block/restriction/restrictions_test.go
+++ b/core/block/restriction/restrictions_test.go
@@ -14,9 +14,10 @@ import (
 const noLayout = -1
 
 type restrictionHolder struct {
-	sbType    smartblock.SmartBlockType
-	uniqueKey domain.UniqueKey
-	layout    model.ObjectTypeLayout
+	sbType       smartblock.SmartBlockType
+	uniqueKey    domain.UniqueKey
+	layout       model.ObjectTypeLayout
+	localDetails *domain.Details
 }
 
 func (rh *restrictionHolder) Type() smartblock.SmartBlockType {
@@ -29,6 +30,10 @@ func (rh *restrictionHolder) Layout() (model.ObjectTypeLayout, bool) {
 
 func (rh *restrictionHolder) UniqueKey() domain.UniqueKey {
 	return rh.uniqueKey
+}
+
+func (rh *restrictionHolder) LocalDetails() *domain.Details {
+	return rh.localDetails
 }
 
 func givenObjectType(typeKey domain.TypeKey) RestrictionHolder {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3588/restrict-new-block-creation-by-dragging-and-dropping-filesfolders-into

We should restrict all actions upon objects in the Bin