### PR TITLE
GO-6317 Optimize option reorder

### DIFF
--- a/core/order/order.go
+++ b/core/order/order.go
@@ -186,9 +186,9 @@ func (o *orderSetter) reorder(objectIds []string, originalOrderIds map[string]st
 	}
 
 	nextExisting := o.precalcNext(originalOrderIds, objectIds)
-	prev := ""
 	out := map[string]string{}
 
+	var prev, pprev, prevId string
 	var ops []reorderOp
 	var err error
 
@@ -196,29 +196,47 @@ func (o *orderSetter) reorder(objectIds []string, originalOrderIds map[string]st
 		curr := originalOrderIds[id]
 		next := nextExisting[i]
 
-		if curr != "" && curr > prev {
-			// Current lexid is valid - keep it
-			out[id] = curr
-		} else if i == 0 {
+		if i == 0 && (curr == "" || curr >= next) {
 			curr, err = o.getNewOrderId("", next, true)
 			if err != nil {
 				return o.rebuildAllLexIds(objectIds, inputObjectIds)
 			}
 			ops = append(ops, reorderOp{id: id, newOrderId: curr})
-		} else {
-			// When inserting, check if next is valid relative to prev
-			// If prev >= next, ignore next (treat as unbounded)
+		} else if curr == "" || prev >= curr {
 			if next != "" && prev >= next {
-				next = ""
+				// let's try to modify prev value, as it seems to be inserted from the end of the list
+				if pprev != "" {
+					prev, err = o.getNewOrderId(pprev, curr, false)
+					if err != nil {
+						return o.rebuildAllLexIds(objectIds, inputObjectIds)
+					}
+					if len(ops) > 0 && ops[len(ops)-1].id == prevId {
+						ops[len(ops)-1].newOrderId = prev
+					} else {
+						ops = append(ops, reorderOp{id: prevId, newOrderId: prev})
+					}
+					out[prevId] = prev
+				} else {
+					// pprev is not saved, let's generate new orderId for curr ignoring next (treat as unbounded)
+					curr, err = o.getNewOrderId(prev, "", false)
+					if err != nil {
+						return o.rebuildAllLexIds(objectIds, inputObjectIds)
+					}
+					ops = append(ops, reorderOp{id: id, newOrderId: curr})
+				}
+			} else {
+				curr, err = o.getNewOrderId(prev, next, false)
+				if err != nil {
+					return o.rebuildAllLexIds(objectIds, inputObjectIds)
+				}
+				ops = append(ops, reorderOp{id: id, newOrderId: curr})
 			}
-			curr, err = o.getNewOrderId(prev, next, false)
-			if err != nil {
-				return o.rebuildAllLexIds(objectIds, inputObjectIds)
-			}
-			ops = append(ops, reorderOp{id: id, newOrderId: curr})
 		}
+
 		out[id] = curr
+		pprev = prev
 		prev = curr
+		prevId = id
 	}
 
 	outList := make([]string, len(inputObjectIds))

--- a/core/order/order.go
+++ b/core/order/order.go
@@ -196,7 +196,7 @@ func (o *orderSetter) reorder(objectIds []string, originalOrderIds map[string]st
 		curr := originalOrderIds[id]
 		next := nextExisting[i]
 
-		if curr == "" || prev >= curr || next != "" && curr >= next && prev < next {
+		if curr == "" || prev >= curr || (next != "" && curr >= next && prev < next) {
 			if prev >= next {
 				next = ""
 			}

--- a/core/order/order.go
+++ b/core/order/order.go
@@ -197,6 +197,9 @@ func (o *orderSetter) reorder(objectIds []string, originalOrderIds map[string]st
 		next := nextExisting[i]
 
 		if curr == "" || prev >= curr || next != "" && curr >= next && prev < next {
+			if prev >= next {
+				next = ""
+			}
 			curr, err = o.getNewOrderId(prev, next, i == 0)
 			if err != nil {
 				return o.rebuildAllLexIds(objectIds, inputObjectIds)

--- a/core/order/order_test.go
+++ b/core/order/order_test.go
@@ -2,7 +2,6 @@ package order
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"testing"
 
@@ -302,7 +301,6 @@ func testReorder(t *testing.T, objectIds []string, originalOrderIds map[string]s
 	require.NoError(t, err)
 
 	t.Log(gotOps)
-	fmt.Println(gotOps)
 
 	gotObjectIdsWithOrder := make([]idAndOrderId, len(gotNewOrder))
 	for i := range gotObjectIdsWithOrder {

--- a/core/order/order_test.go
+++ b/core/order/order_test.go
@@ -2,6 +2,7 @@ package order
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -226,6 +227,68 @@ func TestReorder(t *testing.T) {
 			},
 			objectIds: []string{"b", "d", "a", "e", "c"},
 		},
+		{
+			name: "drag to top",
+			originalOrderIds: map[string]string{
+				"a": "A001",
+				"b": "B002",
+				"c": "C003",
+				"d": "D004",
+				"e": "E005",
+			},
+			objectIds: []string{"a", "d", "b", "c", "e"},
+		},
+		{
+			name: "drag to bottom",
+			originalOrderIds: map[string]string{
+				"a": "A001",
+				"b": "B002",
+				"c": "C003",
+				"d": "D004",
+				"e": "E005",
+			},
+			objectIds: []string{"a", "c", "d", "e", "b"},
+		},
+		{
+			name: "real world data - drag tag 57 to first position",
+			originalOrderIds: map[string]string{
+				"tag14": "XeOt",
+				"tag60": "XfOO",
+				"tag55": "XgNs",
+				"tag56": "XhNN",
+				"tag57": "XiMr",
+				"tag58": "XjMM",
+				"tag59": "XkLq",
+				"tag6":  "XlLL",
+				"tag61": "XmKp",
+				"tag62": "XnKK",
+				"tag63": "XoJo",
+				"tag64": "XpJJ",
+				"tag9":  "XqIn",
+				"tag65": "XrII",
+			},
+			objectIds: []string{"tag57", "tag14", "tag60", "tag55", "tag56", "tag58", "tag59", "tag6", "tag61", "tag62", "tag63", "tag64", "tag9", "tag65"},
+		},
+		{
+			name: "real world data - drag tag 14 to other position",
+			originalOrderIds: map[string]string{
+				"tag14": "XeOt",
+				"tag60": "XfOO",
+				"tag55": "XgNs",
+				"tag56": "XhNN",
+				"tag57": "XiMr",
+				"tag58": "XjMM",
+				"tag59": "XkLq",
+				"tag6":  "XlLL",
+				"tag61": "XmKp",
+				"tag62": "XnKK",
+				"tag63": "XoJo",
+				"tag64": "XpJJ",
+				"tag9":  "XqIn",
+				"tag65": "XrII",
+			},
+			objectIds: []string{"tag60", "tag55", "tag56", "tag57", "tag58", "tag59", "tag6", "tag61", "tag14", "tag62", "tag63", "tag64", "tag9", "tag65"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testReorder(t, tc.objectIds, tc.originalOrderIds)
@@ -239,6 +302,7 @@ func testReorder(t *testing.T, objectIds []string, originalOrderIds map[string]s
 	require.NoError(t, err)
 
 	t.Log(gotOps)
+	fmt.Println(gotOps)
 
 	gotObjectIdsWithOrder := make([]idAndOrderId, len(gotNewOrder))
 	for i := range gotObjectIdsWithOrder {

--- a/core/order/order_test.go
+++ b/core/order/order_test.go
@@ -288,6 +288,16 @@ func TestReorder(t *testing.T) {
 			},
 			objectIds: []string{"tag60", "tag55", "tag56", "tag57", "tag58", "tag59", "tag6", "tag61", "tag14", "tag62", "tag63", "tag64", "tag9", "tag65"},
 		},
+		{
+			name: "reverse",
+			originalOrderIds: map[string]string{
+				"a": "A001",
+				"b": "B002",
+				"c": "C003",
+				"d": "D004",
+			},
+			objectIds: []string{"d", "c", "b", "a"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testReorder(t, tc.objectIds, tc.originalOrderIds)


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6317/sort-order-of-multi-select-options-corrupt

We should optimize option reorder in case option is dragged to top of the list