### PR TITLE
core/api/filter: allow select tag ids

### DIFF
--- a/core/api/filter/types.go
+++ b/core/api/filter/types.go
@@ -54,6 +54,11 @@ var (
 		model.BlockContentDataviewFilter_NotEmpty,
 	}
 
+	selectConditions = append([]model.BlockContentDataviewFilterCondition{
+		model.BlockContentDataviewFilter_Equal,
+		model.BlockContentDataviewFilter_NotEqual,
+	}, arrayConditions...)
+
 	// Number properties support comparison operations
 	numberConditions = []model.BlockContentDataviewFilterCondition{
 		model.BlockContentDataviewFilter_Equal,
@@ -103,7 +108,7 @@ var ConditionsForPropertyType = map[apimodel.PropertyFormat][]model.BlockContent
 	apimodel.PropertyFormatCheckbox: checkboxConditions,
 
 	// Array-like types
-	apimodel.PropertyFormatSelect:      arrayConditions,
+	apimodel.PropertyFormatSelect:      selectConditions,
 	apimodel.PropertyFormatMultiSelect: arrayConditions,
 	apimodel.PropertyFormatFiles:       arrayConditions,
 	apimodel.PropertyFormatObjects:     arrayConditions,

--- a/core/api/filter/types_test.go
+++ b/core/api/filter/types_test.go
@@ -255,10 +255,16 @@ func TestIsValidConditionForType(t *testing.T) {
 		},
 		// Select format tests
 		{
-			name:      "select with equal (invalid)",
+			name:      "select with equal",
 			format:    apimodel.PropertyFormatSelect,
 			condition: model.BlockContentDataviewFilter_Equal,
-			expected:  false,
+			expected:  true,
+		},
+		{
+			name:      "select with not equal",
+			format:    apimodel.PropertyFormatSelect,
+			condition: model.BlockContentDataviewFilter_NotEqual,
+			expected:  true,
 		},
 		{
 			name:      "select with in",

--- a/core/api/filter/validator.go
+++ b/core/api/filter/validator.go
@@ -111,6 +111,39 @@ func (v *Validator) convertAndValidateValue(spaceId string, filter *Filter, prop
 	}
 
 	value := filter.Value
+	if property.Format == apimodel.PropertyFormatSelect &&
+		(filter.Condition == model.BlockContentDataviewFilter_In || filter.Condition == model.BlockContentDataviewFilter_NotIn) {
+		var items []interface{}
+		switch v := value.(type) {
+		case []string:
+			items = make([]interface{}, 0, len(v))
+			for _, item := range v {
+				items = append(items, item)
+			}
+		case []interface{}:
+			items = v
+		default:
+			items = []interface{}{v}
+		}
+
+		values := make([]string, 0, len(items))
+		for _, item := range items {
+			itemStr, ok := item.(string)
+			if !ok {
+				return nil, util.ErrBadInput(fmt.Sprintf("invalid select option for %q: %v", filter.PropertyKey, item))
+			}
+			sanitized, err := v.apiService.SanitizeAndValidatePropertyValue(spaceId, filter.PropertyKey, itemStr, property, propertyMap)
+			if err != nil {
+				return nil, err
+			}
+			tagId, ok := sanitized.(string)
+			if !ok {
+				return nil, util.ErrBadInput(fmt.Sprintf("invalid select option for %q: %v", filter.PropertyKey, itemStr))
+			}
+			values = append(values, tagId)
+		}
+		return values, nil
+	}
 	if filter.Condition == model.BlockContentDataviewFilter_In || filter.Condition == model.BlockContentDataviewFilter_NotIn {
 		switch v := value.(type) {
 		case []string, []interface{}:

--- a/core/api/filter/validator.go
+++ b/core/api/filter/validator.go
@@ -130,7 +130,7 @@ func (v *Validator) convertAndValidateValue(spaceId string, filter *Filter, prop
 		for _, item := range items {
 			itemStr, ok := item.(string)
 			if !ok {
-				return nil, util.ErrBadInput(fmt.Sprintf("invalid select option for %q: %v", filter.PropertyKey, item))
+				return nil, util.ErrBadInput(fmt.Sprintf("invalid select filter value for property %q: expected string, got %T (%v)", filter.PropertyKey, item, item))
 			}
 			sanitized, err := v.apiService.SanitizeAndValidatePropertyValue(spaceId, filter.PropertyKey, itemStr, property, propertyMap)
 			if err != nil {
@@ -138,7 +138,7 @@ func (v *Validator) convertAndValidateValue(spaceId string, filter *Filter, prop
 			}
 			tagId, ok := sanitized.(string)
 			if !ok {
-				return nil, util.ErrBadInput(fmt.Sprintf("invalid select option for %q: %v", filter.PropertyKey, itemStr))
+				return nil, util.ErrBadInput(fmt.Sprintf("invalid select option for property %q: could not resolve %v to a tag id", filter.PropertyKey, itemStr))
 			}
 			values = append(values, tagId)
 		}

--- a/core/api/filter/validator_test.go
+++ b/core/api/filter/validator_test.go
@@ -174,6 +174,69 @@ func TestValidator_ValidateFilters(t *testing.T) {
 			},
 		},
 		{
+			name: "valid select filter with tag id",
+			filters: &filter.ParsedFilters{
+				Filters: []filter.Filter{
+					{
+						PropertyKey: "status",
+						Condition:   model.BlockContentDataviewFilter_Equal,
+						Value:       "tag-1",
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				m.On("GetCachedProperties", testSpaceId).Return(mockProperties)
+				m.On("ResolvePropertyApiKey", mockProperties, "status").Return("status", true)
+				m.On("SanitizeAndValidatePropertyValue",
+					testSpaceId,
+					"status",
+					"tag-1",
+					mockProperties["status"],
+					mockProperties,
+				).Return("tag-1", nil)
+			},
+			checkResult: func(t *testing.T, filters *filter.ParsedFilters) {
+				require.Len(t, filters.Filters, 1)
+				assert.Equal(t, "status", filters.Filters[0].PropertyKey)
+				assert.Equal(t, "tag-1", filters.Filters[0].Value)
+			},
+		},
+		{
+			name: "valid select in filter with tag ids",
+			filters: &filter.ParsedFilters{
+				Filters: []filter.Filter{
+					{
+						PropertyKey: "status",
+						Condition:   model.BlockContentDataviewFilter_In,
+						Value:       []string{"tag-1", "tag-2"},
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				m.On("GetCachedProperties", testSpaceId).Return(mockProperties)
+				m.On("ResolvePropertyApiKey", mockProperties, "status").Return("status", true)
+				m.On("SanitizeAndValidatePropertyValue",
+					testSpaceId,
+					"status",
+					"tag-1",
+					mockProperties["status"],
+					mockProperties,
+				).Return("tag-1", nil)
+				m.On("SanitizeAndValidatePropertyValue",
+					testSpaceId,
+					"status",
+					"tag-2",
+					mockProperties["status"],
+					mockProperties,
+				).Return("tag-2", nil)
+			},
+			checkResult: func(t *testing.T, filters *filter.ParsedFilters) {
+				require.Len(t, filters.Filters, 1)
+				assert.Equal(t, "status", filters.Filters[0].PropertyKey)
+				assert.Equal(t, []string{"tag-1", "tag-2"}, filters.Filters[0].Value)
+			},
+		},
+		{
 			name: "property resolved by API key",
 			filters: &filter.ParsedFilters{
 				Filters: []filter.Filter{
@@ -417,7 +480,8 @@ func TestValidator_ConditionValidation(t *testing.T) {
 		{"checkbox with greater", apimodel.PropertyFormatCheckbox, model.BlockContentDataviewFilter_Greater, false},
 
 		// Select format
-		{"select with equal", apimodel.PropertyFormatSelect, model.BlockContentDataviewFilter_Equal, false},
+		{"select with equal", apimodel.PropertyFormatSelect, model.BlockContentDataviewFilter_Equal, true},
+		{"select with not equal", apimodel.PropertyFormatSelect, model.BlockContentDataviewFilter_NotEqual, true},
 		{"select with in", apimodel.PropertyFormatSelect, model.BlockContentDataviewFilter_In, true},
 		{"select with like", apimodel.PropertyFormatSelect, model.BlockContentDataviewFilter_Like, false},
 


### PR DESCRIPTION
Support eq/in select filters with tag ids and validate select conditions.

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

Filters of the form 'property_key=value' don't work for select properties, where value is a valid tag id for the select format property.

Also [in] and [not-in] don't work for select properties where value is a tag id.

### What type of PR is this? (check all applicable)

* The Select [in]/[not-in] change is definitely a bug fix. 
* Technically, the change to accept Select [eq] filters as valid is a feature change, not a bug fix. Personally, I think it's intuitive to think of eq as a natural filter condition for Select. (though not multi-select). 

- [X] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [X] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

This is one of three bug fix PRs that arose out of testing object queries and filters in a rust SDK for Anytype (the problems can be reproduced with curl so they are not rust-related).

[2881](https://github.com/anyproto/anytype-heart/pull/2881) Filter bool numbers
[2880](https://github.com/anyproto/anytype-heart/pull/2880) core/api: allow type object ids in type filters
[2882](https://github.com/anyproto/anytype-heart/pull/2882) core/api/filter: allow select tag ids

To keep the changes simpler and easier to review, they are separate PRs. I have another [branch](https://github.com/stevelr/anytype-heart/tree/testing)  that combines them for testing - let me know if you'd rather I submit that as a PR instead.

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
