### PR TITLE
GO-6380 Set correct type order on 1st partial reorder

### DIFF
--- a/core/order/order.go
+++ b/core/order/order.go
@@ -183,7 +183,6 @@ func (o *orderSetter) reorder(objectIds []string, originalOrderIds map[string]st
 	originalIds := getAllOriginalIds(originalOrderIds)
 	if needFullList {
 		objectIds = calculateFullList(objectIds, originalIds, originalOrderIds)
-
 	}
 
 	nextExisting := o.precalcNext(originalOrderIds, objectIds)
@@ -242,17 +241,14 @@ func getAllOriginalIds(originalOrderIds map[string]string) []string {
 	})
 }
 
-func getIdsInOriginalOrder(objectIds []string, originalOrderIds map[string]string) []string {
-	listWithOrder := make([]idAndOrderId, 0, len(objectIds))
-	for _, id := range objectIds {
-		listWithOrder = append(listWithOrder, idAndOrderId{id: id, orderId: originalOrderIds[id]})
+func getIdsInOriginalOrder(objectIdsSet map[string]struct{}, fullOriginalIds []string) []string {
+	originalIds := make([]string, 0, len(objectIdsSet))
+	for _, id := range fullOriginalIds {
+		if _, ok := objectIdsSet[id]; ok {
+			originalIds = append(originalIds, id)
+		}
 	}
-	sort.Slice(listWithOrder, func(i, j int) bool {
-		return listWithOrder[i].orderId < listWithOrder[j].orderId
-	})
-	return lo.Map(listWithOrder, func(it idAndOrderId, _ int) string {
-		return it.id
-	})
+	return originalIds
 }
 
 func hasItemNotInSet[T comparable](items []T, set map[T]struct{}) bool {
@@ -283,7 +279,7 @@ func calculateFullList(objectIds []string, fullOriginalIds []string, originalOrd
 		return objectIds
 	}
 
-	originalIds := getIdsInOriginalOrder(objectIds, originalOrderIds)
+	originalIds := getIdsInOriginalOrder(objectIdsSet, fullOriginalIds)
 	ops := slice.Diff(originalIds, objectIds, func(s string) string {
 		return s
 	}, func(s string, s2 string) bool {

--- a/core/order/order_test.go
+++ b/core/order/order_test.go
@@ -163,6 +163,28 @@ func TestReorder(t *testing.T) {
 			objectIds: []string{"obj1", "obj2", "obj3"},
 		},
 		{
+			name: "empty orders + incomplete list",
+			originalOrderIds: map[string]string{
+				"obj1": "",
+				"obj2": "",
+				"obj3": "",
+				"obj4": "",
+				"obj5": "",
+			},
+			objectIds: []string{"obj3", "obj2", "obj5"},
+		},
+		{
+			name: "some orders are empty + incomplete list",
+			originalOrderIds: map[string]string{
+				"obj1": "",
+				"obj2": "xxx",
+				"obj3": "",
+				"obj4": "bbb",
+				"obj5": "aaa",
+			},
+			objectIds: []string{"obj3", "obj2", "obj5"},
+		},
+		{
 			name: "4 elements #1",
 			originalOrderIds: map[string]string{
 				"a": "AAA001",


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6380/after-manually-sorting-the-types-in-sidebar-the-sorting-breaks-down

We had a problem on calculation of correct type order on 1st partial reorder. In this case all types have empty orderIds, so original order is calculated randomly because orders are collected in a map.
When we calculated original order of target type ids (subset of all types), we also got random order that did not correspond to original full list order, because again it was gathered from map with empty orderIds.

E.g.:
Input: desired order -> `[Page, Task, Note]`
Original order map: `{Note: "", Set: "", Page:"", Task: "", File: ""}`

We calculate original order for all types. It will be random because of empty orderIds!
fullOrders: `[Set, Page, File, Task, Note]`

After that we are trying to calculate original order for **TARGET** types, based on provided imput slice and order map. Result is random again: e.g. `[Task, Page, Note]`

And it does not correspond to fullOrders. All further logic is useless, because these two lists do not correspond each other.

Fix:
- use precalculated fullOrders to form original orders list