### PR TITLE
Fix array-type filter conditions (ObjectsFilterItem, MultiSelectFilterItem)

### DIFF
--- a/core/api/filter/expression_test.go
+++ b/core/api/filter/expression_test.go
@@ -499,6 +499,71 @@ func TestBuildExpressionFilters(t *testing.T) {
 				assert.Equal(t, pbtypes.String("test"), result.Value)
 			},
 		},
+		{
+			name: "objects filter with in condition",
+			expr: &apimodel.FilterExpression{
+				Conditions: []apimodel.FilterItem{
+					{
+						WrappedFilterItem: apimodel.ObjectsFilterItem{
+							PropertyKey: "links",
+							Condition:   apimodel.FilterConditionIn,
+							Objects:     &[]string{"obj1", "obj2"},
+						},
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				propertyMap := map[string]*apimodel.Property{
+					"links": {
+						Key:         "links",
+						RelationKey: bundle.RelationKeyLinks.String(),
+						Format:      apimodel.PropertyFormatObjects,
+					},
+				}
+				m.On("GetCachedProperties", spaceId).Return(propertyMap)
+				m.On("ResolvePropertyApiKey", propertyMap, "links").Return("links", true)
+				// ObjectsFilterItem.GetValue() returns []string, not []interface{}
+				m.On("SanitizeAndValidatePropertyValue", spaceId, "links", []string{"obj1", "obj2"}, propertyMap["links"], propertyMap).Return([]string{"obj1", "obj2"}, nil)
+			},
+			checkResult: func(t *testing.T, result *model.BlockContentDataviewFilter) {
+				require.NotNil(t, result)
+				assert.Equal(t, bundle.RelationKeyLinks.String(), result.RelationKey)
+				assert.Equal(t, model.BlockContentDataviewFilter_In, result.Condition)
+				assert.Equal(t, pbtypes.StringList([]string{"obj1", "obj2"}), result.Value)
+			},
+		},
+		{
+			name: "objects filter with all condition",
+			expr: &apimodel.FilterExpression{
+				Conditions: []apimodel.FilterItem{
+					{
+						WrappedFilterItem: apimodel.ObjectsFilterItem{
+							PropertyKey: "assignee",
+							Condition:   apimodel.FilterConditionAll,
+							Objects:     &[]string{"user1", "user2"},
+						},
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				propertyMap := map[string]*apimodel.Property{
+					"assignee": {
+						Key:         "assignee",
+						RelationKey: bundle.RelationKeyAssignee.String(),
+						Format:      apimodel.PropertyFormatObjects,
+					},
+				}
+				m.On("GetCachedProperties", spaceId).Return(propertyMap)
+				m.On("ResolvePropertyApiKey", propertyMap, "assignee").Return("assignee", true)
+				m.On("SanitizeAndValidatePropertyValue", spaceId, "assignee", []string{"user1", "user2"}, propertyMap["assignee"], propertyMap).Return([]string{"user1", "user2"}, nil)
+			},
+			checkResult: func(t *testing.T, result *model.BlockContentDataviewFilter) {
+				require.NotNil(t, result)
+				assert.Equal(t, bundle.RelationKeyAssignee.String(), result.RelationKey)
+				assert.Equal(t, model.BlockContentDataviewFilter_AllIn, result.Condition)
+				assert.Equal(t, pbtypes.StringList([]string{"user1", "user2"}), result.Value)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/api/filter/expression_test.go
+++ b/core/api/filter/expression_test.go
@@ -523,7 +523,13 @@ func TestBuildExpressionFilters(t *testing.T) {
 				m.On("GetCachedProperties", spaceId).Return(propertyMap)
 				m.On("ResolvePropertyApiKey", propertyMap, "links").Return("links", true)
 				// ObjectsFilterItem.GetValue() returns []string, not []interface{}
-				m.On("SanitizeAndValidatePropertyValue", spaceId, "links", []string{"obj1", "obj2"}, propertyMap["links"], propertyMap).Return([]string{"obj1", "obj2"}, nil)
+				// The service must accept []string input for this to work
+				m.On("SanitizeAndValidatePropertyValue", spaceId, "links",
+					mock.MatchedBy(func(v interface{}) bool {
+						_, ok := v.([]string)
+						return ok // Must be []string type
+					}),
+					propertyMap["links"], propertyMap).Return([]string{"obj1", "obj2"}, nil)
 			},
 			checkResult: func(t *testing.T, result *model.BlockContentDataviewFilter) {
 				require.NotNil(t, result)
@@ -555,7 +561,14 @@ func TestBuildExpressionFilters(t *testing.T) {
 				}
 				m.On("GetCachedProperties", spaceId).Return(propertyMap)
 				m.On("ResolvePropertyApiKey", propertyMap, "assignee").Return("assignee", true)
-				m.On("SanitizeAndValidatePropertyValue", spaceId, "assignee", []string{"user1", "user2"}, propertyMap["assignee"], propertyMap).Return([]string{"user1", "user2"}, nil)
+				// ObjectsFilterItem.GetValue() returns []string, not []interface{}
+				// The service must accept []string input for this to work
+				m.On("SanitizeAndValidatePropertyValue", spaceId, "assignee",
+					mock.MatchedBy(func(v interface{}) bool {
+						_, ok := v.([]string)
+						return ok // Must be []string type
+					}),
+					propertyMap["assignee"], propertyMap).Return([]string{"user1", "user2"}, nil)
 			},
 			checkResult: func(t *testing.T, result *model.BlockContentDataviewFilter) {
 				require.NotNil(t, result)

--- a/core/api/service/property.go
+++ b/core/api/service/property.go
@@ -422,20 +422,29 @@ func (s *Service) SanitizeAndValidatePropertyValue(spaceId string, key string, v
 		}
 		return b, nil
 	case apimodel.PropertyFormatObjects, apimodel.PropertyFormatFiles:
-		ids, ok := value.([]interface{})
-		if !ok {
+		// Accept both []interface{} (from JSON unmarshaling) and []string (from ObjectsFilterItem.GetValue())
+		var rawIds []string
+		switch v := value.(type) {
+		case []interface{}:
+			for _, item := range v {
+				id, ok := item.(string)
+				if !ok {
+					return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of strings (object/file ids)", key))
+				}
+				rawIds = append(rawIds, id)
+			}
+		case []string:
+			rawIds = v
+		default:
 			return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of strings (object/file ids)", key))
 		}
+
 		var validIds []string
-		for _, v := range ids {
-			id, ok := v.(string)
-			if !ok {
-				return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of strings (object/file ids)", key))
-			}
+		for _, id := range rawIds {
 			id = s.sanitizedString(id)
 			if prop.Format == apimodel.PropertyFormatFiles && !s.isValidFileReference(spaceId, id) {
 				return nil, util.ErrBadInput(fmt.Sprintf("invalid file reference for %q: %s", key, id))
-			} else if prop.Format == apimodel.PropertyFormatObjects && !s.isValidObjectOrMemberReference(spaceId, id) {
+			} else if prop.Format == apimodel.PropertyFormatObjects && !s.isValidObjectReferenceForProperty(spaceId, id, prop.RelationKey) {
 				return nil, util.ErrBadInput(fmt.Sprintf("invalid object reference for %q: %s", key, id))
 			}
 			validIds = append(validIds, id)
@@ -469,6 +478,20 @@ func (s *Service) isValidObjectOrMemberReference(spaceId string, objectId string
 	}
 	layout := model.ObjectTypeLayout(fields[bundle.RelationKeyResolvedLayout.String()].GetNumberValue())
 	return util.IsObjectOrMemberLayout(layout)
+}
+
+// isValidObjectReferenceForProperty validates an object reference based on the property's relation key.
+// For the "links" property (a derived system property that can contain any type of linked object),
+// we only check that the object exists. For other object properties, we require the referenced
+// object to have an object or member layout.
+func (s *Service) isValidObjectReferenceForProperty(spaceId string, objectId string, relationKey string) bool {
+	if relationKey == bundle.RelationKeyLinks.String() {
+		// The links property can reference any object type (files, types, pages, etc.)
+		// Just verify the object exists by checking if we can retrieve any fields
+		fields, err := util.GetFieldsById(s.mw, spaceId, objectId, []string{bundle.RelationKeyResolvedLayout.String()})
+		return err == nil && fields != nil
+	}
+	return s.isValidObjectOrMemberReference(spaceId, objectId)
 }
 
 func (s *Service) isValidFileReference(spaceId string, fileId string) bool {

--- a/core/api/service/property.go
+++ b/core/api/service/property.go
@@ -381,16 +381,25 @@ func (s *Service) SanitizeAndValidatePropertyValue(spaceId string, key string, v
 		}
 		return tag.Id, nil
 	case apimodel.PropertyFormatMultiSelect:
-		keysOrIds, ok := value.([]interface{})
-		if !ok {
+		// Accept both []interface{} (from JSON unmarshaling) and []string (from MultiSelectFilterItem.GetValue())
+		var rawKeysOrIds []string
+		switch v := value.(type) {
+		case []interface{}:
+			for _, item := range v {
+				keyOrId, ok := item.(string)
+				if !ok {
+					return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of strings (tag ids or keys)", key))
+				}
+				rawKeysOrIds = append(rawKeysOrIds, keyOrId)
+			}
+		case []string:
+			rawKeysOrIds = v
+		default:
 			return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of tag ids or keys", key))
 		}
+
 		var validIds []string
-		for _, v := range keysOrIds {
-			keyOrId, ok := v.(string)
-			if !ok {
-				return nil, util.ErrBadInput(fmt.Sprintf("property %q must be an array of strings (tag ids or keys)", key))
-			}
+		for _, keyOrId := range rawKeysOrIds {
 			keyOrId = s.sanitizedString(keyOrId)
 			if !s.isValidSelectOption(spaceId, prop, keyOrId, propertyMap) {
 				return nil, util.ErrBadInput(fmt.Sprintf("invalid multi_select option for %q: %s", key, keyOrId))

--- a/core/api/service/property_test.go
+++ b/core/api/service/property_test.go
@@ -17,6 +17,123 @@ import (
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
+func TestSanitizeAndValidatePropertyValue_ObjectsFormat(t *testing.T) {
+	// Test that SanitizeAndValidatePropertyValue correctly handles []string input for objects properties.
+	// This is important for filter values from ObjectsFilterItem which returns []string, not []interface{}.
+
+	setupValidationMock := func(fx *fixture, objectId string, isValid bool, layout model.ObjectTypeLayout) {
+		response := &pb.RpcObjectSearchResponse{
+			Error: &pb.RpcObjectSearchResponseError{Code: pb.RpcObjectSearchResponseError_NULL},
+		}
+		if isValid {
+			response.Records = []*types.Struct{
+				{
+					Fields: map[string]*types.Value{
+						bundle.RelationKeyResolvedLayout.String(): pbtypes.Int64(int64(layout)),
+					},
+				},
+			}
+		}
+		fx.mwMock.On("ObjectSearch", mock.Anything, &pb.RpcObjectSearchRequest{
+			SpaceId: mockedSpaceId,
+			Filters: []*model.BlockContentDataviewFilter{
+				{
+					RelationKey: bundle.RelationKeyId.String(),
+					Condition:   model.BlockContentDataviewFilter_Equal,
+					Value:       pbtypes.String(objectId),
+				},
+			},
+			Keys: []string{bundle.RelationKeyResolvedLayout.String()},
+		}).Return(response).Maybe()
+	}
+
+	t.Run("accepts []string input for objects property", func(t *testing.T) {
+		// Bug 1: ObjectsFilterItem.GetValue() returns []string but SanitizeAndValidatePropertyValue
+		// expects []interface{}. This test verifies that []string input is handled correctly.
+		fx := newFixture(t)
+		fx.populateCache(mockedSpaceId)
+		setupValidationMock(fx, "obj1", true, model.ObjectType_basic)
+		setupValidationMock(fx, "obj2", true, model.ObjectType_basic)
+
+		prop := &apimodel.Property{
+			Key:         "objects_prop",
+			RelationKey: "objects_prop",
+			Format:      apimodel.PropertyFormatObjects,
+		}
+		propertyMap := fx.service.cache.getProperties(mockedSpaceId)
+
+		// This should work with []string input (from ObjectsFilterItem.GetValue())
+		result, err := fx.service.SanitizeAndValidatePropertyValue(
+			mockedSpaceId,
+			"objects_prop",
+			[]string{"obj1", "obj2"}, // []string, not []interface{}
+			prop,
+			propertyMap,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"obj1", "obj2"}, result)
+	})
+
+	t.Run("accepts []interface{} input for objects property", func(t *testing.T) {
+		// Existing behavior: []interface{} should still work
+		fx := newFixture(t)
+		fx.populateCache(mockedSpaceId)
+		setupValidationMock(fx, "obj1", true, model.ObjectType_basic)
+		setupValidationMock(fx, "obj2", true, model.ObjectType_basic)
+
+		prop := &apimodel.Property{
+			Key:         "objects_prop",
+			RelationKey: "objects_prop",
+			Format:      apimodel.PropertyFormatObjects,
+		}
+		propertyMap := fx.service.cache.getProperties(mockedSpaceId)
+
+		result, err := fx.service.SanitizeAndValidatePropertyValue(
+			mockedSpaceId,
+			"objects_prop",
+			[]interface{}{"obj1", "obj2"},
+			prop,
+			propertyMap,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"obj1", "obj2"}, result)
+	})
+
+	t.Run("links property allows filtering by any object ID", func(t *testing.T) {
+		// Bug 2: The links property is a derived/system property that can contain
+		// references to any type of object. The validation should not require
+		// that the referenced objects have specific layouts (basic, todo, etc.)
+		fx := newFixture(t)
+		fx.populateCache(mockedSpaceId)
+
+		// Add the links property to the cache
+		linksProp := &apimodel.Property{
+			Id:          "links_prop_id",
+			Key:         "links",
+			Name:        "Links",
+			Format:      apimodel.PropertyFormatObjects,
+			RelationKey: bundle.RelationKeyLinks.String(),
+		}
+		fx.service.cache.cacheProperty(mockedSpaceId, linksProp)
+
+		// Mock an object with a file layout (not an "object" layout)
+		// This should still be valid for the links property
+		setupValidationMock(fx, "file_obj", true, model.ObjectType_file)
+
+		propertyMap := fx.service.cache.getProperties(mockedSpaceId)
+
+		result, err := fx.service.SanitizeAndValidatePropertyValue(
+			mockedSpaceId,
+			"links",
+			[]string{"file_obj"},
+			linksProp,
+			propertyMap,
+		)
+		require.NoError(t, err, "links property should accept file objects")
+		assert.Equal(t, []string{"file_obj"}, result)
+	})
+}
+
 func TestProcessProperties(t *testing.T) {
 	ctx := context.Background()
 

--- a/core/api/service/property_test.go
+++ b/core/api/service/property_test.go
@@ -134,6 +134,87 @@ func TestSanitizeAndValidatePropertyValue_ObjectsFormat(t *testing.T) {
 	})
 }
 
+func TestSanitizeAndValidatePropertyValue_MultiSelectFormat(t *testing.T) {
+	// Test that SanitizeAndValidatePropertyValue correctly handles []string input for multi_select properties.
+	// This is important for filter values from MultiSelectFilterItem which returns []string, not []interface{}.
+
+	setupTagValidationMock := func(fx *fixture, tagId string, propertyKey string, isValid bool) {
+		response := &pb.RpcObjectSearchResponse{
+			Error: &pb.RpcObjectSearchResponseError{Code: pb.RpcObjectSearchResponseError_NULL},
+		}
+		if isValid {
+			response.Records = []*types.Struct{
+				{
+					Fields: map[string]*types.Value{
+						bundle.RelationKeyResolvedLayout.String(): pbtypes.Int64(int64(model.ObjectType_tag)),
+						bundle.RelationKeyRelationKey.String():    pbtypes.String(propertyKey),
+					},
+				},
+			}
+		}
+		fx.mwMock.On("ObjectSearch", mock.Anything, &pb.RpcObjectSearchRequest{
+			SpaceId: mockedSpaceId,
+			Filters: []*model.BlockContentDataviewFilter{
+				{
+					RelationKey: bundle.RelationKeyId.String(),
+					Condition:   model.BlockContentDataviewFilter_Equal,
+					Value:       pbtypes.String(tagId),
+				},
+			},
+			Keys: []string{bundle.RelationKeyResolvedLayout.String(), bundle.RelationKeyRelationKey.String()},
+		}).Return(response).Maybe()
+	}
+
+	t.Run("accepts []string input for multi_select property", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.populateCache(mockedSpaceId)
+		setupTagValidationMock(fx, "tag1", "multi_select_prop", true)
+		setupTagValidationMock(fx, "tag2", "multi_select_prop", true)
+
+		prop := &apimodel.Property{
+			Key:         "multi_select_prop",
+			RelationKey: "multi_select_prop",
+			Format:      apimodel.PropertyFormatMultiSelect,
+		}
+		propertyMap := fx.service.cache.getProperties(mockedSpaceId)
+
+		// This should work with []string input (from MultiSelectFilterItem.GetValue())
+		result, err := fx.service.SanitizeAndValidatePropertyValue(
+			mockedSpaceId,
+			"multi_select_prop",
+			[]string{"tag1", "tag2"}, // []string, not []interface{}
+			prop,
+			propertyMap,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tag1", "tag2"}, result)
+	})
+
+	t.Run("accepts []interface{} input for multi_select property", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.populateCache(mockedSpaceId)
+		setupTagValidationMock(fx, "tag1", "multi_select_prop", true)
+		setupTagValidationMock(fx, "tag2", "multi_select_prop", true)
+
+		prop := &apimodel.Property{
+			Key:         "multi_select_prop",
+			RelationKey: "multi_select_prop",
+			Format:      apimodel.PropertyFormatMultiSelect,
+		}
+		propertyMap := fx.service.cache.getProperties(mockedSpaceId)
+
+		result, err := fx.service.SanitizeAndValidatePropertyValue(
+			mockedSpaceId,
+			"multi_select_prop",
+			[]interface{}{"tag1", "tag2"},
+			prop,
+			propertyMap,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tag1", "tag2"}, result)
+	})
+}
+
 func TestProcessProperties(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

Fixes the `failed to build expression filters` error when using `in`, `all`, or `nin` conditions on array-type properties (`objects`, `multi_select`, `files`) in the Search API.

## Problem

The filter item types (`ObjectsFilterItem`, `MultiSelectFilterItem`, `FilesFilterItem`) return `[]string` from their `GetValue()` methods, but `SanitizeAndValidatePropertyValue` expected `[]interface{}`. This type assertion failure caused all array-based filter conditions to fail.

Additionally, the `links` property (a derived system property) was incorrectly validated to require object/member layouts, but it can contain references to any object type (files, types, pages, etc.).

## Changes

- **`core/api/service/property.go`**: 
  - `SanitizeAndValidatePropertyValue` now accepts both `[]string` and `[]interface{}` for `objects`, `files`, and `multi_select` property formats
  - Added `isValidObjectReferenceForProperty()` that relaxes validation for the `links` property

- **`core/api/filter/expression_test.go`**: Added tests for `ObjectsFilterItem` with `in`/`all` conditions

- **`core/api/service/property_test.go`**: Added tests for `SanitizeAndValidatePropertyValue` handling `[]string` input for objects and multi_select formats

## Test Plan

- [x] All existing tests pass
- [x] New tests verify `[]string` input is accepted for objects properties
- [x] New tests verify `[]string` input is accepted for multi_select properties  
- [x] New tests verify `links` property accepts any object type (e.g., files)

Fixes #2897

🤖 Generated with [Claude Code](https://claude.ai/code)