### PR TITLE
GO-6552 Fix race in change handler

### DIFF
--- a/core/block/object/objecthandler/registry.go
+++ b/core/block/object/objecthandler/registry.go
@@ -13,15 +13,13 @@ type SmartblockHandler interface {
 	GetLastModifiedInfo() (lastModified int64, lastModifiedBy string)
 }
 
-var handlersBySmartblockType = map[smartblock.SmartBlockType]SmartblockHandler{
-	smartblock.SmartBlockTypeFileObject: &filesHandler{},
-}
-
 func GetSmartblockHandler(sbt smartblock.SmartBlockType) SmartblockHandler {
-	if handler, ok := handlersBySmartblockType[sbt]; ok {
-		return handler
+	switch sbt {
+	case smartblock.SmartBlockTypeFileObject:
+		return &filesHandler{}
+	default:
+		return &defaultHandler{}
 	}
-	return &defaultHandler{}
 }
 
 type defaultHandler struct {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6552/data-race-in-the-change-handler

We used to have a map with single entity of fileHandler that is inited on app start, so when states of two file objects are built in parallel probability of data race raises to 100%