### PR TITLE
GO-6443 Add chat name to push notifications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
+
+## Commit Messages
+
+Every commit message must be prefixed with an issue number following this pattern:
+```
+GO-{issueNumber} Short description
+
+Optional longer description.
+```
+
+Example:
+```
+GO-6443 Add chat name to push notifications
+
+Include chatName field in push notification payload so users can see
+which chat a message was sent from.
+```
+
+## Testing Guidelines
+
+### Test Structure
+
+1. **Use fixture pattern** for consistent test setup:
+   ```go
+   type fixture struct {
+       *service
+       objectStore          *objectstore.StoreFixture
+       // other dependencies
+   }
+
+   func newFixture(t *testing.T) *fixture {
+       objectStore := objectstore.NewStoreFixture(t)
+       // setup mocks and dependencies
+       return &fixture{
+           service:     New().(*service),
+           objectStore: objectStore,
+       }
+   }
+   ```
+
+2. **Use `want` structure** in tests for clarity - it makes expected values explicit:
+   ```go
+   t.Run("test case name", func(t *testing.T) {
+       // given
+       fx := newFixture(t)
+       req := SomeRequest{...}
+       want := &ExpectedType{
+           Field1: "expected value",
+           Field2: 123,
+       }
+
+       // when
+       got, err := fx.methodUnderTest(req)
+
+       // then
+       require.NoError(t, err)
+       assert.Equal(t, want, got)
+   })
+   ```
+
+3. **Use `AddObjects` method** of `StoreFixture` for setting up test data:
+   ```go
+   fx.objectStore.AddObjects(t, spaceId, []objectstore.TestObject{
+       {
+           bundle.RelationKeyId:             domain.String("objectId"),
+           bundle.RelationKeyName:           domain.String("Object Name"),
+           bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+       },
+   })
+   ```
+
+4. **Tech space ID** - use `objectstore.TestTechSpaceId` constant for space view setup:
+   ```go
+   fx.objectStore.AddObjects(t, objectstore.TestTechSpaceId, []objectstore.TestObject{
+       {
+           bundle.RelationKeyId:             domain.String("spaceView1"),
+           bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
+           bundle.RelationKeyTargetSpaceId:  domain.String(spaceId),
+           bundle.RelationKeyName:           domain.String(spaceName),
+       },
+   })
+   ```
+
+5. **Test naming**: Use descriptive names that explain what's being tested:
+   - `"basic message with space and sender names"`
+   - `"message with attachments"`
+   - `"message with emoji marks"`
+   - `"empty chat name"`
+
+### Assertion Style
+
+Use testify assertions:
+```go
+assert.Equal(t, expected, actual)
+require.NoError(t, err)
+require.Len(t, slice, expectedLen)
+```
+
+### Mock Usage
+
+1. **Mock generation**: Use mockery with `.mockery.yaml` configuration
+   ```bash
+   # Regenerate mocks
+   make test-deps
+   ```
+
+2. **Mock expectations**: Use `EXPECT()` pattern with testify/mock:
+   ```go
+   fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+       Records: []*domain.Details{},
+   }, nil).Maybe()
+   ```
+
+3. **Flexible matching**: Use `mock.Anything` for parameters you don't need to match exactly

--- a/core/block/chats/chatpush/push.go
+++ b/core/block/chats/chatpush/push.go
@@ -17,6 +17,7 @@ type NewMessagePayload struct {
 	ChatId         string        `json:"chatId"`
 	MsgId          string        `json:"msgId"`
 	SpaceName      string        `json:"spaceName"`
+	ChatName       string        `json:"chatName"`
 	SenderName     string        `json:"senderName"`
 	Text           string        `json:"text"`
 	HasAttachments bool          `json:"hasAttachments"`

--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -389,6 +389,7 @@ func (s *service) AddMessage(ctx context.Context, sessionCtx session.Context, ch
 	var (
 		messageId, spaceId string
 		mentions           []string
+		chatName           string
 	)
 
 	err := s.chatObjectDo(ctx, chatObjectId, func(sb chatobject.StoreObject) error {
@@ -396,22 +397,38 @@ func (s *service) AddMessage(ctx context.Context, sessionCtx session.Context, ch
 		messageId, err = sb.AddMessage(ctx, sessionCtx, message)
 		spaceId = sb.SpaceID()
 		mentions, _ = message.MentionIdentities(ctx, sb)
+		chatName = sb.Details().GetString(bundle.RelationKeyName)
 		return err
 	})
 	if err == nil {
-		pushErr := s.sendPushNotification(ctx, spaceId, chatObjectId, messageId, message, mentions)
+		pushErr := s.sendPushNotification(ctx, pushNotificationRequest{
+			spaceId:      spaceId,
+			chatObjectId: chatObjectId,
+			chatName:     chatName,
+			messageId:    messageId,
+			message:      message,
+			mentions:     mentions,
+		})
 		if pushErr != nil {
 			log.Error("sendPushNotification: ", zap.Error(pushErr))
 		}
-
 	}
 	return messageId, err
 }
 
-func (s *service) sendPushNotification(ctx context.Context, spaceId, chatObjectId, messageId string, message *chatmodel.Message, mentions []string) (err error) {
+type pushNotificationRequest struct {
+	spaceId      string
+	chatObjectId string
+	chatName     string
+	messageId    string
+	message      *chatmodel.Message
+	mentions     []string
+}
+
+func (s *service) sendPushNotification(ctx context.Context, req pushNotificationRequest) (err error) {
 	accountId := s.accountService.AccountID()
-	spaceName := s.objectStore.GetSpaceName(spaceId)
-	details, err := s.objectStore.SpaceIndex(spaceId).GetDetails(domain.NewParticipantId(spaceId, accountId))
+	spaceName := s.objectStore.GetSpaceName(req.spaceId)
+	details, err := s.objectStore.SpaceIndex(req.spaceId).GetDetails(domain.NewParticipantId(req.spaceId, accountId))
 	var senderName string
 	if err != nil {
 		log.Warn("sendPushNotification: failed to get profile name, details are empty", zap.Error(err))
@@ -419,24 +436,25 @@ func (s *service) sendPushNotification(ctx context.Context, spaceId, chatObjectI
 		senderName = details.GetString(bundle.RelationKeyName)
 	}
 
-	attachments, err := s.collectAttachmentPayloads(message, spaceId)
+	attachments, err := s.collectAttachmentPayloads(req.message, req.spaceId)
 	if err != nil {
 		return fmt.Errorf("collect attachments: %w", err)
 	}
 
-	text := applyEmojiMarks(message.Message.Text, message.Message.Marks)
+	text := applyEmojiMarks(req.message.Message.Text, req.message.Message.Marks)
 
 	payload := &chatpush.Payload{
-		SpaceId:  spaceId,
+		SpaceId:  req.spaceId,
 		SenderId: accountId,
 		Type:     chatpush.ChatMessage,
 		NewMessagePayload: &chatpush.NewMessagePayload{
-			ChatId:         chatObjectId,
-			MsgId:          messageId,
+			ChatId:         req.chatObjectId,
+			MsgId:          req.messageId,
 			SpaceName:      spaceName,
+			ChatName:       req.chatName,
 			SenderName:     senderName,
 			Text:           textUtil.Truncate(text, 1024, "..."),
-			HasAttachments: len(message.Attachments) > 0,
+			HasAttachments: len(req.message.Attachments) > 0,
 			Attachments:    attachments,
 		},
 	}
@@ -452,14 +470,14 @@ func (s *service) sendPushNotification(ctx context.Context, spaceId, chatObjectI
 	// 2. chats/sha256(<chatObjectId>)
 	// 3. chats/sha256(<chatObjectId>)/<mentionIdentity>
 	// 4. <mentionIdentity>
-	topics := make([]string, 0, (len(mentions)*2)+2)
+	topics := make([]string, 0, (len(req.mentions)*2)+2)
 	topics = append(topics, chatpush.ChatsTopicName)
-	topics = append(topics, chatpush.ChatsTopicName+"/"+pushGroupId(chatObjectId))
-	for _, mention := range mentions {
+	topics = append(topics, chatpush.ChatsTopicName+"/"+pushGroupId(req.chatObjectId))
+	for _, mention := range req.mentions {
 		topics = append(topics, mention)
-		topics = append(topics, chatpush.ChatsTopicName+"/"+pushGroupId(chatObjectId)+"/"+mention)
+		topics = append(topics, chatpush.ChatsTopicName+"/"+pushGroupId(req.chatObjectId)+"/"+mention)
 	}
-	err = s.pushService.Notify(s.componentCtx, spaceId, pushGroupId(chatObjectId), topics, jsonPayload)
+	err = s.pushService.Notify(s.componentCtx, req.spaceId, pushGroupId(req.chatObjectId), topics, jsonPayload)
 	if err != nil {
 		err = fmt.Errorf("pushService.Notify: %w", err)
 		return

--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -425,25 +425,25 @@ type pushNotificationRequest struct {
 	mentions     []string
 }
 
-func (s *service) sendPushNotification(ctx context.Context, req pushNotificationRequest) (err error) {
+func (s *service) buildPushPayload(req pushNotificationRequest) (*chatpush.Payload, error) {
 	accountId := s.accountService.AccountID()
 	spaceName := s.objectStore.GetSpaceName(req.spaceId)
 	details, err := s.objectStore.SpaceIndex(req.spaceId).GetDetails(domain.NewParticipantId(req.spaceId, accountId))
 	var senderName string
 	if err != nil {
-		log.Warn("sendPushNotification: failed to get profile name, details are empty", zap.Error(err))
+		log.Warn("buildPushPayload: failed to get profile name, details are empty", zap.Error(err))
 	} else {
 		senderName = details.GetString(bundle.RelationKeyName)
 	}
 
 	attachments, err := s.collectAttachmentPayloads(req.message, req.spaceId)
 	if err != nil {
-		return fmt.Errorf("collect attachments: %w", err)
+		return nil, fmt.Errorf("collect attachments: %w", err)
 	}
 
 	text := applyEmojiMarks(req.message.Message.Text, req.message.Message.Marks)
 
-	payload := &chatpush.Payload{
+	return &chatpush.Payload{
 		SpaceId:  req.spaceId,
 		SenderId: accountId,
 		Type:     chatpush.ChatMessage,
@@ -457,6 +457,13 @@ func (s *service) sendPushNotification(ctx context.Context, req pushNotification
 			HasAttachments: len(req.message.Attachments) > 0,
 			Attachments:    attachments,
 		},
+	}, nil
+}
+
+func (s *service) sendPushNotification(ctx context.Context, req pushNotificationRequest) (err error) {
+	payload, err := s.buildPushPayload(req)
+	if err != nil {
+		return fmt.Errorf("build push payload: %w", err)
 	}
 
 	jsonPayload, err := json.Marshal(payload)

--- a/core/block/chats/service_test.go
+++ b/core/block/chats/service_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/block/cache/mock_cache"
 	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+	"github.com/anyproto/anytype-heart/core/block/chats/chatpush"
 	"github.com/anyproto/anytype-heart/core/block/chats/chatsubscription"
 	"github.com/anyproto/anytype-heart/core/block/chats/chatsubscription/mock_chatsubscription"
 	"github.com/anyproto/anytype-heart/core/block/editor/chatobject/mock_chatobject"
@@ -84,6 +85,7 @@ type fixture struct {
 	app                  *app.App
 	crossSpaceSubService *mock_crossspacesub.MockService
 	ftSearch             *mock_ftsearch.MockFTSearch
+	objectStore          *objectstore.StoreFixture
 
 	lock sync.Mutex
 	// recorded actions (subscribe/unsubscribe) per chat object, in temporal order
@@ -134,6 +136,7 @@ func newFixture(t *testing.T) *fixture {
 		subscriptionService:  subscriptionService,
 		objectGetter:         objectGetter,
 		ftSearch:             ftSearch,
+		objectStore:          objectStore,
 		actions:              map[string][]recordedAction{},
 	}
 
@@ -535,6 +538,235 @@ func TestApplyEmojiMarks(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestBuildPushPayload(t *testing.T) {
+	t.Run("basic message with space and sender names", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		spaceId := "space1"
+		spaceName := "My Workspace"
+		senderName := "John Doe"
+		participantId := domain.NewParticipantId(spaceId, "testAccountId")
+
+		// Set up space name
+		fx.objectStore.AddObjects(t, objectstore.TestTechSpaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("spaceView1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
+				bundle.RelationKeyTargetSpaceId:  domain.String(spaceId),
+				bundle.RelationKeyName:           domain.String(spaceName),
+			},
+		})
+
+		// Set up sender name (participant)
+		fx.objectStore.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:   domain.String(participantId),
+				bundle.RelationKeyName: domain.String(senderName),
+			},
+		})
+
+		fx.start(t)
+
+		req := pushNotificationRequest{
+			spaceId:      spaceId,
+			chatObjectId: "chat1",
+			chatName:     "General",
+			messageId:    "msg1",
+			message: &chatmodel.Message{
+				ChatMessage: &model.ChatMessage{
+					Message: &model.ChatMessageMessageContent{
+						Text: "Hello world",
+					},
+				},
+			},
+		}
+		want := &chatpush.Payload{
+			SpaceId:  spaceId,
+			SenderId: "testAccountId",
+			Type:     chatpush.ChatMessage,
+			NewMessagePayload: &chatpush.NewMessagePayload{
+				ChatId:         "chat1",
+				MsgId:          "msg1",
+				SpaceName:      spaceName,
+				ChatName:       "General",
+				SenderName:     senderName,
+				Text:           "Hello world",
+				HasAttachments: false,
+				Attachments:    nil,
+			},
+		}
+
+		// when
+		got, err := fx.buildPushPayload(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("message with attachments", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		spaceId := "space1"
+
+		// Set up attachment details
+		fx.objectStore.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("file1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_file)),
+			},
+		})
+
+		fx.start(t)
+
+		req := pushNotificationRequest{
+			spaceId:      spaceId,
+			chatObjectId: "chat1",
+			chatName:     "Team Chat",
+			messageId:    "msg1",
+			message: &chatmodel.Message{
+				ChatMessage: &model.ChatMessage{
+					Message: &model.ChatMessageMessageContent{
+						Text: "Check this file",
+					},
+					Attachments: []*model.ChatMessageAttachment{
+						{Target: "file1"},
+					},
+				},
+			},
+		}
+		want := &chatpush.Payload{
+			SpaceId:  spaceId,
+			SenderId: "testAccountId",
+			Type:     chatpush.ChatMessage,
+			NewMessagePayload: &chatpush.NewMessagePayload{
+				ChatId:         "chat1",
+				MsgId:          "msg1",
+				SpaceName:      "",
+				ChatName:       "Team Chat",
+				SenderName:     "",
+				Text:           "Check this file",
+				HasAttachments: true,
+				Attachments: []*chatpush.Attachment{
+					{Layout: int(model.ObjectType_file)},
+				},
+			},
+		}
+
+		// when
+		got, err := fx.buildPushPayload(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("message with emoji marks", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+		fx.start(t)
+
+		req := pushNotificationRequest{
+			spaceId:      "space1",
+			chatObjectId: "chat1",
+			chatName:     "Fun Chat",
+			messageId:    "msg1",
+			message: &chatmodel.Message{
+				ChatMessage: &model.ChatMessage{
+					Message: &model.ChatMessageMessageContent{
+						Text: "Great  ",
+						Marks: []*model.BlockContentTextMark{
+							{
+								Type:  model.BlockContentTextMark_Emoji,
+								Range: &model.Range{From: 6, To: 7},
+								Param: "👍",
+							},
+						},
+					},
+				},
+			},
+		}
+		want := &chatpush.Payload{
+			SpaceId:  "space1",
+			SenderId: "testAccountId",
+			Type:     chatpush.ChatMessage,
+			NewMessagePayload: &chatpush.NewMessagePayload{
+				ChatId:         "chat1",
+				MsgId:          "msg1",
+				SpaceName:      "",
+				ChatName:       "Fun Chat",
+				SenderName:     "",
+				Text:           "Great 👍",
+				HasAttachments: false,
+				Attachments:    nil,
+			},
+		}
+
+		// when
+		got, err := fx.buildPushPayload(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("empty chat name", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+		fx.start(t)
+
+		req := pushNotificationRequest{
+			spaceId:      "space1",
+			chatObjectId: "chat1",
+			chatName:     "",
+			messageId:    "msg1",
+			message: &chatmodel.Message{
+				ChatMessage: &model.ChatMessage{
+					Message: &model.ChatMessageMessageContent{
+						Text: "Hello",
+					},
+				},
+			},
+		}
+		want := &chatpush.Payload{
+			SpaceId:  "space1",
+			SenderId: "testAccountId",
+			Type:     chatpush.ChatMessage,
+			NewMessagePayload: &chatpush.NewMessagePayload{
+				ChatId:         "chat1",
+				MsgId:          "msg1",
+				SpaceName:      "",
+				ChatName:       "",
+				SenderName:     "",
+				Text:           "Hello",
+				HasAttachments: false,
+				Attachments:    nil,
+			},
+		}
+
+		// when
+		got, err := fx.buildPushPayload(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
 }
 
 func TestService_Search(t *testing.T) {

--- a/pkg/lib/localstore/objectstore/fixture.go
+++ b/pkg/lib/localstore/objectstore/fixture.go
@@ -55,10 +55,12 @@ func (d *stubDetailsFromId) AddVirtualDetails(id string, det *domain.Details) {
 	d.details[id] = det
 }
 
+const TestTechSpaceId = "test-tech-space"
+
 type stubTechSpaceIdProvider struct{}
 
 func (s *stubTechSpaceIdProvider) TechSpaceId() string {
-	return "test-tech-space"
+	return TestTechSpaceId
 }
 
 func (s *stubTechSpaceIdProvider) Name() string {


### PR DESCRIPTION
## Summary
- Add `chatName` field to push notification payload
- Refactor `sendPushNotification` to use `pushNotificationRequest` struct
- Fetch chat name from object details inside `chatObjectDo` callback

## Test plan
- [x] Run existing tests: `go test ./core/block/chats/...`
- [x] Build: `go build ./core/block/chats/...`
- [ ] Manual test: Send a chat message and verify the push notification JSON includes `chatName`

🤖 Generated with [Claude Code](https://claude.ai/code)