### PR TITLE
GO-6426 Check noop details setting

### DIFF
--- a/core/block/editor/basic/details.go
+++ b/core/block/editor/basic/details.go
@@ -53,6 +53,10 @@ func (bs *basic) UpdateDetails(ctx session.Context, update func(current *domain.
 		return err
 	}
 
+	if isEmptyValueSet(oldDetails, diff, removedKeys) {
+		return nil // Client tries to set empty value to detail that is not included in state. It is a noop
+	}
+
 	s.SetDetails(newDetails)
 	if err = bs.addRelationLinks(s, newDetails.Keys()...); err != nil {
 		return err
@@ -99,6 +103,20 @@ func applyDetailUpdates(oldDetails *domain.Details, updates []domain.Detail) *do
 		}
 	}
 	return newDetails
+}
+
+func isEmptyValueSet(oldDetails, diff *domain.Details, removedKeys []domain.RelationKey) bool {
+	if len(removedKeys) != 0 {
+		return false
+	}
+
+	for k, v := range diff.Iterate() {
+		if oldDetails.Has(k) || !v.IsString() || !v.IsEmpty() {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (bs *basic) validateDetailFormat(key domain.RelationKey, v domain.Value) error {

--- a/core/block/editor/basic/details_test.go
+++ b/core/block/editor/basic/details_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/converter"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
@@ -139,32 +140,56 @@ func TestBasic_UpdateDetails(t *testing.T) {
 		assert.False(t, f.sb.NewState().HasRelation(bundle.RelationKeyTargetObjectType))
 	})
 
-	// TODO: GO-6248 uncomment when deletion of internal relations will be excluded on all clients
-	// t.Run("removal of internal relation should fail", func(t *testing.T) {
-	// 	// given
-	// 	f := newBasicFixture(t)
-	//
-	// 	err := f.sb.SetDetails(nil, []domain.Detail{
-	// 		{Key: bundle.RelationKeyName, Value: domain.String("test object")},
-	// 		{Key: bundle.RelationKeyDescription, Value: domain.String("Description")},
-	// 		{Key: bundle.RelationKeyCreatedDate, Value: domain.Int64(1234567890)},
-	// 	}, false)
-	// 	require.NoError(t, err)
-	//
-	// 	// when
-	// 	err = f.basic.UpdateDetails(nil, func(current *domain.Details) (*domain.Details, error) {
-	// 		current.Delete(bundle.RelationKeyName)
-	// 		current.Delete(bundle.RelationKeyDescription)
-	// 		current.Delete(bundle.RelationKeyCreatedDate)
-	// 		return current, nil
-	// 	})
-	//
-	// 	// then
-	// 	assert.Error(t, err)
-	// 	assert.Equal(t, "test object", f.sb.Details().GetString(bundle.RelationKeyName))
-	// 	assert.Equal(t, "Description", f.sb.Details().GetString(bundle.RelationKeyDescription))
-	// 	assert.Equal(t, int64(1234567890), f.sb.LocalDetails().GetInt64(bundle.RelationKeyCreatedDate))
-	// })
+	t.Run("removal of internal relation should fail", func(t *testing.T) {
+		// given
+		f := newBasicFixture(t)
+
+		err := f.sb.SetDetails(nil, []domain.Detail{
+			{Key: bundle.RelationKeyName, Value: domain.String("test object")},
+			{Key: bundle.RelationKeyDescription, Value: domain.String("Description")},
+			{Key: bundle.RelationKeyCreatedDate, Value: domain.Int64(1234567890)},
+		}, false)
+		require.NoError(t, err)
+
+		// when
+		err = f.basic.UpdateDetails(nil, func(current *domain.Details) (*domain.Details, error) {
+			current.Delete(bundle.RelationKeyName)
+			current.Delete(bundle.RelationKeyDescription)
+			current.Delete(bundle.RelationKeyCreatedDate)
+			return current, nil
+		})
+
+		// then
+		assert.Error(t, err)
+		assert.Equal(t, "test object", f.sb.Details().GetString(bundle.RelationKeyName))
+		assert.Equal(t, "Description", f.sb.Details().GetString(bundle.RelationKeyDescription))
+		assert.Equal(t, int64(1234567890), f.sb.LocalDetails().GetInt64(bundle.RelationKeyCreatedDate))
+	})
+
+	t.Run("setting empty string is noop", func(t *testing.T) {
+		// given
+		f := newBasicFixture(t)
+		f.store.AddObjects(t, []objectstore.TestObject{{
+			bundle.RelationKeyId:             domain.String("rel-aperture"),
+			bundle.RelationKeySpaceId:        domain.String(spaceId),
+			bundle.RelationKeyRelationKey:    domain.String("aperture"),
+			bundle.RelationKeyUniqueKey:      domain.String("rel-aperture"),
+			bundle.RelationKeyRelationFormat: domain.Int64(int64(model.RelationFormat_longtext)),
+		}})
+
+		// when
+		err := f.basic.UpdateDetails(nil, func(current *domain.Details) (*domain.Details, error) {
+			current.Set(bundle.RelationKeyAperture, domain.String(""))
+			return current, nil
+		})
+
+		// then
+		assert.NoError(t, err)
+
+		_, found := f.sb.Details().TryString(bundle.RelationKeyAperture)
+		assert.False(t, found)
+		assert.False(t, f.sb.NewState().HasRelation(bundle.RelationKeyAperture))
+	})
 }
 
 func TestBasic_SetObjectTypesInState(t *testing.T) {


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6426/the-object-is-edited-after-clicking-on-the-properties-field-in-the-set

We should not call sb.Apply in case empty string detail is added to state