### PR TITLE
GO-6659: Add AI-generated documentation headers to components

### DIFF
--- a/.claude/agents/document-component.md
+++ b/.claude/agents/document-component.md
@@ -1,0 +1,118 @@
+---
+name: document-component
+description: |
+  Use this agent to document a Go service component with a concise header. Examples: <example>Context: User wants to understand or document a service. user: "document core/block/service.go" assistant: "I'll use the document-component agent to analyze and document this component" <commentary>User explicitly asked to document a component.</commentary></example> <example>Context: User finished implementing a new service. user: "I've created a new service in pkg/lib/myservice/service.go, can you add docs?" assistant: "I'll use the document-component agent to generate documentation for this new service" <commentary>New service needs documentation header.</commentary></example>
+tools: Glob, Grep, Read, LS, Edit, MultiEdit, Write, LSP, AskUserQuestion
+model: opus
+color: green
+---
+
+You are a Go component documentation specialist for the Anytype Heart codebase. Your role is to analyze Go service components and generate concise, no-water documentation headers.
+
+## Output Template
+
+Insert after `package X` line, before `import`:
+
+```go
+/*
+AI generated
+
+Name: {1-6 word precise name based on responsibility}
+Scope: {global|space|other-child}
+
+## Responsibility
+- {specific responsibility}
+- DONTs: {what should NOT be in this component}
+
+## Background Tasks
+- {name}: {description} {methodName}
+
+## External State
+- {dbs, configs, lock files managed by this component}
+
+## Documentation
+{overall flow only: state machines, modes, lifecycle - NOT method-specific}
+*/
+```
+
+## Scope Definitions
+
+- **global** - `CName` constant present, registered with `app.App`
+- **space** - Created as child of space (via space's `app.App`)
+- **other-child** - Created as child of another component (specify parent)
+
+## When to Ask User
+
+If you're uncertain about responsibilities or data flow after analyzing the code, use AskUserQuestion tool. Ask when:
+- Component responsibilities are ambiguous from code alone
+- Data flow or state machine logic is unclear
+- You're unsure if something is a core responsibility or edge case
+- The relationship between this component and others is confusing
+
+Better to ask than to document incorrectly.
+
+## Analysis Approach
+
+1. Read ALL `.go` files in the package, not just the main file
+2. Identify scope from `CName` constant and registration pattern
+3. Determine a precise 1-6 word name reflecting actual responsibility
+4. Find background tasks (`go func()`, select loops, watchers)
+5. Find external state only (databases, configs, lock files) - ignore in-memory maps/caches
+6. Identify complex internal flows worth documenting (see below)
+
+### What Flows to Document
+Only document non-obvious complex flows:
+- State machines (e.g., space state transitions)
+- Batching mechanisms
+- Queues and processing pipelines
+- Complex indexation flows
+- Multi-stage data processing
+
+Do NOT document:
+- Simple trigger-based hooks
+- Obvious CRUD operations
+- Straightforward event handlers
+
+## Rules
+
+- **No water** - every line must add value
+- **No generic Go advice** - only THIS component
+- **No obvious statements** - skip "handles errors", "implements interface"
+- **Omit empty sections** - if no background tasks, don't include the section
+- **Code should be readable** - don't document what's clear from Init/Run/Close
+
+### Name Section
+- 1-6 words describing what component is responsible for
+- Focus on responsibility, not actions
+- Do NOT rely on CName or package name - these can be misleading
+- Derive the name from actual responsibilities found in code
+- Examples: "File Downloader", "Space State Manager", "Block Change Processor"
+
+### Responsibility Section
+- Don't iterate over specific instances or types
+- BAD: "handles text spaces, streamable spaces, personal spaces"
+- GOOD: "handles all space types" or "handles any space type"
+- Only specify specific types if there's an actual limitation
+
+### External State Section
+- Only external persistent state: databases, config files, lock files
+- Do NOT include in-memory maps, caches, or internal component state
+- These are things other components or restarts need to know about
+
+### Documentation Section
+- Only for overall flow: state machines, mode transitions, lifecycle
+- Method-specific documentation belongs on interface method comments (or struct methods if no interface)
+- If docs can be placed "in context" (on the method/interface), put them there instead
+
+### Method Comments (on interface or struct)
+- Only when NOT obvious from method name, input args, and output args
+- Only for important non-obvious things: concurrency guarantees, safety constraints, side effects
+- If component exposes an interface: put comments on interface methods
+- If component exposes struct directly (no interface): put comments on struct methods
+- Skip comments for self-explanatory methods
+
+### What NOT to Document
+- **Dependents Constraints** - leave for humans to add manually if needed
+- **Known Issues** - TODOs stay in code; only humans add conceptual issues
+- **"Don't call before init/run"** - this is a default constraint for all components
+- **Method-specific constraints** - put these as comments on the interface methods

--- a/.claude/agents/document-component.md
+++ b/.claude/agents/document-component.md
@@ -22,7 +22,6 @@ Scope: {global|space|other-child}
 
 ## Responsibility
 - {specific responsibility}
-- DONTs: {what should NOT be in this component}
 
 ## Background Tasks
 - {name}: {description} {methodName}

--- a/.claude/skills/go-reviewer/SKILL.md
+++ b/.claude/skills/go-reviewer/SKILL.md
@@ -1,0 +1,623 @@
+| name | description |
+|------|-------------|
+| go-reviewer | Review Go code changes for idiomatic patterns, concurrency safety, memory optimization, and test quality specific to Anytype Heart. Use when implementing Go features, modifying existing code, or creating new modules. Triggers on requests like "review this code", "check for issues", or after implementing features. |
+
+# Go Code Review Agent - Anytype Heart
+
+You are a Go specialist reviewing code in the Anytype Heart codebase. Apply exceptionally high standards for idiomatic, safe, and performant Go code following established patterns in this repository.
+
+## When to Use
+
+- After implementing new Go services or handlers
+- After refactoring existing Go code
+- After modifying concurrency-related code
+- When creating new Go modules or packages
+- On requests like "review this", "check for issues", "review my changes"
+
+## Review Process
+
+### Stage 1: Context Gathering
+
+1. **Identify changed files** - Use `git diff` or read provided files
+2. **Understand the component** - Check for `CName`, `Init()`, `Run()`, `Close()` patterns
+3. **Note the scope** - global singleton, per-space, or per-session component
+
+### Stage 2: Apply Review Checklists
+
+Work through each checklist relevant to the changed code.
+
+---
+
+## Checklist 1: Concurrency Safety
+
+### 1.1 Goroutine Management
+
+**Required Pattern** - Background goroutines MUST use component context:
+```go
+// CORRECT - core/block/service.go pattern
+func (s *Service) Init(a *app.App) error {
+    s.componentCtx, s.componentCtxCancel = context.WithCancel(context.Background())
+    return nil
+}
+
+func (s *Service) Run(ctx context.Context) error {
+    go func() {
+        for {
+            select {
+            case <-s.componentCtx.Done():
+                return  // Clean exit on shutdown
+            case item := <-s.workChan:
+                // process
+            }
+        }
+    }()
+    return nil
+}
+
+func (s *Service) Close(_ context.Context) error {
+    s.componentCtxCancel()  // Signal goroutines to exit
+    return nil
+}
+```
+
+**Check for**:
+- [ ] Every `go func()` has corresponding shutdown mechanism
+- [ ] Context cancellation is checked in loops
+- [ ] No goroutine leaks (all paths lead to termination)
+
+### 1.2 Context Propagation
+
+**Required Pattern** - Always cancel derived contexts:
+```go
+// CORRECT - space/service.go:267 pattern
+timeoutCtx, cancel := context.WithTimeout(ctx, deadline)
+defer cancel()  // ALWAYS defer cancel
+err := s.operation(timeoutCtx)
+```
+
+**Check for**:
+- [ ] `context.WithTimeout` / `context.WithCancel` paired with `defer cancel()`
+- [ ] Context not stored in structs (except component-level `componentCtx`)
+- [ ] Long operations accept and respect context
+
+### 1.3 Mutex Usage
+
+**Required Pattern** - Always defer unlock:
+```go
+// CORRECT - standard pattern throughout codebase
+func (s *service) Method() {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    // critical section
+}
+
+// CORRECT - Using helper (util/mutex/convenience.go)
+result := mutex.WithLock(s.mu, func() T {
+    return s.protectedOp()
+})
+```
+
+**Check for**:
+- [ ] `Lock()` immediately followed by `defer Unlock()`
+- [ ] No lock held during blocking operations (channel waits, I/O)
+- [ ] RWMutex used when reads greatly outnumber writes
+- [ ] Critical sections are minimal
+
+### 1.4 Atomic Operations
+
+**Required Pattern** - Atomic booleans for shutdown flags:
+```go
+// CORRECT - space/service.go:172 pattern
+type service struct {
+    isClosing atomic.Bool
+}
+
+func (s *service) Method() error {
+    if s.isClosing.Load() {
+        return ErrServiceClosing
+    }
+    // ...
+}
+
+func (s *service) Close(ctx context.Context) error {
+    s.isClosing.Store(true)
+    // cleanup...
+}
+```
+
+**Check for**:
+- [ ] Shutdown flags use `atomic.Bool`, not regular bool with mutex
+- [ ] Statistics counters use `atomic.Uint64` / `atomic.Int64`
+- [ ] No race between Load() and dependent operations
+
+### 1.5 Channel Patterns
+
+**Required Pattern** - Select with context cancellation:
+```go
+// CORRECT - space/spacecore/keyvalueobserver/observer.go pattern
+for {
+    select {
+    case <-ctx.Done():
+        return
+    case item := <-ch:
+        // process
+    case <-time.After(delay):
+        delay *= 2  // backoff
+    }
+}
+```
+
+**Check for**:
+- [ ] All channel receives have context cancellation case
+- [ ] Buffered channels have documented capacity reasoning
+- [ ] No send on potentially closed channels
+- [ ] Close() handles channel cleanup safely
+
+### 1.6 WaitGroup Usage
+
+**Required Pattern** - Parallel shutdown with WaitGroup:
+```go
+// CORRECT - space/service.go:502-513 pattern
+func (s *service) Close(ctx context.Context) error {
+    s.mu.Lock()
+    items := make([]Item, 0, len(s.items))
+    for _, item := range s.items {
+        items = append(items, item)
+    }
+    s.mu.Unlock()  // Release lock before goroutines
+
+    wg := sync.WaitGroup{}
+    for _, item := range items {
+        wg.Add(1)
+        go func(item Item) {  // Pass as parameter, not closure capture
+            defer wg.Done()
+            item.Close(ctx)
+        }(item)
+    }
+    wg.Wait()
+    return nil
+}
+```
+
+**Check for**:
+- [ ] Loop variables passed as goroutine arguments (not captured)
+- [ ] `wg.Add()` called before `go func()`
+- [ ] `defer wg.Done()` at start of goroutine
+- [ ] Lock released before starting parallel operations
+
+---
+
+## Checklist 2: Code Patterns
+
+### 2.1 Service Registration
+
+**Required Pattern** - app.Component interface:
+```go
+// CORRECT - standard pattern
+const CName = "package.service"
+
+type Service interface {
+    Method() error
+    app.Component
+}
+
+type service struct {
+    dep1 Dependency1
+    dep2 Dependency2
+}
+
+func New() Service {
+    return &service{}
+}
+
+func (s *service) Init(a *app.App) error {
+    s.dep1 = app.MustComponent[Dependency1](a)
+    s.dep2 = app.MustComponent[Dependency2](a)
+    return nil
+}
+
+func (s *service) Name() string {
+    return CName
+}
+```
+
+**Check for**:
+- [ ] `CName` constant defined at package level
+- [ ] `New()` returns interface type, not concrete struct pointer
+- [ ] Dependencies injected in `Init()`, not constructor
+- [ ] `Name()` returns `CName`
+
+### 2.2 Object Access
+
+**Required Pattern** - Always use cache.Do for SmartBlock access:
+```go
+// CORRECT - core/block/cache/cache.go pattern
+err := cache.Do(s.picker, objectId, func(sb basic.CommonOperations) error {
+    state := sb.NewState()
+    // operations on locked object
+    return sb.Apply(state)
+})
+
+// CORRECT - With context
+err := cache.DoContext(s.picker, ctx, objectId, func(sb smartblock.SmartBlock) error {
+    // ...
+})
+```
+
+**Check for**:
+- [ ] Never manually call `Lock()`/`Unlock()` on SmartBlock
+- [ ] Use appropriate cache.Do variant (Do, DoContext, DoWait, DoContextFullID)
+- [ ] Type parameter specifies required interface, not concrete type
+- [ ] Error from callback is returned
+
+### 2.3 Error Handling
+
+**Required Pattern** - Wrap errors with context:
+```go
+// CORRECT
+if err != nil {
+    return fmt.Errorf("operation description: %w", err)
+}
+
+// CORRECT - Error comparison
+if errors.Is(err, ErrNotFound) {
+    // handle specific error
+}
+
+// CORRECT - Custom errors (core/acl/errors.go pattern)
+var (
+    ErrNotFound     = errors.New("not found")
+    ErrInvalidInput = errors.New("invalid input")
+)
+```
+
+**Check for**:
+- [ ] All errors wrapped with `fmt.Errorf("context: %w", err)`
+- [ ] Use `errors.Is()` for comparison, never `==`
+- [ ] Sentinel errors defined at package level as `var`
+- [ ] Error messages describe what was being attempted
+
+### 2.4 Interface Design
+
+**Required Pattern** - Small focused interfaces:
+```go
+// CORRECT - Define interfaces for dependencies
+type nodeConfGetter interface {
+    GetNodeConf() nodeconf.Configuration
+}
+
+// CORRECT - Compose with app.Component for registration
+type Service interface {
+    app.Component
+    Operation() error
+}
+```
+
+**Check for**:
+- [ ] Interfaces defined where they're used, not where implemented
+- [ ] Unexported interfaces for internal dependencies (camelCase)
+- [ ] Exported interfaces for public API (PascalCase)
+- [ ] No "god interfaces" with many methods
+
+---
+
+## Checklist 3: Memory and Performance
+
+### 3.1 sync.Pool Usage
+
+**Required Pattern** - Pool reusable objects in hot paths:
+```go
+// CORRECT - util/pbtypes/copy.go pattern
+var bytesPool = &sync.Pool{
+    New: func() interface{} {
+        return []byte{}
+    },
+}
+
+func ProcessData(in []byte) []byte {
+    buf := bytesPool.Get().([]byte)
+    defer bytesPool.Put(buf)
+
+    if cap(buf) < len(in) {
+        buf = make([]byte, 0, len(in)*2)  // Grow with headroom
+    }
+    // use buf
+    return result
+}
+```
+
+**Check for**:
+- [ ] Objects reset/cleared before Put() back to pool
+- [ ] Pool used for frequently allocated objects (buffers, tasks)
+- [ ] Capacity check before growing pooled slices
+
+### 3.2 Arena Pool for JSON/Encoding
+
+**Required Pattern** - Use arena for JSON operations:
+```go
+// CORRECT - pkg/lib/localstore/objectstore/spaceindex/store.go pattern
+type store struct {
+    arenaPool *anyenc.ArenaPool
+}
+
+func (s *store) Method() {
+    arena := s.arenaPool.Get()
+    defer s.arenaPool.Put(arena)
+    // use arena for encoding
+}
+```
+
+**Check for**:
+- [ ] `anyenc.ArenaPool` or `fastjson.ArenaPool` for JSON operations
+- [ ] Arena acquired and released in same function
+- [ ] No arena references escape the function
+
+### 3.3 Slice Pre-allocation
+
+**Required Pattern** - Pre-allocate when size is known:
+```go
+// CORRECT - Known exact size
+result := make([]Item, len(source))
+
+// CORRECT - Known capacity estimate
+result := make([]Item, 0, len(source))
+
+// CORRECT - Map capacity
+cache := make(map[string]Value, expectedSize)
+```
+
+**Check for**:
+- [ ] `make([]T, 0, n)` when length unknown but capacity estimable
+- [ ] `make([]T, n)` when exact length known
+- [ ] Map capacity hint for maps with known size
+
+### 3.4 strings.Builder
+
+**Required Pattern** - Use Builder for string concatenation:
+```go
+// CORRECT
+var b strings.Builder
+b.WriteString("prefix")
+b.WriteString(variable)
+result := b.String()
+
+// WRONG
+result := "prefix" + variable + suffix  // Multiple allocations
+```
+
+**Check for**:
+- [ ] strings.Builder for 3+ concatenations
+- [ ] No `+` operator in loops for string building
+- [ ] Builder.Grow() called if size known
+
+### 3.5 Buffer Reuse
+
+**Required Pattern** - Use bufferpool for file I/O:
+```go
+// CORRECT - util/bufferpool pattern
+pool := bufferpool.NewPool()
+buf := pool.Get()
+defer buf.Close()  // Returns to pool
+```
+
+**Check for**:
+- [ ] bytes.Buffer created in loops should use pool
+- [ ] Hot paths don't allocate new buffers repeatedly
+- [ ] File I/O operations use pooled buffers
+
+---
+
+## Checklist 4: Testing
+
+### 4.1 Table-Driven Tests
+
+**Required Pattern**:
+```go
+// CORRECT
+func TestOperation(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   Input
+        want    Output
+        wantErr error
+    }{
+        {"valid input", Input{...}, Output{...}, nil},
+        {"invalid input", Input{...}, Output{}, ErrInvalid},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := Operation(tt.input)
+            if tt.wantErr != nil {
+                require.ErrorIs(t, err, tt.wantErr)
+                return
+            }
+            require.NoError(t, err)
+            assert.Equal(t, tt.want, got)
+        })
+    }
+}
+```
+
+**Check for**:
+- [ ] Table-driven structure for multiple test cases
+- [ ] Descriptive test case names
+- [ ] `t.Run()` for subtests
+- [ ] Both success and error cases covered
+
+### 4.2 Fixture Pattern
+
+**Required Pattern**:
+```go
+// CORRECT - core/block/detailservice/service_test.go pattern
+type fixture struct {
+    Service
+    mockDep1 *mock_dep.MockDep1
+    mockDep2 *mock_dep.MockDep2
+}
+
+func newFixture(t *testing.T) *fixture {
+    mockDep1 := mock_dep.NewMockDep1(t)
+    mockDep2 := mock_dep.NewMockDep2(t)
+
+    // Setup default expectations
+    mockDep1.EXPECT().Method().Return(nil).Maybe()
+
+    svc := &service{
+        dep1: mockDep1,
+        dep2: mockDep2,
+    }
+
+    return &fixture{svc, mockDep1, mockDep2}
+}
+```
+
+**Check for**:
+- [ ] Fixture struct groups service with mocks
+- [ ] `newFixture(t *testing.T)` constructor
+- [ ] Default mock expectations set with `.Maybe()`
+- [ ] Mocks created with `t` for automatic cleanup
+
+### 4.3 Mock Usage
+
+**Required Pattern**:
+```go
+// CORRECT - testify mock
+mock.EXPECT().Method(mock.Anything).Return(value)
+mock.EXPECT().Method(specificArg).Return(value).Times(1)
+
+// CORRECT - gomock
+ctrl := gomock.NewController(t)
+mock := mock_pkg.NewMockInterface(ctrl)
+mock.EXPECT().Method(gomock.Any()).Return(value)
+```
+
+**Check for**:
+- [ ] `mock.Anything` / `gomock.Any()` for non-essential args
+- [ ] Specific expectations for behavior under test
+- [ ] `.Times()` / `.Once()` when call count matters
+- [ ] Mock controller cleanup (automatic with `t`)
+
+### 4.4 Assertions
+
+**Required Pattern** - Use testify consistently:
+```go
+// CORRECT
+require.NoError(t, err)           // Fatal on error
+require.NotNil(t, result)         // Fatal if nil
+assert.Equal(t, expected, actual) // Continue on failure
+assert.True(t, condition)
+assert.Contains(t, slice, element)
+```
+
+**Check for**:
+- [ ] `require` for preconditions (test cannot continue)
+- [ ] `assert` for validations (test can continue)
+- [ ] No `if err != nil { t.Fatal(err) }` - use `require.NoError`
+
+---
+
+## Checklist 5: Component Documentation Compliance
+
+Every component MUST have a documentation header (comment block after `package` with `Name:`, `Scope:`, `## Responsibility`, etc.). **Only report mismatches and missing documentation.**
+
+### 5.1 Check Documentation Exists
+
+1. Look for doc header after `package X` line
+2. If no documentation exists, report as **High** severity issue - documentation is required
+
+### 5.2 Verify Code Against Documentation
+
+**Report only mismatches** - don't list things that are correct:
+
+- [ ] **Name**: Does the code actually do what the documented name suggests?
+- [ ] **Scope**: Is the component registered correctly for its documented scope (global/space/other-child)?
+- [ ] **Responsibilities**: Does the code implement ALL documented responsibilities? Is it doing things NOT in responsibilities (scope creep)?
+- [ ] **DONTs**: Is the code violating any documented DONTs?
+- [ ] **Background Tasks**: Are all documented background tasks present? Are there undocumented background tasks?
+- [ ] **External State**: Does the code access/modify external state not documented? Is documented state actually used?
+
+### 5.3 Report Format
+
+**Missing documentation:**
+```markdown
+### [High] Missing Component Documentation
+
+**Location**: `path/to/file.go`
+
+**Problem**: Component lacks required documentation header.
+
+**Resolution**: Use document-component agent to generate documentation.
+```
+
+**Documentation mismatch:**
+```markdown
+### [Medium] Documentation Mismatch: {specific issue}
+
+**Documented**: {what documentation says}
+
+**Actual Code**: {what code actually does}
+
+**Resolution**: Update code to match docs OR update docs to match code (specify which)
+```
+
+**Do NOT report**:
+- Things that match documentation
+- Minor implementation details not covered by documentation
+- Internal state or helper functions
+
+---
+
+## Output Format
+
+For each issue found, report:
+
+```markdown
+### [Severity] Issue Title
+
+**Location**: `path/to/file.go:line`
+
+**Problem**: Clear description of what's wrong.
+
+**Current Code**:
+```go
+// problematic code
+```
+
+**Suggested Fix**:
+```go
+// corrected code following codebase patterns
+```
+
+**Reference**: Similar pattern at `reference/file.go:line` (optional)
+```
+
+## Severity Levels
+
+- **Critical**: Goroutine leaks, race conditions, deadlocks, data corruption, security issues
+- **High**: Memory leaks, performance issues in hot paths, broken functionality, missing error handling
+- **Medium**: Anti-patterns, style inconsistencies, suboptimal patterns, test gaps
+- **Low**: Minor style issues, documentation, minor optimizations
+
+## Anti-Patterns Quick Reference
+
+| Anti-Pattern | Correct Pattern | Reference File |
+|--------------|-----------------|----------------|
+| `err == ErrX` | `errors.Is(err, ErrX)` | core/acl/errors.go |
+| Manual SmartBlock lock | `cache.Do(picker, id, func...)` | core/block/cache/cache.go |
+| `go func() { ... }()` without context | Check `ctx.Done()` in loop | space/service.go:562-580 |
+| Lock held during I/O | Unlock before blocking | core/subscription/service.go:498-509 |
+| `+ ` string concat in loop | `strings.Builder` | util/strutil/str.go |
+| `make([]T, 0)` in hot path | Pre-allocate or use pool | util/pbtypes/copy.go |
+| `&bytes.Buffer{}` in loop | Use bufferpool | util/bufferpool/pool.go |
+| Loop var in goroutine closure | Pass as function argument | space/service.go:505-511 |
+| `New() *serviceImpl` | `New() ServiceInterface` | All services |
+| Context stored in struct | Pass as method parameter | - |
+
+## Codebase-Specific Notes
+
+1. **Any-Sync Integration**: Space operations involve CRDT sync - be careful with concurrent modifications
+2. **Object IDs**: Always validate object IDs exist before operations
+3. **Tech Space**: Account-level data stored separately - different access patterns
+4. **Message Batching**: Use `mb.MB` for decoupling producers/consumers (core/subscription pattern)
+5. **File Queue**: Actor model in core/files/filesync/filequeue - no locks in main loop

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -1,5 +1,32 @@
 package acl
 
+/*
+AI generated
+
+Name: Space Access Control and Sharing
+Scope: global
+
+## Responsibility
+- Space invite management (generate, view, change, revoke invites for member/guest/anyone types)
+- ACL membership operations (join, leave, accept, decline, remove participants)
+- Permission management (change participant permissions, approve leave requests)
+- Guest user account management
+- DONTs: participant object storage (handled by space), ACL record persistence (handled by any-sync)
+
+## Background Tasks
+- aclUpdater: monitors participants with "Removing" status via cross-space subscription,
+  schedules automatic ApproveLeave for owners; monitors space views for spaces where user
+  should self-remove, schedules Leave retries. Uses retryscheduler for exponential backoff.
+
+## Documentation
+The aclUpdater coordinates two subscription-based flows:
+1. participantSub: subscribes to participants with status=Removing across all owned spaces,
+   triggers ApproveLeave for each (owner auto-approves leave requests)
+2. spaceSubscription: subscribes to space views where user is not owner but space is deleted,
+   triggers self-Leave requests with retry logic
+Both flows use a shared retryscheduler that handles failures with exponential backoff.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -11,7 +11,6 @@ Scope: global
 - ACL membership operations (join, leave, accept, decline, remove participants)
 - Permission management (change participant permissions, approve leave requests)
 - Guest user account management
-- DONTs: participant object storage (handled by space), ACL record persistence (handled by any-sync)
 
 ## Background Tasks
 - aclUpdater: monitors participants with "Removing" status via cross-space subscription,

--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -11,7 +11,6 @@ Scope: global
 - Fetches URL metadata asynchronously (title, description, cover image, favicon)
 - Updates bookmark objects/blocks with fetched content
 - Parses HTML content into blocks when requested
-- DONTs: does NOT handle bookmark block rendering, only data fetching and object management
 
 ## Background Tasks
 - Content fetching: parallel goroutines fetch metadata, images, favicon concurrently via ContentUpdaters

--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -1,5 +1,30 @@
 package bookmark
 
+/*
+AI generated
+
+Name: URL Bookmark Object Manager
+Scope: global
+
+## Responsibility
+- Creates bookmark objects from URLs with deduplication (reuses existing bookmark if same URL exists)
+- Fetches URL metadata asynchronously (title, description, cover image, favicon)
+- Updates bookmark objects/blocks with fetched content
+- Parses HTML content into blocks when requested
+- DONTs: does NOT handle bookmark block rendering, only data fetching and object management
+
+## Background Tasks
+- Content fetching: parallel goroutines fetch metadata, images, favicon concurrently via ContentUpdaters
+- Object update: goroutine updates object details after content is fetched in CreateBookmarkObject
+
+## Documentation
+Content fetching uses a channel-based updater pattern:
+1. ContentUpdaters returns a channel of update functions
+2. Multiple goroutines send updaters for metadata, cover image, favicon in parallel
+3. Consumer applies updaters sequentially to build final ObjectContent
+4. ContentFuture wraps this for synchronous access - blocks until all updaters complete
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/block/bookmark/bookmarkimporter/bookmark_importer_decorator.go
+++ b/core/block/bookmark/bookmarkimporter/bookmark_importer_decorator.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Decorates bookmark.Service to prefer web import when creating bookmark objects
 - Falls back to standard CreateBookmarkObject if web import fails
-- DONTs: fetching bookmark content, managing bookmark state
 */
 
 import (

--- a/core/block/bookmark/bookmarkimporter/bookmark_importer_decorator.go
+++ b/core/block/bookmark/bookmarkimporter/bookmark_importer_decorator.go
@@ -1,5 +1,17 @@
 package bookmarkimporter
 
+/*
+AI generated
+
+Name: Bookmark Creation with Web Import Fallback
+Scope: global
+
+## Responsibility
+- Decorates bookmark.Service to prefer web import when creating bookmark objects
+- Falls back to standard CreateBookmarkObject if web import fails
+- DONTs: fetching bookmark content, managing bookmark state
+*/
+
 import (
 	"context"
 

--- a/core/block/chats/chatrepository/repository.go
+++ b/core/block/chats/chatrepository/repository.go
@@ -11,7 +11,6 @@ Scope: global
 - Stores and queries chat messages with pagination support
 - Tracks read/unread state for messages and mentions separately
 - Tracks sync state for messages
-- DONTs: message processing logic, real-time subscriptions
 
 ## External State
 - CRDT DB collections: one per chat object (`{chatObjectId}chats`)

--- a/core/block/chats/chatrepository/repository.go
+++ b/core/block/chats/chatrepository/repository.go
@@ -1,5 +1,22 @@
 package chatrepository
 
+/*
+AI generated
+
+Name: Chat Message Storage
+Scope: global
+
+## Responsibility
+- Provides per-chat Repository instances for message persistence
+- Stores and queries chat messages with pagination support
+- Tracks read/unread state for messages and mentions separately
+- Tracks sync state for messages
+- DONTs: message processing logic, real-time subscriptions
+
+## External State
+- CRDT DB collections: one per chat object (`{chatObjectId}chats`)
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/block/chats/chatsubscription/service.go
+++ b/core/block/chats/chatsubscription/service.go
@@ -1,5 +1,25 @@
 package chatsubscription
 
+/*
+AI generated
+
+Name: Chat Message Subscription Events
+Scope: global
+
+## Responsibility
+- Manages subscriptions to chat messages and sends real-time events on changes
+- Tracks message state: add, delete, update, reactions, read status, sync status
+- Maintains chat state with unread counters for messages and mentions
+- Resolves message dependencies (creator identity, attachment details)
+- DONTs: message persistence (handled by chatrepository)
+
+## Documentation
+Each chat object has one subscriptionManager, initialized lazily via futures for lock-free concurrent access.
+Manager maintains a sliding window of messages (skiplist ordered by OrderId, capped by limit).
+Changes accumulate in messagesState and flush as batched events after commit.
+Supports sync events (via session context) and async events (via broadcast).
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/block/chats/chatsubscription/service.go
+++ b/core/block/chats/chatsubscription/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Tracks message state: add, delete, update, reactions, read status, sync status
 - Maintains chat state with unread counters for messages and mentions
 - Resolves message dependencies (creator identity, attachment details)
-- DONTs: message persistence (handled by chatrepository)
 
 ## Documentation
 Each chat object has one subscriptionManager, initialized lazily via futures for lock-free concurrent access.

--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Tracks all chat objects across spaces via cross-space subscription
 - Manages cross-space message preview subscriptions (last message + state per chat)
 - Sends push notifications on new messages with mentions routing
-- DONTs: message persistence (chatrepository), subscription event delivery (chatsubscription)
 
 ## Background Tasks
 - monitorMessagePreviews: Processes cross-space subscription events to track chat object additions/removals and update preview subscriptions

--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -1,5 +1,28 @@
 package chats
 
+/*
+AI generated
+
+Name: Chat API and Cross-Space Tracking
+Scope: global
+
+## Responsibility
+- Provides RPC API for chat message operations: add, edit, delete, toggle reactions, read/unread
+- Tracks all chat objects across spaces via cross-space subscription
+- Manages cross-space message preview subscriptions (last message + state per chat)
+- Sends push notifications on new messages with mentions routing
+- DONTs: message persistence (chatrepository), subscription event delivery (chatsubscription)
+
+## Background Tasks
+- monitorMessagePreviews: Processes cross-space subscription events to track chat object additions/removals and update preview subscriptions
+
+## Documentation
+Preview subscriptions work at two levels:
+1. Cross-space subscription tracks all chatDerived objects across all spaces
+2. For each active preview subscription, subscribes to last message of each chat via chatsubscription.Service
+When chats are added/removed, preview subscriptions are automatically updated and events broadcasted.
+*/
+
 import (
 	"context"
 	"crypto/sha256"

--- a/core/block/dataviewservice/service.go
+++ b/core/block/dataviewservice/service.go
@@ -1,5 +1,19 @@
 package dataviewservice
 
+/*
+AI generated
+
+Name: Dataview Block Operations
+Scope: global
+
+## Responsibility
+- CRUD operations for dataview views, filters, sorts, and view relations
+- Manage dataview relation links and data sources
+- Copy dataview configuration between objects
+- Sync view relations with relation links (ensures new relation links appear in views)
+- DONTs: query execution, data fetching - this is purely configuration/state management
+*/
+
 import (
 	"fmt"
 

--- a/core/block/dataviewservice/service.go
+++ b/core/block/dataviewservice/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Manage dataview relation links and data sources
 - Copy dataview configuration between objects
 - Sync view relations with relation links (ensures new relation links appear in views)
-- DONTs: query execution, data fetching - this is purely configuration/state management
 */
 
 import (

--- a/core/block/detailservice/service.go
+++ b/core/block/detailservice/service.go
@@ -1,5 +1,20 @@
 package detailservice
 
+/*
+AI generated
+
+Name: Object Details and Properties Manager
+Scope: global
+
+## Responsibility
+- Set/modify object details (properties) on single or multiple objects
+- Manage object type relations (recommended, featured)
+- Set favorite/archived status via Home/Archive collections
+- Set space info and workspace dashboard
+- List relations containing specific values across a space
+- DONTs: does not handle object creation/deletion, block content, or indexing
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/block/detailservice/service.go
+++ b/core/block/detailservice/service.go
@@ -8,11 +8,10 @@ Scope: global
 
 ## Responsibility
 - Set/modify object details (properties) on single or multiple objects
-- Manage object type relations (recommended, featured)
+- Manage object type recommended relations
 - Set favorite/archived status via Home/Archive collections
 - Set space info and workspace dashboard
-- List relations containing specific values across a space
-- DONTs: does not handle object creation/deletion, block content, or indexing
+- List relations containing specific value
 */
 
 import (

--- a/core/block/editor/factory.go
+++ b/core/block/editor/factory.go
@@ -10,7 +10,6 @@ Scope: global
 - Creates editor instances (Page, Profile, Archive, Widget, etc.) based on SmartBlockType
 - Initializes objects from sources: loads tree, runs migrations, applies initial state
 - Composes editors with service dependencies (file handling, clipboard, bookmarks, dataview, etc.)
-- DONTs: object caching (done by objectcache), tree synchronization
 */
 
 import (

--- a/core/block/editor/factory.go
+++ b/core/block/editor/factory.go
@@ -1,5 +1,18 @@
 package editor
 
+/*
+AI generated
+
+Name: SmartBlock Editor Factory
+Scope: global
+
+## Responsibility
+- Creates editor instances (Page, Profile, Archive, Widget, etc.) based on SmartBlockType
+- Initializes objects from sources: loads tree, runs migrations, applies initial state
+- Composes editors with service dependencies (file handling, clipboard, bookmarks, dataview, etc.)
+- DONTs: object caching (done by objectcache), tree synchronization
+*/
+
 import (
 	"errors"
 	"fmt"

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -11,7 +11,6 @@ Scope: global
 - Resolves and includes dependent objects (nested links, files, relations, types, templates)
 - Manages export output as zip archives or directory structures
 - Provides in-memory single-object export for programmatic use
-- DONTs: import functionality (handled by separate importer)
 
 ## Documentation
 Export collects objects to export via two paths:

--- a/core/block/export/export.go
+++ b/core/block/export/export.go
@@ -1,5 +1,36 @@
 package export
 
+/*
+AI generated
+
+Name: Object Exporter
+Scope: global
+
+## Responsibility
+- Exports objects to various formats: Protobuf, JSON, Markdown, DOT, SVG, GraphJSON
+- Resolves and includes dependent objects (nested links, files, relations, types, templates)
+- Manages export output as zip archives or directory structures
+- Provides in-memory single-object export for programmatic use
+- DONTs: import functionality (handled by separate importer)
+
+## Documentation
+Export collects objects to export via two paths:
+1. All objects: queries objectStore for all non-archived objects in space
+2. Specific IDs: queries only requested objects, then expands based on flags
+
+Dependency resolution for Protobuf format (most complete):
+- Collects object types and relations used by exported objects
+- Recursively resolves types referenced in setOf/targetObjectType
+- Adds templates matching collected object types
+- Includes relation options for tag/status relations
+- Adds recommended relations from custom types
+
+For nested objects (includeNested=true):
+- Recursively follows links in blocks and details
+- Creates exportContext copy with isLinkProcess=true for linked objects
+- Linked objects may have filtered state via linkStateFilters
+*/
+
 import (
 	"bytes"
 	"context"

--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -1,5 +1,27 @@
 package importer
 
+/*
+AI generated
+
+Name: Multi-Format Object Importer
+Scope: global
+
+## Responsibility
+- Orchestrate import from multiple formats (Markdown, Notion, HTML, CSV, TXT, Protobuf, Web)
+- Convert external data into snapshots via format-specific converters
+- Create Anytype objects from snapshots using worker pool parallelization
+- Assign IDs and payloads to imported objects, handle ID remapping
+- DONTs: format-specific parsing (delegated to converters in subpackages)
+
+## Documentation
+Import flow:
+1. Request received (sync or async via goroutine)
+2. Converter.GetSnapshots() produces snapshots from source format
+3. IdProvider assigns new IDs and payloads to all snapshots
+4. Worker pool (10 workers) creates objects in parallel via objectcreator.Service
+5. Post-processing: file sync events, root collection widget, notifications
+*/
+
 import (
 	"context"
 

--- a/core/block/import/importer.go
+++ b/core/block/import/importer.go
@@ -11,7 +11,6 @@ Scope: global
 - Convert external data into snapshots via format-specific converters
 - Create Anytype objects from snapshots using worker pool parallelization
 - Assign IDs and payloads to imported objects, handle ID remapping
-- DONTs: format-specific parsing (delegated to converters in subpackages)
 
 ## Documentation
 Import flow:

--- a/core/block/object/idderiver/idderiverimpl/impl.go
+++ b/core/block/object/idderiver/idderiverimpl/impl.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Provides a facade to derive deterministic object IDs from UniqueKey within a space
 - Delegates to space.DeriveObjectID after resolving the space by ID
-- DONTs: actual ID derivation logic (handled by space), unique key management
 */
 
 import (

--- a/core/block/object/idderiver/idderiverimpl/impl.go
+++ b/core/block/object/idderiver/idderiverimpl/impl.go
@@ -1,5 +1,17 @@
 package idderiverimpl
 
+/*
+AI generated
+
+Name: Object ID Derivation Facade
+Scope: global
+
+## Responsibility
+- Provides a facade to derive deterministic object IDs from UniqueKey within a space
+- Delegates to space.DeriveObjectID after resolving the space by ID
+- DONTs: actual ID derivation logic (handled by space), unique key management
+*/
+
 import (
 	"context"
 

--- a/core/block/object/idresolver/resolver.go
+++ b/core/block/object/idresolver/resolver.go
@@ -1,5 +1,16 @@
 package idresolver
 
+/*
+AI generated
+
+Name: Object to Space ID Resolver
+Scope: global
+
+## Responsibility
+- Resolves object IDs to their containing space IDs via object store lookup
+- Provides retry variant for eventual consistency scenarios
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -1,5 +1,19 @@
 package objectcreator
 
+/*
+AI generated
+
+Name: Object Creation and Bundled Object Installation
+Scope: global
+
+## Responsibility
+- Create objects with type-specific handling (object types, relations, relation options, templates, bookmarks, chat-derived, dates)
+- Install bundled objects (types and relations) from marketplace to user space
+- Reinstall previously deleted bundled objects
+- Create smartblocks from state with appropriate tree derivation
+- DONTs: File objects must be created via fileobject service, not this component
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/block/object/objectcreator/creator.go
+++ b/core/block/object/objectcreator/creator.go
@@ -11,7 +11,6 @@ Scope: global
 - Install bundled objects (types and relations) from marketplace to user space
 - Reinstall previously deleted bundled objects
 - Create smartblocks from state with appropriate tree derivation
-- DONTs: File objects must be created via fileobject service, not this component
 */
 
 import (

--- a/core/block/object/objectgraph/graph.go
+++ b/core/block/object/objectgraph/graph.go
@@ -1,5 +1,19 @@
 package objectgraph
 
+/*
+AI generated
+
+Name: Object Graph Builder
+Scope: global
+
+## Responsibility
+- Build graph representation (nodes and edges) for objects within a space
+- Create edges from object/file-type relations and direct links between objects
+- Filter out system relations (Creator, LastModifiedBy, Cover, etc.) that are not meaningful in graph context
+- Auto-fetch Date objects referenced in links but not in initial query results
+- DONTs: object storage, subscription management, relation schema management
+*/
+
 import (
 	"fmt"
 

--- a/core/block/object/objectgraph/graph.go
+++ b/core/block/object/objectgraph/graph.go
@@ -9,9 +9,6 @@ Scope: global
 ## Responsibility
 - Build graph representation (nodes and edges) for objects within a space
 - Create edges from object/file-type relations and direct links between objects
-- Filter out system relations (Creator, LastModifiedBy, Cover, etc.) that are not meaningful in graph context
-- Auto-fetch Date objects referenced in links but not in initial query results
-- DONTs: object storage, subscription management, relation schema management
 */
 
 import (

--- a/core/block/process/service.go
+++ b/core/block/process/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Broadcasts process lifecycle events (new/update/done) to clients
 - Provides Queue (worker pool with tasks) and Progress (simple counter) abstractions
 - Allows sessions to opt-out of progress update events
-- DONTs: actual task execution logic - that belongs to consumers
 
 ## Background Tasks
 - monitor: Per-process goroutine that broadcasts state updates every 500ms until done

--- a/core/block/process/service.go
+++ b/core/block/process/service.go
@@ -1,5 +1,27 @@
 package process
 
+/*
+AI generated
+
+Name: Long-Running Process Pool Manager
+Scope: global
+
+## Responsibility
+- Tracks active long-running processes (imports, exports, migrations)
+- Broadcasts process lifecycle events (new/update/done) to clients
+- Provides Queue (worker pool with tasks) and Progress (simple counter) abstractions
+- Allows sessions to opt-out of progress update events
+- DONTs: actual task execution logic - that belongs to consumers
+
+## Background Tasks
+- monitor: Per-process goroutine that broadcasts state updates every 500ms until done
+
+## Documentation
+Process lifecycle: None -> Running -> Done/Canceled/Error
+Update events are broadcast only when Info() changes (compared via reflect.DeepEqual)
+Sessions can unsubscribe to avoid receiving ProcessUpdate events (still receive New/Done)
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -1,5 +1,29 @@
 package block
 
+/*
+AI generated
+
+Name: Object Operations Facade
+Scope: global
+
+## Responsibility
+- Provides unified API for object lifecycle operations (open, close, show, duplicate, delete)
+- Handles block-level editing operations (create, update, move, split, merge, copy/paste)
+- Manages file upload/download with progress tracking
+- Coordinates workspace/space creation including one-to-one spaces
+- Exposes ObjectGetter interface for cache.Do pattern used throughout codebase
+- Tracks currently opened objects to prevent premature cache eviction
+- DONTs: actual object storage (delegated to space), block content parsing (delegated to editors)
+
+## Background Tasks
+- ObjectBookmarkFetch: async bookmark content update after initial fetch
+- DownloadFile: progress reporting goroutine during file download
+
+## Documentation
+The service uses cache.Do pattern extensively - it implements ObjectGetter interface which allows
+type-safe access to smartblocks via generics. Most operations follow: resolve space -> get object from space cache -> lock -> apply operation -> unlock pattern.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -13,7 +13,6 @@ Scope: global
 - Coordinates workspace/space creation including one-to-one spaces
 - Exposes ObjectGetter interface for cache.Do pattern used throughout codebase
 - Tracks currently opened objects to prevent premature cache eviction
-- DONTs: actual object storage (delegated to space), block content parsing (delegated to editors)
 
 ## Background Tasks
 - ObjectBookmarkFetch: async bookmark content update after initial fetch

--- a/core/block/source/sourceimpl/service.go
+++ b/core/block/source/sourceimpl/service.go
@@ -1,5 +1,22 @@
 package sourceimpl
 
+/*
+AI generated
+
+Name: Object Source Factory
+Scope: global
+
+## Responsibility
+- Creates Source instances for reading/writing object state from underlying storage
+- Routes to appropriate Source implementation based on object ID or smartblock type:
+  - treeSource: synced objects backed by ObjectTree (CRDT)
+  - store: chat/account objects using StoreState (sequential changes)
+  - static: in-memory read-only objects (participants, bundled templates)
+  - Virtual sources: date, bundledObjectType, bundledRelation, anytypeProfile, missingObject
+- Binds object IDs to space IDs in object store
+- DONTs: does NOT manage object lifecycle beyond source creation
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/block/source/sourceimpl/service.go
+++ b/core/block/source/sourceimpl/service.go
@@ -14,7 +14,6 @@ Scope: global
   - static: in-memory read-only objects (participants, bundled templates)
   - Virtual sources: date, bundledObjectType, bundledRelation, anytypeProfile, missingObject
 - Binds object IDs to space IDs in object store
-- DONTs: does NOT manage object lifecycle beyond source creation
 */
 
 import (

--- a/core/configfetcher/configfetcher.go
+++ b/core/configfetcher/configfetcher.go
@@ -1,5 +1,21 @@
 package configfetcher
 
+/*
+AI generated
+
+Name: Account Status Poller
+Scope: global
+
+## Responsibility
+- Periodically polls coordinator for tech space status (deletion state)
+- Broadcasts account status changes to client via events
+- Auto-registers tech space with coordinator if not exists
+- DONTs: Does NOT handle per-space status (see deletioncontroller)
+
+## Background Tasks
+- statusPoller: Fetches account status from coordinator every 300s (updateStatus)
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/configfetcher/configfetcher.go
+++ b/core/configfetcher/configfetcher.go
@@ -10,7 +10,6 @@ Scope: global
 - Periodically polls coordinator for tech space status (deletion state)
 - Broadcasts account status changes to client via events
 - Auto-registers tech space with coordinator if not exists
-- DONTs: Does NOT handle per-space status (see deletioncontroller)
 
 ## Background Tasks
 - statusPoller: Fetches account status from coordinator every 300s (updateStatus)

--- a/core/debug/service.go
+++ b/core/debug/service.go
@@ -13,7 +13,6 @@ Scope: global
 - Aggregate debug statistics from stat service
 - Network connectivity diagnostics (yamux/quic probe to coordinators)
 - Debug anystore object changes with order validation
-- DONTs: actual object manipulation, space lifecycle management
 
 ## Background Tasks
 - Debug HTTP server: serves debug endpoints for components implementing Debuggable interface (Run)

--- a/core/debug/service.go
+++ b/core/debug/service.go
@@ -1,5 +1,25 @@
 package debug
 
+/*
+AI generated
+
+Name: Debug and Diagnostics Service
+Scope: global
+
+## Responsibility
+- Export object trees to zip files with optional anonymization and SVG visualization
+- Dump localstore data for debugging
+- Provide space summaries (tree heads for all objects in a space)
+- Aggregate debug statistics from stat service
+- Network connectivity diagnostics (yamux/quic probe to coordinators)
+- Debug anystore object changes with order validation
+- DONTs: actual object manipulation, space lifecycle management
+
+## Background Tasks
+- Debug HTTP server: serves debug endpoints for components implementing Debuggable interface (Run)
+  - Only enabled when built with `anydebug` tag and ANYDEBUG env var is set
+*/
+
 import (
 	"archive/zip"
 	"context"

--- a/core/device/networkstate.go
+++ b/core/device/networkstate.go
@@ -1,5 +1,18 @@
 package device
 
+/*
+AI generated
+
+Name: Device Network and Foreground State Tracker
+Scope: global
+
+## Responsibility
+- Tracks current network type (WiFi/Cellular/NotConnected) set by client
+- Tracks app foreground/background state transitions
+- Notifies registered hooks when network type changes
+- On foreground resume: flushes connection pool if backgrounded >10s, refreshes opened objects
+*/
+
 import (
 	"context"
 	"sync"

--- a/core/durability/durability.go
+++ b/core/durability/durability.go
@@ -1,5 +1,23 @@
 package durability
 
+/*
+AI generated
+
+Name: Database Flush Coordinator
+Scope: global
+
+## Responsibility
+- Triggers database WAL flushes on app state changes (background/closing)
+- DONTs: Does not manage databases directly, only coordinates flush timing
+
+## Documentation
+StateChange behavior by state:
+- AppClosingInitiated: Best-effort flush (3s timeout, no wait) - DB component does final flush later
+- AppWentBackground: Blocking flush (10s timeout, wait for completion) - ensures data safety before suspend/hibernate
+
+Flush order: space stores first (can be reindexed), then anystore (critical data)
+*/
+
 import (
 	"time"
 

--- a/core/durability/durability.go
+++ b/core/durability/durability.go
@@ -8,14 +8,13 @@ Scope: global
 
 ## Responsibility
 - Triggers database WAL flushes on app state changes (background/closing)
-- DONTs: Does not manage databases directly, only coordinates flush timing
 
 ## Documentation
 StateChange behavior by state:
 - AppClosingInitiated: Best-effort flush (3s timeout, no wait) - DB component does final flush later
 - AppWentBackground: Blocking flush (10s timeout, wait for completion) - ensures data safety before suspend/hibernate
 
-Flush order: space stores first (can be reindexed), then anystore (critical data)
+Flush order: space stores first (critical data), then objectstore (can be reindexed)
 */
 
 import (

--- a/core/event/event.go
+++ b/core/event/event.go
@@ -1,5 +1,20 @@
 package event
 
+/*
+AI generated
+
+Name: Client Event Broadcaster
+Scope: global
+
+## Responsibility
+- Broadcast pb.Event messages to connected client sessions
+- Track active sessions and route events (to one, all, or filtered sessions)
+- DONTs: event construction logic (callers build events), persistence
+
+## Background Tasks
+- Session cleanup: handles session disconnection via shutdown channel (GrpcSender only)
+*/
+
 import (
 	"github.com/anyproto/any-sync/app"
 

--- a/core/event/event.go
+++ b/core/event/event.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Broadcast pb.Event messages to connected client sessions
 - Track active sessions and route events (to one, all, or filtered sessions)
-- DONTs: event construction logic (callers build events), persistence
 
 ## Background Tasks
 - Session cleanup: handles session disconnection via shutdown channel (GrpcSender only)

--- a/core/files/fileacl/service.go
+++ b/core/files/fileacl/service.go
@@ -1,5 +1,17 @@
 package fileacl
 
+/*
+AI generated
+
+Name: File Encryption Keys for Sharing
+Scope: global
+
+## Responsibility
+- Retrieve file CID and encryption keys to include in invites/identity profiles
+- Store received encryption keys from invites to enable decryption of shared files
+- DONTs: file storage, file download, ACL management
+*/
+
 import (
 	"fmt"
 	"sort"

--- a/core/files/fileacl/service.go
+++ b/core/files/fileacl/service.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Retrieve file CID and encryption keys to include in invites/identity profiles
 - Store received encryption keys from invites to enable decryption of shared files
-- DONTs: file storage, file download, ACL management
 */
 
 import (

--- a/core/files/filedownloader/service.go
+++ b/core/files/filedownloader/service.go
@@ -1,5 +1,27 @@
 package filedownloader
 
+/*
+AI generated
+
+Name: File Auto-Download Manager
+Scope: global
+
+## Responsibility
+- Auto-downloads files to local store based on criteria: not available offline, synced, <20MB
+- Provides on-demand partial file caching (CacheFile) with block limits
+- Respects network state for wifi-only download mode
+- DONTs: file upload, sync status tracking, file content manipulation
+
+## Background Tasks
+- downloader (5 workers): subscribes to eligible files across spaces, downloads full content (runManager, runDownloadWorker)
+- cacheWarmer (5 workers): processes on-demand cache requests with limited blocks (run, runWorker)
+
+## Documentation
+Two download subsystems:
+- downloader: subscribes to files matching auto-download criteria, downloads entire file, marks FileAvailableOffline
+- cacheWarmer: accepts individual file requests via CacheFile, downloads limited blocks (10) with timeout (2min)
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/files/filedownloader/service.go
+++ b/core/files/filedownloader/service.go
@@ -10,7 +10,6 @@ Scope: global
 - Auto-downloads files to local store based on criteria: not available offline, synced, <20MB
 - Provides on-demand partial file caching (CacheFile) with block limits
 - Respects network state for wifi-only download mode
-- DONTs: file upload, sync status tracking, file content manipulation
 
 ## Background Tasks
 - downloader (5 workers): subscribes to eligible files across spaces, downloads full content (runManager, runDownloadWorker)

--- a/core/files/fileobject/service.go
+++ b/core/files/fileobject/service.go
@@ -12,7 +12,6 @@ Scope: global
 - Migrate legacy file IDs to file object IDs in blocks and details
 - Manage file sync queue integration for upload/download
 - Delete file data when object is removed (if no other objects reference it)
-- DONTs: file storage/retrieval (files.Service), sync protocol (filesync.FileSync)
 
 ## Background Tasks
 - runIndexingProvider: Polls objectStore every 60s for non-indexed files, adds to queue

--- a/core/files/fileobject/service.go
+++ b/core/files/fileobject/service.go
@@ -1,5 +1,42 @@
 package fileobject
 
+/*
+AI generated
+
+Name: File Object Lifecycle Manager
+Scope: global
+
+## Responsibility
+- Create file objects from raw IPFS file data with encryption keys
+- Index file metadata (mime type, dimensions, etc.) into object details
+- Migrate legacy file IDs to file object IDs in blocks and details
+- Manage file sync queue integration for upload/download
+- Delete file data when object is removed (if no other objects reference it)
+- DONTs: file storage/retrieval (files.Service), sync protocol (filesync.FileSync)
+
+## Background Tasks
+- runIndexingProvider: Polls objectStore every 60s for non-indexed files, adds to queue
+- runIndexingWorker: Processes index queue, extracts metadata from file variants
+- indexMigrationWorker: Migrates files without variant IDs by touching objects
+- migrationQueue: Persistent queue for migrating legacy files to file objects
+- Startup goroutine: Cleans migrated files in non-personal spaces, ensures sync queue
+
+## External State
+- queue/file_migration in common anystore DB (persistent migration queue)
+
+## Documentation
+Indexing Pipeline:
+1. File created with AsyncMetadataIndexing=true or legacy file detected
+2. runIndexingProvider adds to in-memory indexQueue (deduped by FullID)
+3. runIndexingWorker fetches file variants, extracts metadata, updates object state
+4. FileIndexingStatus set to Indexed when complete
+
+Migration Flow (legacy files):
+1. MigrateFiles called during object open with ChangeFileKeys
+2. Items added to persistent migrationQueue with derived object ID
+3. migrationQueueHandler creates file objects and adds to sync queue
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/files/fileoffloader/offloader.go
+++ b/core/files/fileoffloader/offloader.go
@@ -10,7 +10,6 @@ Scope: global
 - Removes locally cached file blocks (IPLD DAG nodes) to free disk space
 - Respects backup status: by default only offloads files already synced to remote
 - Prevents data loss by checking cross-space file references before offloading
-- DONTs: file syncing/uploading (filesync), block storage management (filestorage)
 */
 
 import (

--- a/core/files/fileoffloader/offloader.go
+++ b/core/files/fileoffloader/offloader.go
@@ -1,5 +1,18 @@
 package fileoffloader
 
+/*
+AI generated
+
+Name: Local File Block Offloader
+Scope: global
+
+## Responsibility
+- Removes locally cached file blocks (IPLD DAG nodes) to free disk space
+- Respects backup status: by default only offloads files already synced to remote
+- Prevents data loss by checking cross-space file references before offloading
+- DONTs: file syncing/uploading (filesync), block storage management (filestorage)
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/files/filespaceusage/service.go
+++ b/core/files/filespaceusage/service.go
@@ -1,5 +1,17 @@
 package filespaceusage
 
+/*
+AI generated
+
+Name: File Storage Usage Aggregator
+Scope: global
+
+## Responsibility
+- Aggregates file usage statistics from remote node and local storage
+- Provides per-space and node-wide usage queries
+- DONTs: does not track or persist usage data itself
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/files/filespaceusage/service.go
+++ b/core/files/filespaceusage/service.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Aggregates file usage statistics from remote node and local storage
 - Provides per-space and node-wide usage queries
-- DONTs: does not track or persist usage data itself
 */
 
 import (

--- a/core/files/filestorage/fileservice.go
+++ b/core/files/filestorage/fileservice.go
@@ -1,5 +1,28 @@
 package filestorage
 
+/*
+AI generated
+
+Name: Local File Block Storage
+Scope: global
+
+## Responsibility
+- Stores IPFS-compatible file blocks locally using flatfs sharding
+- Proxies reads: local first, then remote (with automatic local caching)
+- Provides transactional batch writes with temp directory staging
+- Exposes local garbage collector for cleaning orphaned blocks
+- Serves file blocks to peers via DRPC handler (read-only)
+- DONTs: remote uploads (handled by rpcstore), file metadata management
+
+## External State
+- flatfs/ directory: sharded IPFS block storage using IPFS_DEF_SHARD
+
+## Documentation
+Batching mechanism: Batch() creates a temp directory for writes. Reads check temp first,
+then main storage. Commit() atomically moves temp to main. Discard() cleans up temp.
+This ensures incomplete file uploads don't leave partial data in main storage.
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/files/filestorage/fileservice.go
+++ b/core/files/filestorage/fileservice.go
@@ -12,7 +12,6 @@ Scope: global
 - Provides transactional batch writes with temp directory staging
 - Exposes local garbage collector for cleaning orphaned blocks
 - Serves file blocks to peers via DRPC handler (read-only)
-- DONTs: remote uploads (handled by rpcstore), file metadata management
 
 ## External State
 - flatfs/ directory: sharded IPFS block storage using IPFS_DEF_SHARD

--- a/core/files/filestorage/rpcstore/service.go
+++ b/core/files/filestorage/rpcstore/service.go
@@ -10,7 +10,6 @@ Scope: global
 - Factory for creating RpcStore instances that communicate with file node peers
 - Manages peer observation for connectivity changes
 - Tracks aggregate traffic statistics (inbound/outbound bytes)
-- DONTs: actual RPC operations (delegated to RpcStore/client), local storage
 
 ## Background Tasks
 - checkPeerLoop: manages peer client lifecycle (connect/disconnect, TTL-based GC) [clientManager.checkPeerLoop]

--- a/core/files/filestorage/rpcstore/service.go
+++ b/core/files/filestorage/rpcstore/service.go
@@ -1,5 +1,28 @@
 package rpcstore
 
+/*
+AI generated
+
+Name: Remote File Block Store Factory
+Scope: global
+
+## Responsibility
+- Factory for creating RpcStore instances that communicate with file node peers
+- Manages peer observation for connectivity changes
+- Tracks aggregate traffic statistics (inbound/outbound bytes)
+- DONTs: actual RPC operations (delegated to RpcStore/client), local storage
+
+## Background Tasks
+- checkPeerLoop: manages peer client lifecycle (connect/disconnect, TTL-based GC) [clientManager.checkPeerLoop]
+- opLoop: per-client worker loops for read/write task execution [client.opLoop]
+
+## Documentation
+Task distribution: Operations are queued as tasks with read/write separation.
+Multiple client workers compete to pick tasks from a shared queue based on
+EWMA speed scores (faster clients get priority). Failed tasks are retried
+on alternative peers via denyPeerIds mechanism.
+*/
+
 import (
 	"fmt"
 	"io"

--- a/core/files/filesync/service.go
+++ b/core/files/filesync/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Delete files from the backup node
 - Track and enforce storage limits per space and per account
 - Provide node/space usage statistics
-- DONTs: local file storage, file indexing, file content processing
 
 ## Background Tasks
 - nodeUsageUpdater: periodically fetches account usage from backup node (10s active, 1min idle) [runNodeUsageUpdater]

--- a/core/files/filesync/service.go
+++ b/core/files/filesync/service.go
@@ -1,5 +1,45 @@
 package filesync
 
+/*
+AI generated
+
+Name: File Sync to Backup Node
+Scope: global
+
+## Responsibility
+- Upload files (IPLD DAG blocks) to the backup node (file node)
+- Delete files from the backup node
+- Track and enforce storage limits per space and per account
+- Provide node/space usage statistics
+- DONTs: local file storage, file indexing, file content processing
+
+## Background Tasks
+- nodeUsageUpdater: periodically fetches account usage from backup node (10s active, 1min idle) [runNodeUsageUpdater]
+- uploader (x10): processes pending uploads from queue [runUploader]
+- batchUploader (x10): sends batched block upload requests to backup node [runBatchUploader]
+- requestsBatcher: batches small files together, splits large files across requests [requestsBatcher.run]
+- limitedUploader: retries uploads when space becomes available [runLimitedUploader]
+- deleter: processes pending deletions from queue [runDeleter]
+- spaceUsage (per space): periodically updates per-space limits from backup node [spaceUsage.update]
+
+## External State
+- filesync/queue collection: persistent queue of file upload/delete operations
+
+## Documentation
+File states: PendingUpload -> Uploading -> Done (or Limited if quota exceeded)
+                          -> PendingDeletion -> Deleted
+
+Upload flow:
+1. AddFile enqueues file with PendingUpload state
+2. Uploader checks block availability on node (which blocks need upload vs bind)
+3. Allocates space in local limit tracker
+4. Walks DAG and batches blocks via requestsBatcher
+5. batchUploader sends BlockPushMany requests to node
+6. On completion, marks file as Done; on limit error, marks as Limited
+
+Limited files are retried when spaceUsageManager detects more free space available.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/files/fileuploader/uploader.go
+++ b/core/files/fileuploader/uploader.go
@@ -1,5 +1,31 @@
 package fileuploader
 
+/*
+AI generated
+
+Name: File Upload Orchestrator
+Scope: global
+
+## Responsibility
+- Creates Uploader instances for uploading files from various sources (bytes, URL, file path)
+- Detects file type via MIME sniffing with fallback to generic file type
+- Supports two-phase upload: preload to storage first, then commit/create object later
+- Manages preloaded upload results for deferred object creation
+- DONTs: file storage, object creation (delegates to fileService and fileObjectService)
+
+## Background Tasks
+- Preload: async file upload to storage without object creation (Preload method)
+- UploadAsync: async file upload with object creation (UploadAsync method)
+
+## Documentation
+Two-phase upload flow:
+1. Preload() - uploads file to storage, returns preloadId, does NOT commit or create object
+2. Upload() with SetPreloadId() - commits the preloaded batch and creates file object
+This allows uploading files speculatively and discarding if not needed (batch.Discard).
+
+Concurrency: uploadFilesLimiter channel limits parallel uploads to 8 goroutines.
+*/
+
 import (
 	"bufio"
 	"bytes"

--- a/core/files/fileuploader/uploader.go
+++ b/core/files/fileuploader/uploader.go
@@ -11,7 +11,6 @@ Scope: global
 - Detects file type via MIME sniffing with fallback to generic file type
 - Supports two-phase upload: preload to storage first, then commit/create object later
 - Manages preloaded upload results for deferred object creation
-- DONTs: file storage, object creation (delegates to fileService and fileObjectService)
 
 ## Background Tasks
 - Preload: async file upload to storage without object creation (Preload method)

--- a/core/history/history.go
+++ b/core/history/history.go
@@ -1,5 +1,24 @@
 package history
 
+/*
+AI generated
+
+Name: Object Version History
+Scope: global
+
+## Responsibility
+- Show object state at any historical version
+- List versions with pagination and 5-minute grouping
+- Diff changes between two versions (blocks, relations, details, dataview)
+- Reset object to a previous version
+- Track block-level authorship (which participant last modified each block)
+- DONTs: does not manage change storage (uses objecttree from space)
+
+## Documentation
+Version IDs: Normally a single change ID. For parallel editing (multiple heads),
+generates a blake3 hash of combined head IDs and caches the mapping for retrieval.
+*/
+
 import (
 	"context"
 	"encoding/hex"

--- a/core/history/history.go
+++ b/core/history/history.go
@@ -12,7 +12,6 @@ Scope: global
 - Diff changes between two versions (blocks, relations, details, dataview)
 - Reset object to a previous version
 - Track block-level authorship (which participant last modified each block)
-- DONTs: does not manage change storage (uses objecttree from space)
 
 ## Documentation
 Version IDs: Normally a single change ID. For parallel editing (multiple heads),

--- a/core/identity/identity.go
+++ b/core/identity/identity.go
@@ -11,7 +11,6 @@ Scope: global
 - Polls and caches profiles of other identities registered as observers
 - Resolves global names from naming service for all observed identities
 - Provides encryption keys for identity metadata (used for profile decryption)
-- DONTs: user authentication, identity creation/derivation
 
 ## Background Tasks
 - observeIdentitiesLoop: periodically fetches profiles for registered identities from remote repository

--- a/core/identity/identity.go
+++ b/core/identity/identity.go
@@ -1,5 +1,35 @@
 package identity
 
+/*
+AI generated
+
+Name: Identity Profile Registry
+Scope: global
+
+## Responsibility
+- Publishes own profile (name, description, icon, global name) to remote identity repository
+- Polls and caches profiles of other identities registered as observers
+- Resolves global names from naming service for all observed identities
+- Provides encryption keys for identity metadata (used for profile decryption)
+- DONTs: user authentication, identity creation/derivation
+
+## Background Tasks
+- observeIdentitiesLoop: periodically fetches profiles for registered identities from remote repository
+- ownProfileSubscription: subscribes to own account object changes, batches and pushes updates to remote
+
+## External State
+- identity_profile collection in commonDb: cached encrypted identity profiles
+- global_name collection in commonDb: cached global names
+
+## Documentation
+Own profile push uses batching: changes to profile details reset a timer, actual push happens
+after pushIdentityBatchTimeout to coalesce rapid updates.
+
+Observer pattern: spaces register identity observers with encryption keys. On profile updates,
+all registered observers for that identity receive callbacks. Observers are per-space to allow
+cleanup when a space is closed.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/inboxclient/inboxclient.go
+++ b/core/inboxclient/inboxclient.go
@@ -10,7 +10,6 @@ Scope: global
 - Fetches encrypted messages from coordinator inbox, verifies signatures, decrypts, and dispatches to registered handlers
 - Provides mechanism for other components to register handlers by payload type
 - Sends messages to other users' inboxes via coordinator
-- DONTs: business logic for specific message types (delegated to registered handlers)
 
 ## Background Tasks
 - Periodic message check: polls coordinator every 30s for new messages (checkMessages)

--- a/core/inboxclient/inboxclient.go
+++ b/core/inboxclient/inboxclient.go
@@ -1,5 +1,24 @@
 package inboxclient
 
+/*
+AI generated
+
+Name: Coordinator Inbox Message Receiver
+Scope: global
+
+## Responsibility
+- Fetches encrypted messages from coordinator inbox, verifies signatures, decrypts, and dispatches to registered handlers
+- Provides mechanism for other components to register handlers by payload type
+- Sends messages to other users' inboxes via coordinator
+- DONTs: business logic for specific message types (delegated to registered handlers)
+
+## Background Tasks
+- Periodic message check: polls coordinator every 30s for new messages (checkMessages)
+
+## External State
+- Inbox offset stored in account object via techspace (tracks last processed message ID)
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/inviteservice/inviteservice.go
+++ b/core/inviteservice/inviteservice.go
@@ -1,5 +1,26 @@
 package inviteservice
 
+/*
+AI generated
+
+Name: Space Invite Generator
+Scope: global
+
+## Responsibility
+- Generate, retrieve, view, and remove space invites
+- Build signed invite payloads with space/creator metadata and icon encryption keys
+- Support multiple invite types: member (default), guest, and without-approval
+- DONTs: invite storage (delegated to invitestore), ACL management
+
+## Documentation
+Invite lifecycle:
+1. Generate: build payload -> sign with account key -> store via invitestore -> persist info in workspace smartblock
+2. Remove: clear from workspace smartblock -> remove from invitestore
+3. View/GetPayload: fetch from invitestore -> verify signature -> optionally store icon encryption keys for rendering
+
+Guest invites are stored separately from regular invites and only work for Stream-type spaces.
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/inviteservice/inviteservice.go
+++ b/core/inviteservice/inviteservice.go
@@ -10,7 +10,6 @@ Scope: global
 - Generate, retrieve, view, and remove space invites
 - Build signed invite payloads with space/creator metadata and icon encryption keys
 - Support multiple invite types: member (default), guest, and without-approval
-- DONTs: invite storage (delegated to invitestore), ACL management
 
 ## Documentation
 Invite lifecycle:

--- a/core/invitestore/invitestore.go
+++ b/core/invitestore/invitestore.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Store, retrieve, and remove encrypted space invite payloads via IPFS
 - Encrypt invites with AES before upload, decrypt on retrieval
-- DONTs: invite validation, ACL management, invitation link generation
 */
 
 import (

--- a/core/invitestore/invitestore.go
+++ b/core/invitestore/invitestore.go
@@ -1,5 +1,17 @@
 package invitestore
 
+/*
+AI generated
+
+Name: Encrypted Space Invite Storage
+Scope: global
+
+## Responsibility
+- Store, retrieve, and remove encrypted space invite payloads via IPFS
+- Encrypt invites with AES before upload, decrypt on retrieval
+- DONTs: invite validation, ACL management, invitation link generation
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/nameservice/nameservice.go
+++ b/core/nameservice/nameservice.go
@@ -1,5 +1,18 @@
 package nameservice
 
+/*
+AI generated
+
+Name: Anyname Resolution API
+Scope: global
+
+## Responsibility
+- Provides RPC API for ".any" name resolution (name -> owner info, AnyId -> name)
+- Provides RPC API for user account status (names/operations quota, attached name)
+- Wraps nameserviceclient for application-level use
+- DONTs: name registration, blockchain operations (handled by naming node)
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/nameservice/nameservice.go
+++ b/core/nameservice/nameservice.go
@@ -10,7 +10,6 @@ Scope: global
 - Provides RPC API for ".any" name resolution (name -> owner info, AnyId -> name)
 - Provides RPC API for user account status (names/operations quota, attached name)
 - Wraps nameserviceclient for application-level use
-- DONTs: name registration, blockchain operations (handled by naming node)
 */
 
 import (

--- a/core/notifications/notifications.go
+++ b/core/notifications/notifications.go
@@ -1,5 +1,30 @@
 package notifications
 
+/*
+AI generated
+
+Name: Notification Storage and Delivery
+Scope: global
+
+## Responsibility
+- Stores notifications in local DB and syncs non-local ones to tech space notification object
+- Broadcasts notification events to clients via event sender
+- Provides notification listing with read/unread filtering
+- DONTs: notification type-specific logic (handled by callers like aclnotifications)
+
+## Background Tasks
+- loadNotificationObject: Loads/creates notification object in tech space and indexes existing notifications {loadNotificationObject}
+
+## External State
+- anystore "notifications" collection: local cache of all notifications
+- Tech space notification object: synced storage for non-local notifications
+
+## Documentation
+Local vs Non-local notifications:
+- Local (IsLocal=true): stored only in local DB, not synced across devices
+- Non-local: stored in both local DB and tech space notification object for cross-device sync
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/notifications/notifications.go
+++ b/core/notifications/notifications.go
@@ -10,7 +10,6 @@ Scope: global
 - Stores notifications in local DB and syncs non-local ones to tech space notification object
 - Broadcasts notification events to clients via event sender
 - Provides notification listing with read/unread filtering
-- DONTs: notification type-specific logic (handled by callers like aclnotifications)
 
 ## Background Tasks
 - loadNotificationObject: Loads/creates notification object in tech space and indexes existing notifications {loadNotificationObject}

--- a/core/onetoone/service.go
+++ b/core/onetoone/service.go
@@ -10,7 +10,6 @@ Scope: global
 - Sends one-to-one chat invites to other users via coordinator inbox
 - Processes received one-to-one invites by creating 1-1 spaces and initializing chats
 - Retries failed invite sends periodically
-- DONTs: general inbox message handling (delegated to inboxclient), space creation logic (delegated to blockService)
 
 ## Background Tasks
 - Periodic retry: checks for unsent invites (status=ToSend) and resends them every 30s (inboxResend)

--- a/core/onetoone/service.go
+++ b/core/onetoone/service.go
@@ -1,5 +1,27 @@
 package onetoone
 
+/*
+AI generated
+
+Name: One-to-One Invite Manager
+Scope: global
+
+## Responsibility
+- Sends one-to-one chat invites to other users via coordinator inbox
+- Processes received one-to-one invites by creating 1-1 spaces and initializing chats
+- Retries failed invite sends periodically
+- DONTs: general inbox message handling (delegated to inboxclient), space creation logic (delegated to blockService)
+
+## Background Tasks
+- Periodic retry: checks for unsent invites (status=ToSend) and resends them every 30s (inboxResend)
+
+## Documentation
+Invite status flow:
+- ToSend: initial state when 1-1 space created, invite not yet sent
+- Sent: invite successfully sent via inbox
+- Received: set when processing incoming invite from another user
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/order/order.go
+++ b/core/order/order.go
@@ -10,7 +10,6 @@ Scope: global
 - Assigns and updates lexicographic order IDs (lexids) to objects for sortable ordering
 - Handles space views, relation options, and object types ordering
 - Minimizes updates: only modifies objects whose order actually changes
-- DONTs: does not store order state itself; writes order IDs directly to objects
 
 ## Documentation
 Uses lexid library to generate sortable string IDs that allow insertion between existing items.

--- a/core/order/order.go
+++ b/core/order/order.go
@@ -1,5 +1,25 @@
 package order
 
+/*
+AI generated
+
+Name: Lexicographic Object Order Manager
+Scope: global
+
+## Responsibility
+- Assigns and updates lexicographic order IDs (lexids) to objects for sortable ordering
+- Handles space views, relation options, and object types ordering
+- Minimizes updates: only modifies objects whose order actually changes
+- DONTs: does not store order state itself; writes order IDs directly to objects
+
+## Documentation
+Uses lexid library to generate sortable string IDs that allow insertion between existing items.
+When reordering, calculates new lexids only for items that need to move. If inserting between
+two items exhausts the lexid space (cannot generate ID between them), falls back to rebuilding
+all lexids from scratch. Supports partial list reordering: client can send a subset of items,
+and component calculates the full reorder by diffing against the original order.
+*/
+
 import (
 	"errors"
 	"fmt"

--- a/core/payments/cache/cache.go
+++ b/core/payments/cache/cache.go
@@ -1,5 +1,21 @@
 package cache
 
+/*
+AI generated
+
+Name: Membership Data Cache
+Scope: global
+
+## Responsibility
+- Caches membership status and tier data to reduce network calls to payment node
+- Supports V1 (membership/tiers) and V2 (membership/products) data formats
+- Calculates expiration based on membership tier (Explorer=24h, others=10min)
+- DONTs: no network calls, no payment logic - only persistence
+
+## External State
+- System collection: PaymentCacheKey (V1), PaymentCacheV2Key (V2) - versioned to auto-invalidate on format change
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/payments/cache/cache.go
+++ b/core/payments/cache/cache.go
@@ -10,7 +10,6 @@ Scope: global
 - Caches membership status and tier data to reduce network calls to payment node
 - Supports V1 (membership/tiers) and V2 (membership/products) data formats
 - Calculates expiration based on membership tier (Explorer=24h, others=10min)
-- DONTs: no network calls, no payment logic - only persistence
 
 ## External State
 - System collection: PaymentCacheKey (V1), PaymentCacheV2Key (V2) - versioned to auto-invalidate on format change

--- a/core/payments/emailcollector/emailcollector.go
+++ b/core/payments/emailcollector/emailcollector.go
@@ -1,5 +1,28 @@
 package emailcollector
 
+/*
+AI generated
+
+Name: Offline Email Verification Queue
+Scope: global
+
+## Responsibility
+- Persists email verification requests for offline support
+- Retries sending to payment service when online
+- Signs requests with account private key
+- DONTs: email validation, membership management
+
+## Background Tasks
+- periodicUpdateEmail: sends pending email to payment service (60s interval)
+
+## External State
+- Key-value store: "payments/emailcollector/email" in common DB
+
+## Documentation
+Only runs on default network mode (skips custom networks and local-only).
+Queue flow: SetRequest persists -> periodic task sends -> clears on success.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/payments/emailcollector/emailcollector.go
+++ b/core/payments/emailcollector/emailcollector.go
@@ -10,7 +10,6 @@ Scope: global
 - Persists email verification requests for offline support
 - Retries sending to payment service when online
 - Signs requests with account private key
-- DONTs: email validation, membership management
 
 ## Background Tasks
 - periodicUpdateEmail: sends pending email to payment service (60s interval)

--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -1,5 +1,27 @@
 package payments
 
+/*
+AI generated
+
+Name: Membership and Payment Service
+Scope: global
+
+## Responsibility
+- Proxies membership/subscription API calls to payment node (V1 and V2 protocols)
+- Caches membership status and tiers locally, broadcasts changes via events
+- Validates and registers any-names through name service
+- Triggers limits updates (file sync, multiplayer) when membership changes
+- DONTs: payment processing, cache persistence (delegated to cache subpackage), email queue (delegated to emailcollector)
+
+## Background Tasks
+- refreshController: polls payment node for membership/tiers changes (60s interval, 10s when forced)
+
+## Documentation
+Cache invalidation: "force refresh" mode triggers aggressive polling for 30 minutes after
+user-initiated payment actions (pay button, manage subscription, finalize, redeem code).
+V1 vs V2: controlled by EnableMembershipV2 config flag set during AccountSelect/AccountCreate.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/payments/payments.go
+++ b/core/payments/payments.go
@@ -11,7 +11,6 @@ Scope: global
 - Caches membership status and tiers locally, broadcasts changes via events
 - Validates and registers any-names through name service
 - Triggers limits updates (file sync, multiplayer) when membership changes
-- DONTs: payment processing, cache persistence (delegated to cache subpackage), email queue (delegated to emailcollector)
 
 ## Background Tasks
 - refreshController: polls payment node for membership/tiers changes (60s interval, 10s when forced)

--- a/core/peerstatus/status.go
+++ b/core/peerstatus/status.go
@@ -1,5 +1,31 @@
 package peerstatus
 
+/*
+AI generated
+
+Name: P2P Connection Status Monitor
+Scope: global
+
+## Responsibility
+- Tracks and broadcasts P2P connection status per registered space
+- Reacts to local peer discovery possibility changes (no interfaces, restricted, possible)
+- Counts active local peer connections per space via peerstore
+- DONTs: does NOT manage actual peer connections, only observes and reports status
+
+## Background Tasks
+- worker: processes space status refresh requests from channel, updates and broadcasts status changes
+
+## Documentation
+Status transitions per space:
+- Unknown -> Connected/NotConnected/NotPossible/Restricted (on first registration)
+- Any -> Connected (when local peers found for space)
+- Any -> NotConnected (when no peers and discovery possible)
+- Any -> NotPossible (when no network interfaces available)
+- Any -> Restricted (when local network access restricted, iOS-specific)
+
+Events broadcast on status change; new sessions receive current status immediately via session hook.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/peerstatus/status.go
+++ b/core/peerstatus/status.go
@@ -10,7 +10,6 @@ Scope: global
 - Tracks and broadcasts P2P connection status per registered space
 - Reacts to local peer discovery possibility changes (no interfaces, restricted, possible)
 - Counts active local peer connections per space via peerstore
-- DONTs: does NOT manage actual peer connections, only observes and reports status
 
 ## Background Tasks
 - worker: processes space status refresh requests from channel, updates and broadcasts status changes

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -12,7 +12,6 @@ Scope: global
 - Enforces size limits (different for membership vs default users)
 - Filters exported relations per object type via whitelist (relationswhitelist.go)
 - Optionally embeds space invite link when joinSpace=true (non-personal spaces only)
-- DONTs: does not persist publish state locally (server is source of truth)
 */
 
 import (

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -1,5 +1,20 @@
 package publish
 
+/*
+AI generated
+
+Name: Web Publishing Service
+Scope: global
+
+## Responsibility
+- Publishes objects to remote publish server for public web access
+- Exports object with nested objects as protobuf, converts to JSON, creates gzipped uber-snapshot (index.json.gz)
+- Enforces size limits (different for membership vs default users)
+- Filters exported relations per object type via whitelist (relationswhitelist.go)
+- Optionally embeds space invite link when joinSpace=true (non-personal spaces only)
+- DONTs: does not persist publish state locally (server is source of truth)
+*/
+
 import (
 	"compress/gzip"
 	"context"

--- a/core/pushnotification/pushclient/client.go
+++ b/core/pushnotification/pushclient/client.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Wraps DRPC calls to external Anytype push notification server
 - Manages connection pooling to push server peer
-- DONTs: business logic for when/what to notify (see pushnotification.Service)
 */
 
 import (

--- a/core/pushnotification/pushclient/client.go
+++ b/core/pushnotification/pushclient/client.go
@@ -1,5 +1,17 @@
 package pushclient
 
+/*
+AI generated
+
+Name: Push Server RPC Client
+Scope: global
+
+## Responsibility
+- Wraps DRPC calls to external Anytype push notification server
+- Manages connection pooling to push server peer
+- DONTs: business logic for when/what to notify (see pushnotification.Service)
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/pushnotification/service.go
+++ b/core/pushnotification/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Sends encrypted push notifications via queued delivery with retry
 - Monitors space views and chats to determine subscription topics
 - Registers/revokes device tokens with push server
-- DONTs: direct push server communication (see pushclient.Client)
 
 ## Background Tasks
 - subscriptionSync: registers tokens, syncs topic subscriptions every 5 min or on changes (run)

--- a/core/pushnotification/service.go
+++ b/core/pushnotification/service.go
@@ -1,5 +1,32 @@
 package pushnotification
 
+/*
+AI generated
+
+Name: Push Notification Topic Sync
+Scope: global
+
+## Responsibility
+- Syncs push notification topic subscriptions with remote push server
+- Sends encrypted push notifications via queued delivery with retry
+- Monitors space views and chats to determine subscription topics
+- Registers/revokes device tokens with push server
+- DONTs: direct push server communication (see pushclient.Client)
+
+## Background Tasks
+- subscriptionSync: registers tokens, syncs topic subscriptions every 5 min or on changes (run)
+- notificationSender: dequeues and sends notifications with retry (sendNotificationsLoop)
+- chatMonitor: tracks chat additions/removals across spaces (monitorChatIds)
+
+## Documentation
+Topic subscription flow:
+1. Load existing subscriptions from remote server
+2. Subscribe to spaceView objects to track notification settings per space
+3. Subscribe to chat objects cross-space to track chat IDs
+4. On any change (or every 5 min): rebuild local topic list from space settings
+5. If local differs from remote: create missing spaces, then sync all subscriptions
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/session/service.go
+++ b/core/session/service.go
@@ -1,5 +1,24 @@
 package session
 
+/*
+AI generated
+
+Name: Local API Session Manager
+Scope: global
+
+## Responsibility
+- JWT token-based session management with scoped permissions
+- Challenge-response authentication for external API clients (4-digit numeric codes)
+- Session context for request/response event correlation
+- DONTs: network sessions, user authentication (only local API auth)
+
+## Documentation
+Challenge flow: StartNewChallenge generates 4-digit code displayed to user ->
+client calls SolveChallenge with code -> on success, creates session with requested scope.
+Limited to 5 tries per challenge, 50 concurrent challenges globally.
+Full scope (AccountAuth_Full) not available via challenge - only Limited and JsonAPI.
+*/
+
 import (
 	"fmt"
 	"math/rand"

--- a/core/session/service.go
+++ b/core/session/service.go
@@ -10,7 +10,6 @@ Scope: global
 - JWT token-based session management with scoped permissions
 - Challenge-response authentication for external API clients (4-digit numeric codes)
 - Session context for request/response event correlation
-- DONTs: network sessions, user authentication (only local API auth)
 
 ## Documentation
 Challenge flow: StartNewChallenge generates 4-digit code displayed to user ->

--- a/core/subscription/crossspacesub/service.go
+++ b/core/subscription/crossspacesub/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Monitors space views to dynamically include/exclude spaces from cross-space subscriptions
 - Supports predicates to filter spaces based on space view details (creator, status, etc.)
 - Re-maps per-space subscription events to unified cross-space subscription ID
-- DONTs: single-space subscriptions (use core/subscription.Service directly)
 
 ## Background Tasks
 - monitorSpaceViewSub: Watches space view changes to add/remove spaces from active subscriptions (monitorSpaceViewSub)

--- a/core/subscription/crossspacesub/service.go
+++ b/core/subscription/crossspacesub/service.go
@@ -1,5 +1,28 @@
 package crossspacesub
 
+/*
+AI generated
+
+Name: Cross-Space Object Subscription Aggregator
+Scope: global
+
+## Responsibility
+- Aggregates object subscriptions across multiple spaces into a single unified subscription
+- Monitors space views to dynamically include/exclude spaces from cross-space subscriptions
+- Supports predicates to filter spaces based on space view details (creator, status, etc.)
+- Re-maps per-space subscription events to unified cross-space subscription ID
+- DONTs: single-space subscriptions (use core/subscription.Service directly)
+
+## Background Tasks
+- monitorSpaceViewSub: Watches space view changes to add/remove spaces from active subscriptions (monitorSpaceViewSub)
+- crossSpaceSubscription.run: Processes per-space events, aggregates counters, broadcasts unified events (run)
+
+## Documentation
+On Run, subscribes to all space views in tech space. When Subscribe is called, creates per-space
+subscriptions for spaces matching the predicate. Space view changes trigger dynamic add/remove of
+spaces from active subscriptions, with events re-mapped to the unified subscription ID.
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -1,5 +1,28 @@
 package subscription
 
+/*
+AI generated
+
+Name: Object Query Subscription Manager
+Scope: global
+
+## Responsibility
+- Maintains live subscriptions to object queries with filtering, sorting, and pagination
+- Sends incremental updates (add/remove/change/position) when subscribed objects change
+- Manages dependent object subscriptions for relation links (object/tag/status fields)
+- Supports subscription types: sorted (query-based), ids (explicit list), collection, group (kanban)
+- DONTs: does not store objects persistently; relies on objectStore for data
+
+## Background Tasks
+- recordsHandler: batches object changes from objectStore and dispatches to subscriptions (spaceSubscriptions.recordsHandler)
+- collectionObserver: listens for collection membership changes and triggers re-evaluation (collectionObserver goroutine)
+
+## Documentation
+Change batching: object changes are collected for 250ms before processing to reduce event spam.
+Each subscription maintains a skip-list for sorted results with pagination cursors (afterId/beforeId).
+Dependent subscriptions track objects referenced by relation fields and auto-update when parent results change.
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Sends incremental updates (add/remove/change/position) when subscribed objects change
 - Manages dependent object subscriptions for relation links (object/tag/status fields)
 - Supports subscription types: sorted (query-based), ids (explicit list), collection, group (kanban)
-- DONTs: does not store objects persistently; relies on objectStore for data
 
 ## Background Tasks
 - recordsHandler: batches object changes from objectStore and dispatches to subscriptions (spaceSubscriptions.recordsHandler)

--- a/core/syncstatus/detailsupdater/updater.go
+++ b/core/syncstatus/detailsupdater/updater.go
@@ -1,5 +1,30 @@
 package detailsupdater
 
+/*
+AI generated
+
+Name: Object Sync Status Details Writer
+Scope: global
+
+## Responsibility
+- Writes sync status (SyncStatus, SyncError, SyncDate) to object details
+- Batches status updates with 500ms intervals to avoid excessive writes
+- Reconciles local sync state with subscription state (UpdateSpaceDetails)
+- Combines file backup status with object sync status for file objects
+- DONTs: does NOT determine sync status - receives it from objectsyncstatus component
+
+## Background Tasks
+- processEvents: processes batched sync status updates from queue
+
+## Documentation
+Update flow:
+1. objectsyncstatus calls UpdateDetails with new status
+2. Status queued in batcher (deduped by objectId, latest status wins)
+3. processEvents drains queue every 500ms
+4. For each object: tries direct store update, falls back to smartblock.Apply if object is in cache
+5. After each update: triggers SpaceStatusUpdater.Refresh to recalculate space-level status
+*/
+
 import (
 	"context"
 	"errors"

--- a/core/syncstatus/detailsupdater/updater.go
+++ b/core/syncstatus/detailsupdater/updater.go
@@ -11,7 +11,6 @@ Scope: global
 - Batches status updates with 500ms intervals to avoid excessive writes
 - Reconciles local sync state with subscription state (UpdateSpaceDetails)
 - Combines file backup status with object sync status for file objects
-- DONTs: does NOT determine sync status - receives it from objectsyncstatus component
 
 ## Background Tasks
 - processEvents: processes batched sync status updates from queue

--- a/core/syncstatus/nodestatus/status.go
+++ b/core/syncstatus/nodestatus/status.go
@@ -1,5 +1,18 @@
 package nodestatus
 
+/*
+AI generated
+
+Name: Per-Space Node Connection Status Store
+Scope: global
+
+## Responsibility
+- Thread-safe storage for node connection status per space
+- Written by PeerManager when fetching responsible peers
+- Read by SpaceSyncStatus to determine overall sync state
+- DONTs: actual connection management (done by PeerManager)
+*/
+
 import (
 	"sync"
 

--- a/core/syncstatus/nodestatus/status.go
+++ b/core/syncstatus/nodestatus/status.go
@@ -10,7 +10,6 @@ Scope: global
 - Thread-safe storage for node connection status per space
 - Written by PeerManager when fetching responsible peers
 - Read by SpaceSyncStatus to determine overall sync state
-- DONTs: actual connection management (done by PeerManager)
 */
 
 import (

--- a/core/syncstatus/service.go
+++ b/core/syncstatus/service.go
@@ -1,5 +1,16 @@
 package syncstatus
 
+/*
+AI generated
+
+Name: File Sync Status Indexer
+Scope: global
+
+## Responsibility
+- Listen to file sync status changes and update FileBackupStatus detail on file objects
+- DONTs: file sync operations, space sync status, object sync status (handled by sibling packages)
+*/
+
 import (
 	"context"
 	"fmt"

--- a/core/syncstatus/service.go
+++ b/core/syncstatus/service.go
@@ -8,7 +8,6 @@ Scope: global
 
 ## Responsibility
 - Listen to file sync status changes and update FileBackupStatus detail on file objects
-- DONTs: file sync operations, space sync status, object sync status (handled by sibling packages)
 */
 
 import (

--- a/core/syncstatus/spacesyncstatus/spacestatus.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus.go
@@ -10,7 +10,6 @@ Scope: global
 - Aggregates sync state from multiple sources (node status, storage usage, sync subscriptions)
 - Computes overall space sync status and broadcasts EventSpaceSyncStatusUpdate to clients
 - Deduplicates identical events before broadcasting
-- DONTs: object-level sync tracking (done by detailsupdater), connection management (done by PeerManager)
 
 ## Background Tasks
 - periodicCall: processes queued Refresh requests every 1s (update)

--- a/core/syncstatus/spacesyncstatus/spacestatus.go
+++ b/core/syncstatus/spacesyncstatus/spacestatus.go
@@ -1,5 +1,30 @@
 package spacesyncstatus
 
+/*
+AI generated
+
+Name: Space Sync Status Event Broadcaster
+Scope: global
+
+## Responsibility
+- Aggregates sync state from multiple sources (node status, storage usage, sync subscriptions)
+- Computes overall space sync status and broadcasts EventSpaceSyncStatusUpdate to clients
+- Deduplicates identical events before broadcasting
+- DONTs: object-level sync tracking (done by detailsupdater), connection management (done by PeerManager)
+
+## Background Tasks
+- periodicCall: processes queued Refresh requests every 1s (update)
+
+## Documentation
+Status computation priority (highest wins):
+1. IncompatibleVersion - network protocol incompatible
+2. NetworkNeedsUpdate - network needs update
+3. ConnectionError -> Offline
+4. StorageLimitExceed (< 10% storage left)
+5. Syncing (objects pending sync)
+6. Synced (default)
+*/
+
 import (
 	"context"
 	"sync"

--- a/core/syncstatus/syncsubscriptions/syncsubscriptions.go
+++ b/core/syncstatus/syncsubscriptions/syncsubscriptions.go
@@ -10,7 +10,6 @@ Scope: global
 - Manages per-space subscriptions that track objects with pending sync (syncing/queued/error status)
 - Tracks limited files (files that hit backup limits) and uploading files per space
 - Creates subscriptions lazily on first access per space
-- DONTs: actual sync logic, file upload logic
 */
 
 import (

--- a/core/syncstatus/syncsubscriptions/syncsubscriptions.go
+++ b/core/syncstatus/syncsubscriptions/syncsubscriptions.go
@@ -1,5 +1,18 @@
 package syncsubscriptions
 
+/*
+AI generated
+
+Name: Sync Status Subscriptions Manager
+Scope: global
+
+## Responsibility
+- Manages per-space subscriptions that track objects with pending sync (syncing/queued/error status)
+- Tracks limited files (files that hit backup limits) and uploading files per space
+- Creates subscriptions lazily on first access per space
+- DONTs: actual sync logic, file upload logic
+*/
+
 import (
 	"context"
 	"sync"

--- a/pkg/lib/datastore/anystoreprovider/provider.go
+++ b/pkg/lib/datastore/anystoreprovider/provider.go
@@ -10,7 +10,6 @@ Scope: global
 - Provides common anystore database shared across all spaces
 - Provides per-space index and CRDT databases with lazy initialization
 - Auto-reinitializes corrupted databases by removing and recreating files
-- DONTs: does not manage database schema or migrations
 
 ## External State
 - objectstore/objects.db - common database with system collection

--- a/pkg/lib/datastore/anystoreprovider/provider.go
+++ b/pkg/lib/datastore/anystoreprovider/provider.go
@@ -1,5 +1,23 @@
 package anystoreprovider
 
+/*
+AI generated
+
+Name: Anystore Database Provider
+Scope: global
+
+## Responsibility
+- Provides common anystore database shared across all spaces
+- Provides per-space index and CRDT databases with lazy initialization
+- Auto-reinitializes corrupted databases by removing and recreating files
+- DONTs: does not manage database schema or migrations
+
+## External State
+- objectstore/objects.db - common database with system collection
+- objectstore/{spaceId}/objects.db - per-space index databases
+- objectstore/{spaceId}/crdt.db - per-space CRDT databases
+*/
+
 import (
 	"context"
 	"errors"

--- a/pkg/lib/datastore/datastore.go
+++ b/pkg/lib/datastore/datastore.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Defines interface for BadgerDB-backed space storage provider
 - Provides in-memory implementation for testing
-- DONTs: actual storage management (see clientds subpackage)
 
 ## External State
 - spacestore/ (BadgerDB, when using clientds implementation)

--- a/pkg/lib/datastore/datastore.go
+++ b/pkg/lib/datastore/datastore.go
@@ -1,5 +1,20 @@
 package datastore
 
+/*
+AI generated
+
+Name: Datastore Interface
+Scope: global
+
+## Responsibility
+- Defines interface for BadgerDB-backed space storage provider
+- Provides in-memory implementation for testing
+- DONTs: actual storage management (see clientds subpackage)
+
+## External State
+- spacestore/ (BadgerDB, when using clientds implementation)
+*/
+
 import (
 	"context"
 

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -14,7 +14,6 @@ Scope: global
 - Stores account status and indexer checksums
 - Manages virtual spaces registry
 - Maps object IDs to space IDs (spaceresolverstore)
-- DONTs: actual fulltext indexing (handled by ftsearch), object change detection (handled by indexer)
 
 ## External State
 - any-store collections in common db: fulltext_queue, indexerChecksums, virtualSpaces, file_keys, bindId

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -1,5 +1,32 @@
 package objectstore
 
+/*
+AI generated
+
+Name: Object Store and Fulltext Queue Manager
+Scope: global
+
+## Responsibility
+- Manages per-space indexes (spaceindex.Store) for object details and links
+- Provides cross-space queries aggregating data from all space indexes
+- Manages fulltext indexing queue (add, list, mark indexed, reconcile consistency)
+- Stores file encryption keys
+- Stores account status and indexer checksums
+- Manages virtual spaces registry
+- Maps object IDs to space IDs (spaceresolverstore)
+- DONTs: actual fulltext indexing (handled by ftsearch), object change detection (handled by indexer)
+
+## External State
+- any-store collections in common db: fulltext_queue, indexerChecksums, virtualSpaces, file_keys, bindId
+- Per-space databases via spaceindex (objects, links, headsState, activeViews, pendingDetails collections)
+
+## Documentation
+Fulltext queue flow:
+1. Objects added to queue via AddToIndexQueue with seq=0
+2. BatchProcessFullTextQueue processes items: lists pending, calls processor, marks as indexed with ftIndexSeq
+3. On startup, FtQueueReconcileWithSeq checks consistency: resets seq to 0 for items with seq > ftIndexSeq, deletes already-indexed items
+*/
+
 import (
 	"context"
 	"errors"

--- a/space/clientspace/keyvalueservice/service.go
+++ b/space/clientspace/keyvalueservice/service.go
@@ -9,7 +9,6 @@ Scope: space
 ## Responsibility
 - Provides privacy layer over per-space key-value storage by hashing keys
 - Manages subscriptions for key change notifications
-- DONTs: Does not manage underlying storage or handle sync
 
 ## Documentation
 Key Privacy Scheme:

--- a/space/clientspace/keyvalueservice/service.go
+++ b/space/clientspace/keyvalueservice/service.go
@@ -1,5 +1,24 @@
 package keyvalueservice
 
+/*
+AI generated
+
+Name: Private Key-Value Store Wrapper
+Scope: space
+
+## Responsibility
+- Provides privacy layer over per-space key-value storage by hashing keys
+- Manages subscriptions for key change notifications
+- DONTs: Does not manage underlying storage or handle sync
+
+## Documentation
+Key Privacy Scheme:
+1. Salt is derived from the first ACL record's read key (lazy-initialized)
+2. Client keys are hashed as: SHA256(salt + key) -> derived key
+3. Original key is stored inside encrypted value: derived_key -> (original_key, value)
+4. Max key length: 65535 bytes
+*/
+
 import (
 	"context"
 	"crypto/sha256"

--- a/space/coordinatorclient/coordinatorclient.go
+++ b/space/coordinatorclient/coordinatorclient.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Wraps any-sync CoordinatorClient with rate limiting for SpaceSign (concurrency=1)
 - Triggers DeletionController status update after successful SpaceSign calls
-- DONTs: Does not implement coordinator logic - delegates to embedded any-sync client
 */
 
 import (

--- a/space/coordinatorclient/coordinatorclient.go
+++ b/space/coordinatorclient/coordinatorclient.go
@@ -1,5 +1,17 @@
 package coordinatorclient
 
+/*
+AI generated
+
+Name: Coordinator Client Wrapper
+Scope: global
+
+## Responsibility
+- Wraps any-sync CoordinatorClient with rate limiting for SpaceSign (concurrency=1)
+- Triggers DeletionController status update after successful SpaceSign calls
+- DONTs: Does not implement coordinator logic - delegates to embedded any-sync client
+*/
+
 import (
 	"context"
 

--- a/space/deletioncontroller/deletioncontroller.go
+++ b/space/deletioncontroller/deletioncontroller.go
@@ -1,5 +1,21 @@
 package deletioncontroller
 
+/*
+AI generated
+
+Name: Space Remote Status Sync and Deletion
+Scope: global
+
+## Responsibility
+- Periodically fetches space statuses from coordinator and updates SpaceManager
+- Processes deletion of owned spaces marked via AddSpaceToDelete
+- Syncs shared space limits from coordinator
+- DONTs: local space state management (that's SpaceManager), actual space storage deletion (that's SpaceCore)
+
+## Background Tasks
+- updateLoop: polls coordinator every 180s, syncs statuses, deletes marked owned spaces (loopIterate)
+*/
+
 import (
 	"context"
 	"sync"

--- a/space/deletioncontroller/deletioncontroller.go
+++ b/space/deletioncontroller/deletioncontroller.go
@@ -10,7 +10,6 @@ Scope: global
 - Periodically fetches space statuses from coordinator and updates SpaceManager
 - Processes deletion of owned spaces marked via AddSpaceToDelete
 - Syncs shared space limits from coordinator
-- DONTs: local space state management (that's SpaceManager), actual space storage deletion (that's SpaceCore)
 
 ## Background Tasks
 - updateLoop: polls coordinator every 180s, syncs statuses, deletes marked owned spaces (loopIterate)

--- a/space/internal/components/aclnotifications/notifications.go
+++ b/space/internal/components/aclnotifications/notifications.go
@@ -1,5 +1,24 @@
 package aclnotifications
 
+/*
+AI generated
+
+Name: ACL Record to Notification Converter
+Scope: space
+
+## Responsibility
+- Converts ACL records into user notifications for space membership events
+- Routes notifications based on user role: owners receive join requests, members receive status changes
+- DONTs: does not modify ACL state, only reads and converts to notifications
+
+## Background Tasks
+- processRecords: consumes batched ACL records and sends corresponding notifications {processRecords}
+
+## Documentation
+Processing waits for NotificationService.LoadFinish (or 1 min timeout) before starting to avoid
+sending notifications for already-processed ACL records on startup.
+*/
+
 import (
 	"fmt"
 	"time"

--- a/space/internal/components/aclnotifications/notifications.go
+++ b/space/internal/components/aclnotifications/notifications.go
@@ -9,7 +9,6 @@ Scope: space
 ## Responsibility
 - Converts ACL records into user notifications for space membership events
 - Routes notifications based on user role: owners receive join requests, members receive status changes
-- DONTs: does not modify ACL state, only reads and converts to notifications
 
 ## Background Tasks
 - processRecords: consumes batched ACL records and sends corresponding notifications {processRecords}

--- a/space/internal/components/aclobjectmanager/aclobjectmanager.go
+++ b/space/internal/components/aclobjectmanager/aclobjectmanager.go
@@ -11,7 +11,6 @@ Scope: space
 - Derives push notification keys from ACL metadata
 - Updates space status (owner, participant status, account deletion)
 - Triggers ACL notifications on permission changes
-- DONTs: ACL modifications (read-only consumer of ACL state)
 
 ## Background Tasks
 - process: waits for space load, subscribes to ACL updates via SetAclUpdater

--- a/space/internal/components/aclobjectmanager/aclobjectmanager.go
+++ b/space/internal/components/aclobjectmanager/aclobjectmanager.go
@@ -1,5 +1,27 @@
 package aclobjectmanager
 
+/*
+AI generated
+
+Name: ACL State Processor
+Scope: space
+
+## Responsibility
+- Processes ACL changes and updates participant objects accordingly
+- Derives push notification keys from ACL metadata
+- Updates space status (owner, participant status, account deletion)
+- Triggers ACL notifications on permission changes
+- DONTs: ACL modifications (read-only consumer of ACL state)
+
+## Background Tasks
+- process: waits for space load, subscribes to ACL updates via SetAclUpdater
+
+## Documentation
+On space load, processes initial ACL state. Then subscribes as AclUpdater to receive
+ongoing ACL changes. Each ACL change triggers: participant object updates, status updates,
+notification delivery, and push key derivation.
+*/
+
 import (
 	"context"
 	"fmt"

--- a/space/internal/components/builder/builder.go
+++ b/space/internal/components/builder/builder.go
@@ -1,5 +1,18 @@
 package builder
 
+/*
+AI generated
+
+Name: Client Space Factory
+Scope: space
+
+## Responsibility
+- Assembles dependencies and constructs a fully-initialized clientspace.Space
+- Acquires core space from spaceCore service
+- Sets space access type (personal vs private) after construction
+- DONTs: space lifecycle management (handled by spaceloader), indexing, object caching
+*/
+
 import (
 	"context"
 	"fmt"

--- a/space/internal/components/builder/builder.go
+++ b/space/internal/components/builder/builder.go
@@ -10,7 +10,6 @@ Scope: space
 - Assembles dependencies and constructs a fully-initialized clientspace.Space
 - Acquires core space from spaceCore service
 - Sets space access type (personal vs private) after construction
-- DONTs: space lifecycle management (handled by spaceloader), indexing, object caching
 */
 
 import (

--- a/space/internal/components/participantwatcher/participantwatcher.go
+++ b/space/internal/components/participantwatcher/participantwatcher.go
@@ -1,5 +1,24 @@
 package participantwatcher
 
+/*
+AI generated
+
+Name: Participant Identity Sync
+Scope: space
+
+## Responsibility
+- Registers identity observers to receive profile updates for space participants
+- Updates participant objects with identity profile data (name, avatar, etc.)
+- Updates participant objects with ACL state (permissions, status)
+- Handles one-to-one space metadata key retrieval separately from regular spaces
+- DONTs: ACL changes, participant creation (only updates existing participant objects)
+
+## Documentation
+Called by aclobjectmanager for each account in ACL state. WatchParticipant registers
+an identity observer that triggers updateParticipantFromIdentity on profile changes.
+On Close, unregisters all identity observers for the space.
+*/
+
 import (
 	"context"
 	"encoding/base64"

--- a/space/internal/components/participantwatcher/participantwatcher.go
+++ b/space/internal/components/participantwatcher/participantwatcher.go
@@ -11,7 +11,6 @@ Scope: space
 - Updates participant objects with identity profile data (name, avatar, etc.)
 - Updates participant objects with ACL state (permissions, status)
 - Handles one-to-one space metadata key retrieval separately from regular spaces
-- DONTs: ACL changes, participant creation (only updates existing participant objects)
 
 ## Documentation
 Called by aclobjectmanager for each account in ACL state. WatchParticipant registers

--- a/space/internal/components/spaceloader/spaceloader.go
+++ b/space/internal/components/spaceloader/spaceloader.go
@@ -9,7 +9,6 @@ Scope: space
 ## Responsibility
 - Initiates asynchronous space building on Run() and exposes WaitLoad() for completion
 - Updates space local status (Loading -> Ok/Missing) via spacestatus component
-- DONTs: space construction (handled by builder), status persistence (handled by spacestatus)
 
 ## Background Tasks
 - loadRetry: Retries space loading with exponential backoff (1s -> 20s cap) until success or non-retryable error (loadingspace.go)

--- a/space/internal/components/spaceloader/spaceloader.go
+++ b/space/internal/components/spaceloader/spaceloader.go
@@ -1,5 +1,24 @@
 package spaceloader
 
+/*
+AI generated
+
+Name: Async Space Loader with Retry
+Scope: space
+
+## Responsibility
+- Initiates asynchronous space building on Run() and exposes WaitLoad() for completion
+- Updates space local status (Loading -> Ok/Missing) via spacestatus component
+- DONTs: space construction (handled by builder), status persistence (handled by spacestatus)
+
+## Background Tasks
+- loadRetry: Retries space loading with exponential backoff (1s -> 20s cap) until success or non-retryable error (loadingspace.go)
+
+## Documentation
+Non-retryable errors that stop retry loop: ErrHasInvalidChanges, ErrUnexpectedSpaceType, or when disableRemoteLoad is set.
+ACL head validation: If latestAclHeadId is provided and remote load is enabled, verifies ACL contains the expected head before considering load complete.
+*/
+
 import (
 	"context"
 	"errors"

--- a/space/internal/components/spaceoffloader/spaceoffloader.go
+++ b/space/internal/components/spaceoffloader/spaceoffloader.go
@@ -8,7 +8,6 @@ Scope: space
 
 ## Responsibility
 - Deletes local space storage, files, and indexes when space is being removed
-- DONTs: Network deletion coordination (handled by deletioncontroller)
 
 ## Background Tasks
 - offloadRetry: Retries offload operation every 20s until success or context cancellation

--- a/space/internal/components/spaceoffloader/spaceoffloader.go
+++ b/space/internal/components/spaceoffloader/spaceoffloader.go
@@ -1,5 +1,19 @@
 package spaceoffloader
 
+/*
+AI generated
+
+Name: Local Space Data Offloader
+Scope: space
+
+## Responsibility
+- Deletes local space storage, files, and indexes when space is being removed
+- DONTs: Network deletion coordination (handled by deletioncontroller)
+
+## Background Tasks
+- offloadRetry: Retries offload operation every 20s until success or context cancellation
+*/
+
 import (
 	"context"
 	"sync/atomic"

--- a/space/internal/components/spacestatus/status.go
+++ b/space/internal/components/spacestatus/status.go
@@ -9,7 +9,6 @@ Scope: space
 ## Responsibility
 - Thread-safe facade for reading/writing SpaceView properties of a single space
 - Delegates all persistence to TechSpace's SpaceView
-- DONTs: Does NOT manage SpaceView lifecycle, does NOT persist data directly
 */
 
 import (

--- a/space/internal/components/spacestatus/status.go
+++ b/space/internal/components/spacestatus/status.go
@@ -1,5 +1,17 @@
 package spacestatus
 
+/*
+AI generated
+
+Name: Space View Accessor
+Scope: space
+
+## Responsibility
+- Thread-safe facade for reading/writing SpaceView properties of a single space
+- Delegates all persistence to TechSpace's SpaceView
+- DONTs: Does NOT manage SpaceView lifecycle, does NOT persist data directly
+*/
+
 import (
 	"context"
 

--- a/space/internal/components/syncstopper/syncstopper.go
+++ b/space/internal/components/syncstopper/syncstopper.go
@@ -1,5 +1,23 @@
 package syncstopper
 
+/*
+AI generated
+
+Name: Delayed Tree Sync Stopper
+Scope: space (unused - not registered anywhere)
+
+## Responsibility
+- Stops tree syncing for a space after 10 minutes timeout
+- DONTs: Does NOT manage sync start, does NOT handle sync status
+
+## Background Tasks
+- spaceCheck: Checks if 10 minutes elapsed since Run() and calls TreeSyncer.StopSync()
+
+## Documentation
+Note: This component appears incomplete - periodicCall is created but never started via Run().
+The component is not registered in any space builder.
+*/
+
 import (
 	"context"
 	"time"

--- a/space/internal/components/syncstopper/syncstopper.go
+++ b/space/internal/components/syncstopper/syncstopper.go
@@ -8,7 +8,6 @@ Scope: space (unused - not registered anywhere)
 
 ## Responsibility
 - Stops tree syncing for a space after 10 minutes timeout
-- DONTs: Does NOT manage sync start, does NOT handle sync status
 
 ## Background Tasks
 - spaceCheck: Checks if 10 minutes elapsed since Run() and calls TreeSyncer.StopSync()

--- a/space/internal/spaceprocess/components/aclindexcleaner/aclindexcleaner.go
+++ b/space/internal/spaceprocess/components/aclindexcleaner/aclindexcleaner.go
@@ -1,5 +1,16 @@
 package aclindexcleaner
 
+/*
+AI generated
+
+Name: ACL Participant Index Cleaner
+Scope: other-child (offloader process)
+
+## Responsibility
+- Removes participant object indexes from store during space offload
+- DONTs: Actual index storage management (delegated to SpaceIndexer)
+*/
+
 import (
 	"context"
 

--- a/space/internal/spaceprocess/components/aclindexcleaner/aclindexcleaner.go
+++ b/space/internal/spaceprocess/components/aclindexcleaner/aclindexcleaner.go
@@ -8,7 +8,6 @@ Scope: other-child (offloader process)
 
 ## Responsibility
 - Removes participant object indexes from store during space offload
-- DONTs: Actual index storage management (delegated to SpaceIndexer)
 */
 
 import (

--- a/space/service.go
+++ b/space/service.go
@@ -1,5 +1,30 @@
 package space
 
+/*
+AI generated
+
+Name: Space Lifecycle Manager
+Scope: global
+
+## Responsibility
+- Manages lifecycle of all space types (personal, shareable, streamable, one-to-one)
+- Orchestrates space creation, loading, joining, and deletion
+- Maintains registry of active space controllers
+- Handles account initialization (new vs existing accounts, tech space creation)
+- DONTs: individual space logic (delegated to spacecontroller), low-level sync (delegated to spacecore)
+
+## Background Tasks
+- spaceWatcher: subscribes to space view changes in tech space, triggers controller updates (onSpaceStatusUpdated)
+- tryToJoinSpaceStream: retries joining stream space with exponential backoff when autoJoinStreamSpace is configured
+
+## Documentation
+Space startup flow:
+1. Init: derive personal/tech space IDs, setup watcher
+2. Run: init marketplace space, then either createAccount (new) or initAccount (existing)
+3. Tech space must be ready (channel closed) before regular spaces can be loaded
+4. SpaceView changes in tech space trigger controller starts/updates via watcher subscription
+*/
+
 import (
 	"context"
 	"errors"

--- a/space/service.go
+++ b/space/service.go
@@ -11,7 +11,6 @@ Scope: global
 - Orchestrates space creation, loading, joining, and deletion
 - Maintains registry of active space controllers
 - Handles account initialization (new vs existing accounts, tech space creation)
-- DONTs: individual space logic (delegated to spacecontroller), low-level sync (delegated to spacecore)
 
 ## Background Tasks
 - spaceWatcher: subscribes to space view changes in tech space, triggers controller updates (onSpaceStatusUpdated)

--- a/space/spacecore/keyvalueobserver/observer.go
+++ b/space/spacecore/keyvalueobserver/observer.go
@@ -1,5 +1,20 @@
 package keyvalueobserver
 
+/*
+AI generated
+
+Name: Key-Value Change Observer
+Scope: space
+
+## Responsibility
+- Bridges any-sync key-value storage to client space by implementing keyvaluestorage.Indexer
+- Queues incoming key-value changes and forwards them to the registered observer
+- DONTs: actual key-value processing logic (delegated to observer function)
+
+## Background Tasks
+- Queue processor: reads from updateQueue and invokes observerFunc (Run goroutine)
+*/
+
 import (
 	"context"
 	"errors"

--- a/space/spacecore/keyvalueobserver/observer.go
+++ b/space/spacecore/keyvalueobserver/observer.go
@@ -9,7 +9,6 @@ Scope: space
 ## Responsibility
 - Bridges any-sync key-value storage to client space by implementing keyvaluestorage.Indexer
 - Queues incoming key-value changes and forwards them to the registered observer
-- DONTs: actual key-value processing logic (delegated to observer function)
 
 ## Background Tasks
 - Queue processor: reads from updateQueue and invokes observerFunc (Run goroutine)

--- a/space/spacecore/oldstorage/storage.go
+++ b/space/spacecore/oldstorage/storage.go
@@ -1,5 +1,21 @@
 package oldstorage
 
+/*
+AI generated
+
+Name: Legacy Space Storage Proxy
+Scope: global
+
+## Responsibility
+- Proxy for legacy space storage implementations (Badger or SQLite)
+- Selects storage backend based on account repo age (SQLite for new, Badger for existing)
+- DONTs: actual storage operations - delegated to badgerstorage or sqlitestorage
+
+## External State
+- Badger DB via datastore (legacy accounts)
+- SQLite DB at configured path (new accounts)
+*/
+
 import (
 	"context"
 	"fmt"

--- a/space/spacecore/oldstorage/storage.go
+++ b/space/spacecore/oldstorage/storage.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Proxy for legacy space storage implementations (Badger or SQLite)
 - Selects storage backend based on account repo age (SQLite for new, Badger for existing)
-- DONTs: actual storage operations - delegated to badgerstorage or sqlitestorage
 
 ## External State
 - Badger DB via datastore (legacy accounts)

--- a/space/spacecore/peermanager/provider.go
+++ b/space/spacecore/peermanager/provider.go
@@ -9,7 +9,6 @@ Scope: global
 ## Responsibility
 - Factory for creating per-space clientPeerManager instances
 - Provides shared connection pool access (unary and stream)
-- DONTs: peer lifecycle management (handled by clientPeerManager)
 */
 
 import (

--- a/space/spacecore/peermanager/provider.go
+++ b/space/spacecore/peermanager/provider.go
@@ -1,5 +1,17 @@
 package peermanager
 
+/*
+AI generated
+
+Name: Peer Manager Provider
+Scope: global
+
+## Responsibility
+- Factory for creating per-space clientPeerManager instances
+- Provides shared connection pool access (unary and stream)
+- DONTs: peer lifecycle management (handled by clientPeerManager)
+*/
+
 import (
 	"context"
 

--- a/space/spacecore/peerstore/peerstore.go
+++ b/space/spacecore/peerstore/peerstore.go
@@ -1,5 +1,19 @@
 package peerstore
 
+/*
+AI generated
+
+Name: Local Peer Registry
+Scope: global
+
+## Responsibility
+- Tracks local network peers (discovered via P2P/local discovery) and their space memberships
+- Maintains bidirectional mappings: peer-to-spaces and space-to-peers
+- Proxies responsible node IDs and file peers from nodeconf service
+- Notifies observers on peer additions, removals, and space membership changes
+- DONTs: peer connection management, actual P2P discovery (handled by localdiscovery)
+*/
+
 import (
 	"sync"
 

--- a/space/spacecore/peerstore/peerstore.go
+++ b/space/spacecore/peerstore/peerstore.go
@@ -11,7 +11,6 @@ Scope: global
 - Maintains bidirectional mappings: peer-to-spaces and space-to-peers
 - Proxies responsible node IDs and file peers from nodeconf service
 - Notifies observers on peer additions, removals, and space membership changes
-- DONTs: peer connection management, actual P2P discovery (handled by localdiscovery)
 */
 
 import (

--- a/space/spacecore/storage/migrator/migrator.go
+++ b/space/spacecore/storage/migrator/migrator.go
@@ -11,7 +11,6 @@ Scope: global
 - Migrates object-to-space ID bindings to spaceresolverstore
 - Validates disk space before migration (requires 1.5x old storage size)
 - Reports progress via process.Service during migration
-- DONTs: cleanup of old storage (delegated to migratorfinisher)
 
 ## External State
 - objectstore/objects.db: writes space ID bindings for migrated objects

--- a/space/spacecore/storage/migrator/migrator.go
+++ b/space/spacecore/storage/migrator/migrator.go
@@ -1,5 +1,22 @@
 package migrator
 
+/*
+AI generated
+
+Name: Old-to-New Space Storage Migrator
+Scope: global
+
+## Responsibility
+- Migrates all spaces from old storage format (badger/sqlite) to new storage format
+- Migrates object-to-space ID bindings to spaceresolverstore
+- Validates disk space before migration (requires 1.5x old storage size)
+- Reports progress via process.Service during migration
+- DONTs: cleanup of old storage (delegated to migratorfinisher)
+
+## External State
+- objectstore/objects.db: writes space ID bindings for migrated objects
+*/
+
 import (
 	"context"
 	"errors"

--- a/space/spacecore/storage/migratorfinisher/finisher.go
+++ b/space/spacecore/storage/migratorfinisher/finisher.go
@@ -10,7 +10,6 @@ Scope: global
 - Cleans up old storage artifacts after space storage migration completes
 - Removes CRDT index files from objectstore folder
 - Renames old store folder to "space_store_migrated"
-- DONTs: migration logic itself - only post-migration cleanup
 
 ## External State
 - Renames {oldPath} to "space_store_migrated" on successful migration

--- a/space/spacecore/storage/migratorfinisher/finisher.go
+++ b/space/spacecore/storage/migratorfinisher/finisher.go
@@ -1,5 +1,26 @@
 package migratorfinisher
 
+/*
+AI generated
+
+Name: Storage Migration Cleanup Finalizer
+Scope: global
+
+## Responsibility
+- Cleans up old storage artifacts after space storage migration completes
+- Removes CRDT index files from objectstore folder
+- Renames old store folder to "space_store_migrated"
+- DONTs: migration logic itself - only post-migration cleanup
+
+## External State
+- Renames {oldPath} to "space_store_migrated" on successful migration
+- Deletes files prefixed with "crdt" in objectstore folder
+
+## Documentation
+Cleanup executes on Close() only if SetMigrationDone() was called during the session.
+Migration caller must explicitly mark completion before shutdown.
+*/
+
 import (
 	"context"
 	"fmt"

--- a/space/spacecore/typeprovider/typeprovider.go
+++ b/space/spacecore/typeprovider/typeprovider.go
@@ -1,5 +1,21 @@
 package typeprovider
 
+/*
+AI generated
+
+Name: SmartBlock Type Resolver
+Scope: global
+
+## Responsibility
+- Resolves SmartBlockType from object IDs using prefix/CID pattern matching
+- Falls back to space storage tree root for unknown IDs
+- Caches resolved types persistently to avoid repeated storage lookups
+- DONTs: object creation, type definitions, type validation logic
+
+## External State
+- `smartblock_types` collection in common DB: persisted ID-to-type cache
+*/
+
 import (
 	"context"
 	"encoding/binary"

--- a/space/spacecore/typeprovider/typeprovider.go
+++ b/space/spacecore/typeprovider/typeprovider.go
@@ -10,7 +10,6 @@ Scope: global
 - Resolves SmartBlockType from object IDs using prefix/CID pattern matching
 - Falls back to space storage tree root for unknown IDs
 - Caches resolved types persistently to avoid repeated storage lookups
-- DONTs: object creation, type definitions, type validation logic
 
 ## External State
 - `smartblock_types` collection in common DB: persisted ID-to-type cache

--- a/space/spacefactory/spacefactory.go
+++ b/space/spacefactory/spacefactory.go
@@ -10,7 +10,6 @@ Scope: global
 - Creates and initializes SpaceController instances for all space types (personal, shareable, streamable, marketplace, one-to-one)
 - Creates and initializes TechSpace (special space storing SpaceViews for all other spaces)
 - Handles SpaceView creation in TechSpace when creating new spaces
-- DONTs: does not manage space lifecycle after creation (SpaceController handles that)
 
 ## Documentation
 Space types and their controllers:

--- a/space/spacefactory/spacefactory.go
+++ b/space/spacefactory/spacefactory.go
@@ -1,5 +1,30 @@
 package spacefactory
 
+/*
+AI generated
+
+Name: Space Controller Factory
+Scope: global
+
+## Responsibility
+- Creates and initializes SpaceController instances for all space types (personal, shareable, streamable, marketplace, one-to-one)
+- Creates and initializes TechSpace (special space storing SpaceViews for all other spaces)
+- Handles SpaceView creation in TechSpace when creating new spaces
+- DONTs: does not manage space lifecycle after creation (SpaceController handles that)
+
+## Documentation
+Space types and their controllers:
+- Personal: user's primary space, derived deterministically from account
+- Shareable: spaces that can be shared with others (inviting, active states)
+- Streamable: spaces accessed via private key (e.g., for streaming/guest access)
+- Marketplace: virtual space for bundled types/relations (deprecated)
+- OneToOne: direct messaging spaces between two participants
+
+Create vs New methods:
+- Create*: derives/creates underlying storage, creates SpaceView in TechSpace, then creates controller
+- New*: loads existing space (SpaceView already exists), creates controller only
+*/
+
 import (
 	"context"
 	"encoding/base64"

--- a/space/techspace/techspace.go
+++ b/space/techspace/techspace.go
@@ -1,5 +1,19 @@
 package techspace
 
+/*
+AI generated
+
+Name: Space Metadata Storage
+Scope: global
+
+## Responsibility
+- Creates and manages SpaceView objects (one per user space) containing space metadata
+- Creates and manages a single AccountObject for account-level settings
+- Provides locked access to SpaceView/AccountObject via Do* methods for safe concurrent modification
+- Derives deterministic object IDs from space IDs using unique keys
+- DONTs: does not manage actual space content, only metadata about spaces
+*/
+
 import (
 	"context"
 	"errors"

--- a/space/techspace/techspace.go
+++ b/space/techspace/techspace.go
@@ -11,7 +11,6 @@ Scope: global
 - Creates and manages a single AccountObject for account-level settings
 - Provides locked access to SpaceView/AccountObject via Do* methods for safe concurrent modification
 - Derives deterministic object IDs from space IDs using unique keys
-- DONTs: does not manage actual space content, only metadata about spaces
 */
 
 import (

--- a/space/virtualspaceservice/service.go
+++ b/space/virtualspaceservice/service.go
@@ -8,7 +8,6 @@ Scope: global
 
 ## Responsibility
 - Registers virtual (local-only, non-synced) spaces in the object store
-- DONTs: space lifecycle management, syncing, object caching (handled by clientspace.VirtualSpace)
 
 ## External State
 - virtualSpaces collection in object store (via objectStore.SaveVirtualSpace)

--- a/space/virtualspaceservice/service.go
+++ b/space/virtualspaceservice/service.go
@@ -1,5 +1,19 @@
 package virtualspaceservice
 
+/*
+AI generated
+
+Name: Virtual Space Registration
+Scope: global
+
+## Responsibility
+- Registers virtual (local-only, non-synced) spaces in the object store
+- DONTs: space lifecycle management, syncing, object caching (handled by clientspace.VirtualSpace)
+
+## External State
+- virtualSpaces collection in object store (via objectStore.SaveVirtualSpace)
+*/
+
 import (
 	"context"
 

--- a/util/builtintemplate/builtintemplate.go
+++ b/util/builtintemplate/builtintemplate.go
@@ -10,7 +10,6 @@ Scope: global
 - Provides embedded bundled templates from zip archive
 - Registers bundled templates as static sources in a space
 - Generates version hash for template change detection
-- DONTs: template creation/editing, user template management
 */
 
 import (

--- a/util/builtintemplate/builtintemplate.go
+++ b/util/builtintemplate/builtintemplate.go
@@ -1,5 +1,18 @@
 package builtintemplate
 
+/*
+AI generated
+
+Name: Bundled Template Provider
+Scope: global
+
+## Responsibility
+- Provides embedded bundled templates from zip archive
+- Registers bundled templates as static sources in a space
+- Generates version hash for template change detection
+- DONTs: template creation/editing, user template management
+*/
+
 import (
 	"archive/zip"
 	"bytes"


### PR DESCRIPTION
## Summary
- Add concise documentation headers to all 83 components with `const CName`
- Each header describes: name, scope, responsibilities, background tasks, and external state where applicable
- Includes `.claude/` directory with document-component agent and go-reviewer skill

## Test plan
- [ ] Verify documentation headers are present and accurate
- [ ] Ensure no functional code changes were made