### PR TITLE
Fix RunProfiler temp file creation on Android

### DIFF
--- a/core/application/profiler.go
+++ b/core/application/profiler.go
@@ -15,9 +15,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/anyproto/any-sync/app"
 	"github.com/klauspost/compress/flate"
 	exptrace "golang.org/x/exp/trace"
 
+	"github.com/anyproto/anytype-heart/pkg/lib/core"
 	"github.com/anyproto/anytype-heart/util/debug"
 )
 
@@ -66,7 +68,7 @@ func (s *Service) RunProfiler(ctx context.Context, seconds int) (string, error) 
 	goroutinesEnd := debug.Stack(true)
 
 	// Write
-	f, err := os.CreateTemp("", "anytype_profile.*.zip")
+	f, err := os.CreateTemp(s.getTempDir(), "anytype_profile.*.zip")
 	if err != nil {
 		return "", fmt.Errorf("create temp file: %w", err)
 	}
@@ -113,6 +115,22 @@ func createZipArchive(w io.Writer, files []zipFile) error {
 		return nil
 	}()
 	return errors.Join(err, zipw.Close())
+}
+
+// getTempDir returns the temp directory from TempDirProvider if available,
+// otherwise falls back to the system temp directory.
+// This ensures proper temp directory access on Android where the system temp
+// directory may not be writable.
+func (s *Service) getTempDir() string {
+	a := s.GetApp()
+	if a == nil {
+		return os.TempDir()
+	}
+	tempDirProvider, err := app.Component[core.TempDirProvider](a)
+	if err != nil || tempDirProvider == nil {
+		return os.TempDir()
+	}
+	return tempDirProvider.TempDir()
 }
 
 func (s *Service) SaveLoginTrace(dir string) (string, error) {


### PR DESCRIPTION
Use TempDirProvider to get a platform-appropriate temp directory instead of relying on os.TempDir(). On Android, the system temp directory is not writable by the app, causing RunProfiler to fail when creating the profile ZIP file.

The new getTempDir helper retrieves the temp directory from TempDirProvider (which creates a temp directory inside the wallet root path) and falls back to os.TempDir() if the app container is not available.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
