### PR TITLE
fix: handle nil OldAccount for post-migration accounts

### DIFF
--- a/core/configfetcher/configfetcher.go
+++ b/core/configfetcher/configfetcher.go
@@ -88,10 +88,16 @@ func (c *configFetcher) updateStatus(ctx context.Context) (err error) {
 		if sErr != nil {
 			return sErr
 		}
+		// For accounts created after identity migration, OldAccount doesn't exist.
+		// Fall back to current identity to avoid nil pointer in SpaceSign.
+		oldAccount := c.wallet.GetOldAccountKey()
+		if oldAccount == nil {
+			oldAccount = c.wallet.GetAccountPrivkey()
+		}
 		payload := coordinatorclient.SpaceSignPayload{
 			SpaceId:     techSpace.Id(),
 			SpaceHeader: state.SpaceHeader,
-			OldAccount:  c.wallet.GetOldAccountKey(),
+			OldAccount:  oldAccount,
 			Identity:    c.wallet.GetAccountPrivkey(),
 		}
 		// registering space inside coordinator

--- a/space/spacecore/credentialprovider/credentialprovider.go
+++ b/space/spacecore/credentialprovider/credentialprovider.go
@@ -32,10 +32,16 @@ func (c *credentialProvider) Name() (name string) {
 }
 
 func (c *credentialProvider) GetCredential(ctx context.Context, spaceHeader *spacesyncproto.RawSpaceHeaderWithId) ([]byte, error) {
+	// For accounts created after identity migration, OldAccount doesn't exist.
+	// Fall back to current identity to avoid nil pointer in SpaceSign.
+	oldAccount := c.wallet.GetOldAccountKey()
+	if oldAccount == nil {
+		oldAccount = c.wallet.GetAccountPrivkey()
+	}
 	payload := coordinatorclient.SpaceSignPayload{
 		SpaceId:     spaceHeader.Id,
 		SpaceHeader: spaceHeader.RawHeader,
-		OldAccount:  c.wallet.GetOldAccountKey(),
+		OldAccount:  oldAccount,
 		Identity:    c.wallet.GetAccountPrivkey(),
 	}
 	receipt, err := c.client.SpaceSign(ctx, payload)


### PR DESCRIPTION
## Problem

Accounts created after the identity migration (from `m/44'/607'` to `m/44'/2046'`) don't have an `oldIdentity` stored in their wallet. When these accounts attempt to sync, the `SpaceSign` payload contains a nil `OldAccount`, causing:

```
SpaceSign: payload.OldAccount is nil
```

This prevents new accounts from syncing with self-hosted coordinators.

## Solution

Check if `GetOldAccountKey()` returns nil and fall back to the current identity (`GetAccountPrivkey()`). This allows new accounts to sync while maintaining backward compatibility for migrated accounts.

## Changes

- `space/spacecore/credentialprovider/credentialprovider.go`: Add nil check with fallback
- `core/configfetcher/configfetcher.go`: Same pattern

## Testing

Tested locally with a fresh account on a self-hosted Anytype deployment. Account now syncs successfully.