### PR TITLE
GO-3916 Fix webp images layout

### DIFF
--- a/core/files/fileobject/fileindex.go
+++ b/core/files/fileobject/fileindex.go
@@ -303,10 +303,11 @@ func (ind *indexer) buildDetails(ctx context.Context, id domain.FullFileId, info
 		}
 	}
 
-	// Overwrite typeKey for images in case that image is uploaded as file.
+	// Overwrite typeKey and layout for images in case that image is uploaded as a file.
 	// That can be possible because some images can't be handled properly and wee fall back to
 	// handling them as files
 	if mill.IsImage(file.MimeType()) {
+		details.SetInt64(bundle.RelationKeyLayout, int64(model.ObjectType_image))
 		typeKey = bundle.TypeKeyImage
 	}
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-3916/the-gallery-doesnt-show-images-in-webp-format

Webp resizer fails in case of animated Wepb images, however we set type=Image for file objects with image mime type and that are supported on client. We should do the same with layout detail