### PR TITLE
Add file upload REST API endpoint

### DIFF
--- a/core/api/core/core.go
+++ b/core/api/core/core.go
@@ -65,6 +65,9 @@ type ClientCommands interface {
 	RelationListRemoveOption(context.Context, *pb.RpcRelationListRemoveOptionRequest) *pb.RpcRelationListRemoveOptionResponse
 	RelationOptions(context.Context, *pb.RpcRelationOptionsRequest) *pb.RpcRelationOptionsResponse
 
+	// File
+	FileUpload(context.Context, *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse
+
 	// Block
 	BlockCreate(context.Context, *pb.RpcBlockCreateRequest) *pb.RpcBlockCreateResponse
 	BlockPaste(context.Context, *pb.RpcBlockPasteRequest) *pb.RpcBlockPasteResponse

--- a/core/api/core/mock_apicore/mock_ClientCommands.go
+++ b/core/api/core/mock_apicore/mock_ClientCommands.go
@@ -267,6 +267,55 @@ func (_c *MockClientCommands_BlockPaste_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// FileUpload provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) FileUpload(_a0 context.Context, _a1 *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FileUpload")
+	}
+
+	var r0 *pb.RpcFileUploadResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcFileUploadResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_FileUpload_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FileUpload'
+type MockClientCommands_FileUpload_Call struct {
+	*mock.Call
+}
+
+// FileUpload is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcFileUploadRequest
+func (_e *MockClientCommands_Expecter) FileUpload(_a0 interface{}, _a1 interface{}) *MockClientCommands_FileUpload_Call {
+	return &MockClientCommands_FileUpload_Call{Call: _e.mock.On("FileUpload", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_FileUpload_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcFileUploadRequest)) *MockClientCommands_FileUpload_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcFileUploadRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_FileUpload_Call) Return(_a0 *pb.RpcFileUploadResponse) *MockClientCommands_FileUpload_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_FileUpload_Call) RunAndReturn(run func(context.Context, *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse) *MockClientCommands_FileUpload_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ObjectCollectionAdd provides a mock function with given fields: _a0, _a1
 func (_m *MockClientCommands) ObjectCollectionAdd(_a0 context.Context, _a1 *pb.RpcObjectCollectionAddRequest) *pb.RpcObjectCollectionAddResponse {
 	ret := _m.Called(_a0, _a1)

--- a/core/api/handler/file.go
+++ b/core/api/handler/file.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/anyproto/anytype-heart/core/api/service"
+	"github.com/anyproto/anytype-heart/core/api/util"
+)
+
+// UploadFileHandler handles file uploads
+//
+//	@Summary		Upload file
+//	@Description	Uploads a file to the specified space. Accepts multipart/form-data with a file field. The file is processed and stored, then a file object is created. Returns the file object ID and file ID (IPFS CID).
+//	@Id				upload_file
+//	@Tags			Files
+//	@Accept			multipart/form-data
+//	@Produce		json
+//	@Param			Anytype-Version	header		string							true	"The version of the API to use"	default(2025-05-20)
+//	@Param			space_id		path		string							true	"The ID of the space to upload the file to"
+//	@Param			file			formData	file							true	"The file to upload"
+//	@Success		200				{object}	apimodel.FileUploadResponse		"File uploaded successfully"
+//	@Failure		400				{object}	util.BadRequestError			"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError			"Unauthorized"
+//	@Failure		500				{object}	util.ServerError				"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/files [post]
+func UploadFileHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spaceId := c.Param("space_id")
+
+		// Get uploaded file from multipart form
+		fileHeader, err := c.FormFile("file")
+		if err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, "missing file in request")
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		// Open uploaded file
+		file, err := fileHeader.Open()
+		if err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, "failed to read uploaded file")
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+		defer file.Close()
+
+		// Create temp file
+		tempFile, err := os.CreateTemp("", "anytype-upload-*-"+filepath.Base(fileHeader.Filename))
+		if err != nil {
+			apiErr := util.CodeToApiError(http.StatusInternalServerError, "failed to create temp file")
+			c.JSON(http.StatusInternalServerError, apiErr)
+			return
+		}
+		tempPath := tempFile.Name()
+		defer os.Remove(tempPath) // cleanup
+
+		// Copy uploaded file to temp file
+		_, err = io.Copy(tempFile, file)
+		tempFile.Close()
+		if err != nil {
+			apiErr := util.CodeToApiError(http.StatusInternalServerError, "failed to save uploaded file")
+			c.JSON(http.StatusInternalServerError, apiErr)
+			return
+		}
+
+		// Upload via service
+		result, err := s.UploadFile(c.Request.Context(), spaceId, tempPath)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrFailedUploadFile, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusOK, result)
+	}
+}

--- a/core/api/handler/file_test.go
+++ b/core/api/handler/file_test.go
@@ -1,0 +1,127 @@
+package handler
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/api/core/mock_apicore"
+	"github.com/anyproto/anytype-heart/core/api/service"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+func TestUploadFileHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("successful upload", func(t *testing.T) {
+		// given
+		mwMock := mock_apicore.NewMockClientCommands(t)
+		crossSpaceSubService := mock_apicore.NewMockCrossSpaceSubscriptionService(t)
+		svc := service.NewService(mwMock, "http://localhost:31006", "techspace", crossSpaceSubService)
+
+		mwMock.On("FileUpload", mock.Anything, mock.MatchedBy(func(req *pb.RpcFileUploadRequest) bool {
+			return req.SpaceId == "space1" && req.Type == model.BlockContentFile_File
+		})).Return(&pb.RpcFileUploadResponse{
+			ObjectId:      "obj123",
+			PreloadFileId: "bafyreiabc123",
+			Details: &types.Struct{
+				Fields: map[string]*types.Value{
+					"name":        pbtypes.String("test.txt"),
+					"sizeInBytes": pbtypes.Int64(12),
+				},
+			},
+			Error: &pb.RpcFileUploadResponseError{Code: pb.RpcFileUploadResponseError_NULL},
+		}).Once()
+
+		// Create multipart form
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		part, err := writer.CreateFormFile("file", "test.txt")
+		require.NoError(t, err)
+		_, err = part.Write([]byte("test content"))
+		require.NoError(t, err)
+		writer.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/spaces/space1/files", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		w := httptest.NewRecorder()
+
+		router := gin.New()
+		router.POST("/v1/spaces/:space_id/files", UploadFileHandler(svc))
+
+		// when
+		router.ServeHTTP(w, req)
+
+		// then
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "obj123")
+		assert.Contains(t, w.Body.String(), "bafyreiabc123")
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		// given
+		mwMock := mock_apicore.NewMockClientCommands(t)
+		crossSpaceSubService := mock_apicore.NewMockCrossSpaceSubscriptionService(t)
+		svc := service.NewService(mwMock, "http://localhost:31006", "techspace", crossSpaceSubService)
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/spaces/space1/files", nil)
+		w := httptest.NewRecorder()
+
+		router := gin.New()
+		router.POST("/v1/spaces/:space_id/files", UploadFileHandler(svc))
+
+		// when
+		router.ServeHTTP(w, req)
+
+		// then
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "missing file in request")
+	})
+
+	t.Run("service upload error", func(t *testing.T) {
+		// given
+		mwMock := mock_apicore.NewMockClientCommands(t)
+		crossSpaceSubService := mock_apicore.NewMockCrossSpaceSubscriptionService(t)
+		svc := service.NewService(mwMock, "http://localhost:31006", "techspace", crossSpaceSubService)
+
+		mwMock.On("FileUpload", mock.Anything, mock.Anything).
+			Return(&pb.RpcFileUploadResponse{
+				Error: &pb.RpcFileUploadResponseError{
+					Code:        pb.RpcFileUploadResponseError_UNKNOWN_ERROR,
+					Description: "upload failed",
+				},
+			}).Once()
+
+		// Create multipart form
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		part, err := writer.CreateFormFile("file", "test.txt")
+		require.NoError(t, err)
+		_, err = part.Write([]byte("test content"))
+		require.NoError(t, err)
+		writer.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/spaces/space1/files", body)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		w := httptest.NewRecorder()
+
+		router := gin.New()
+		router.POST("/v1/spaces/:space_id/files", UploadFileHandler(svc))
+
+		// when
+		router.ServeHTTP(w, req)
+
+		// then
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}

--- a/core/api/model/file.go
+++ b/core/api/model/file.go
@@ -1,0 +1,8 @@
+package apimodel
+
+// FileUploadResponse represents the response after uploading a file
+type FileUploadResponse struct {
+	ObjectId string         `json:"object_id"`         // File object ID
+	FileId   string         `json:"file_id"`           // Preload file ID (IPFS CID)
+	Details  map[string]any `json:"details,omitempty"` // File metadata
+}

--- a/core/api/server/router.go
+++ b/core/api/server/router.go
@@ -36,6 +36,7 @@ func (srv *Server) NewRouter(mw apicore.ClientCommands, eventService apicore.Eve
 	v1.Use(srv.ensureCacheInitialized())
 	v1.Use(srv.ensureAuthenticated(mw))
 
+	srv.registerFileRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerListRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerMemberRoutes(v1, eventService)
 	srv.registerObjectRoutes(v1, eventService, writeRateLimitMW)
@@ -106,6 +107,15 @@ func (srv *Server) registerAuthRoutes(router *gin.Engine) {
 		authGroup.POST("/auth/challenges", handler.CreateChallengeHandler(srv.service))
 		authGroup.POST("/auth/api_keys", handler.CreateApiKeyHandler(srv.service))
 	}
+}
+
+// registerFileRoutes registers file-related routes
+func (srv *Server) registerFileRoutes(v1 *gin.RouterGroup, eventService apicore.EventService, writeRateLimitMW gin.HandlerFunc) {
+	v1.POST("/spaces/:space_id/files",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("UploadFile", eventService),
+		handler.UploadFileHandler(srv.service),
+	)
 }
 
 // registerListRoutes registers list-related routes

--- a/core/api/service/file.go
+++ b/core/api/service/file.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/anyproto/anytype-heart/pb"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+var (
+	ErrFailedUploadFile = errors.New("failed to upload file")
+)
+
+// UploadFile uploads a file to the specified space
+func (s *Service) UploadFile(ctx context.Context, spaceId string, localPath string) (*apimodel.FileUploadResponse, error) {
+	req := &pb.RpcFileUploadRequest{
+		SpaceId:   spaceId,
+		LocalPath: localPath,
+		Type:      model.BlockContentFile_File, // default to generic file
+	}
+
+	resp := s.mw.FileUpload(ctx, req)
+	if resp.Error != nil && resp.Error.Code != pb.RpcFileUploadResponseError_NULL {
+		return nil, fmt.Errorf("%w: %s", ErrFailedUploadFile, resp.Error.Description)
+	}
+
+	// Convert details from proto Struct to map
+	details := pbtypes.ToMap(resp.Details)
+
+	return &apimodel.FileUploadResponse{
+		ObjectId: resp.ObjectId,
+		FileId:   resp.PreloadFileId,
+		Details:  details,
+	}, nil
+}

--- a/core/api/service/file_test.go
+++ b/core/api/service/file_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+)
+
+func TestFileService_UploadFile(t *testing.T) {
+	t.Run("successful upload", func(t *testing.T) {
+		// given
+		ctx := context.Background()
+		fx := newFixture(t)
+
+		fx.mwMock.On("FileUpload", mock.Anything, &pb.RpcFileUploadRequest{
+			SpaceId:   mockedSpaceId,
+			LocalPath: "/tmp/test.txt",
+			Type:      model.BlockContentFile_File,
+		}).Return(&pb.RpcFileUploadResponse{
+			ObjectId:      "obj123",
+			PreloadFileId: "bafyreiabc123",
+			Details: &types.Struct{
+				Fields: map[string]*types.Value{
+					"name":     pbtypes.String("test.txt"),
+					"sizeInBytes": pbtypes.Int64(1024),
+				},
+			},
+			Error: &pb.RpcFileUploadResponseError{Code: pb.RpcFileUploadResponseError_NULL},
+		}).Once()
+
+		// when
+		result, err := fx.service.UploadFile(ctx, mockedSpaceId, "/tmp/test.txt")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "obj123", result.ObjectId)
+		assert.Equal(t, "bafyreiabc123", result.FileId)
+		assert.Equal(t, "test.txt", result.Details["name"])
+		assert.Equal(t, float64(1024), result.Details["sizeInBytes"])
+	})
+
+	t.Run("upload error", func(t *testing.T) {
+		// given
+		ctx := context.Background()
+		fx := newFixture(t)
+
+		fx.mwMock.On("FileUpload", mock.Anything, mock.Anything).
+			Return(&pb.RpcFileUploadResponse{
+				Error: &pb.RpcFileUploadResponseError{
+					Code:        pb.RpcFileUploadResponseError_UNKNOWN_ERROR,
+					Description: "upload failed",
+				},
+			}).Once()
+
+		// when
+		result, err := fx.service.UploadFile(ctx, mockedSpaceId, "/tmp/test.txt")
+
+		// then
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrFailedUploadFile)
+		assert.Contains(t, err.Error(), "upload failed")
+	})
+
+	t.Run("upload with nil details", func(t *testing.T) {
+		// given
+		ctx := context.Background()
+		fx := newFixture(t)
+
+		fx.mwMock.On("FileUpload", mock.Anything, mock.Anything).
+			Return(&pb.RpcFileUploadResponse{
+				ObjectId:      "obj456",
+				PreloadFileId: "bafyreiabc456",
+				Details:       nil,
+				Error:         &pb.RpcFileUploadResponseError{Code: pb.RpcFileUploadResponseError_NULL},
+			}).Once()
+
+		// when
+		result, err := fx.service.UploadFile(ctx, mockedSpaceId, "/tmp/test.txt")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "obj456", result.ObjectId)
+		assert.Equal(t, "bafyreiabc456", result.FileId)
+		assert.Nil(t, result.Details)
+	})
+}

--- a/core/files/fileobject/mock_fileobject/mock_Service.go
+++ b/core/files/fileobject/mock_fileobject/mock_Service.go
@@ -775,40 +775,6 @@ func (_c *MockService_InitEmptyFileState_Call) RunAndReturn(run func(*state.Stat
 	return _c
 }
 
-// MigrateFileIdsInBlocks provides a mock function with given fields: st, spc
-func (_m *MockService) MigrateFileIdsInBlocks(st *state.State, spc source.Space) {
-	_m.Called(st, spc)
-}
-
-// MockService_MigrateFileIdsInBlocks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MigrateFileIdsInBlocks'
-type MockService_MigrateFileIdsInBlocks_Call struct {
-	*mock.Call
-}
-
-// MigrateFileIdsInBlocks is a helper method to define mock.On call
-//   - st *state.State
-//   - spc source.Space
-func (_e *MockService_Expecter) MigrateFileIdsInBlocks(st interface{}, spc interface{}) *MockService_MigrateFileIdsInBlocks_Call {
-	return &MockService_MigrateFileIdsInBlocks_Call{Call: _e.mock.On("MigrateFileIdsInBlocks", st, spc)}
-}
-
-func (_c *MockService_MigrateFileIdsInBlocks_Call) Run(run func(st *state.State, spc source.Space)) *MockService_MigrateFileIdsInBlocks_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*state.State), args[1].(source.Space))
-	})
-	return _c
-}
-
-func (_c *MockService_MigrateFileIdsInBlocks_Call) Return() *MockService_MigrateFileIdsInBlocks_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockService_MigrateFileIdsInBlocks_Call) RunAndReturn(run func(*state.State, source.Space)) *MockService_MigrateFileIdsInBlocks_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // MigrateFileIdsInDetails provides a mock function with given fields: st, spc
 func (_m *MockService) MigrateFileIdsInDetails(st *state.State, spc source.Space) {
 	_m.Called(st, spc)


### PR DESCRIPTION
### Description

  This PR adds a REST API endpoint for file uploads to the anytype-heart API. The new endpoint exposes the existing
  `FileUpload` RPC functionality via a standard HTTP multipart/form-data interface.

  **Endpoint:** `POST /v1/spaces/{space_id}/files`

  **Features:**
  - Accepts multipart/form-data file uploads with standard `file` field
  - Returns file object metadata including ObjectId and IPFS CID (FileId)
  - Integrates with existing authentication and rate limiting middleware
  - Follows existing API patterns and conventions

  **Implementation details:**
  - Handler receives multipart upload, saves to temp file, and calls FileUpload RPC
  - Service layer wraps RPC call with proper error handling
  - Temporary files are cleaned up automatically after processing
  - Response includes file details as JSON

  ### What type of PR is this? (check all applicable)

  - [x] 🍕 Feature

  ### Related Tickets & Documents

  This adds REST API coverage for file operations, complementing the existing RPC interface. No specific issue ticket was
  provided for this enhancement.

  ### Mobile & Desktop Screenshots/Recordings

  N/A - Backend API change only. Example usage:

  ```bash
  curl -X POST \
    -H "Authorization: Bearer YOUR_TOKEN" \
    -F "file=@/path/to/file.pdf" \
    http://localhost:31006/v1/spaces/SPACE_ID/files

  Example response:
  {
    "object_id": "obj123",
    "file_id": "bafyreiabc123",
    "details": {
      "name": "file.pdf",
      "sizeInBytes": 1024
    }
  }
```

### Added tests?

- [x] 👍 yes

Test coverage includes:
  - Handler tests (3 test cases): successful upload, error handling, edge cases
  - Service tests (3 test cases): RPC response handling, error mapping, nil details
  - All tests follow existing AAA (Given/When/Then) pattern
  - Tests use proper mocking of dependencies

### Added to documentation?

- [x] 🙅 no documentation needed