### PR TITLE
GO-6630 Fix HEIC imgs upload

### DIFF
--- a/pkg/lib/mill/image_resize_heic.go
+++ b/pkg/lib/mill/image_resize_heic.go
@@ -15,19 +15,13 @@ import (
 )
 
 func (m *ImageResize) resizeHEIC(r io.ReadSeeker) (*Result, error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, fmt.Errorf("read heic: %w", err)
-	}
-
-	// Get orientation
-	orientation, err := getHEICOrientationFromData(data)
+	orientation, err := getHEICOrientation(r)
 	if err != nil {
 		return nil, err
 	}
 
 	goheif.SafeEncoding = true
-	img, err := goheif.Decode(bytes.NewReader(data))
+	img, err := goheif.Decode(r)
 	if err != nil {
 		return nil, fmt.Errorf("decode heic: %w", err)
 	}
@@ -71,14 +65,28 @@ func (m *ImageResize) resizeHEIC(r io.ReadSeeker) (*Result, error) {
 	}, nil
 }
 
-func getHEICOrientationFromData(data []byte) (int, error) {
-	ra := bytes.NewReader(data)
+func getHEICOrientation(r io.ReadSeeker) (int, error) {
+	var rotations int
+	ra, ok := r.(io.ReaderAt)
+	if !ok {
+		data, err := io.ReadAll(r)
+		if err != nil {
+			return 0, fmt.Errorf("read heic: %w", err)
+		}
+		ra = bytes.NewReader(data)
+	}
+
 	hf := heif.Open(ra)
 	it, err := hf.PrimaryItem()
 	if err != nil {
 		return 0, fmt.Errorf("get primary item: %w", err)
 	}
-	rotations := it.Rotations()
+	rotations = it.Rotations()
+
+	// Seek back to start for decoding
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return 0, fmt.Errorf("seek: %w", err)
+	}
 
 	// Map irot values (0-3) to EXIF orientation values
 	// irot: 0=no rotation, 1=90°CCW, 2=180°, 3=270°CCW (90°CW)

--- a/pkg/lib/mill/image_resize_heic.go
+++ b/pkg/lib/mill/image_resize_heic.go
@@ -15,13 +15,19 @@ import (
 )
 
 func (m *ImageResize) resizeHEIC(r io.ReadSeeker) (*Result, error) {
-	orientation, err := getHEICOrientation(r)
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read heic: %w", err)
+	}
+
+	// Get orientation
+	orientation, err := getHEICOrientationFromData(data)
 	if err != nil {
 		return nil, err
 	}
 
 	goheif.SafeEncoding = true
-	img, err := goheif.Decode(r)
+	img, err := goheif.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("decode heic: %w", err)
 	}
@@ -65,29 +71,14 @@ func (m *ImageResize) resizeHEIC(r io.ReadSeeker) (*Result, error) {
 	}, nil
 }
 
-func getHEICOrientation(r io.ReadSeeker) (int, error) {
-	var rotations int
-	ra, ok := r.(io.ReaderAt)
-	if !ok {
-		data, err := io.ReadAll(r)
-		if err != nil {
-			return 0, fmt.Errorf("read heic: %w", err)
-		}
-		ra = bytes.NewReader(data)
-		r = bytes.NewReader(data)
-	}
-
+func getHEICOrientationFromData(data []byte) (int, error) {
+	ra := bytes.NewReader(data)
 	hf := heif.Open(ra)
 	it, err := hf.PrimaryItem()
 	if err != nil {
 		return 0, fmt.Errorf("get primary item: %w", err)
 	}
-	rotations = it.Rotations()
-
-	// Seek back to start for decoding
-	if _, err := r.Seek(0, io.SeekStart); err != nil {
-		return 0, fmt.Errorf("seek: %w", err)
-	}
+	rotations := it.Rotations()
 
 	// Map irot values (0-3) to EXIF orientation values
 	// irot: 0=no rotation, 1=90°CCW, 2=180°, 3=270°CCW (90°CW)

--- a/pkg/lib/mill/image_resize_heic_test.go
+++ b/pkg/lib/mill/image_resize_heic_test.go
@@ -1,1 +1,0 @@
-package mill

--- a/pkg/lib/mill/image_resize_heic_test.go
+++ b/pkg/lib/mill/image_resize_heic_test.go
@@ -1,0 +1,1 @@
+package mill


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6630/the-image-heic-format-is-broken

ReadSeeker of Heif image file is used twice: 
- first to find orientation info
- second to call goheif.Decode

Seek to beginning of file was not made correctly on first step, that's why file was not decoded.

Fix: Read all bytes at the beginning and then call functions with two independent readers
