### PR TITLE
GO-6371 Check irot field in heic imgs

### DIFF
--- a/pkg/lib/mill/image_resize.go
+++ b/pkg/lib/mill/image_resize.go
@@ -129,7 +129,7 @@ func (m *ImageResize) Mill(r io.ReadSeeker, name string) (*Result, error) {
 	case GIF:
 		return m.resizeGIF(&imgConfig, r)
 	case HEIC:
-		return m.resizeHEIC(&imgConfig, r)
+		return m.resizeHEIC(r)
 	case TIFF:
 		return m.resizeTIFF(&imgConfig, r)
 	case PSD:


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6371/image-is-rotated

**irot** field is ignored when decoding HEIC images. We must check it and rotate image if necessary