### PR TITLE
Fix OpenAPI docs server URL to match actual listen address

### DIFF
--- a/core/api/service.go
+++ b/core/api/service.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"errors"
@@ -112,13 +113,20 @@ func (s *apiService) startServer() error {
 		return nil
 	}
 
+	// Update OpenAPI docs server URL to match actual listen address
+	actualURL := "http://" + s.listenAddr
+	defaultURL := "http://127.0.0.1:31009" // Hardcoded in swagger annotations
+
+	updatedYAML := bytes.Replace(openapiYAML, []byte("url: "+defaultURL), []byte("url: "+actualURL), 1)
+	updatedJSON := bytes.Replace(openapiJSON, []byte(`"url": "`+defaultURL+`"`), []byte(`"url": "`+actualURL+`"`), 1)
+
 	s.srv = server.NewServer(
 		s.mw,
 		s.accountService,
 		s.eventService,
 		s.crossSpaceSubService,
-		openapiYAML,
-		openapiJSON,
+		updatedYAML,
+		updatedJSON,
 	)
 
 	s.httpSrv = &http.Server{


### PR DESCRIPTION
The OpenAPI specification was hardcoded to http://127.0.0.1:31009 but anytype-cli runs on port 31012 by default. 

This PR updates the OpenAPI 3.1.0 spec to dynamically set the server URL (`servers[0].url`) to match the actual listen address.

**Changes:**
- Modified `core/api/service.go` to update the server URL in embedded OpenAPI docs
- The server URL now reflects the actual port configured via `--listen-address` or default settings
- Works with OpenAPI 3.1.0 spec (uses `servers[0].url` instead of legacy Swagger 2.0 `host` field)

This is needed for `anytime-mcp` to be able to work with the `anytype-cli`-hosted endpoint out of the box