### PR TITLE
GO-6429 Allow to delete archived objects

### DIFF
--- a/core/block/restriction/object.go
+++ b/core/block/restriction/object.go
@@ -184,7 +184,7 @@ func getObjectRestrictions(rh RestrictionHolder) (r ObjectRestrictions) {
 	}
 
 	if rh.LocalDetails().GetBool(bundle.RelationKeyIsArchived) {
-		return objRestrictAll.Copy()
+		return objRestrictAll.Copy().Remove(model.Restrictions_Delete)
 	}
 
 	return

--- a/core/block/restriction/object_test.go
+++ b/core/block/restriction/object_test.go
@@ -130,6 +130,7 @@ func TestTemplateRestriction(t *testing.T) {
 
 func TestArchivedObjectRestrictions(t *testing.T) {
 	archived := &restrictionHolder{
+		sbType: smartblock.SmartBlockTypePage,
 		localDetails: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
 			bundle.RelationKeyIsArchived: domain.Bool(true),
 		}),
@@ -137,6 +138,10 @@ func TestArchivedObjectRestrictions(t *testing.T) {
 
 	rs := GetRestrictions(archived).Object
 	for r := range objRestrictAll {
+		if r == model.Restrictions_Delete {
+			assert.NoError(t, rs.Check(r))
+			continue
+		}
 		assert.Error(t, rs.Check(r))
 	}
 	assert.NoError(t, rs.Check(model.Restrictions_None))


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6429/05030-alpha-unable-to-delete-objects-from-bin

Remove **Delete** restriction from archived objects, so they could be deleted