### PR TITLE
GO-6505 Deprecate the smartblock.NotPushChanges apply option

### DIFF
--- a/core/block/editor/accountobject/accountobject.go
+++ b/core/block/editor/accountobject/accountobject.go
@@ -181,7 +181,7 @@ func (a *accountObject) Init(ctx *smartblock.InitContext) error {
 	if err != nil {
 		return fmt.Errorf("init state: %w", err)
 	}
-	return a.SmartBlock.Apply(ctx.State, smartblock.NotPushChanges, smartblock.NoHistory, smartblock.SkipIfNoChanges)
+	return a.SmartBlock.Apply(ctx.State, smartblock.NotPushChanges, smartblock.NoHistory)
 }
 
 func (a *accountObject) genInitialDoc() (builder *storestate.Builder, err error) {

--- a/core/block/editor/factory.go
+++ b/core/block/editor/factory.go
@@ -173,7 +173,7 @@ func (f *ObjectFactory) InitObject(space smartblock.Space, id string, initCtx *s
 		return nil, fmt.Errorf("init smartblock: %w", err)
 	}
 
-	applyFlags := []smartblock.ApplyFlag{smartblock.NoHistory, smartblock.NoEvent, smartblock.NoRestrictions, smartblock.SkipIfNoChanges, smartblock.KeepInternalFlags, smartblock.IgnoreNoPermissions}
+	applyFlags := []smartblock.ApplyFlag{smartblock.NoHistory, smartblock.NoEvent, smartblock.NoRestrictions, smartblock.KeepInternalFlags, smartblock.IgnoreNoPermissions}
 	if initCtx.IsNewObject {
 		applyFlags = append(applyFlags, smartblock.AllowApplyWithEmptyTree)
 	}

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -59,7 +59,6 @@ const (
 	NoRestrictions
 	NoHooks
 	DoSnapshot
-	SkipIfNoChanges
 	KeepInternalFlags
 	IgnoreNoPermissions
 	NotPushChanges // Used only for read-only actions like InitObject or OpenObject
@@ -625,7 +624,6 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 		doSnapshot              = false
 		checkRestrictions       = true
 		hooks                   = true
-		skipIfNoChanges         = false
 		keepInternalFlags       = false
 		ignoreNoPermissions     = false
 		notPushChanges          = false
@@ -643,8 +641,6 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 			checkRestrictions = false
 		case NoHooks:
 			hooks = false
-		case SkipIfNoChanges:
-			skipIfNoChanges = true
 		case KeepInternalFlags:
 			keepInternalFlags = true
 		case IgnoreNoPermissions:
@@ -723,7 +719,7 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 
 	changes := st.GetChanges()
 	var changeId string
-	if skipIfNoChanges && len(changes) == 0 && !migrationVersionUpdated {
+	if len(changes) == 0 && !migrationVersionUpdated {
 		if hasDetailsMsgs(msgs) {
 			// means we have only local details changed, so lets index but skip full text
 			sb.runIndexer(st, SkipFullTextIfHeadsNotChanged)
@@ -1277,7 +1273,7 @@ func ObjectApplyTemplate(sb SmartBlock, s *state.State, templates ...template.St
 	}
 	template.InitTemplate(s, templates...)
 
-	return sb.Apply(s, NoHistory, NoEvent, NoRestrictions, SkipIfNoChanges)
+	return sb.Apply(s, NoHistory, NoEvent, NoRestrictions)
 }
 
 func hasChangesToPush(changes []*pb.ChangeContent) bool {

--- a/core/block/editor/spaceview.go
+++ b/core/block/editor/spaceview.go
@@ -369,7 +369,7 @@ func (s *SpaceView) SetSpaceData(details *domain.Details) error {
 func (s *SpaceView) UpdateLastOpenedDate() error {
 	st := s.NewState()
 	st.SetLocalDetail(bundle.RelationKeyLastOpenedDate, domain.Int64(time.Now().Unix()))
-	return s.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.SkipIfNoChanges, smartblock.KeepInternalFlags)
+	return s.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.KeepInternalFlags)
 }
 
 func stateSetAccessType(st *state.State, accessType spaceinfo.AccessType) {

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -230,7 +230,7 @@ func (s *Service) OpenBlock(sctx session.Context, id domain.FullID, includeRelat
 		st := ob.NewState()
 
 		st.SetLocalDetail(bundle.RelationKeyLastOpenedDate, domain.Int64(time.Now().Unix()))
-		if err = ob.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.SkipIfNoChanges, smartblock.KeepInternalFlags, smartblock.IgnoreNoPermissions); err != nil {
+		if err = ob.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.KeepInternalFlags, smartblock.IgnoreNoPermissions); err != nil {
 			log.Errorf("failed to update lastOpenedDate: %s", err)
 		}
 		if err = ob.Space().RefreshObjects([]string{ob.Id()}); err != nil {
@@ -430,7 +430,7 @@ func (s *Service) SpaceInitChat(ctx context.Context, spaceId string) error {
 		st.SetLocalDetail(bundle.RelationKeyChatId, domain.String(chatId))
 		st.SetDetail(bundle.RelationKeyHasChat, domain.Bool(true))
 
-		return b.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.SkipIfNoChanges, smartblock.KeepInternalFlags, smartblock.IgnoreNoPermissions)
+		return b.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.KeepInternalFlags, smartblock.IgnoreNoPermissions)
 	})
 	if err != nil {
 		return fmt.Errorf("apply chatId to workspace: %w", err)


### PR DESCRIPTION
Initially we had an idea that we can miss some changes generation and we should create a snapshot in this case. Thats wy we decided to add an explicit option smartblock.NotPushChanges. 

I've analyzed logs and we have these cases so far:
- missed smartblock.NotPushChanges flag when setting some system properties(objectDetailsAmend) in SpaceView, Workspace and other objects: (syncStatus, myParticipantStatus and many others). In some cases this is local-only relations and they make a change because they create a relationLinks(already deprecated). In some cases it happens because we update the value to the same one we already have in the state.
- blockSetChildrenIds when client send the same list of block ids

So therefore there are no cases where this mechanism is helpful. Lets deprecate this flag and make it a default behavior to skip the change generation instead of creating a snapshot