### PR TITLE
Add Chat REST API endpoints

### DIFF
--- a/core/api/core/core.go
+++ b/core/api/core/core.go
@@ -69,4 +69,13 @@ type ClientCommands interface {
 	BlockCreate(context.Context, *pb.RpcBlockCreateRequest) *pb.RpcBlockCreateResponse
 	BlockPaste(context.Context, *pb.RpcBlockPasteRequest) *pb.RpcBlockPasteResponse
 	BlockListDelete(context.Context, *pb.RpcBlockListDeleteRequest) *pb.RpcBlockListDeleteResponse
+
+	// Chat
+	ChatAddMessage(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse
+	ChatEditMessageContent(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse
+	ChatDeleteMessage(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse
+	ChatGetMessages(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse
+	ChatGetMessagesByIds(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse
+	ChatToggleMessageReaction(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse
+	ChatSearch(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse
 }

--- a/core/api/core/core.go
+++ b/core/api/core/core.go
@@ -15,6 +15,7 @@ type AccountService interface {
 
 type EventService interface {
 	Broadcast(event *pb.Event)
+	RegisterCallback(callback func(*pb.Event)) func() // Returns unregister function
 }
 
 type CrossSpaceSubscriptionService interface {
@@ -78,4 +79,8 @@ type ClientCommands interface {
 	ChatGetMessagesByIds(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse
 	ChatToggleMessageReaction(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse
 	ChatSearch(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse
+
+	// Chat subscriptions
+	ChatSubscribeLastMessages(context.Context, *pb.RpcChatSubscribeLastMessagesRequest) *pb.RpcChatSubscribeLastMessagesResponse
+	ChatUnsubscribe(context.Context, *pb.RpcChatUnsubscribeRequest) *pb.RpcChatUnsubscribeResponse
 }

--- a/core/api/core/core.go
+++ b/core/api/core/core.go
@@ -84,4 +84,7 @@ type ClientCommands interface {
 	ChatSubscribeLastMessages(context.Context, *pb.RpcChatSubscribeLastMessagesRequest) *pb.RpcChatSubscribeLastMessagesResponse
 	ChatUnsubscribe(context.Context, *pb.RpcChatUnsubscribeRequest) *pb.RpcChatUnsubscribeResponse
 	ChatReadMessages(context.Context, *pb.RpcChatReadMessagesRequest) *pb.RpcChatReadMessagesResponse
+
+	// File
+	FileUpload(context.Context, *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse
 }

--- a/core/api/core/core.go
+++ b/core/api/core/core.go
@@ -83,4 +83,5 @@ type ClientCommands interface {
 	// Chat subscriptions
 	ChatSubscribeLastMessages(context.Context, *pb.RpcChatSubscribeLastMessagesRequest) *pb.RpcChatSubscribeLastMessagesResponse
 	ChatUnsubscribe(context.Context, *pb.RpcChatUnsubscribeRequest) *pb.RpcChatUnsubscribeResponse
+	ChatReadMessages(context.Context, *pb.RpcChatReadMessagesRequest) *pb.RpcChatReadMessagesResponse
 }

--- a/core/api/core/mock_apicore/mock_ClientCommands.go
+++ b/core/api/core/mock_apicore/mock_ClientCommands.go
@@ -267,6 +267,447 @@ func (_c *MockClientCommands_BlockPaste_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// ChatAddMessage provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatAddMessage(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatAddMessage")
+	}
+
+	var r0 *pb.RpcChatAddMessageResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatAddMessageResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatAddMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatAddMessage'
+type MockClientCommands_ChatAddMessage_Call struct {
+	*mock.Call
+}
+
+// ChatAddMessage is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatAddMessageRequest
+func (_e *MockClientCommands_Expecter) ChatAddMessage(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatAddMessage_Call {
+	return &MockClientCommands_ChatAddMessage_Call{Call: _e.mock.On("ChatAddMessage", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatAddMessage_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest)) *MockClientCommands_ChatAddMessage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatAddMessageRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatAddMessage_Call) Return(_a0 *pb.RpcChatAddMessageResponse) *MockClientCommands_ChatAddMessage_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatAddMessage_Call) RunAndReturn(run func(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse) *MockClientCommands_ChatAddMessage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatDeleteMessage provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatDeleteMessage(_a0 context.Context, _a1 *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatDeleteMessage")
+	}
+
+	var r0 *pb.RpcChatDeleteMessageResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatDeleteMessageResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatDeleteMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatDeleteMessage'
+type MockClientCommands_ChatDeleteMessage_Call struct {
+	*mock.Call
+}
+
+// ChatDeleteMessage is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatDeleteMessageRequest
+func (_e *MockClientCommands_Expecter) ChatDeleteMessage(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatDeleteMessage_Call {
+	return &MockClientCommands_ChatDeleteMessage_Call{Call: _e.mock.On("ChatDeleteMessage", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatDeleteMessage_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatDeleteMessageRequest)) *MockClientCommands_ChatDeleteMessage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatDeleteMessageRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatDeleteMessage_Call) Return(_a0 *pb.RpcChatDeleteMessageResponse) *MockClientCommands_ChatDeleteMessage_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatDeleteMessage_Call) RunAndReturn(run func(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse) *MockClientCommands_ChatDeleteMessage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatEditMessageContent provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatEditMessageContent(_a0 context.Context, _a1 *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatEditMessageContent")
+	}
+
+	var r0 *pb.RpcChatEditMessageContentResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatEditMessageContentResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatEditMessageContent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatEditMessageContent'
+type MockClientCommands_ChatEditMessageContent_Call struct {
+	*mock.Call
+}
+
+// ChatEditMessageContent is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatEditMessageContentRequest
+func (_e *MockClientCommands_Expecter) ChatEditMessageContent(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatEditMessageContent_Call {
+	return &MockClientCommands_ChatEditMessageContent_Call{Call: _e.mock.On("ChatEditMessageContent", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatEditMessageContent_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatEditMessageContentRequest)) *MockClientCommands_ChatEditMessageContent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatEditMessageContentRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatEditMessageContent_Call) Return(_a0 *pb.RpcChatEditMessageContentResponse) *MockClientCommands_ChatEditMessageContent_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatEditMessageContent_Call) RunAndReturn(run func(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse) *MockClientCommands_ChatEditMessageContent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatGetMessages provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatGetMessages(_a0 context.Context, _a1 *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatGetMessages")
+	}
+
+	var r0 *pb.RpcChatGetMessagesResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatGetMessagesResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatGetMessages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatGetMessages'
+type MockClientCommands_ChatGetMessages_Call struct {
+	*mock.Call
+}
+
+// ChatGetMessages is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatGetMessagesRequest
+func (_e *MockClientCommands_Expecter) ChatGetMessages(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatGetMessages_Call {
+	return &MockClientCommands_ChatGetMessages_Call{Call: _e.mock.On("ChatGetMessages", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatGetMessages_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatGetMessagesRequest)) *MockClientCommands_ChatGetMessages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatGetMessagesRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessages_Call) Return(_a0 *pb.RpcChatGetMessagesResponse) *MockClientCommands_ChatGetMessages_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessages_Call) RunAndReturn(run func(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse) *MockClientCommands_ChatGetMessages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatGetMessagesByIds provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatGetMessagesByIds(_a0 context.Context, _a1 *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatGetMessagesByIds")
+	}
+
+	var r0 *pb.RpcChatGetMessagesByIdsResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatGetMessagesByIdsResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatGetMessagesByIds_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatGetMessagesByIds'
+type MockClientCommands_ChatGetMessagesByIds_Call struct {
+	*mock.Call
+}
+
+// ChatGetMessagesByIds is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatGetMessagesByIdsRequest
+func (_e *MockClientCommands_Expecter) ChatGetMessagesByIds(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatGetMessagesByIds_Call {
+	return &MockClientCommands_ChatGetMessagesByIds_Call{Call: _e.mock.On("ChatGetMessagesByIds", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatGetMessagesByIds_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatGetMessagesByIdsRequest)) *MockClientCommands_ChatGetMessagesByIds_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatGetMessagesByIdsRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessagesByIds_Call) Return(_a0 *pb.RpcChatGetMessagesByIdsResponse) *MockClientCommands_ChatGetMessagesByIds_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessagesByIds_Call) RunAndReturn(run func(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse) *MockClientCommands_ChatGetMessagesByIds_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatSearch provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatSearch(_a0 context.Context, _a1 *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatSearch")
+	}
+
+	var r0 *pb.RpcChatSearchResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatSearchResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatSearch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatSearch'
+type MockClientCommands_ChatSearch_Call struct {
+	*mock.Call
+}
+
+// ChatSearch is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatSearchRequest
+func (_e *MockClientCommands_Expecter) ChatSearch(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatSearch_Call {
+	return &MockClientCommands_ChatSearch_Call{Call: _e.mock.On("ChatSearch", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatSearch_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatSearchRequest)) *MockClientCommands_ChatSearch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatSearchRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatSearch_Call) Return(_a0 *pb.RpcChatSearchResponse) *MockClientCommands_ChatSearch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatSearch_Call) RunAndReturn(run func(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse) *MockClientCommands_ChatSearch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatSubscribeLastMessages provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatSubscribeLastMessages(_a0 context.Context, _a1 *pb.RpcChatSubscribeLastMessagesRequest) *pb.RpcChatSubscribeLastMessagesResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatSubscribeLastMessages")
+	}
+
+	var r0 *pb.RpcChatSubscribeLastMessagesResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatSubscribeLastMessagesRequest) *pb.RpcChatSubscribeLastMessagesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatSubscribeLastMessagesResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatSubscribeLastMessages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatSubscribeLastMessages'
+type MockClientCommands_ChatSubscribeLastMessages_Call struct {
+	*mock.Call
+}
+
+// ChatSubscribeLastMessages is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatSubscribeLastMessagesRequest
+func (_e *MockClientCommands_Expecter) ChatSubscribeLastMessages(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatSubscribeLastMessages_Call {
+	return &MockClientCommands_ChatSubscribeLastMessages_Call{Call: _e.mock.On("ChatSubscribeLastMessages", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatSubscribeLastMessages_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatSubscribeLastMessagesRequest)) *MockClientCommands_ChatSubscribeLastMessages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatSubscribeLastMessagesRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatSubscribeLastMessages_Call) Return(_a0 *pb.RpcChatSubscribeLastMessagesResponse) *MockClientCommands_ChatSubscribeLastMessages_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatSubscribeLastMessages_Call) RunAndReturn(run func(context.Context, *pb.RpcChatSubscribeLastMessagesRequest) *pb.RpcChatSubscribeLastMessagesResponse) *MockClientCommands_ChatSubscribeLastMessages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatToggleMessageReaction provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatToggleMessageReaction(_a0 context.Context, _a1 *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatToggleMessageReaction")
+	}
+
+	var r0 *pb.RpcChatToggleMessageReactionResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatToggleMessageReactionResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatToggleMessageReaction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatToggleMessageReaction'
+type MockClientCommands_ChatToggleMessageReaction_Call struct {
+	*mock.Call
+}
+
+// ChatToggleMessageReaction is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatToggleMessageReactionRequest
+func (_e *MockClientCommands_Expecter) ChatToggleMessageReaction(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatToggleMessageReaction_Call {
+	return &MockClientCommands_ChatToggleMessageReaction_Call{Call: _e.mock.On("ChatToggleMessageReaction", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatToggleMessageReaction_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatToggleMessageReactionRequest)) *MockClientCommands_ChatToggleMessageReaction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatToggleMessageReactionRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatToggleMessageReaction_Call) Return(_a0 *pb.RpcChatToggleMessageReactionResponse) *MockClientCommands_ChatToggleMessageReaction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatToggleMessageReaction_Call) RunAndReturn(run func(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse) *MockClientCommands_ChatToggleMessageReaction_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatUnsubscribe provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatUnsubscribe(_a0 context.Context, _a1 *pb.RpcChatUnsubscribeRequest) *pb.RpcChatUnsubscribeResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatUnsubscribe")
+	}
+
+	var r0 *pb.RpcChatUnsubscribeResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatUnsubscribeRequest) *pb.RpcChatUnsubscribeResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatUnsubscribeResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatUnsubscribe_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatUnsubscribe'
+type MockClientCommands_ChatUnsubscribe_Call struct {
+	*mock.Call
+}
+
+// ChatUnsubscribe is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatUnsubscribeRequest
+func (_e *MockClientCommands_Expecter) ChatUnsubscribe(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatUnsubscribe_Call {
+	return &MockClientCommands_ChatUnsubscribe_Call{Call: _e.mock.On("ChatUnsubscribe", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatUnsubscribe_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatUnsubscribeRequest)) *MockClientCommands_ChatUnsubscribe_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatUnsubscribeRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatUnsubscribe_Call) Return(_a0 *pb.RpcChatUnsubscribeResponse) *MockClientCommands_ChatUnsubscribe_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatUnsubscribe_Call) RunAndReturn(run func(context.Context, *pb.RpcChatUnsubscribeRequest) *pb.RpcChatUnsubscribeResponse) *MockClientCommands_ChatUnsubscribe_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ObjectCollectionAdd provides a mock function with given fields: _a0, _a1
 func (_m *MockClientCommands) ObjectCollectionAdd(_a0 context.Context, _a1 *pb.RpcObjectCollectionAddRequest) *pb.RpcObjectCollectionAddResponse {
 	ret := _m.Called(_a0, _a1)
@@ -1537,349 +1978,6 @@ func (_c *MockClientCommands_WorkspaceSetInfo_Call) Return(_a0 *pb.RpcWorkspaceS
 }
 
 func (_c *MockClientCommands_WorkspaceSetInfo_Call) RunAndReturn(run func(context.Context, *pb.RpcWorkspaceSetInfoRequest) *pb.RpcWorkspaceSetInfoResponse) *MockClientCommands_WorkspaceSetInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatAddMessage provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatAddMessage(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatAddMessage")
-	}
-
-	var r0 *pb.RpcChatAddMessageResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatAddMessageResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatAddMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatAddMessage'
-type MockClientCommands_ChatAddMessage_Call struct {
-	*mock.Call
-}
-
-// ChatAddMessage is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatAddMessageRequest
-func (_e *MockClientCommands_Expecter) ChatAddMessage(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatAddMessage_Call {
-	return &MockClientCommands_ChatAddMessage_Call{Call: _e.mock.On("ChatAddMessage", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatAddMessage_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest)) *MockClientCommands_ChatAddMessage_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatAddMessageRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatAddMessage_Call) Return(_a0 *pb.RpcChatAddMessageResponse) *MockClientCommands_ChatAddMessage_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatAddMessage_Call) RunAndReturn(run func(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse) *MockClientCommands_ChatAddMessage_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatDeleteMessage provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatDeleteMessage(_a0 context.Context, _a1 *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatDeleteMessage")
-	}
-
-	var r0 *pb.RpcChatDeleteMessageResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatDeleteMessageResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatDeleteMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatDeleteMessage'
-type MockClientCommands_ChatDeleteMessage_Call struct {
-	*mock.Call
-}
-
-// ChatDeleteMessage is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatDeleteMessageRequest
-func (_e *MockClientCommands_Expecter) ChatDeleteMessage(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatDeleteMessage_Call {
-	return &MockClientCommands_ChatDeleteMessage_Call{Call: _e.mock.On("ChatDeleteMessage", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatDeleteMessage_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatDeleteMessageRequest)) *MockClientCommands_ChatDeleteMessage_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatDeleteMessageRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatDeleteMessage_Call) Return(_a0 *pb.RpcChatDeleteMessageResponse) *MockClientCommands_ChatDeleteMessage_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatDeleteMessage_Call) RunAndReturn(run func(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse) *MockClientCommands_ChatDeleteMessage_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatEditMessageContent provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatEditMessageContent(_a0 context.Context, _a1 *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatEditMessageContent")
-	}
-
-	var r0 *pb.RpcChatEditMessageContentResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatEditMessageContentResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatEditMessageContent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatEditMessageContent'
-type MockClientCommands_ChatEditMessageContent_Call struct {
-	*mock.Call
-}
-
-// ChatEditMessageContent is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatEditMessageContentRequest
-func (_e *MockClientCommands_Expecter) ChatEditMessageContent(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatEditMessageContent_Call {
-	return &MockClientCommands_ChatEditMessageContent_Call{Call: _e.mock.On("ChatEditMessageContent", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatEditMessageContent_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatEditMessageContentRequest)) *MockClientCommands_ChatEditMessageContent_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatEditMessageContentRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatEditMessageContent_Call) Return(_a0 *pb.RpcChatEditMessageContentResponse) *MockClientCommands_ChatEditMessageContent_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatEditMessageContent_Call) RunAndReturn(run func(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse) *MockClientCommands_ChatEditMessageContent_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatGetMessages provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatGetMessages(_a0 context.Context, _a1 *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatGetMessages")
-	}
-
-	var r0 *pb.RpcChatGetMessagesResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatGetMessagesResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatGetMessages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatGetMessages'
-type MockClientCommands_ChatGetMessages_Call struct {
-	*mock.Call
-}
-
-// ChatGetMessages is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatGetMessagesRequest
-func (_e *MockClientCommands_Expecter) ChatGetMessages(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatGetMessages_Call {
-	return &MockClientCommands_ChatGetMessages_Call{Call: _e.mock.On("ChatGetMessages", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatGetMessages_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatGetMessagesRequest)) *MockClientCommands_ChatGetMessages_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatGetMessagesRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatGetMessages_Call) Return(_a0 *pb.RpcChatGetMessagesResponse) *MockClientCommands_ChatGetMessages_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatGetMessages_Call) RunAndReturn(run func(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse) *MockClientCommands_ChatGetMessages_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatGetMessagesByIds provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatGetMessagesByIds(_a0 context.Context, _a1 *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatGetMessagesByIds")
-	}
-
-	var r0 *pb.RpcChatGetMessagesByIdsResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatGetMessagesByIdsResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatGetMessagesByIds_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatGetMessagesByIds'
-type MockClientCommands_ChatGetMessagesByIds_Call struct {
-	*mock.Call
-}
-
-// ChatGetMessagesByIds is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatGetMessagesByIdsRequest
-func (_e *MockClientCommands_Expecter) ChatGetMessagesByIds(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatGetMessagesByIds_Call {
-	return &MockClientCommands_ChatGetMessagesByIds_Call{Call: _e.mock.On("ChatGetMessagesByIds", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatGetMessagesByIds_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatGetMessagesByIdsRequest)) *MockClientCommands_ChatGetMessagesByIds_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatGetMessagesByIdsRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatGetMessagesByIds_Call) Return(_a0 *pb.RpcChatGetMessagesByIdsResponse) *MockClientCommands_ChatGetMessagesByIds_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatGetMessagesByIds_Call) RunAndReturn(run func(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse) *MockClientCommands_ChatGetMessagesByIds_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatSearch provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatSearch(_a0 context.Context, _a1 *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatSearch")
-	}
-
-	var r0 *pb.RpcChatSearchResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatSearchResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatSearch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatSearch'
-type MockClientCommands_ChatSearch_Call struct {
-	*mock.Call
-}
-
-// ChatSearch is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatSearchRequest
-func (_e *MockClientCommands_Expecter) ChatSearch(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatSearch_Call {
-	return &MockClientCommands_ChatSearch_Call{Call: _e.mock.On("ChatSearch", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatSearch_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatSearchRequest)) *MockClientCommands_ChatSearch_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatSearchRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatSearch_Call) Return(_a0 *pb.RpcChatSearchResponse) *MockClientCommands_ChatSearch_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatSearch_Call) RunAndReturn(run func(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse) *MockClientCommands_ChatSearch_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// ChatToggleMessageReaction provides a mock function with given fields: _a0, _a1
-func (_m *MockClientCommands) ChatToggleMessageReaction(_a0 context.Context, _a1 *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse {
-	ret := _m.Called(_a0, _a1)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ChatToggleMessageReaction")
-	}
-
-	var r0 *pb.RpcChatToggleMessageReactionResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse); ok {
-		r0 = rf(_a0, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*pb.RpcChatToggleMessageReactionResponse)
-		}
-	}
-
-	return r0
-}
-
-// MockClientCommands_ChatToggleMessageReaction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatToggleMessageReaction'
-type MockClientCommands_ChatToggleMessageReaction_Call struct {
-	*mock.Call
-}
-
-// ChatToggleMessageReaction is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *pb.RpcChatToggleMessageReactionRequest
-func (_e *MockClientCommands_Expecter) ChatToggleMessageReaction(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatToggleMessageReaction_Call {
-	return &MockClientCommands_ChatToggleMessageReaction_Call{Call: _e.mock.On("ChatToggleMessageReaction", _a0, _a1)}
-}
-
-func (_c *MockClientCommands_ChatToggleMessageReaction_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatToggleMessageReactionRequest)) *MockClientCommands_ChatToggleMessageReaction_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*pb.RpcChatToggleMessageReactionRequest))
-	})
-	return _c
-}
-
-func (_c *MockClientCommands_ChatToggleMessageReaction_Call) Return(_a0 *pb.RpcChatToggleMessageReactionResponse) *MockClientCommands_ChatToggleMessageReaction_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockClientCommands_ChatToggleMessageReaction_Call) RunAndReturn(run func(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse) *MockClientCommands_ChatToggleMessageReaction_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/api/core/mock_apicore/mock_ClientCommands.go
+++ b/core/api/core/mock_apicore/mock_ClientCommands.go
@@ -708,6 +708,55 @@ func (_c *MockClientCommands_ChatUnsubscribe_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// ChatReadMessages provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatReadMessages(_a0 context.Context, _a1 *pb.RpcChatReadMessagesRequest) *pb.RpcChatReadMessagesResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatReadMessages")
+	}
+
+	var r0 *pb.RpcChatReadMessagesResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatReadMessagesRequest) *pb.RpcChatReadMessagesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatReadMessagesResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatReadMessages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatReadMessages'
+type MockClientCommands_ChatReadMessages_Call struct {
+	*mock.Call
+}
+
+// ChatReadMessages is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatReadMessagesRequest
+func (_e *MockClientCommands_Expecter) ChatReadMessages(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatReadMessages_Call {
+	return &MockClientCommands_ChatReadMessages_Call{Call: _e.mock.On("ChatReadMessages", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatReadMessages_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatReadMessagesRequest)) *MockClientCommands_ChatReadMessages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatReadMessagesRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatReadMessages_Call) Return(_a0 *pb.RpcChatReadMessagesResponse) *MockClientCommands_ChatReadMessages_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatReadMessages_Call) RunAndReturn(run func(context.Context, *pb.RpcChatReadMessagesRequest) *pb.RpcChatReadMessagesResponse) *MockClientCommands_ChatReadMessages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ObjectCollectionAdd provides a mock function with given fields: _a0, _a1
 func (_m *MockClientCommands) ObjectCollectionAdd(_a0 context.Context, _a1 *pb.RpcObjectCollectionAddRequest) *pb.RpcObjectCollectionAddResponse {
 	ret := _m.Called(_a0, _a1)

--- a/core/api/core/mock_apicore/mock_ClientCommands.go
+++ b/core/api/core/mock_apicore/mock_ClientCommands.go
@@ -1541,6 +1541,349 @@ func (_c *MockClientCommands_WorkspaceSetInfo_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// ChatAddMessage provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatAddMessage(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatAddMessage")
+	}
+
+	var r0 *pb.RpcChatAddMessageResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatAddMessageResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatAddMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatAddMessage'
+type MockClientCommands_ChatAddMessage_Call struct {
+	*mock.Call
+}
+
+// ChatAddMessage is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatAddMessageRequest
+func (_e *MockClientCommands_Expecter) ChatAddMessage(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatAddMessage_Call {
+	return &MockClientCommands_ChatAddMessage_Call{Call: _e.mock.On("ChatAddMessage", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatAddMessage_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest)) *MockClientCommands_ChatAddMessage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatAddMessageRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatAddMessage_Call) Return(_a0 *pb.RpcChatAddMessageResponse) *MockClientCommands_ChatAddMessage_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatAddMessage_Call) RunAndReturn(run func(context.Context, *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse) *MockClientCommands_ChatAddMessage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatDeleteMessage provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatDeleteMessage(_a0 context.Context, _a1 *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatDeleteMessage")
+	}
+
+	var r0 *pb.RpcChatDeleteMessageResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatDeleteMessageResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatDeleteMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatDeleteMessage'
+type MockClientCommands_ChatDeleteMessage_Call struct {
+	*mock.Call
+}
+
+// ChatDeleteMessage is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatDeleteMessageRequest
+func (_e *MockClientCommands_Expecter) ChatDeleteMessage(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatDeleteMessage_Call {
+	return &MockClientCommands_ChatDeleteMessage_Call{Call: _e.mock.On("ChatDeleteMessage", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatDeleteMessage_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatDeleteMessageRequest)) *MockClientCommands_ChatDeleteMessage_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatDeleteMessageRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatDeleteMessage_Call) Return(_a0 *pb.RpcChatDeleteMessageResponse) *MockClientCommands_ChatDeleteMessage_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatDeleteMessage_Call) RunAndReturn(run func(context.Context, *pb.RpcChatDeleteMessageRequest) *pb.RpcChatDeleteMessageResponse) *MockClientCommands_ChatDeleteMessage_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatEditMessageContent provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatEditMessageContent(_a0 context.Context, _a1 *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatEditMessageContent")
+	}
+
+	var r0 *pb.RpcChatEditMessageContentResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatEditMessageContentResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatEditMessageContent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatEditMessageContent'
+type MockClientCommands_ChatEditMessageContent_Call struct {
+	*mock.Call
+}
+
+// ChatEditMessageContent is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatEditMessageContentRequest
+func (_e *MockClientCommands_Expecter) ChatEditMessageContent(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatEditMessageContent_Call {
+	return &MockClientCommands_ChatEditMessageContent_Call{Call: _e.mock.On("ChatEditMessageContent", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatEditMessageContent_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatEditMessageContentRequest)) *MockClientCommands_ChatEditMessageContent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatEditMessageContentRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatEditMessageContent_Call) Return(_a0 *pb.RpcChatEditMessageContentResponse) *MockClientCommands_ChatEditMessageContent_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatEditMessageContent_Call) RunAndReturn(run func(context.Context, *pb.RpcChatEditMessageContentRequest) *pb.RpcChatEditMessageContentResponse) *MockClientCommands_ChatEditMessageContent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatGetMessages provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatGetMessages(_a0 context.Context, _a1 *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatGetMessages")
+	}
+
+	var r0 *pb.RpcChatGetMessagesResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatGetMessagesResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatGetMessages_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatGetMessages'
+type MockClientCommands_ChatGetMessages_Call struct {
+	*mock.Call
+}
+
+// ChatGetMessages is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatGetMessagesRequest
+func (_e *MockClientCommands_Expecter) ChatGetMessages(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatGetMessages_Call {
+	return &MockClientCommands_ChatGetMessages_Call{Call: _e.mock.On("ChatGetMessages", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatGetMessages_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatGetMessagesRequest)) *MockClientCommands_ChatGetMessages_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatGetMessagesRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessages_Call) Return(_a0 *pb.RpcChatGetMessagesResponse) *MockClientCommands_ChatGetMessages_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessages_Call) RunAndReturn(run func(context.Context, *pb.RpcChatGetMessagesRequest) *pb.RpcChatGetMessagesResponse) *MockClientCommands_ChatGetMessages_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatGetMessagesByIds provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatGetMessagesByIds(_a0 context.Context, _a1 *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatGetMessagesByIds")
+	}
+
+	var r0 *pb.RpcChatGetMessagesByIdsResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatGetMessagesByIdsResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatGetMessagesByIds_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatGetMessagesByIds'
+type MockClientCommands_ChatGetMessagesByIds_Call struct {
+	*mock.Call
+}
+
+// ChatGetMessagesByIds is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatGetMessagesByIdsRequest
+func (_e *MockClientCommands_Expecter) ChatGetMessagesByIds(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatGetMessagesByIds_Call {
+	return &MockClientCommands_ChatGetMessagesByIds_Call{Call: _e.mock.On("ChatGetMessagesByIds", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatGetMessagesByIds_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatGetMessagesByIdsRequest)) *MockClientCommands_ChatGetMessagesByIds_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatGetMessagesByIdsRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessagesByIds_Call) Return(_a0 *pb.RpcChatGetMessagesByIdsResponse) *MockClientCommands_ChatGetMessagesByIds_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatGetMessagesByIds_Call) RunAndReturn(run func(context.Context, *pb.RpcChatGetMessagesByIdsRequest) *pb.RpcChatGetMessagesByIdsResponse) *MockClientCommands_ChatGetMessagesByIds_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatSearch provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatSearch(_a0 context.Context, _a1 *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatSearch")
+	}
+
+	var r0 *pb.RpcChatSearchResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatSearchResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatSearch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatSearch'
+type MockClientCommands_ChatSearch_Call struct {
+	*mock.Call
+}
+
+// ChatSearch is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatSearchRequest
+func (_e *MockClientCommands_Expecter) ChatSearch(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatSearch_Call {
+	return &MockClientCommands_ChatSearch_Call{Call: _e.mock.On("ChatSearch", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatSearch_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatSearchRequest)) *MockClientCommands_ChatSearch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatSearchRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatSearch_Call) Return(_a0 *pb.RpcChatSearchResponse) *MockClientCommands_ChatSearch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatSearch_Call) RunAndReturn(run func(context.Context, *pb.RpcChatSearchRequest) *pb.RpcChatSearchResponse) *MockClientCommands_ChatSearch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ChatToggleMessageReaction provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) ChatToggleMessageReaction(_a0 context.Context, _a1 *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ChatToggleMessageReaction")
+	}
+
+	var r0 *pb.RpcChatToggleMessageReactionResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcChatToggleMessageReactionResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_ChatToggleMessageReaction_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ChatToggleMessageReaction'
+type MockClientCommands_ChatToggleMessageReaction_Call struct {
+	*mock.Call
+}
+
+// ChatToggleMessageReaction is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcChatToggleMessageReactionRequest
+func (_e *MockClientCommands_Expecter) ChatToggleMessageReaction(_a0 interface{}, _a1 interface{}) *MockClientCommands_ChatToggleMessageReaction_Call {
+	return &MockClientCommands_ChatToggleMessageReaction_Call{Call: _e.mock.On("ChatToggleMessageReaction", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_ChatToggleMessageReaction_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcChatToggleMessageReactionRequest)) *MockClientCommands_ChatToggleMessageReaction_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcChatToggleMessageReactionRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_ChatToggleMessageReaction_Call) Return(_a0 *pb.RpcChatToggleMessageReactionResponse) *MockClientCommands_ChatToggleMessageReaction_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_ChatToggleMessageReaction_Call) RunAndReturn(run func(context.Context, *pb.RpcChatToggleMessageReactionRequest) *pb.RpcChatToggleMessageReactionResponse) *MockClientCommands_ChatToggleMessageReaction_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockClientCommands creates a new instance of MockClientCommands. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockClientCommands(t interface {

--- a/core/api/core/mock_apicore/mock_ClientCommands.go
+++ b/core/api/core/mock_apicore/mock_ClientCommands.go
@@ -757,6 +757,55 @@ func (_c *MockClientCommands_ChatReadMessages_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// FileUpload provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) FileUpload(_a0 context.Context, _a1 *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FileUpload")
+	}
+
+	var r0 *pb.RpcFileUploadResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcFileUploadResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_FileUpload_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FileUpload'
+type MockClientCommands_FileUpload_Call struct {
+	*mock.Call
+}
+
+// FileUpload is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcFileUploadRequest
+func (_e *MockClientCommands_Expecter) FileUpload(_a0 interface{}, _a1 interface{}) *MockClientCommands_FileUpload_Call {
+	return &MockClientCommands_FileUpload_Call{Call: _e.mock.On("FileUpload", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_FileUpload_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcFileUploadRequest)) *MockClientCommands_FileUpload_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcFileUploadRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_FileUpload_Call) Return(_a0 *pb.RpcFileUploadResponse) *MockClientCommands_FileUpload_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_FileUpload_Call) RunAndReturn(run func(context.Context, *pb.RpcFileUploadRequest) *pb.RpcFileUploadResponse) *MockClientCommands_FileUpload_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ObjectCollectionAdd provides a mock function with given fields: _a0, _a1
 func (_m *MockClientCommands) ObjectCollectionAdd(_a0 context.Context, _a1 *pb.RpcObjectCollectionAddRequest) *pb.RpcObjectCollectionAddResponse {
 	ret := _m.Called(_a0, _a1)

--- a/core/api/core/mock_apicore/mock_EventService.go
+++ b/core/api/core/mock_apicore/mock_EventService.go
@@ -49,6 +49,54 @@ func (_c *MockEventService_Broadcast_Call) Return() *MockEventService_Broadcast_
 }
 
 func (_c *MockEventService_Broadcast_Call) RunAndReturn(run func(*pb.Event)) *MockEventService_Broadcast_Call {
+	_c.Run(run)
+	return _c
+}
+
+// RegisterCallback provides a mock function with given fields: callback
+func (_m *MockEventService) RegisterCallback(callback func(*pb.Event)) func() {
+	ret := _m.Called(callback)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegisterCallback")
+	}
+
+	var r0 func()
+	if rf, ok := ret.Get(0).(func(func(*pb.Event)) func()); ok {
+		r0 = rf(callback)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(func())
+		}
+	}
+
+	return r0
+}
+
+// MockEventService_RegisterCallback_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegisterCallback'
+type MockEventService_RegisterCallback_Call struct {
+	*mock.Call
+}
+
+// RegisterCallback is a helper method to define mock.On call
+//   - callback func(*pb.Event)
+func (_e *MockEventService_Expecter) RegisterCallback(callback interface{}) *MockEventService_RegisterCallback_Call {
+	return &MockEventService_RegisterCallback_Call{Call: _e.mock.On("RegisterCallback", callback)}
+}
+
+func (_c *MockEventService_RegisterCallback_Call) Run(run func(callback func(*pb.Event))) *MockEventService_RegisterCallback_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func(*pb.Event)))
+	})
+	return _c
+}
+
+func (_c *MockEventService_RegisterCallback_Call) Return(_a0 func()) *MockEventService_RegisterCallback_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockEventService_RegisterCallback_Call) RunAndReturn(run func(func(*pb.Event)) func()) *MockEventService_RegisterCallback_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/api/handler/chat.go
+++ b/core/api/handler/chat.go
@@ -1,9 +1,15 @@
 package handler
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
 	apimodel "github.com/anyproto/anytype-heart/core/api/model"
 	"github.com/anyproto/anytype-heart/core/api/pagination"
@@ -343,5 +349,121 @@ func SearchMessagesHandler(s *service.Service) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, apimodel.SearchMessagesResponse{Results: results})
+	}
+}
+
+const (
+	defaultSSELimit    = 50
+	sseChannelSize     = 100
+	ssePingInterval    = 30 * time.Second
+	sseMaxInitialLimit = 1000
+)
+
+// SubscribeChatHandler establishes an SSE connection for real-time chat updates
+//
+//	@Summary		Subscribe to chat events
+//	@Description	Establishes a Server-Sent Events (SSE) connection to receive real-time chat updates including new messages, edits, deletions, and reactions.
+//	@Id				subscribe_chat
+//	@Tags			Chat
+//	@Produce		text/event-stream
+//	@Param			Anytype-Version	header	string	true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path	string	true	"The ID of the space"
+//	@Param			chat_id			path	string	true	"The ID of the chat object"
+//	@Param			limit			query	int		false	"Number of initial messages to return"	default(50)	maximum(1000)
+//	@Success		200				"SSE event stream"
+//	@Failure		401				{object}	util.UnauthorizedError	"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError		"Chat not found"
+//	@Failure		500				{object}	util.ServerError		"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/subscribe [get]
+func SubscribeChatHandler(s *service.Service, sseManager *service.SSESessionManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+		limit := parseSSELimit(c.Query("limit"))
+		subId := uuid.New().String()
+
+		// Set SSE headers
+		c.Writer.Header().Set("Content-Type", "text/event-stream")
+		c.Writer.Header().Set("Cache-Control", "no-cache")
+		c.Writer.Header().Set("Connection", "keep-alive")
+		c.Writer.Header().Set("X-Accel-Buffering", "no") // Disable nginx buffering
+
+		// Create subscription and get initial messages
+		messages, state, err := s.SubscribeChat(c.Request.Context(), chatId, subId, limit)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrChatNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedSubscribeChat, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		// Register SSE session
+		session := &service.SSESession{
+			SubId:  subId,
+			ChatId: chatId,
+			Events: make(chan *apimodel.SSEChatEvent, sseChannelSize),
+			Done:   make(chan struct{}),
+		}
+		sseManager.Register(session)
+		defer func() {
+			sseManager.Unregister(subId)
+			_ = s.UnsubscribeChat(c.Request.Context(), chatId, subId) //nolint:errcheck // best effort cleanup
+		}()
+
+		// Send initial messages
+		initialEvent := apimodel.SSEChatEvent{
+			Type:     apimodel.SSEEventTypeInitial,
+			Messages: messages,
+			State:    state,
+		}
+		writeSSE(c.Writer, "initial", initialEvent)
+		c.Writer.Flush()
+
+		// Stream events until client disconnects
+		ticker := time.NewTicker(ssePingInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-c.Request.Context().Done():
+				return
+			case event := <-session.Events:
+				writeSSE(c.Writer, string(event.Type), event)
+				c.Writer.Flush()
+			case <-ticker.C:
+				writeSSE(c.Writer, "ping", nil)
+				c.Writer.Flush()
+			case <-session.Done:
+				return
+			}
+		}
+	}
+}
+
+func parseSSELimit(limitStr string) int {
+	if limitStr == "" {
+		return defaultSSELimit
+	}
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit < 1 {
+		return defaultSSELimit
+	}
+	if limit > sseMaxInitialLimit {
+		return sseMaxInitialLimit
+	}
+	return limit
+}
+
+func writeSSE(w io.Writer, eventType string, data interface{}) {
+	fmt.Fprintf(w, "event: %s\n", eventType)
+	if data != nil {
+		jsonData, _ := json.Marshal(data) //nolint:errcheck // SSE best effort
+		fmt.Fprintf(w, "data: %s\n\n", jsonData)
+	} else {
+		fmt.Fprintf(w, "data:\n\n")
 	}
 }

--- a/core/api/handler/chat.go
+++ b/core/api/handler/chat.go
@@ -352,6 +352,55 @@ func SearchMessagesHandler(s *service.Service) gin.HandlerFunc {
 	}
 }
 
+// ReadMessagesHandler marks messages as read in a chat
+//
+//	@Summary		Mark messages as read
+//	@Description	Marks messages as read in the specified chat. This updates the unread counter. Use the type parameter to specify whether to mark messages or mentions as read. Rate limited.
+//	@Id				read_messages
+//	@Tags			Chat
+//	@Accept			json
+//	@Produce		json
+//	@Param			Anytype-Version	header	string							true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path	string							true	"The ID of the space"
+//	@Param			chat_id			path	string							true	"The ID of the chat object"
+//	@Param			request			body	apimodel.ReadMessagesRequest	true	"The read request specifying the range of messages to mark as read"
+//	@Success		204				"Messages marked as read successfully"
+//	@Failure		400				{object}	util.ValidationError	"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError	"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError		"Chat or messages not found"
+//	@Failure		429				{object}	util.RateLimitError		"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError		"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/read [post]
+func ReadMessagesHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+
+		request := apimodel.ReadMessagesRequest{}
+		if err := c.BindJSON(&request); err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, err.Error())
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		err := s.ReadMessages(c.Request.Context(), chatId, request)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(util.ErrBad, http.StatusBadRequest),
+			util.ErrToCode(service.ErrChatNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrMessagesNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedReadMessages, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.Status(http.StatusNoContent)
+	}
+}
+
 const (
 	defaultSSELimit    = 50
 	sseChannelSize     = 100

--- a/core/api/handler/chat.go
+++ b/core/api/handler/chat.go
@@ -1,0 +1,347 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/core/api/pagination"
+	"github.com/anyproto/anytype-heart/core/api/service"
+	"github.com/anyproto/anytype-heart/core/api/util"
+)
+
+// ListMessagesHandler retrieves a list of chat messages
+//
+//	@Summary		List messages
+//	@Description	Retrieves a paginated list of messages in the specified chat. Supports cursor-based pagination using before_order_id or after_order_id parameters for infinite scroll, or offset-based pagination for initial loads.
+//	@Id				list_messages
+//	@Tags			Chat
+//	@Produce		json
+//	@Param			Anytype-Version	header		string						true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string						true	"The ID of the space"
+//	@Param			chat_id			path		string						true	"The ID of the chat object"
+//	@Param			offset			query		int							false	"The number of items to skip (for offset-based pagination)"	default(0)
+//	@Param			limit			query		int							false	"The number of items to return"								default(100)	maximum(1000)
+//	@Param			before_order_id	query		string						false	"Return messages before this order ID (cursor-based pagination for older messages)"
+//	@Param			after_order_id	query		string						false	"Return messages after this order ID (cursor-based pagination for newer messages)"
+//	@Success		200				{object}	apimodel.MessagesResponse	"The list of chat messages"
+//	@Failure		401				{object}	util.UnauthorizedError		"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError			"Chat not found"
+//	@Failure		500				{object}	util.ServerError			"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/messages [get]
+func ListMessagesHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+		limit := c.GetInt(pagination.QueryParamLimit)
+		beforeOrderId := c.Query("before_order_id")
+		afterOrderId := c.Query("after_order_id")
+
+		messages, chatState, err := s.GetMessages(c.Request.Context(), chatId, beforeOrderId, afterOrderId, limit)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrChatNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedRetrieveMessages, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusOK, apimodel.MessagesResponse{
+			Messages: messages,
+			State:    chatState,
+		})
+	}
+}
+
+// GetMessageHandler retrieves a single chat message
+//
+//	@Summary		Get message
+//	@Description	Retrieves a single message by its ID from the specified chat.
+//	@Id				get_message
+//	@Tags			Chat
+//	@Produce		json
+//	@Param			Anytype-Version	header		string						true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string						true	"The ID of the space"
+//	@Param			chat_id			path		string						true	"The ID of the chat object"
+//	@Param			message_id		path		string						true	"The ID of the message to retrieve"
+//	@Success		200				{object}	apimodel.MessageResponse	"The chat message"
+//	@Failure		401				{object}	util.UnauthorizedError		"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError			"Message not found"
+//	@Failure		500				{object}	util.ServerError			"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id} [get]
+func GetMessageHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+		messageId := c.Param("message_id")
+
+		message, err := s.GetMessageById(c.Request.Context(), chatId, messageId)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrMessageNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedRetrieveMessages, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusOK, apimodel.MessageResponse{Message: *message})
+	}
+}
+
+// CreateMessageHandler creates a new chat message
+//
+//	@Summary		Create message
+//	@Description	Creates a new message in the specified chat. Rate limited.
+//	@Id				create_message
+//	@Tags			Chat
+//	@Accept			json
+//	@Produce		json
+//	@Param			Anytype-Version	header		string							true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string							true	"The ID of the space"
+//	@Param			chat_id			path		string							true	"The ID of the chat object"
+//	@Param			message			body		apimodel.CreateMessageRequest	true	"The message to create"
+//	@Success		201				{object}	apimodel.MessageResponse		"The created message"
+//	@Failure		400				{object}	util.ValidationError			"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError			"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError				"Chat not found"
+//	@Failure		429				{object}	util.RateLimitError				"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError				"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/messages [post]
+func CreateMessageHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+
+		request := apimodel.CreateMessageRequest{}
+		if err := c.BindJSON(&request); err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, err.Error())
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		message, err := s.CreateMessage(c.Request.Context(), chatId, request)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(util.ErrBad, http.StatusBadRequest),
+			util.ErrToCode(service.ErrChatNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedCreateMessage, http.StatusInternalServerError),
+			util.ErrToCode(service.ErrMessageNotFound, http.StatusInternalServerError),
+			util.ErrToCode(service.ErrFailedRetrieveMessages, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusCreated, apimodel.MessageResponse{Message: *message})
+	}
+}
+
+// UpdateMessageHandler updates an existing chat message
+//
+//	@Summary		Update message
+//	@Description	Updates an existing message in the specified chat. Rate limited.
+//	@Id				update_message
+//	@Tags			Chat
+//	@Accept			json
+//	@Produce		json
+//	@Param			Anytype-Version	header		string							true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string							true	"The ID of the space"
+//	@Param			chat_id			path		string							true	"The ID of the chat object"
+//	@Param			message_id		path		string							true	"The ID of the message to update"
+//	@Param			message			body		apimodel.UpdateMessageRequest	true	"The message updates"
+//	@Success		200				{object}	apimodel.MessageResponse		"The updated message"
+//	@Failure		400				{object}	util.ValidationError			"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError			"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError				"Message not found"
+//	@Failure		429				{object}	util.RateLimitError				"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError				"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id} [patch]
+func UpdateMessageHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+		messageId := c.Param("message_id")
+
+		request := apimodel.UpdateMessageRequest{}
+		if err := c.BindJSON(&request); err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, err.Error())
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		err := s.UpdateMessage(c.Request.Context(), chatId, messageId, request)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(util.ErrBad, http.StatusBadRequest),
+			util.ErrToCode(service.ErrMessageNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedUpdateMessage, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		// Retrieve the updated message to return
+		message, err := s.GetMessageById(c.Request.Context(), chatId, messageId)
+		if err != nil {
+			code := util.MapErrorCode(err,
+				util.ErrToCode(service.ErrMessageNotFound, http.StatusNotFound),
+				util.ErrToCode(service.ErrFailedRetrieveMessages, http.StatusInternalServerError),
+			)
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusOK, apimodel.MessageResponse{Message: *message})
+	}
+}
+
+// DeleteMessageHandler deletes a chat message
+//
+//	@Summary		Delete message
+//	@Description	Deletes a message from the specified chat. Rate limited.
+//	@Id				delete_message
+//	@Tags			Chat
+//	@Produce		json
+//	@Param			Anytype-Version	header	string	true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path	string	true	"The ID of the space"
+//	@Param			chat_id			path	string	true	"The ID of the chat object"
+//	@Param			message_id		path	string	true	"The ID of the message to delete"
+//	@Success		204				"Message deleted successfully"
+//	@Failure		401				{object}	util.UnauthorizedError	"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError		"Message not found"
+//	@Failure		429				{object}	util.RateLimitError		"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError		"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id} [delete]
+func DeleteMessageHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+		messageId := c.Param("message_id")
+
+		err := s.DeleteMessage(c.Request.Context(), chatId, messageId)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrMessageNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedDeleteMessage, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// ToggleReactionHandler toggles a reaction on a chat message
+//
+//	@Summary		Toggle reaction
+//	@Description	Toggles a reaction (emoji) on a message. If the reaction already exists from the user, it is removed; otherwise, it is added. Rate limited.
+//	@Id				toggle_reaction
+//	@Tags			Chat
+//	@Accept			json
+//	@Produce		json
+//	@Param			Anytype-Version	header		string							true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string							true	"The ID of the space"
+//	@Param			chat_id			path		string							true	"The ID of the chat object"
+//	@Param			message_id		path		string							true	"The ID of the message"
+//	@Param			reaction		body		apimodel.ToggleReactionRequest	true	"The reaction to toggle"
+//	@Success		200				{object}	apimodel.ToggleReactionResponse	"The result of the toggle operation"
+//	@Failure		400				{object}	util.ValidationError			"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError			"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError				"Message not found"
+//	@Failure		429				{object}	util.RateLimitError				"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError				"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id}/reactions [post]
+func ToggleReactionHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		chatId := c.Param("chat_id")
+		messageId := c.Param("message_id")
+
+		request := apimodel.ToggleReactionRequest{}
+		if err := c.BindJSON(&request); err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, err.Error())
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		added, err := s.ToggleReaction(c.Request.Context(), chatId, messageId, request.Emoji)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(util.ErrBad, http.StatusBadRequest),
+			util.ErrToCode(service.ErrMessageNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrFailedToggleReaction, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusOK, apimodel.ToggleReactionResponse{Added: added})
+	}
+}
+
+// SearchMessagesHandler searches for messages in a chat
+//
+//	@Summary		Search messages
+//	@Description	Searches for messages in the specified chat using full-text search.
+//	@Id				search_messages
+//	@Tags			Chat
+//	@Accept			json
+//	@Produce		json
+//	@Param			Anytype-Version	header		string							true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string							true	"The ID of the space"
+//	@Param			chat_id			path		string							true	"The ID of the chat object"
+//	@Param			search			body		apimodel.SearchMessagesRequest	true	"The search query"
+//	@Param			offset			query		int								false	"The number of items to skip"	default(0)
+//	@Param			limit			query		int								false	"The number of items to return"	default(100)	maximum(1000)
+//	@Success		200				{object}	apimodel.SearchMessagesResponse	"The search results"
+//	@Failure		400				{object}	util.ValidationError			"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError			"Unauthorized"
+//	@Failure		500				{object}	util.ServerError				"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/chats/{chat_id}/search [post]
+func SearchMessagesHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spaceId := c.Param("space_id")
+		chatId := c.Param("chat_id")
+		offset := c.GetInt(pagination.QueryParamOffset)
+		limit := c.GetInt(pagination.QueryParamLimit)
+
+		request := apimodel.SearchMessagesRequest{}
+		if err := c.BindJSON(&request); err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, err.Error())
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		results, err := s.SearchMessages(c.Request.Context(), spaceId, chatId, request.Query, offset, limit)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(util.ErrBad, http.StatusBadRequest),
+			util.ErrToCode(service.ErrFailedSearchMessages, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusOK, apimodel.SearchMessagesResponse{Results: results})
+	}
+}

--- a/core/api/handler/file.go
+++ b/core/api/handler/file.go
@@ -1,0 +1,88 @@
+package handler
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/core/api/service"
+	"github.com/anyproto/anytype-heart/core/api/util"
+)
+
+// UploadFileHandler uploads a file to Anytype
+//
+//	@Summary		Upload file
+//	@Description	Uploads a file to the specified space. The file is uploaded via multipart/form-data. Returns the object ID which can be used as an attachment in chat messages or other objects. Rate limited.
+//	@Id				upload_file
+//	@Tags			Files
+//	@Accept			multipart/form-data
+//	@Produce		json
+//	@Param			Anytype-Version	header		string						true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string						true	"The ID of the space"
+//	@Param			file			formData	file						true	"The file to upload"
+//	@Param			type			formData	string						false	"The type of file (file, image, video, audio, pdf). If not specified, the type is auto-detected."	Enums(file, image, video, audio, pdf)
+//	@Success		201				{object}	apimodel.FileUploadResponse	"The uploaded file"
+//	@Failure		400				{object}	util.ValidationError		"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError		"Unauthorized"
+//	@Failure		429				{object}	util.RateLimitError			"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError			"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/files [post]
+func UploadFileHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spaceId := c.Param("space_id")
+
+		// Get the uploaded file
+		file, err := c.FormFile("file")
+		if err != nil {
+			apiErr := util.CodeToApiError(http.StatusBadRequest, "file is required")
+			c.JSON(http.StatusBadRequest, apiErr)
+			return
+		}
+
+		// Create temp file with original extension preserved
+		ext := filepath.Ext(file.Filename)
+		tempFile, err := os.CreateTemp("", "anytype-upload-*"+ext)
+		if err != nil {
+			apiErr := util.CodeToApiError(http.StatusInternalServerError, "failed to create temp file")
+			c.JSON(http.StatusInternalServerError, apiErr)
+			return
+		}
+		tempPath := tempFile.Name()
+		tempFile.Close()
+
+		// Ensure temp file is cleaned up
+		defer os.Remove(tempPath)
+
+		// Save uploaded file to temp location
+		if err := c.SaveUploadedFile(file, tempPath); err != nil {
+			apiErr := util.CodeToApiError(http.StatusInternalServerError, "failed to save uploaded file")
+			c.JSON(http.StatusInternalServerError, apiErr)
+			return
+		}
+
+		// Get optional file type
+		fileType := apimodel.FileType(c.PostForm("type"))
+
+		// Upload to Anytype
+		objectId, err := s.UploadFile(c.Request.Context(), spaceId, tempPath, fileType)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrInvalidFile, http.StatusBadRequest),
+			util.ErrToCode(service.ErrFailedUploadFile, http.StatusInternalServerError),
+		)
+
+		if code != http.StatusOK {
+			apiErr := util.CodeToApiError(code, err.Error())
+			c.JSON(code, apiErr)
+			return
+		}
+
+		c.JSON(http.StatusCreated, apimodel.FileUploadResponse{
+			Object:   "file",
+			ObjectId: objectId,
+		})
+	}
+}

--- a/core/api/model/chat.go
+++ b/core/api/model/chat.go
@@ -138,3 +138,19 @@ type Range struct {
 type SearchMessagesResponse struct {
 	Results []SearchMessageResult `json:"results"` // The search results
 }
+
+// ReadMessagesType represents the type of messages to mark as read
+type ReadMessagesType string
+
+const (
+	ReadMessagesTypeMessages ReadMessagesType = "messages"
+	ReadMessagesTypeMentions ReadMessagesType = "mentions"
+)
+
+// ReadMessagesRequest represents a request to mark messages as read
+type ReadMessagesRequest struct {
+	Type          ReadMessagesType `json:"type" binding:"required,oneof=messages mentions" example:"messages"` // The type of counter to mark as read
+	AfterOrderId  string           `json:"after_order_id,omitempty" example:""`                                // Read from this orderId; if empty, read from the beginning
+	BeforeOrderId string           `json:"before_order_id" binding:"required" example:"!!Xz"`                  // Read up to this orderId
+	LastStateId   string           `json:"last_state_id" binding:"required" example:"6980b7db..."`             // The last state ID from ChatState to prevent race conditions
+}

--- a/core/api/model/chat.go
+++ b/core/api/model/chat.go
@@ -1,0 +1,140 @@
+package apimodel
+
+// MessageStyle represents the style of a chat message
+type MessageStyle string
+
+const (
+	MessageStyleParagraph   MessageStyle = "paragraph"
+	MessageStyleHeader1     MessageStyle = "header1"
+	MessageStyleHeader2     MessageStyle = "header2"
+	MessageStyleHeader3     MessageStyle = "header3"
+	MessageStyleHeader4     MessageStyle = "header4"
+	MessageStyleQuote       MessageStyle = "quote"
+	MessageStyleCode        MessageStyle = "code"
+	MessageStyleTitle       MessageStyle = "title"
+	MessageStyleCheckbox    MessageStyle = "checkbox"
+	MessageStyleMarked      MessageStyle = "marked"
+	MessageStyleNumbered    MessageStyle = "numbered"
+	MessageStyleToggle      MessageStyle = "toggle"
+	MessageStyleDescription MessageStyle = "description"
+	MessageStyleCallout     MessageStyle = "callout"
+)
+
+// AttachmentType represents the type of a chat message attachment
+type AttachmentType string
+
+const (
+	AttachmentTypeFile  AttachmentType = "file"
+	AttachmentTypeImage AttachmentType = "image"
+	AttachmentTypeLink  AttachmentType = "link"
+)
+
+// MessageContent represents the content of a chat message
+type MessageContent struct {
+	Text  string       `json:"text" example:"Hello, world!"` // The text content of the message
+	Style MessageStyle `json:"style" example:"paragraph"`    // The style of the message text
+	Marks []TextMark   `json:"marks,omitempty"`              // Text formatting marks
+}
+
+// TextMark represents a formatting mark in the message text
+type TextMark struct {
+	Type  string `json:"type" example:"bold"` // The type of mark (bold, italic, link, etc.)
+	From  int32  `json:"from" example:"0"`    // Start position of the mark
+	To    int32  `json:"to" example:"5"`      // End position of the mark
+	Param string `json:"param,omitempty"`     // Optional parameter (e.g., URL for links)
+}
+
+// MessageAttachment represents an attachment in a chat message
+type MessageAttachment struct {
+	Target string         `json:"target" example:"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ"` // The target object ID of the attachment
+	Type   AttachmentType `json:"type" example:"file"`                                                          // The type of attachment
+}
+
+// ChatMessage represents a chat message in the API response
+type ChatMessage struct {
+	Object           string              `json:"object" example:"chat_message"`                      // The data model of the object
+	Id               string              `json:"id" example:"msg_abc123"`                            // The unique identifier of the message
+	OrderId          string              `json:"order_id" example:"2024-01-15T10:30:00Z"`            // The order ID for pagination cursor
+	Creator          string              `json:"creator" example:"user_xyz"`                         // The creator identity of the message
+	CreatedAt        int64               `json:"created_at" example:"1705312200"`                    // Unix timestamp when the message was created
+	ModifiedAt       int64               `json:"modified_at" example:"1705312200"`                   // Unix timestamp when the message was last modified
+	ReplyToMessageId string              `json:"reply_to_message_id,omitempty" example:"msg_abc122"` // The ID of the message being replied to
+	Content          MessageContent      `json:"content"`                                            // The content of the message
+	Attachments      []MessageAttachment `json:"attachments"`                                        // The attachments of the message
+	Reactions        map[string][]string `json:"reactions"`                                          // Map of emoji to list of user IDs who reacted
+	Read             bool                `json:"read" example:"true"`                                // Whether the message has been read
+}
+
+// ChatState represents the state of a chat
+type ChatState struct {
+	Messages    *UnreadState `json:"messages,omitempty"`      // Unread state for messages
+	Mentions    *UnreadState `json:"mentions,omitempty"`      // Unread state for mentions
+	LastStateId string       `json:"last_state_id,omitempty"` // The last state ID
+}
+
+// UnreadState represents the unread state for a counter type
+type UnreadState struct {
+	Counter       int32  `json:"counter" example:"5"`       // Number of unread items
+	OldestOrderId string `json:"oldest_order_id,omitempty"` // Order ID of the oldest unread item
+}
+
+// MessageResponse wraps a single chat message response
+type MessageResponse struct {
+	Message ChatMessage `json:"message"` // The chat message
+}
+
+// MessagesResponse wraps a list of chat messages with chat state
+type MessagesResponse struct {
+	Messages []ChatMessage `json:"messages"`        // The list of chat messages
+	State    *ChatState    `json:"state,omitempty"` // The chat state
+}
+
+// CreateMessageRequest represents a request to create a new chat message
+type CreateMessageRequest struct {
+	Text             string              `json:"text" binding:"required" example:"Hello, world!"`    // The text content of the message
+	Style            MessageStyle        `json:"style,omitempty" example:"paragraph"`                // The style of the message text
+	ReplyToMessageId string              `json:"reply_to_message_id,omitempty" example:"msg_abc122"` // The ID of the message to reply to
+	Attachments      []MessageAttachment `json:"attachments,omitempty"`                              // Attachments to include in the message
+}
+
+// UpdateMessageRequest represents a request to update an existing chat message
+type UpdateMessageRequest struct {
+	Text  string       `json:"text" binding:"required" example:"Updated message text"` // The updated text content
+	Style MessageStyle `json:"style,omitempty" example:"paragraph"`                    // The updated style
+}
+
+// ToggleReactionRequest represents a request to toggle a reaction on a message
+type ToggleReactionRequest struct {
+	Emoji string `json:"emoji" binding:"required" example:"👍"` // The emoji to toggle
+}
+
+// ToggleReactionResponse represents the response from toggling a reaction
+type ToggleReactionResponse struct {
+	Added bool `json:"added" example:"true"` // Whether the reaction was added (true) or removed (false)
+}
+
+// SearchMessagesRequest represents a request to search chat messages
+type SearchMessagesRequest struct {
+	Query string `json:"query" binding:"required" example:"hello"` // The search query text
+}
+
+// SearchMessageResult represents a single search result
+type SearchMessageResult struct {
+	ChatId          string      `json:"chat_id" example:"chat_abc123"`         // The chat ID containing the message
+	MessageId       string      `json:"message_id" example:"msg_abc123"`       // The message ID
+	Score           int64       `json:"score" example:"100"`                   // The relevance score
+	Highlight       string      `json:"highlight" example:"...hello world..."` // Highlighted snippet
+	HighlightRanges []Range     `json:"highlight_ranges,omitempty"`            // Ranges of highlighted text
+	Message         ChatMessage `json:"message"`                               // The full message
+}
+
+// Range represents a text range
+type Range struct {
+	From int32 `json:"from" example:"0"` // Start position
+	To   int32 `json:"to" example:"5"`   // End position
+}
+
+// SearchMessagesResponse wraps the search results
+type SearchMessagesResponse struct {
+	Results []SearchMessageResult `json:"results"` // The search results
+}

--- a/core/api/model/file.go
+++ b/core/api/model/file.go
@@ -1,0 +1,19 @@
+package apimodel
+
+// FileType represents the type of file being uploaded
+type FileType string
+
+const (
+	FileTypeNone  FileType = ""
+	FileTypeFile  FileType = "file"
+	FileTypeImage FileType = "image"
+	FileTypeVideo FileType = "video"
+	FileTypeAudio FileType = "audio"
+	FileTypePDF   FileType = "pdf"
+)
+
+// FileUploadResponse represents a successful file upload response
+type FileUploadResponse struct {
+	Object   string `json:"object" example:"file"`                                                         // The data model of the object
+	ObjectId string `json:"object_id" example:"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ"` // The object ID of the uploaded file
+}

--- a/core/api/model/sse.go
+++ b/core/api/model/sse.go
@@ -1,0 +1,22 @@
+package apimodel
+
+// SSEEventType represents the type of SSE event
+type SSEEventType string
+
+const (
+	SSEEventTypeInitial   SSEEventType = "initial"
+	SSEEventTypeAdd       SSEEventType = "add"
+	SSEEventTypeUpdate    SSEEventType = "update"
+	SSEEventTypeDelete    SSEEventType = "delete"
+	SSEEventTypeReactions SSEEventType = "reactions"
+	SSEEventTypeState     SSEEventType = "state"
+)
+
+// SSEChatEvent represents a chat event sent over SSE
+type SSEChatEvent struct {
+	Type     SSEEventType  `json:"type"`
+	Message  *ChatMessage  `json:"message,omitempty"`
+	Messages []ChatMessage `json:"messages,omitempty"`
+	State    *ChatState    `json:"state,omitempty"`
+	Deleted  string        `json:"deleted,omitempty"`
+}

--- a/core/api/server/middleware_test.go
+++ b/core/api/server/middleware_test.go
@@ -162,7 +162,16 @@ func TestEnsureAnalyticsEvent(t *testing.T) {
 
 		expectedPayload, err := util.NewAnalyticsEventForApi(context.Background(), code, http.StatusAccepted)
 		require.NoError(t, err)
-		msgArg := fx.eventMock.Calls[0].Arguments.Get(0).(*pb.Event)
+
+		// Find the Broadcast call (skip RegisterCallback call from fixture setup)
+		var msgArg *pb.Event
+		for _, call := range fx.eventMock.Calls {
+			if call.Method == "Broadcast" {
+				msgArg = call.Arguments.Get(0).(*pb.Event)
+				break
+			}
+		}
+		require.NotNil(t, msgArg, "Broadcast call not found")
 		require.Len(t, msgArg.Messages, 1)
 
 		wrapper := msgArg.Messages[0].GetPayloadBroadcast()

--- a/core/api/server/router.go
+++ b/core/api/server/router.go
@@ -36,6 +36,7 @@ func (srv *Server) NewRouter(mw apicore.ClientCommands, eventService apicore.Eve
 	v1.Use(srv.ensureCacheInitialized())
 	v1.Use(srv.ensureAuthenticated(mw))
 
+	srv.registerChatRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerListRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerMemberRoutes(v1, eventService)
 	srv.registerObjectRoutes(v1, eventService, writeRateLimitMW)
@@ -307,5 +308,41 @@ func (srv *Server) registerTypeRoutes(v1 *gin.RouterGroup, eventService apicore.
 		writeRateLimitMW,
 		ensureAnalyticsEvent("DeleteType", eventService),
 		handler.DeleteTypeHandler(srv.service),
+	)
+}
+
+// registerChatRoutes registers chat-related routes
+func (srv *Server) registerChatRoutes(v1 *gin.RouterGroup, eventService apicore.EventService, writeRateLimitMW gin.HandlerFunc) {
+	v1.GET("/spaces/:space_id/chats/:chat_id/messages",
+		ensureAnalyticsEvent("ListMessages", eventService),
+		handler.ListMessagesHandler(srv.service),
+	)
+	v1.GET("/spaces/:space_id/chats/:chat_id/messages/:message_id",
+		ensureAnalyticsEvent("GetMessage", eventService),
+		handler.GetMessageHandler(srv.service),
+	)
+	v1.POST("/spaces/:space_id/chats/:chat_id/messages",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("CreateMessage", eventService),
+		handler.CreateMessageHandler(srv.service),
+	)
+	v1.PATCH("/spaces/:space_id/chats/:chat_id/messages/:message_id",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("UpdateMessage", eventService),
+		handler.UpdateMessageHandler(srv.service),
+	)
+	v1.DELETE("/spaces/:space_id/chats/:chat_id/messages/:message_id",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("DeleteMessage", eventService),
+		handler.DeleteMessageHandler(srv.service),
+	)
+	v1.POST("/spaces/:space_id/chats/:chat_id/messages/:message_id/reactions",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("ToggleReaction", eventService),
+		handler.ToggleReactionHandler(srv.service),
+	)
+	v1.POST("/spaces/:space_id/chats/:chat_id/search",
+		ensureAnalyticsEvent("SearchMessages", eventService),
+		handler.SearchMessagesHandler(srv.service),
 	)
 }

--- a/core/api/server/router.go
+++ b/core/api/server/router.go
@@ -37,6 +37,7 @@ func (srv *Server) NewRouter(mw apicore.ClientCommands, eventService apicore.Eve
 	v1.Use(srv.ensureAuthenticated(mw))
 
 	srv.registerChatRoutes(v1, eventService, writeRateLimitMW)
+	srv.registerFileRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerListRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerMemberRoutes(v1, eventService)
 	srv.registerObjectRoutes(v1, eventService, writeRateLimitMW)
@@ -353,5 +354,14 @@ func (srv *Server) registerChatRoutes(v1 *gin.RouterGroup, eventService apicore.
 	v1.GET("/spaces/:space_id/chats/:chat_id/subscribe",
 		ensureAnalyticsEvent("SubscribeChat", eventService),
 		handler.SubscribeChatHandler(srv.service, srv.sseManager),
+	)
+}
+
+// registerFileRoutes registers file-related routes
+func (srv *Server) registerFileRoutes(v1 *gin.RouterGroup, eventService apicore.EventService, writeRateLimitMW gin.HandlerFunc) {
+	v1.POST("/spaces/:space_id/files",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("UploadFile", eventService),
+		handler.UploadFileHandler(srv.service),
 	)
 }

--- a/core/api/server/router.go
+++ b/core/api/server/router.go
@@ -345,6 +345,11 @@ func (srv *Server) registerChatRoutes(v1 *gin.RouterGroup, eventService apicore.
 		ensureAnalyticsEvent("SearchMessages", eventService),
 		handler.SearchMessagesHandler(srv.service),
 	)
+	v1.POST("/spaces/:space_id/chats/:chat_id/read",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("ReadMessages", eventService),
+		handler.ReadMessagesHandler(srv.service),
+	)
 	v1.GET("/spaces/:space_id/chats/:chat_id/subscribe",
 		ensureAnalyticsEvent("SubscribeChat", eventService),
 		handler.SubscribeChatHandler(srv.service, srv.sseManager),

--- a/core/api/server/router.go
+++ b/core/api/server/router.go
@@ -345,4 +345,8 @@ func (srv *Server) registerChatRoutes(v1 *gin.RouterGroup, eventService apicore.
 		ensureAnalyticsEvent("SearchMessages", eventService),
 		handler.SearchMessagesHandler(srv.service),
 	)
+	v1.GET("/spaces/:space_id/chats/:chat_id/subscribe",
+		ensureAnalyticsEvent("SubscribeChat", eventService),
+		handler.SubscribeChatHandler(srv.service, srv.sseManager),
+	)
 }

--- a/core/api/server/server.go
+++ b/core/api/server/server.go
@@ -23,6 +23,9 @@ type Server struct {
 	mu         sync.Mutex
 	KeyToToken map[string]ApiSessionEntry // appKey -> token
 
+	sseManager         *service.SSESessionManager
+	unregisterCallback func() // To unregister event callback on shutdown
+
 	initOnce sync.Once
 }
 
@@ -33,9 +36,21 @@ func NewServer(mw apicore.ClientCommands, accountService apicore.AccountService,
 		panic(err)
 	}
 
-	s := &Server{service: service.NewService(mw, gatewayUrl, techSpaceId, crossSpaceSubService)}
+	svc := service.NewService(mw, gatewayUrl, techSpaceId, crossSpaceSubService)
+	sseManager := service.NewSSESessionManager()
+	sseDispatcher := service.NewSSEEventDispatcher(sseManager, svc)
+
+	// Register callback to receive all events
+	unregisterCallback := eventService.RegisterCallback(sseDispatcher.HandleEvent)
+
+	s := &Server{
+		service:            svc,
+		sseManager:         sseManager,
+		unregisterCallback: unregisterCallback,
+		KeyToToken:         make(map[string]ApiSessionEntry),
+	}
+	_ = sseDispatcher // Used for event registration above
 	s.engine = s.NewRouter(mw, eventService, openapiYAML, openapiJSON)
-	s.KeyToToken = make(map[string]ApiSessionEntry)
 
 	return s
 }
@@ -53,6 +68,14 @@ func getAccountInfo(accountService apicore.AccountService) (gatewayUrl string, t
 
 // Stop the service to clean up caches and subscriptions
 func (srv *Server) Stop() {
+	// Unregister event callback
+	if srv.unregisterCallback != nil {
+		srv.unregisterCallback()
+	}
+	// Close all SSE sessions
+	if srv.sseManager != nil {
+		srv.sseManager.CloseAll()
+	}
 	srv.service.Stop()
 }
 

--- a/core/api/server/server_test.go
+++ b/core/api/server/server_test.go
@@ -36,6 +36,7 @@ func newFixture(t *testing.T) *fixture {
 		GatewayUrl:  mockedGatewayUrl,
 		TechSpaceId: mockedTechSpaceId,
 	}, nil).Once()
+	eventMock.On("RegisterCallback", mock.Anything).Return(func() {}).Once()
 
 	server := NewServer(mwMock, accountMock, eventMock, crossSpaceSubService, []byte{}, []byte{})
 

--- a/core/api/service/chat.go
+++ b/core/api/service/chat.go
@@ -1,0 +1,395 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+var (
+	ErrChatNotFound           = errors.New("chat not found")
+	ErrMessageNotFound        = errors.New("message not found")
+	ErrFailedRetrieveMessages = errors.New("failed to retrieve messages")
+	ErrFailedCreateMessage    = errors.New("failed to create message")
+	ErrFailedUpdateMessage    = errors.New("failed to update message")
+	ErrFailedDeleteMessage    = errors.New("failed to delete message")
+	ErrFailedToggleReaction   = errors.New("failed to toggle reaction")
+	ErrFailedSearchMessages   = errors.New("failed to search messages")
+)
+
+// GetMessages retrieves a paginated list of chat messages.
+func (s *Service) GetMessages(ctx context.Context, chatId string, beforeOrderId string, afterOrderId string, limit int) ([]apimodel.ChatMessage, *apimodel.ChatState, error) {
+	resp := s.mw.ChatGetMessages(ctx, &pb.RpcChatGetMessagesRequest{
+		ChatObjectId:  chatId,
+		BeforeOrderId: beforeOrderId,
+		AfterOrderId:  afterOrderId,
+		Limit:         int32(limit), //nolint:gosec
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatGetMessagesResponseError_NULL {
+		if resp.Error.Code == pb.RpcChatGetMessagesResponseError_BAD_INPUT {
+			return nil, nil, ErrChatNotFound
+		}
+		return nil, nil, ErrFailedRetrieveMessages
+	}
+
+	messages := make([]apimodel.ChatMessage, 0, len(resp.Messages))
+	for _, msg := range resp.Messages {
+		messages = append(messages, s.protoMessageToApiMessage(msg))
+	}
+
+	var chatState *apimodel.ChatState
+	if resp.ChatState != nil {
+		chatState = s.protoChatStateToApiChatState(resp.ChatState)
+	}
+
+	return messages, chatState, nil
+}
+
+// GetMessageById retrieves a single message by its ID.
+func (s *Service) GetMessageById(ctx context.Context, chatId string, messageId string) (*apimodel.ChatMessage, error) {
+	resp := s.mw.ChatGetMessagesByIds(ctx, &pb.RpcChatGetMessagesByIdsRequest{
+		ChatObjectId: chatId,
+		MessageIds:   []string{messageId},
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatGetMessagesByIdsResponseError_NULL {
+		return nil, ErrFailedRetrieveMessages
+	}
+
+	if len(resp.Messages) == 0 {
+		return nil, ErrMessageNotFound
+	}
+
+	message := s.protoMessageToApiMessage(resp.Messages[0])
+	return &message, nil
+}
+
+// CreateMessage creates a new chat message.
+func (s *Service) CreateMessage(ctx context.Context, chatId string, req apimodel.CreateMessageRequest) (*apimodel.ChatMessage, error) {
+	protoMsg := &model.ChatMessage{
+		ReplyToMessageId: req.ReplyToMessageId,
+		Message: &model.ChatMessageMessageContent{
+			Text:  req.Text,
+			Style: s.apiStyleToProtoStyle(req.Style),
+		},
+		Attachments: s.apiAttachmentsToProtoAttachments(req.Attachments),
+	}
+
+	resp := s.mw.ChatAddMessage(ctx, &pb.RpcChatAddMessageRequest{
+		ChatObjectId: chatId,
+		Message:      protoMsg,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatAddMessageResponseError_NULL {
+		if resp.Error.Code == pb.RpcChatAddMessageResponseError_BAD_INPUT {
+			return nil, ErrChatNotFound
+		}
+		return nil, ErrFailedCreateMessage
+	}
+
+	// Retrieve the created message
+	return s.GetMessageById(ctx, chatId, resp.MessageId)
+}
+
+// UpdateMessage updates an existing chat message.
+func (s *Service) UpdateMessage(ctx context.Context, chatId string, messageId string, req apimodel.UpdateMessageRequest) error {
+	editedMsg := &model.ChatMessage{
+		Id: messageId,
+		Message: &model.ChatMessageMessageContent{
+			Text:  req.Text,
+			Style: s.apiStyleToProtoStyle(req.Style),
+		},
+	}
+
+	resp := s.mw.ChatEditMessageContent(ctx, &pb.RpcChatEditMessageContentRequest{
+		ChatObjectId:  chatId,
+		MessageId:     messageId,
+		EditedMessage: editedMsg,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatEditMessageContentResponseError_NULL {
+		if resp.Error.Code == pb.RpcChatEditMessageContentResponseError_BAD_INPUT {
+			return ErrMessageNotFound
+		}
+		return ErrFailedUpdateMessage
+	}
+
+	return nil
+}
+
+// DeleteMessage deletes a chat message.
+func (s *Service) DeleteMessage(ctx context.Context, chatId string, messageId string) error {
+	resp := s.mw.ChatDeleteMessage(ctx, &pb.RpcChatDeleteMessageRequest{
+		ChatObjectId: chatId,
+		MessageId:    messageId,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatDeleteMessageResponseError_NULL {
+		if resp.Error.Code == pb.RpcChatDeleteMessageResponseError_BAD_INPUT {
+			return ErrMessageNotFound
+		}
+		return ErrFailedDeleteMessage
+	}
+
+	return nil
+}
+
+// ToggleReaction toggles a reaction on a message.
+func (s *Service) ToggleReaction(ctx context.Context, chatId string, messageId string, emoji string) (bool, error) {
+	resp := s.mw.ChatToggleMessageReaction(ctx, &pb.RpcChatToggleMessageReactionRequest{
+		ChatObjectId: chatId,
+		MessageId:    messageId,
+		Emoji:        emoji,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatToggleMessageReactionResponseError_NULL {
+		if resp.Error.Code == pb.RpcChatToggleMessageReactionResponseError_BAD_INPUT {
+			return false, ErrMessageNotFound
+		}
+		return false, ErrFailedToggleReaction
+	}
+
+	return resp.Added, nil
+}
+
+// SearchMessages searches for messages in a chat.
+func (s *Service) SearchMessages(ctx context.Context, spaceId string, chatId string, query string, offset int, limit int) ([]apimodel.SearchMessageResult, error) {
+	resp := s.mw.ChatSearch(ctx, &pb.RpcChatSearchRequest{
+		SpaceId:  spaceId,
+		ChatId:   chatId,
+		FullText: query,
+		Offset:   int32(offset), //nolint:gosec
+		Limit:    int32(limit),  //nolint:gosec
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatSearchResponseError_NULL {
+		return nil, ErrFailedSearchMessages
+	}
+
+	results := make([]apimodel.SearchMessageResult, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		result := apimodel.SearchMessageResult{
+			ChatId:    r.ChatId,
+			MessageId: r.MessageId,
+			Score:     r.Score,
+			Highlight: r.Highlight,
+		}
+
+		if r.HighlightRanges != nil {
+			result.HighlightRanges = make([]apimodel.Range, 0, len(r.HighlightRanges))
+			for _, hr := range r.HighlightRanges {
+				result.HighlightRanges = append(result.HighlightRanges, apimodel.Range{
+					From: hr.From,
+					To:   hr.To,
+				})
+			}
+		}
+
+		if r.Message != nil {
+			result.Message = s.protoMessageToApiMessage(r.Message)
+		}
+
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+// protoMessageToApiMessage converts a protobuf ChatMessage to an API ChatMessage.
+func (s *Service) protoMessageToApiMessage(msg *model.ChatMessage) apimodel.ChatMessage {
+	apiMsg := apimodel.ChatMessage{
+		Object:           "chat_message",
+		Id:               msg.Id,
+		OrderId:          msg.OrderId,
+		Creator:          msg.Creator,
+		CreatedAt:        msg.CreatedAt,
+		ModifiedAt:       msg.ModifiedAt,
+		ReplyToMessageId: msg.ReplyToMessageId,
+		Read:             msg.Read,
+		Attachments:      make([]apimodel.MessageAttachment, 0),
+		Reactions:        make(map[string][]string),
+	}
+
+	if msg.Message != nil {
+		apiMsg.Content = apimodel.MessageContent{
+			Text:  msg.Message.Text,
+			Style: s.protoStyleToApiStyle(msg.Message.Style),
+		}
+
+		if msg.Message.Marks != nil {
+			apiMsg.Content.Marks = make([]apimodel.TextMark, 0, len(msg.Message.Marks))
+			for _, mark := range msg.Message.Marks {
+				apiMsg.Content.Marks = append(apiMsg.Content.Marks, apimodel.TextMark{
+					Type:  s.protoMarkTypeToApiMarkType(mark.Type),
+					From:  mark.Range.From,
+					To:    mark.Range.To,
+					Param: mark.Param,
+				})
+			}
+		}
+	}
+
+	for _, att := range msg.Attachments {
+		apiMsg.Attachments = append(apiMsg.Attachments, apimodel.MessageAttachment{
+			Target: att.Target,
+			Type:   s.protoAttachmentTypeToApiType(att.Type),
+		})
+	}
+
+	if msg.Reactions != nil && msg.Reactions.Reactions != nil {
+		for emoji, identityList := range msg.Reactions.Reactions {
+			apiMsg.Reactions[emoji] = identityList.Ids
+		}
+	}
+
+	return apiMsg
+}
+
+// protoChatStateToApiChatState converts a protobuf ChatState to an API ChatState.
+func (s *Service) protoChatStateToApiChatState(state *model.ChatState) *apimodel.ChatState {
+	apiState := &apimodel.ChatState{
+		LastStateId: state.LastStateId,
+	}
+
+	if state.Messages != nil {
+		apiState.Messages = &apimodel.UnreadState{
+			Counter:       state.Messages.Counter,
+			OldestOrderId: state.Messages.OldestOrderId,
+		}
+	}
+
+	if state.Mentions != nil {
+		apiState.Mentions = &apimodel.UnreadState{
+			Counter:       state.Mentions.Counter,
+			OldestOrderId: state.Mentions.OldestOrderId,
+		}
+	}
+
+	return apiState
+}
+
+// protoStyleToApiStyle converts a protobuf BlockContentTextStyle to an API MessageStyle.
+func (s *Service) protoStyleToApiStyle(style model.BlockContentTextStyle) apimodel.MessageStyle {
+	switch style {
+	case model.BlockContentText_Paragraph:
+		return apimodel.MessageStyleParagraph
+	case model.BlockContentText_Header1:
+		return apimodel.MessageStyleHeader1
+	case model.BlockContentText_Header2:
+		return apimodel.MessageStyleHeader2
+	case model.BlockContentText_Header3:
+		return apimodel.MessageStyleHeader3
+	case model.BlockContentText_Header4:
+		return apimodel.MessageStyleHeader4
+	case model.BlockContentText_Quote:
+		return apimodel.MessageStyleQuote
+	case model.BlockContentText_Code:
+		return apimodel.MessageStyleCode
+	case model.BlockContentText_Title:
+		return apimodel.MessageStyleTitle
+	case model.BlockContentText_Checkbox:
+		return apimodel.MessageStyleCheckbox
+	case model.BlockContentText_Marked:
+		return apimodel.MessageStyleMarked
+	case model.BlockContentText_Numbered:
+		return apimodel.MessageStyleNumbered
+	case model.BlockContentText_Toggle:
+		return apimodel.MessageStyleToggle
+	case model.BlockContentText_Description:
+		return apimodel.MessageStyleDescription
+	case model.BlockContentText_Callout:
+		return apimodel.MessageStyleCallout
+	default:
+		return apimodel.MessageStyleParagraph
+	}
+}
+
+// apiStyleToProtoStyle converts an API MessageStyle to a protobuf BlockContentTextStyle.
+func (s *Service) apiStyleToProtoStyle(style apimodel.MessageStyle) model.BlockContentTextStyle {
+	switch style {
+	case apimodel.MessageStyleParagraph:
+		return model.BlockContentText_Paragraph
+	case apimodel.MessageStyleHeader1:
+		return model.BlockContentText_Header1
+	case apimodel.MessageStyleHeader2:
+		return model.BlockContentText_Header2
+	case apimodel.MessageStyleHeader3:
+		return model.BlockContentText_Header3
+	case apimodel.MessageStyleHeader4:
+		return model.BlockContentText_Header4
+	case apimodel.MessageStyleQuote:
+		return model.BlockContentText_Quote
+	case apimodel.MessageStyleCode:
+		return model.BlockContentText_Code
+	case apimodel.MessageStyleTitle:
+		return model.BlockContentText_Title
+	case apimodel.MessageStyleCheckbox:
+		return model.BlockContentText_Checkbox
+	case apimodel.MessageStyleMarked:
+		return model.BlockContentText_Marked
+	case apimodel.MessageStyleNumbered:
+		return model.BlockContentText_Numbered
+	case apimodel.MessageStyleToggle:
+		return model.BlockContentText_Toggle
+	case apimodel.MessageStyleDescription:
+		return model.BlockContentText_Description
+	case apimodel.MessageStyleCallout:
+		return model.BlockContentText_Callout
+	default:
+		return model.BlockContentText_Paragraph
+	}
+}
+
+// protoAttachmentTypeToApiType converts a protobuf attachment type to an API attachment type.
+func (s *Service) protoAttachmentTypeToApiType(t model.ChatMessageAttachmentAttachmentType) apimodel.AttachmentType {
+	switch t {
+	case model.ChatMessageAttachment_FILE:
+		return apimodel.AttachmentTypeFile
+	case model.ChatMessageAttachment_IMAGE:
+		return apimodel.AttachmentTypeImage
+	case model.ChatMessageAttachment_LINK:
+		return apimodel.AttachmentTypeLink
+	default:
+		return apimodel.AttachmentTypeFile
+	}
+}
+
+// apiAttachmentTypeToProtoType converts an API attachment type to a protobuf attachment type.
+func (s *Service) apiAttachmentTypeToProtoType(t apimodel.AttachmentType) model.ChatMessageAttachmentAttachmentType {
+	switch t {
+	case apimodel.AttachmentTypeFile:
+		return model.ChatMessageAttachment_FILE
+	case apimodel.AttachmentTypeImage:
+		return model.ChatMessageAttachment_IMAGE
+	case apimodel.AttachmentTypeLink:
+		return model.ChatMessageAttachment_LINK
+	default:
+		return model.ChatMessageAttachment_FILE
+	}
+}
+
+// apiAttachmentsToProtoAttachments converts API attachments to protobuf attachments.
+func (s *Service) apiAttachmentsToProtoAttachments(attachments []apimodel.MessageAttachment) []*model.ChatMessageAttachment {
+	if attachments == nil {
+		return nil
+	}
+
+	protoAttachments := make([]*model.ChatMessageAttachment, 0, len(attachments))
+	for _, att := range attachments {
+		protoAttachments = append(protoAttachments, &model.ChatMessageAttachment{
+			Target: att.Target,
+			Type:   s.apiAttachmentTypeToProtoType(att.Type),
+		})
+	}
+	return protoAttachments
+}
+
+// protoMarkTypeToApiMarkType converts a protobuf mark type to an API string.
+func (s *Service) protoMarkTypeToApiMarkType(t model.BlockContentTextMarkType) string {
+	return strings.ToLower(model.BlockContentTextMarkType_name[int32(t)])
+}

--- a/core/api/service/chat.go
+++ b/core/api/service/chat.go
@@ -39,12 +39,12 @@ func (s *Service) GetMessages(ctx context.Context, chatId string, beforeOrderId 
 
 	messages := make([]apimodel.ChatMessage, 0, len(resp.Messages))
 	for _, msg := range resp.Messages {
-		messages = append(messages, s.protoMessageToApiMessage(msg))
+		messages = append(messages, s.ProtoMessageToApiMessage(msg))
 	}
 
 	var chatState *apimodel.ChatState
 	if resp.ChatState != nil {
-		chatState = s.protoChatStateToApiChatState(resp.ChatState)
+		chatState = s.ProtoChatStateToApiChatState(resp.ChatState)
 	}
 
 	return messages, chatState, nil
@@ -65,7 +65,7 @@ func (s *Service) GetMessageById(ctx context.Context, chatId string, messageId s
 		return nil, ErrMessageNotFound
 	}
 
-	message := s.protoMessageToApiMessage(resp.Messages[0])
+	message := s.ProtoMessageToApiMessage(resp.Messages[0])
 	return &message, nil
 }
 
@@ -191,7 +191,7 @@ func (s *Service) SearchMessages(ctx context.Context, spaceId string, chatId str
 		}
 
 		if r.Message != nil {
-			result.Message = s.protoMessageToApiMessage(r.Message)
+			result.Message = s.ProtoMessageToApiMessage(r.Message)
 		}
 
 		results = append(results, result)
@@ -200,8 +200,55 @@ func (s *Service) SearchMessages(ctx context.Context, spaceId string, chatId str
 	return results, nil
 }
 
-// protoMessageToApiMessage converts a protobuf ChatMessage to an API ChatMessage.
-func (s *Service) protoMessageToApiMessage(msg *model.ChatMessage) apimodel.ChatMessage {
+var (
+	ErrFailedSubscribeChat   = errors.New("failed to subscribe to chat")
+	ErrFailedUnsubscribeChat = errors.New("failed to unsubscribe from chat")
+)
+
+// SubscribeChat creates a subscription to a chat and returns initial messages
+func (s *Service) SubscribeChat(ctx context.Context, chatId string, subId string, limit int) ([]apimodel.ChatMessage, *apimodel.ChatState, error) {
+	resp := s.mw.ChatSubscribeLastMessages(ctx, &pb.RpcChatSubscribeLastMessagesRequest{
+		ChatObjectId: chatId,
+		SubId:        subId,
+		Limit:        int32(limit),
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatSubscribeLastMessagesResponseError_NULL {
+		if resp.Error.Code == pb.RpcChatSubscribeLastMessagesResponseError_BAD_INPUT {
+			return nil, nil, ErrChatNotFound
+		}
+		return nil, nil, ErrFailedSubscribeChat
+	}
+
+	messages := make([]apimodel.ChatMessage, 0, len(resp.Messages))
+	for _, msg := range resp.Messages {
+		messages = append(messages, s.ProtoMessageToApiMessage(msg))
+	}
+
+	var chatState *apimodel.ChatState
+	if resp.ChatState != nil {
+		chatState = s.ProtoChatStateToApiChatState(resp.ChatState)
+	}
+
+	return messages, chatState, nil
+}
+
+// UnsubscribeChat removes a subscription from a chat
+func (s *Service) UnsubscribeChat(ctx context.Context, chatId string, subId string) error {
+	resp := s.mw.ChatUnsubscribe(ctx, &pb.RpcChatUnsubscribeRequest{
+		ChatObjectId: chatId,
+		SubId:        subId,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatUnsubscribeResponseError_NULL {
+		return ErrFailedUnsubscribeChat
+	}
+
+	return nil
+}
+
+// ProtoMessageToApiMessage converts a protobuf ChatMessage to an API ChatMessage.
+func (s *Service) ProtoMessageToApiMessage(msg *model.ChatMessage) apimodel.ChatMessage {
 	apiMsg := apimodel.ChatMessage{
 		Object:           "chat_message",
 		Id:               msg.Id,
@@ -250,8 +297,8 @@ func (s *Service) protoMessageToApiMessage(msg *model.ChatMessage) apimodel.Chat
 	return apiMsg
 }
 
-// protoChatStateToApiChatState converts a protobuf ChatState to an API ChatState.
-func (s *Service) protoChatStateToApiChatState(state *model.ChatState) *apimodel.ChatState {
+// ProtoChatStateToApiChatState converts a protobuf ChatState to an API ChatState.
+func (s *Service) ProtoChatStateToApiChatState(state *model.ChatState) *apimodel.ChatState {
 	apiState := &apimodel.ChatState{
 		LastStateId: state.LastStateId,
 	}

--- a/core/api/service/chat.go
+++ b/core/api/service/chat.go
@@ -13,12 +13,14 @@ import (
 var (
 	ErrChatNotFound           = errors.New("chat not found")
 	ErrMessageNotFound        = errors.New("message not found")
+	ErrMessagesNotFound       = errors.New("messages not found")
 	ErrFailedRetrieveMessages = errors.New("failed to retrieve messages")
 	ErrFailedCreateMessage    = errors.New("failed to create message")
 	ErrFailedUpdateMessage    = errors.New("failed to update message")
 	ErrFailedDeleteMessage    = errors.New("failed to delete message")
 	ErrFailedToggleReaction   = errors.New("failed to toggle reaction")
 	ErrFailedSearchMessages   = errors.New("failed to search messages")
+	ErrFailedReadMessages     = errors.New("failed to mark messages as read")
 )
 
 // GetMessages retrieves a paginated list of chat messages.
@@ -204,6 +206,35 @@ var (
 	ErrFailedSubscribeChat   = errors.New("failed to subscribe to chat")
 	ErrFailedUnsubscribeChat = errors.New("failed to unsubscribe from chat")
 )
+
+// ReadMessages marks messages as read in a chat.
+func (s *Service) ReadMessages(ctx context.Context, chatId string, req apimodel.ReadMessagesRequest) error {
+	readType := pb.RpcChatReadMessages_Messages
+	if req.Type == apimodel.ReadMessagesTypeMentions {
+		readType = pb.RpcChatReadMessages_Mentions
+	}
+
+	resp := s.mw.ChatReadMessages(ctx, &pb.RpcChatReadMessagesRequest{
+		ChatObjectId:  chatId,
+		Type:          readType,
+		AfterOrderId:  req.AfterOrderId,
+		BeforeOrderId: req.BeforeOrderId,
+		LastStateId:   req.LastStateId,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcChatReadMessagesResponseError_NULL {
+		switch resp.Error.Code {
+		case pb.RpcChatReadMessagesResponseError_BAD_INPUT:
+			return ErrChatNotFound
+		case pb.RpcChatReadMessagesResponseError_MESSAGES_NOT_FOUND:
+			return ErrMessagesNotFound
+		default:
+			return ErrFailedReadMessages
+		}
+	}
+
+	return nil
+}
 
 // SubscribeChat creates a subscription to a chat and returns initial messages
 func (s *Service) SubscribeChat(ctx context.Context, chatId string, subId string, limit int) ([]apimodel.ChatMessage, *apimodel.ChatState, error) {

--- a/core/api/service/file.go
+++ b/core/api/service/file.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+var (
+	ErrFailedUploadFile = errors.New("failed to upload file")
+	ErrInvalidFile      = errors.New("invalid file")
+)
+
+// UploadFile uploads a file and returns the object ID.
+func (s *Service) UploadFile(ctx context.Context, spaceId string, localPath string, fileType apimodel.FileType) (string, error) {
+	pbType := apiFileTypeToProtoType(fileType)
+
+	resp := s.mw.FileUpload(ctx, &pb.RpcFileUploadRequest{
+		SpaceId:   spaceId,
+		LocalPath: localPath,
+		Type:      pbType,
+	})
+
+	if resp.Error != nil && resp.Error.Code != pb.RpcFileUploadResponseError_NULL {
+		switch resp.Error.Code {
+		case pb.RpcFileUploadResponseError_BAD_INPUT:
+			return "", ErrInvalidFile
+		default:
+			return "", ErrFailedUploadFile
+		}
+	}
+
+	return resp.ObjectId, nil
+}
+
+// apiFileTypeToProtoType converts an API file type to a protobuf file type.
+func apiFileTypeToProtoType(t apimodel.FileType) model.BlockContentFileType {
+	switch t {
+	case apimodel.FileTypeFile:
+		return model.BlockContentFile_File
+	case apimodel.FileTypeImage:
+		return model.BlockContentFile_Image
+	case apimodel.FileTypeVideo:
+		return model.BlockContentFile_Video
+	case apimodel.FileTypeAudio:
+		return model.BlockContentFile_Audio
+	case apimodel.FileTypePDF:
+		return model.BlockContentFile_PDF
+	default:
+		return model.BlockContentFile_None
+	}
+}

--- a/core/api/service/sse.go
+++ b/core/api/service/sse.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"sync"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/logging"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+var sseLog = logging.Logger("api-sse")
+
+// SSESession represents an active SSE connection
+type SSESession struct {
+	SubId  string
+	ChatId string
+	Events chan *apimodel.SSEChatEvent
+	Done   chan struct{}
+}
+
+// SSESessionManager manages active SSE sessions
+type SSESessionManager struct {
+	mu       sync.RWMutex
+	sessions map[string]*SSESession // subId -> session
+}
+
+// NewSSESessionManager creates a new SSE session manager
+func NewSSESessionManager() *SSESessionManager {
+	return &SSESessionManager{
+		sessions: make(map[string]*SSESession),
+	}
+}
+
+// Register adds a new SSE session
+func (m *SSESessionManager) Register(session *SSESession) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessions[session.SubId] = session
+	sseLog.Infof("SSE session registered: subId=%s chatId=%s", session.SubId, session.ChatId)
+}
+
+// Unregister removes an SSE session
+func (m *SSESessionManager) Unregister(subId string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if session, ok := m.sessions[subId]; ok {
+		close(session.Done)
+		delete(m.sessions, subId)
+		sseLog.Infof("SSE session unregistered: subId=%s", subId)
+	}
+}
+
+// RouteEvent sends an event to all sessions matching the given subIds
+func (m *SSESessionManager) RouteEvent(subIds []string, event *apimodel.SSEChatEvent) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, subId := range subIds {
+		if session, ok := m.sessions[subId]; ok {
+			select {
+			case session.Events <- event:
+				// Event sent successfully
+			default:
+				// Channel full, log warning
+				sseLog.Warnf("SSE event channel full for subId=%s, dropping event", subId)
+			}
+		}
+	}
+}
+
+// CloseAll closes all active sessions
+func (m *SSESessionManager) CloseAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for subId, session := range m.sessions {
+		close(session.Done)
+		delete(m.sessions, subId)
+	}
+	sseLog.Info("All SSE sessions closed")
+}
+
+// SSEEventDispatcher processes events and routes them to SSE sessions
+type SSEEventDispatcher struct {
+	sessionManager *SSESessionManager
+	service        *Service
+}
+
+// NewSSEEventDispatcher creates a new event dispatcher
+func NewSSEEventDispatcher(sessionManager *SSESessionManager, service *Service) *SSEEventDispatcher {
+	return &SSEEventDispatcher{
+		sessionManager: sessionManager,
+		service:        service,
+	}
+}
+
+// HandleEvent processes an event and routes it to appropriate SSE sessions
+func (d *SSEEventDispatcher) HandleEvent(event *pb.Event) {
+	if event == nil || len(event.Messages) == 0 {
+		return
+	}
+
+	for _, msg := range event.Messages {
+		d.processEventMessage(msg)
+	}
+}
+
+func (d *SSEEventDispatcher) processEventMessage(msg *pb.EventMessage) {
+	if msg == nil {
+		return
+	}
+
+	// Handle chat add event
+	if chatAdd := msg.GetChatAdd(); chatAdd != nil {
+		d.handleChatAdd(chatAdd)
+		return
+	}
+
+	// Handle chat update event
+	if chatUpdate := msg.GetChatUpdate(); chatUpdate != nil {
+		d.handleChatUpdate(chatUpdate)
+		return
+	}
+
+	// Handle chat delete event
+	if chatDelete := msg.GetChatDelete(); chatDelete != nil {
+		d.handleChatDelete(chatDelete)
+		return
+	}
+
+	// Handle chat reactions update
+	if reactionsUpdate := msg.GetChatUpdateReactions(); reactionsUpdate != nil {
+		d.handleChatUpdateReactions(reactionsUpdate)
+		return
+	}
+
+	// Handle chat state update
+	if stateUpdate := msg.GetChatStateUpdate(); stateUpdate != nil {
+		d.handleChatStateUpdate(stateUpdate)
+		return
+	}
+}
+
+func (d *SSEEventDispatcher) handleChatAdd(chatAdd *pb.EventChatAdd) {
+	if chatAdd.Message == nil || len(chatAdd.SubIds) == 0 {
+		return
+	}
+
+	apiMsg := d.service.ProtoMessageToApiMessage(chatAdd.Message)
+	event := &apimodel.SSEChatEvent{
+		Type:    apimodel.SSEEventTypeAdd,
+		Message: &apiMsg,
+	}
+	d.sessionManager.RouteEvent(chatAdd.SubIds, event)
+}
+
+func (d *SSEEventDispatcher) handleChatUpdate(chatUpdate *pb.EventChatUpdate) {
+	if chatUpdate.Message == nil || len(chatUpdate.SubIds) == 0 {
+		return
+	}
+
+	apiMsg := d.service.ProtoMessageToApiMessage(chatUpdate.Message)
+	event := &apimodel.SSEChatEvent{
+		Type:    apimodel.SSEEventTypeUpdate,
+		Message: &apiMsg,
+	}
+	d.sessionManager.RouteEvent(chatUpdate.SubIds, event)
+}
+
+func (d *SSEEventDispatcher) handleChatDelete(chatDelete *pb.EventChatDelete) {
+	if chatDelete.Id == "" || len(chatDelete.SubIds) == 0 {
+		return
+	}
+
+	event := &apimodel.SSEChatEvent{
+		Type:    apimodel.SSEEventTypeDelete,
+		Deleted: chatDelete.Id,
+	}
+	d.sessionManager.RouteEvent(chatDelete.SubIds, event)
+}
+
+func (d *SSEEventDispatcher) handleChatUpdateReactions(reactionsUpdate *pb.EventChatUpdateReactions) {
+	if reactionsUpdate.Reactions == nil || len(reactionsUpdate.SubIds) == 0 {
+		return
+	}
+
+	// Create a minimal message with just the ID and reactions
+	reactions := protoReactionsToApiReactions(reactionsUpdate.Reactions)
+	msg := apimodel.ChatMessage{
+		Id:        reactionsUpdate.Id,
+		Reactions: reactions,
+	}
+	event := &apimodel.SSEChatEvent{
+		Type:    apimodel.SSEEventTypeReactions,
+		Message: &msg,
+	}
+	d.sessionManager.RouteEvent(reactionsUpdate.SubIds, event)
+}
+
+func (d *SSEEventDispatcher) handleChatStateUpdate(stateUpdate *pb.EventChatUpdateState) {
+	if stateUpdate.State == nil || len(stateUpdate.SubIds) == 0 {
+		return
+	}
+
+	apiState := d.service.ProtoChatStateToApiChatState(stateUpdate.State)
+	event := &apimodel.SSEChatEvent{
+		Type:  apimodel.SSEEventTypeState,
+		State: apiState,
+	}
+	d.sessionManager.RouteEvent(stateUpdate.SubIds, event)
+}
+
+// protoReactionsToApiReactions converts protobuf reactions to API format
+func protoReactionsToApiReactions(reactions *model.ChatMessageReactions) map[string][]string {
+	if reactions == nil || reactions.Reactions == nil {
+		return make(map[string][]string)
+	}
+	result := make(map[string][]string)
+	for emoji, identityList := range reactions.Reactions {
+		result[emoji] = identityList.Ids
+	}
+	return result
+}

--- a/core/event/event_grpc.go
+++ b/core/event/event_grpc.go
@@ -4,9 +4,11 @@
 package event
 
 import (
+	"fmt"
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/gogo/status"
@@ -22,6 +24,7 @@ var log = logging.Logger("anytype-grpc")
 func NewGrpcSender() *GrpcSender {
 	gs := &GrpcSender{
 		shutdownCh: make(chan string),
+		callbacks:  make(map[string]func(*pb.Event)),
 	}
 
 	go func() {
@@ -36,6 +39,9 @@ func NewGrpcSender() *GrpcSender {
 type GrpcSender struct {
 	ServerMutex sync.RWMutex
 	Servers     map[string]*SessionServer
+
+	callbackMu sync.RWMutex
+	callbacks  map[string]func(*pb.Event)
 
 	shutdownCh chan string
 }
@@ -83,13 +89,20 @@ func (es *GrpcSender) sendEvent(server *SessionServer, event *pb.Event) {
 
 func (es *GrpcSender) Broadcast(event *pb.Event) {
 	es.ServerMutex.RLock()
-	defer es.ServerMutex.RUnlock()
 	if len(es.Servers) == 0 {
 		log.Warnf("no servers to broadcast event")
 	}
 	for _, s := range es.Servers {
 		es.sendEvent(s, event)
 	}
+	es.ServerMutex.RUnlock()
+
+	// Also call registered callbacks
+	es.callbackMu.RLock()
+	for _, cb := range es.callbacks {
+		go cb(event)
+	}
+	es.callbackMu.RUnlock()
 }
 
 // BroadcastToOtherSessions broadcasts the event from current session. Do not broadcast to the current session
@@ -114,6 +127,29 @@ func (es *GrpcSender) BroadcastExceptSessions(event *pb.Event, exceptTokens []st
 			es.sendEvent(s, event)
 		}
 	}
+}
+
+// RegisterCallback registers a callback to receive all broadcast events.
+// Returns a function to unregister the callback.
+func (es *GrpcSender) RegisterCallback(callback func(*pb.Event)) func() {
+	es.callbackMu.Lock()
+	defer es.callbackMu.Unlock()
+
+	// Generate a unique ID for this callback
+	id := generateCallbackId()
+	es.callbacks[id] = callback
+
+	return func() {
+		es.callbackMu.Lock()
+		defer es.callbackMu.Unlock()
+		delete(es.callbacks, id)
+	}
+}
+
+var callbackIdCounter uint64
+
+func generateCallbackId() string {
+	return fmt.Sprintf("cb_%d_%d", time.Now().UnixNano(), atomic.AddUint64(&callbackIdCounter, 1))
 }
 
 type SessionServer struct {

--- a/core/event/mock_event/mock_Sender.go
+++ b/core/event/mock_event/mock_Sender.go
@@ -52,7 +52,7 @@ func (_c *MockSender_Broadcast_Call) Return() *MockSender_Broadcast_Call {
 }
 
 func (_c *MockSender_Broadcast_Call) RunAndReturn(run func(*pb.Event)) *MockSender_Broadcast_Call {
-	_c.Call.Return(run)
+	_c.Run(run)
 	return _c
 }
 
@@ -86,7 +86,7 @@ func (_c *MockSender_BroadcastExceptSessions_Call) Return() *MockSender_Broadcas
 }
 
 func (_c *MockSender_BroadcastExceptSessions_Call) RunAndReturn(run func(*pb.Event, []string)) *MockSender_BroadcastExceptSessions_Call {
-	_c.Call.Return(run)
+	_c.Run(run)
 	return _c
 }
 
@@ -120,7 +120,7 @@ func (_c *MockSender_BroadcastToOtherSessions_Call) Return() *MockSender_Broadca
 }
 
 func (_c *MockSender_BroadcastToOtherSessions_Call) RunAndReturn(run func(string, *pb.Event)) *MockSender_BroadcastToOtherSessions_Call {
-	_c.Call.Return(run)
+	_c.Run(run)
 	return _c
 }
 
@@ -216,7 +216,7 @@ func (_c *MockSender_IsActive_Call) RunAndReturn(run func(string) bool) *MockSen
 	return _c
 }
 
-// Name provides a mock function with given fields:
+// Name provides a mock function with no fields
 func (_m *MockSender) Name() string {
 	ret := _m.Called()
 
@@ -291,7 +291,7 @@ func (_c *MockSender_SendToSession_Call) Return() *MockSender_SendToSession_Call
 }
 
 func (_c *MockSender_SendToSession_Call) RunAndReturn(run func(string, *pb.Event)) *MockSender_SendToSession_Call {
-	_c.Call.Return(run)
+	_c.Run(run)
 	return _c
 }
 


### PR DESCRIPTION
## Summary

Adds REST API endpoints for chat functionality and file uploads, exposing the existing gRPC layer to the public API.

## New Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/v1/spaces/{space_id}/chats/{chat_id}/messages` | List messages (paginated) |
| GET | `/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id}` | Get single message |
| POST | `/v1/spaces/{space_id}/chats/{chat_id}/messages` | Send message |
| PATCH | `/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id}` | Edit message |
| DELETE | `/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id}` | Delete message |
| POST | `/v1/spaces/{space_id}/chats/{chat_id}/messages/{message_id}/reactions` | Toggle reaction |
| POST | `/v1/spaces/{space_id}/chats/{chat_id}/search` | Search messages |
| **POST** | **`/v1/spaces/{space_id}/chats/{chat_id}/read`** | **Mark messages as read** |
| **GET** | **`/v1/spaces/{space_id}/chats/{chat_id}/subscribe`** | **Real-time SSE event stream** |
| **POST** | **`/v1/spaces/{space_id}/files`** | **Upload file (multipart/form-data)** |

## Features

- Cursor-based pagination for message listing (`before_order_id`, `after_order_id`)
- Message content with text styling and marks
- File/image/link attachments
- Emoji reactions with user tracking
- Full-text message search
- Rate limiting on write operations
- **Mark messages/mentions as read** with race condition protection via `last_state_id`
- **File uploads** via multipart/form-data, returns `object_id` for use in attachments
- **Real-time SSE subscriptions** for live chat events:
  - Initial messages on connect
  - Message add/update/delete events
  - Reaction updates
  - Chat state changes (unread counts)
  - 30-second keepalive pings

## Files Changed

- `core/api/model/chat.go`: Chat message models
- `core/api/model/file.go`: File upload response model
- `core/api/model/sse.go`: SSE event models
- `core/api/service/chat.go`: Chat service (messages, reactions, search, read, subscriptions)
- `core/api/service/file.go`: File upload service
- `core/api/service/sse.go`: SSE session management
- `core/api/handler/chat.go`: Chat HTTP handlers
- `core/api/handler/file.go`: File upload handler
- `core/api/server/router.go`: Route registration
- `core/api/core/core.go`: Extended `ClientCommands` interface

## Usage Examples

```bash
# Mark messages as read
curl -X POST "http://localhost:31012/v1/spaces/$SPACE/chats/$CHAT/read" \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"type":"messages","before_order_id":"!!Xz","last_state_id":"..."}'

# Upload a file
curl -X POST "http://localhost:31012/v1/spaces/$SPACE/files" \
  -H "Authorization: Bearer $API_KEY" \
  -F "file=@image.png" \
  -F "type=image"
# Returns: {"object":"file","object_id":"bafyrei..."}

# Use uploaded file in chat message
curl -X POST "http://localhost:31012/v1/spaces/$SPACE/chats/$CHAT/messages" \
  -H "Authorization: Bearer $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"text":"Check this out","attachments":[{"target":"bafyrei...","type":"image"}]}'
```

## Test Plan

- [x] All chat CRUD operations work correctly
- [x] Pagination with cursor-based navigation
- [x] Reactions toggle on/off
- [x] Message search returns expected results
- [x] Mark as read updates unread counters
- [x] File upload returns valid object_id
- [x] Uploaded files can be attached to messages
- [x] SSE subscription streams real-time events
- [x] Connection cleanup on client disconnect

🤖 Generated with [Claude Code](https://claude.ai/code)