### PR TITLE
core/api: allow type object ids in type filters

### DIFF
--- a/core/api/service/property.go
+++ b/core/api/service/property.go
@@ -381,8 +381,16 @@ func (s *Service) SanitizeAndValidatePropertyValue(spaceId string, key string, v
 		}
 		return tag.Id, nil
 	case apimodel.PropertyFormatMultiSelect:
-		keysOrIds, ok := value.([]interface{})
-		if !ok {
+		var keysOrIds []interface{}
+		switch v := value.(type) {
+		case []interface{}:
+			keysOrIds = v
+		case []string:
+			keysOrIds = make([]interface{}, 0, len(v))
+			for _, item := range v {
+				keysOrIds = append(keysOrIds, item)
+			}
+		default:
 			return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of tag ids or keys", key))
 		}
 		var validIds []string
@@ -422,11 +430,20 @@ func (s *Service) SanitizeAndValidatePropertyValue(spaceId string, key string, v
 		}
 		return b, nil
 	case apimodel.PropertyFormatObjects, apimodel.PropertyFormatFiles:
-		ids, ok := value.([]interface{})
-		if !ok {
+		var ids []interface{}
+		switch v := value.(type) {
+		case []interface{}:
+			ids = v
+		case []string:
+			ids = make([]interface{}, 0, len(v))
+			for _, item := range v {
+				ids = append(ids, item)
+			}
+		default:
 			return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of strings (object/file ids)", key))
 		}
 		var validIds []string
+		allowTypeObject := key == bundle.RelationKeyType.String()
 		for _, v := range ids {
 			id, ok := v.(string)
 			if !ok {
@@ -435,7 +452,7 @@ func (s *Service) SanitizeAndValidatePropertyValue(spaceId string, key string, v
 			id = s.sanitizedString(id)
 			if prop.Format == apimodel.PropertyFormatFiles && !s.isValidFileReference(spaceId, id) {
 				return nil, util.ErrBadInput(fmt.Sprintf("invalid file reference for %q: %s", key, id))
-			} else if prop.Format == apimodel.PropertyFormatObjects && !s.isValidObjectOrMemberReference(spaceId, id) {
+			} else if prop.Format == apimodel.PropertyFormatObjects && !s.isValidObjectReference(spaceId, id, allowTypeObject) {
 				return nil, util.ErrBadInput(fmt.Sprintf("invalid object reference for %q: %s", key, id))
 			}
 			validIds = append(validIds, id)
@@ -462,12 +479,15 @@ func (s *Service) isValidSelectOption(spaceId string, property *apimodel.Propert
 	return util.IsTagLayout(layout) && expectedRk == fields[bundle.RelationKeyRelationKey.String()].GetStringValue()
 }
 
-func (s *Service) isValidObjectOrMemberReference(spaceId string, objectId string) bool {
+func (s *Service) isValidObjectReference(spaceId string, objectId string, allowTypeObject bool) bool {
 	fields, err := util.GetFieldsById(s.mw, spaceId, objectId, []string{bundle.RelationKeyResolvedLayout.String()})
 	if err != nil {
 		return false
 	}
 	layout := model.ObjectTypeLayout(fields[bundle.RelationKeyResolvedLayout.String()].GetNumberValue())
+	if allowTypeObject && layout == model.ObjectType_objectType {
+		return true
+	}
 	return util.IsObjectOrMemberLayout(layout)
 }
 

--- a/core/api/service/property_test.go
+++ b/core/api/service/property_test.go
@@ -929,3 +929,65 @@ func TestProcessProperties(t *testing.T) {
 		})
 	})
 }
+
+func TestSanitizeAndValidatePropertyValueTypeObject(t *testing.T) {
+	setupObjectLayoutMock := func(fx *fixture, objectId string, layout model.ObjectTypeLayout, found bool) {
+		response := &pb.RpcObjectSearchResponse{
+			Error: &pb.RpcObjectSearchResponseError{Code: pb.RpcObjectSearchResponseError_NULL},
+		}
+		if found {
+			response.Records = []*types.Struct{
+				{
+					Fields: map[string]*types.Value{
+						bundle.RelationKeyResolvedLayout.String(): pbtypes.Int64(int64(layout)),
+					},
+				},
+			}
+		}
+		fx.mwMock.On("ObjectSearch", mock.Anything, &pb.RpcObjectSearchRequest{
+			SpaceId: mockedSpaceId,
+			Filters: []*model.BlockContentDataviewFilter{
+				{
+					RelationKey: bundle.RelationKeyId.String(),
+					Condition:   model.BlockContentDataviewFilter_Equal,
+					Value:       pbtypes.String(objectId),
+				},
+			},
+			Keys: []string{bundle.RelationKeyResolvedLayout.String()},
+		}).Return(response).Maybe()
+	}
+
+	t.Run("type property allows object type references", func(t *testing.T) {
+		fx := newFixture(t)
+		typeId := "bafytesttype"
+		setupObjectLayoutMock(fx, typeId, model.ObjectType_objectType, true)
+
+		prop := &apimodel.Property{
+			Key:         bundle.RelationKeyType.String(),
+			RelationKey: bundle.RelationKeyType.String(),
+			Format:      apimodel.PropertyFormatObjects,
+		}
+		propertyMap := map[string]*apimodel.Property{bundle.RelationKeyType.String(): prop}
+
+		value, err := fx.service.SanitizeAndValidatePropertyValue(mockedSpaceId, bundle.RelationKeyType.String(), []string{typeId}, prop, propertyMap)
+		require.NoError(t, err)
+		assert.Equal(t, []string{typeId}, value)
+	})
+
+	t.Run("non-type object properties reject object type references", func(t *testing.T) {
+		fx := newFixture(t)
+		typeId := "bafytesttype"
+		setupObjectLayoutMock(fx, typeId, model.ObjectType_objectType, true)
+
+		prop := &apimodel.Property{
+			Key:         "objects_prop",
+			RelationKey: "objects_prop",
+			Format:      apimodel.PropertyFormatObjects,
+		}
+		propertyMap := map[string]*apimodel.Property{"objects_prop": prop}
+
+		_, err := fx.service.SanitizeAndValidatePropertyValue(mockedSpaceId, "objects_prop", []string{typeId}, prop, propertyMap)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid object reference")
+	})
+}


### PR DESCRIPTION
- accept []string inputs for multi-select and object properties\n
- allow objectType layout for type relation validation 
- add unit test for type object validation

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

Type filters (type[in]=...) rejected valid type object ids because object validation only allowed “object/member” layouts and didn’t handle ObjectType_objectType.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [X] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

This is one of three bug fix PRs that arose out of testing object queries and filters in a rust SDK for Anytype (the problems can be reproduced with curl so they are not rust-related).

[2881](https://github.com/anyproto/anytype-heart/pull/2881) Filter bool numbers
[2880](https://github.com/anyproto/anytype-heart/pull/2880) core/api: allow type object ids in type filters
[2882](https://github.com/anyproto/anytype-heart/pull/2882) core/api/filter: allow select tag ids

To keep the changes simpler and easier to review, they are separate PRs. I have another [branch](https://github.com/stevelr/anytype-heart/tree/testing)  that combines them for testing - let me know if you'd rather I submit that as a PR instead.

### Mobile & Desktop Screenshots/Recordings

n/a

### Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

N/A