### PR TITLE
GO-6746 Add 4000 character limit to chat messages

### DIFF
--- a/core/block/chats/chatmodel/chatmodel.go
+++ b/core/block/chats/chatmodel/chatmodel.go
@@ -22,6 +22,8 @@ const (
 const (
 	DiffManagerMessages = "messages"
 	DiffManagerMentions = "mentions"
+
+	MaxMessageLength = 4000
 )
 
 func (t CounterType) DiffManagerName() string {
@@ -110,6 +112,10 @@ func (m *Message) MentionIdentities(ctx context.Context, repo MessagesGetter) ([
 
 func (m *Message) Validate() error {
 	utf16text := textUtil.StrToUTF16(m.Message.Text)
+
+	if len(utf16text) > MaxMessageLength {
+		return fmt.Errorf("message text exceeds maximum length of %d characters", MaxMessageLength)
+	}
 
 	for _, mark := range m.Message.Marks {
 		if mark.Range.From < 0 {

--- a/core/block/chats/chatmodel/chatmodel_test.go
+++ b/core/block/chats/chatmodel/chatmodel_test.go
@@ -1,6 +1,7 @@
 package chatmodel
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +69,30 @@ func TestValidate(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		}
+
+		assert.Error(t, msg.Validate())
+	})
+
+	t.Run("message at max length is valid", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{
+				Message: &model.ChatMessageMessageContent{
+					Text: strings.Repeat("a", MaxMessageLength),
+				},
+			},
+		}
+
+		assert.NoError(t, msg.Validate())
+	})
+
+	t.Run("message exceeds max length", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{
+				Message: &model.ChatMessageMessageContent{
+					Text: strings.Repeat("a", MaxMessageLength+1),
 				},
 			},
 		}

--- a/core/block/editor/chatobject/chatobject_test.go
+++ b/core/block/editor/chatobject/chatobject_test.go
@@ -3,6 +3,7 @@ package chatobject
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/anyproto/any-sync/app"
@@ -283,6 +284,15 @@ func TestAddMessage(t *testing.T) {
 		assert.Equal(t, testSpaceId, ids[0].SpaceId)
 		assert.Equal(t, chatId, ids[0].ObjectId)
 		assert.NotEmpty(t, ids[0].MsgOrderId)
+	})
+
+	t.Run("message exceeds max length", func(t *testing.T) {
+		ctx := context.Background()
+		fx := newFixture(t)
+
+		inputMessage := givenSimpleMessage(strings.Repeat("a", chatmodel.MaxMessageLength+1))
+		_, err := fx.AddMessage(ctx, nil, inputMessage)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `MaxMessageLength = 4000` constant for chat message validation
- Enforce character limit in `Validate()` method (uses UTF-16 length)
- Add unit tests for boundary and exceeding cases in `chatmodel_test.go`
- Add integration test for `AddMessage` with oversized message

## Test plan
- [x] Unit tests pass for message at exactly max length
- [x] Unit tests pass for message exceeding max length
- [x] Integration test verifies `AddMessage` rejects oversized messages
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)