### PR TITLE
GO-6518 Use URL encoding for metadata key

### DIFF
--- a/core/anytype/account/service.go
+++ b/core/anytype/account/service.go
@@ -181,7 +181,7 @@ func (s *service) GetInfo(ctx context.Context) (*model.AccountInfo, error) {
 		NetworkId:              s.getNetworkId(),
 		TechSpaceId:            s.spaceService.TechSpaceId(),
 		EthereumAddress:        s.wallet.GetAccountEthAddress().Hex(),
-		MetaDataKey:            base64.StdEncoding.EncodeToString(metadataRawKey),
+		MetaDataKey:            base64.URLEncoding.EncodeToString(metadataRawKey),
 	}, nil
 }
 


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6518/1-1-qr-code-and-link

We should use URL encoding in base64 for metadata key