### PR TITLE
Fix account key fallback

### DIFF
--- a/pkg/lib/core/wallet.go
+++ b/pkg/lib/core/wallet.go
@@ -40,7 +40,16 @@ func WalletDeriveFromAccountMasterNode(accountKeyMasterNodeBase64 string) (crypt
 		return crypto.DerivationResult{}, fmt.Errorf("failed to unmarshal account master node: %w", err)
 	}
 
-	return crypto.DeriveKeysFromMasterNode(masterNode)
+	res, err := crypto.DeriveKeysFromMasterNode(masterNode)
+	if err != nil {
+		return crypto.DerivationResult{}, err
+	}
+	if res.OldAccountKey == nil {
+		// Account-key recovery doesn't include the legacy derivation key.
+		// Use the current identity as a fallback to avoid nil signing key.
+		res.OldAccountKey = res.Identity
+	}
+	return res, nil
 }
 
 func WalletInitRepo(rootPath string, pk crypto.PrivKey) error {


### PR DESCRIPTION

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

Ensure account key derivation falls back to identity when legacy key is missing, preventing nil signing keys.

Changes: pkg/lib/core/wallet.go
  
Codex created this tentative patch, which seems to have fixed the issue for me.

### What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix

### Related Tickets & Documents

https://github.com/anyproto/anytype-heart/issues/2883

### Mobile & Desktop Screenshots/Recordings
N/A

### Added tests?

- [X] 🙋 no, because I need help

### Added to documentation?

- [X] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
