### PR TITLE
GO-6742 | GO-6833 - Support TurnInto for toggle headers

### DIFF
--- a/core/block/editor/stext/text.go
+++ b/core/block/editor/stext/text.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/globalsign/mgo/bson"
-
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
@@ -499,63 +497,11 @@ func turnIntoToggleHeaderInDiv(s *state.State, b text.Block, parentDiv simple.Bl
 		return
 	}
 
-	// Collect blocks from current div (after the target block)
-	var currentDivBlocks []string
-	stopped := false
-	for i := pos + 1; i < len(parentDiv.Model().ChildrenIds); i++ {
-		siblingId := parentDiv.Model().ChildrenIds[i]
-		sibling := s.Pick(siblingId)
-		if sibling == nil {
-			continue
-		}
-
-		siblingLevel := getHeaderLevel(getBlockStyle(sibling))
-		if siblingLevel > 0 && siblingLevel <= targetLevel {
-			stopped = true
-			break
-		}
-
-		currentDivBlocks = append(currentDivBlocks, siblingId)
+	blocksToMove := collectBlocksFromDivs(s, grandparent, targetLevel, divPos, pos+1)
+	for _, blockId := range blocksToMove {
+		s.Unlink(blockId)
 	}
-
-	// If we didn't hit a stopping header in current div, continue to sibling divs
-	var siblingDivBlocks [][]string
-	if !stopped {
-		siblingDivBlocks = collectSiblingDivBlocks(s, grandparent, targetLevel, divPos)
-	}
-
-	addNewDiv := func(blockIds []string) {
-		newDivId := bson.NewObjectId().Hex()
-		newDiv := simple.New(&model.Block{
-			Id:          newDivId,
-			ChildrenIds: blockIds,
-			Content: &model.BlockContentOfLayout{
-				Layout: &model.BlockContentLayout{
-					Style: model.BlockContentLayout_Div,
-				},
-			},
-		})
-		s.Add(newDiv)
-		b.Model().ChildrenIds = append(b.Model().ChildrenIds, newDivId)
-	}
-
-	// Now build the children of the toggle header
-	// First, unlink blocks from current div and wrap in a new div if needed
-	if len(currentDivBlocks) > 0 {
-		for _, blockId := range currentDivBlocks {
-			s.Unlink(blockId)
-		}
-		// Create a new div block for content from current div
-		addNewDiv(currentDivBlocks)
-	}
-
-	// Then, for each sibling div's list of blocks, create a new div and add to toggle header
-	for _, blockIds := range siblingDivBlocks {
-		for _, blockId := range blockIds {
-			s.Unlink(blockId)
-		}
-		addNewDiv(blockIds)
-	}
+	b.Model().ChildrenIds = append(b.Model().ChildrenIds, blocksToMove...)
 }
 
 func isLayoutDivBlock(b simple.Block) bool {
@@ -588,24 +534,32 @@ func getBlockStyle(b simple.Block) model.BlockContentTextStyle {
 	return model.BlockContentText_Paragraph
 }
 
-func collectSiblingDivBlocks(s *state.State, divsParent simple.Block, targetLevel, divPos int) (siblingDivBlocks [][]string) {
-	stopped := false
-	siblingDivBlocks = make([][]string, 0)
+// collectBlocksFromDivs collects block IDs from div children of divsParent, starting from the div
+// at divPos (from startChildIdx within that div) and continuing to subsequent sibling divs.
+// It stops when it encounters a header of same or higher level than targetLevel.
+// Empty divs that had all their children collected are unlinked.
+func collectBlocksFromDivs(s *state.State, divsParent simple.Block, targetLevel, divPos, startChildIdx int) []string {
+	var blocks []string
+	var emptyDivsToUnlink []string
 
-	for i := divPos + 1; i < len(divsParent.Model().ChildrenIds); i++ {
-		siblingDivId := divsParent.Model().ChildrenIds[i]
-		siblingDiv := s.Get(siblingDivId)
-		if siblingDiv == nil {
+	// Take a snapshot of div IDs to avoid issues with slice mutation during unlinking
+	divIds := append([]string(nil), divsParent.Model().ChildrenIds[divPos:]...)
+
+	for idx, divId := range divIds {
+		div := s.Get(divId)
+		if div == nil || !isLayoutDivBlock(div) {
 			continue
 		}
 
-		// Only process layout div blocks
-		if !isLayoutDivBlock(siblingDiv) {
-			continue
+		childStart := 0
+		if idx == 0 {
+			childStart = startChildIdx
 		}
 
+		stopped := false
 		var blocksFromDiv []string
-		for _, childId := range siblingDiv.Model().ChildrenIds {
+		for j := childStart; j < len(div.Model().ChildrenIds); j++ {
+			childId := div.Model().ChildrenIds[j]
 			child := s.Pick(childId)
 			if child == nil {
 				continue
@@ -620,20 +574,22 @@ func collectSiblingDivBlocks(s *state.State, divsParent simple.Block, targetLeve
 			blocksFromDiv = append(blocksFromDiv, childId)
 		}
 
-		if len(blocksFromDiv) > 0 {
-			siblingDivBlocks = append(siblingDivBlocks, blocksFromDiv)
-		}
+		blocks = append(blocks, blocksFromDiv...)
 
 		if stopped {
 			break
 		}
 
-		// If we collected all children from this div, remove the empty div
-		if len(blocksFromDiv) == len(siblingDiv.Model().ChildrenIds) {
-			s.Unlink(siblingDivId)
+		// If we collected all children from a sibling div, mark it for removal
+		if idx != 0 && len(blocksFromDiv) == len(div.Model().ChildrenIds) {
+			emptyDivsToUnlink = append(emptyDivsToUnlink, divId)
 		}
 	}
-	return siblingDivBlocks
+
+	for _, divId := range emptyDivsToUnlink {
+		s.Unlink(divId)
+	}
+	return blocks
 }
 
 func (t *textImpl) isLastTextBlockChanged() (bool, error) {

--- a/core/block/editor/stext/text.go
+++ b/core/block/editor/stext/text.go
@@ -519,83 +519,12 @@ func turnIntoToggleHeaderInDiv(s *state.State, b text.Block, parentDiv simple.Bl
 	}
 
 	// If we didn't hit a stopping header in current div, continue to sibling divs
-	siblingDivBlocks := make([][]string, 0)
+	var siblingDivBlocks [][]string
 	if !stopped {
-		// Process sibling divs after the current one
-		for i := divPos + 1; i < len(grandparent.Model().ChildrenIds); i++ {
-			siblingDivId := grandparent.Model().ChildrenIds[i]
-			siblingDiv := s.Get(siblingDivId)
-			if siblingDiv == nil {
-				continue
-			}
-
-			// Only process layout div blocks
-			if !isLayoutDivBlock(siblingDiv) {
-				continue
-			}
-
-			var blocksFromDiv []string
-			divStopped := false
-
-			for _, childId := range siblingDiv.Model().ChildrenIds {
-				child := s.Pick(childId)
-				if child == nil {
-					continue
-				}
-
-				childLevel := getHeaderLevel(getBlockStyle(child))
-				if childLevel > 0 && childLevel <= targetLevel {
-					divStopped = true
-					stopped = true
-					break
-				}
-
-				blocksFromDiv = append(blocksFromDiv, childId)
-			}
-
-			if len(blocksFromDiv) > 0 {
-				siblingDivBlocks = append(siblingDivBlocks, blocksFromDiv)
-			}
-
-			if divStopped {
-				break
-			}
-
-			// If we collected all children from this div, remove the empty div
-			if len(blocksFromDiv) == len(siblingDiv.Model().ChildrenIds) {
-				s.Unlink(siblingDivId)
-			}
-		}
+		siblingDivBlocks = collectSiblingDivBlocks(s, grandparent, targetLevel, divPos)
 	}
 
-	// Now build the children of the toggle header
-	// First, unlink blocks from current div and wrap in a new div if needed
-	if len(currentDivBlocks) > 0 {
-		for _, blockId := range currentDivBlocks {
-			s.Unlink(blockId)
-		}
-
-		// Create a new div block for content from current div
-		newDivId := bson.NewObjectId().Hex()
-		newDiv := simple.New(&model.Block{
-			Id:          newDivId,
-			ChildrenIds: currentDivBlocks,
-			Content: &model.BlockContentOfLayout{
-				Layout: &model.BlockContentLayout{
-					Style: model.BlockContentLayout_Div,
-				},
-			},
-		})
-		s.Add(newDiv)
-		b.Model().ChildrenIds = append(b.Model().ChildrenIds, newDivId)
-	}
-
-	// Then, for each sibling div's list of blocks, create a new div and add to toggle header
-	for _, blockIds := range siblingDivBlocks {
-		for _, blockId := range blockIds {
-			s.Unlink(blockId)
-		}
-
+	addNewDiv := func(blockIds []string) {
 		newDivId := bson.NewObjectId().Hex()
 		newDiv := simple.New(&model.Block{
 			Id:          newDivId,
@@ -608,6 +537,24 @@ func turnIntoToggleHeaderInDiv(s *state.State, b text.Block, parentDiv simple.Bl
 		})
 		s.Add(newDiv)
 		b.Model().ChildrenIds = append(b.Model().ChildrenIds, newDivId)
+	}
+
+	// Now build the children of the toggle header
+	// First, unlink blocks from current div and wrap in a new div if needed
+	if len(currentDivBlocks) > 0 {
+		for _, blockId := range currentDivBlocks {
+			s.Unlink(blockId)
+		}
+		// Create a new div block for content from current div
+		addNewDiv(currentDivBlocks)
+	}
+
+	// Then, for each sibling div's list of blocks, create a new div and add to toggle header
+	for _, blockIds := range siblingDivBlocks {
+		for _, blockId := range blockIds {
+			s.Unlink(blockId)
+		}
+		addNewDiv(blockIds)
 	}
 }
 
@@ -639,6 +586,54 @@ func getBlockStyle(b simple.Block) model.BlockContentTextStyle {
 		return txtContent.Style
 	}
 	return model.BlockContentText_Paragraph
+}
+
+func collectSiblingDivBlocks(s *state.State, divsParent simple.Block, targetLevel, divPos int) (siblingDivBlocks [][]string) {
+	stopped := false
+	siblingDivBlocks = make([][]string, 0)
+
+	for i := divPos + 1; i < len(divsParent.Model().ChildrenIds); i++ {
+		siblingDivId := divsParent.Model().ChildrenIds[i]
+		siblingDiv := s.Get(siblingDivId)
+		if siblingDiv == nil {
+			continue
+		}
+
+		// Only process layout div blocks
+		if !isLayoutDivBlock(siblingDiv) {
+			continue
+		}
+
+		var blocksFromDiv []string
+		for _, childId := range siblingDiv.Model().ChildrenIds {
+			child := s.Pick(childId)
+			if child == nil {
+				continue
+			}
+
+			childLevel := getHeaderLevel(getBlockStyle(child))
+			if childLevel > 0 && childLevel <= targetLevel {
+				stopped = true
+				break
+			}
+
+			blocksFromDiv = append(blocksFromDiv, childId)
+		}
+
+		if len(blocksFromDiv) > 0 {
+			siblingDivBlocks = append(siblingDivBlocks, blocksFromDiv)
+		}
+
+		if stopped {
+			break
+		}
+
+		// If we collected all children from this div, remove the empty div
+		if len(blocksFromDiv) == len(siblingDiv.Model().ChildrenIds) {
+			s.Unlink(siblingDivId)
+		}
+	}
+	return siblingDivBlocks
 }
 
 func (t *textImpl) isLastTextBlockChanged() (bool, error) {

--- a/core/block/editor/stext/text.go
+++ b/core/block/editor/stext/text.go
@@ -542,10 +542,7 @@ func collectBlocksFromDivs(s *state.State, divsParent simple.Block, targetLevel,
 	var blocks []string
 	var emptyDivsToUnlink []string
 
-	// Take a snapshot of div IDs to avoid issues with slice mutation during unlinking
-	divIds := append([]string(nil), divsParent.Model().ChildrenIds[divPos:]...)
-
-	for idx, divId := range divIds {
+	for idx, divId := range divsParent.Model().ChildrenIds[divPos:] {
 		div := s.Get(divId)
 		if div == nil || !isLayoutDivBlock(div) {
 			continue

--- a/core/block/editor/stext/text.go
+++ b/core/block/editor/stext/text.go
@@ -6,9 +6,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/globalsign/mgo/bson"
+
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/block/editor/template"
+	"github.com/anyproto/anytype-heart/core/block/simple"
 	"github.com/anyproto/anytype-heart/core/block/simple/link"
 	"github.com/anyproto/anytype-heart/core/block/simple/text"
 	"github.com/anyproto/anytype-heart/core/block/undo"
@@ -381,10 +384,7 @@ func (t *textImpl) TurnInto(ctx session.Context, style model.BlockContentTextSty
 			model.BlockContentText_Marked,
 			model.BlockContentText_Numbered,
 			model.BlockContentText_Callout,
-			model.BlockContentText_Toggle,
-			model.BlockContentText_ToggleHeader1,
-			model.BlockContentText_ToggleHeader2,
-			model.BlockContentText_ToggleHeader3:
+			model.BlockContentText_Toggle:
 			b.Model().Align = model.Block_AlignLeft
 		case model.BlockContentText_Code:
 			b.Model().Align = model.Block_AlignLeft
@@ -393,6 +393,10 @@ func (t *textImpl) TurnInto(ctx session.Context, style model.BlockContentTextSty
 			b.Model().GetText().Marks = &model.BlockContentTextMarks{
 				Marks: nil,
 			}
+		case model.BlockContentText_ToggleHeader1,
+			model.BlockContentText_ToggleHeader2,
+			model.BlockContentText_ToggleHeader3:
+			turnIntoToggleHeader(s, b, style)
 		}
 	}
 
@@ -424,6 +428,217 @@ func (t *textImpl) TurnInto(ctx session.Context, style model.BlockContentTextSty
 	}
 
 	return t.Apply(s)
+}
+
+func turnIntoToggleHeader(s *state.State, b text.Block, style model.BlockContentTextStyle) {
+	parent := s.GetParentOf(b.Model().Id)
+	if parent == nil {
+		return
+	}
+
+	pos := slice.FindPos(parent.Model().ChildrenIds, b.Model().Id)
+	if pos == -1 {
+		return
+	}
+
+	// Get the level of the target toggle header style
+	targetLevel := getHeaderLevel(style)
+	if targetLevel == 0 {
+		return
+	}
+
+	if isLayoutDivBlock(parent) {
+		turnIntoToggleHeaderInDiv(s, b, parent, pos, targetLevel)
+		return
+	}
+
+	// Standard case: parent is not a div block
+	moveSiblingsToToggleHeader(s, b, parent, pos, targetLevel)
+}
+
+// moveSiblingsToToggleHeader collects siblings after the block until a header of same/higher level
+func moveSiblingsToToggleHeader(s *state.State, b text.Block, parent simple.Block, pos int, targetLevel int) {
+	var siblingsToMove []string
+	for i := pos + 1; i < len(parent.Model().ChildrenIds); i++ {
+		siblingId := parent.Model().ChildrenIds[i]
+		sibling := s.Pick(siblingId)
+		if sibling == nil {
+			continue
+		}
+
+		// Check if it's a header of the same or higher level (stop condition)
+		siblingLevel := getHeaderLevel(getBlockStyle(sibling))
+		if siblingLevel > 0 && siblingLevel <= targetLevel {
+			break
+		}
+
+		siblingsToMove = append(siblingsToMove, siblingId)
+	}
+
+	// Make collected blocks children of current block
+	if len(siblingsToMove) > 0 {
+		for _, siblingId := range siblingsToMove {
+			s.Unlink(siblingId)
+		}
+		b.Model().ChildrenIds = append(b.Model().ChildrenIds, siblingsToMove...)
+	}
+}
+
+// turnIntoToggleHeaderInDiv handles the case when the block is inside a layout div block
+func turnIntoToggleHeaderInDiv(s *state.State, b text.Block, parentDiv simple.Block, pos int, targetLevel int) {
+	// Get grandparent (parent of the div)
+	grandparent := s.GetParentOf(parentDiv.Model().Id)
+	if grandparent == nil {
+		moveSiblingsToToggleHeader(s, b, parentDiv, pos, targetLevel) // fallback
+		return
+	}
+
+	divPos := slice.FindPos(grandparent.Model().ChildrenIds, parentDiv.Model().Id)
+	if divPos == -1 {
+		moveSiblingsToToggleHeader(s, b, parentDiv, pos, targetLevel) // fallback
+		return
+	}
+
+	// Collect blocks from current div (after the target block)
+	var currentDivBlocks []string
+	stopped := false
+	for i := pos + 1; i < len(parentDiv.Model().ChildrenIds); i++ {
+		siblingId := parentDiv.Model().ChildrenIds[i]
+		sibling := s.Pick(siblingId)
+		if sibling == nil {
+			continue
+		}
+
+		siblingLevel := getHeaderLevel(getBlockStyle(sibling))
+		if siblingLevel > 0 && siblingLevel <= targetLevel {
+			stopped = true
+			break
+		}
+
+		currentDivBlocks = append(currentDivBlocks, siblingId)
+	}
+
+	// If we didn't hit a stopping header in current div, continue to sibling divs
+	siblingDivBlocks := make([][]string, 0)
+	if !stopped {
+		// Process sibling divs after the current one
+		for i := divPos + 1; i < len(grandparent.Model().ChildrenIds); i++ {
+			siblingDivId := grandparent.Model().ChildrenIds[i]
+			siblingDiv := s.Get(siblingDivId)
+			if siblingDiv == nil {
+				continue
+			}
+
+			// Only process layout div blocks
+			if !isLayoutDivBlock(siblingDiv) {
+				continue
+			}
+
+			var blocksFromDiv []string
+			divStopped := false
+
+			for _, childId := range siblingDiv.Model().ChildrenIds {
+				child := s.Pick(childId)
+				if child == nil {
+					continue
+				}
+
+				childLevel := getHeaderLevel(getBlockStyle(child))
+				if childLevel > 0 && childLevel <= targetLevel {
+					divStopped = true
+					stopped = true
+					break
+				}
+
+				blocksFromDiv = append(blocksFromDiv, childId)
+			}
+
+			if len(blocksFromDiv) > 0 {
+				siblingDivBlocks = append(siblingDivBlocks, blocksFromDiv)
+			}
+
+			if divStopped {
+				break
+			}
+
+			// If we collected all children from this div, remove the empty div
+			if len(blocksFromDiv) == len(siblingDiv.Model().ChildrenIds) {
+				s.Unlink(siblingDivId)
+			}
+		}
+	}
+
+	// Now build the children of the toggle header
+	// First, unlink blocks from current div and wrap in a new div if needed
+	if len(currentDivBlocks) > 0 {
+		for _, blockId := range currentDivBlocks {
+			s.Unlink(blockId)
+		}
+
+		// Create a new div block for content from current div
+		newDivId := bson.NewObjectId().Hex()
+		newDiv := simple.New(&model.Block{
+			Id:          newDivId,
+			ChildrenIds: currentDivBlocks,
+			Content: &model.BlockContentOfLayout{
+				Layout: &model.BlockContentLayout{
+					Style: model.BlockContentLayout_Div,
+				},
+			},
+		})
+		s.Add(newDiv)
+		b.Model().ChildrenIds = append(b.Model().ChildrenIds, newDivId)
+	}
+
+	// Then, for each sibling div's list of blocks, create a new div and add to toggle header
+	for _, blockIds := range siblingDivBlocks {
+		for _, blockId := range blockIds {
+			s.Unlink(blockId)
+		}
+
+		newDivId := bson.NewObjectId().Hex()
+		newDiv := simple.New(&model.Block{
+			Id:          newDivId,
+			ChildrenIds: blockIds,
+			Content: &model.BlockContentOfLayout{
+				Layout: &model.BlockContentLayout{
+					Style: model.BlockContentLayout_Div,
+				},
+			},
+		})
+		s.Add(newDiv)
+		b.Model().ChildrenIds = append(b.Model().ChildrenIds, newDivId)
+	}
+}
+
+func isLayoutDivBlock(b simple.Block) bool {
+	if layout := b.Model().GetLayout(); layout != nil {
+		return layout.Style == model.BlockContentLayout_Div
+	}
+	return false
+}
+
+// getHeaderLevel returns the header level (1, 2, 3) for header styles, or 0 if not a header.
+// Lower number means higher level (H1 > H2 > H3).
+func getHeaderLevel(style model.BlockContentTextStyle) int {
+	switch style {
+	case model.BlockContentText_Header1, model.BlockContentText_ToggleHeader1:
+		return 1
+	case model.BlockContentText_Header2, model.BlockContentText_ToggleHeader2:
+		return 2
+	case model.BlockContentText_Header3, model.BlockContentText_ToggleHeader3:
+		return 3
+	case model.BlockContentText_Header4:
+		return 4
+	}
+	return 0
+}
+
+func getBlockStyle(b simple.Block) model.BlockContentTextStyle {
+	if txtContent := b.Model().GetText(); txtContent != nil {
+		return txtContent.Style
+	}
+	return model.BlockContentText_Paragraph
 }
 
 func (t *textImpl) isLastTextBlockChanged() (bool, error) {

--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -662,3 +662,512 @@ func flushLocked(tb Text) {
 	tb.(*textImpl).flushSetTextState(smartblock.ApplyInfo{})
 	tb.(*textImpl).Unlock()
 }
+
+func newTextBlockWithStyle(id, contentText string, style model.BlockContentTextStyle, childrenIds ...string) simple.Block {
+	return text.NewText(&model.Block{
+		Id: id,
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  contentText,
+				Style: style,
+			},
+		},
+		ChildrenIds: childrenIds,
+	})
+}
+
+func TestTextImpl_TurnIntoToggleHeader(t *testing.T) {
+	t.Run("collect siblings until end", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3"}})).
+			AddBlock(newTextBlock("1", "header")).
+			AddBlock(newTextBlock("2", "paragraph1")).
+			AddBlock(newTextBlock("3", "paragraph2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("1").Model().GetText().Style)
+		assert.Equal(t, []string{"2", "3"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("H2 stops at H1", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3", "4"}})).
+			AddBlock(newTextBlock("1", "toggle header")).
+			AddBlock(newTextBlock("2", "paragraph")).
+			AddBlock(newTextBlockWithStyle("3", "H1 header", model.BlockContentText_Header1)).
+			AddBlock(newTextBlock("4", "after header"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader2, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader2, r.Pick("1").Model().GetText().Style)
+		assert.Equal(t, []string{"2"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "3", "4"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("H2 stops at H2", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3", "4"}})).
+			AddBlock(newTextBlock("1", "toggle header")).
+			AddBlock(newTextBlock("2", "paragraph")).
+			AddBlock(newTextBlockWithStyle("3", "another H2", model.BlockContentText_Header2)).
+			AddBlock(newTextBlock("4", "after header"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader2, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader2, r.Pick("1").Model().GetText().Style)
+		assert.Equal(t, []string{"2"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "3", "4"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("H2 collects H3", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3", "4", "5"}})).
+			AddBlock(newTextBlock("1", "toggle header H2")).
+			AddBlock(newTextBlock("2", "paragraph")).
+			AddBlock(newTextBlockWithStyle("3", "H3 header", model.BlockContentText_Header3)).
+			AddBlock(newTextBlock("4", "after H3")).
+			AddBlock(newTextBlockWithStyle("5", "H2 header", model.BlockContentText_Header2))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader2, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader2, r.Pick("1").Model().GetText().Style)
+		// H3 and content after it should be collected, stop at H2
+		assert.Equal(t, []string{"2", "3", "4"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "5"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("H1 collects H2 and H3", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3", "4", "5", "6"}})).
+			AddBlock(newTextBlock("1", "toggle header H1")).
+			AddBlock(newTextBlock("2", "paragraph")).
+			AddBlock(newTextBlockWithStyle("3", "H2 header", model.BlockContentText_Header2)).
+			AddBlock(newTextBlockWithStyle("4", "H3 header", model.BlockContentText_Header3)).
+			AddBlock(newTextBlock("5", "more content")).
+			AddBlock(newTextBlockWithStyle("6", "another H1", model.BlockContentText_Header1))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("1").Model().GetText().Style)
+		// H2, H3 and all content should be collected, stop at H1
+		assert.Equal(t, []string{"2", "3", "4", "5"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "6"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("H3 stops at toggle H1", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3", "4"}})).
+			AddBlock(newTextBlock("1", "toggle header")).
+			AddBlock(newTextBlock("2", "paragraph")).
+			AddBlock(newTextBlockWithStyle("3", "toggle H1", model.BlockContentText_ToggleHeader1)).
+			AddBlock(newTextBlock("4", "after toggle header"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader3, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader3, r.Pick("1").Model().GetText().Style)
+		assert.Equal(t, []string{"2"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "3", "4"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("no siblings to collect", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlock("1", "header"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("preserve existing children", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2"}})).
+			AddBlock(newTextBlock("1", "header", "existing-child")).
+			AddBlock(newTextBlock("existing-child", "existing")).
+			AddBlock(newTextBlock("2", "sibling"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("1").Model().GetText().Style)
+		assert.Equal(t, []string{"existing-child", "2"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("last block becomes toggle header", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2"}})).
+			AddBlock(newTextBlock("1", "paragraph")).
+			AddBlock(newTextBlock("2", "last block"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "2")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("2").Model().GetText().Style)
+		assert.Empty(t, r.Pick("2").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "2"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("collect non-text blocks as well", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1", "2", "3", "4"}})).
+			AddBlock(newTextBlock("1", "header")).
+			AddBlock(newTextBlock("2", "text")).
+			AddBlock(simple.New(&model.Block{Id: "3", Content: &model.BlockContentOfDiv{Div: &model.BlockContentDiv{}}})).
+			AddBlock(newTextBlock("4", "more text"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("1").Model().GetText().Style)
+		assert.Equal(t, []string{"2", "3", "4"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1"}, r.Pick("test").Model().ChildrenIds)
+	})
+}
+
+func newLayoutDivBlock(id string, childrenIds ...string) simple.Block {
+	return simple.New(&model.Block{
+		Id:          id,
+		ChildrenIds: childrenIds,
+		Content: &model.BlockContentOfLayout{
+			Layout: &model.BlockContentLayout{
+				Style: model.BlockContentLayout_Div,
+			},
+		},
+	})
+}
+
+func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
+	t.Run("collect from current div and sibling divs", func(t *testing.T) {
+		// Tree Before:
+		// root
+		// -div1
+		// --1
+		// --H1 (converting to TH1)
+		// --2
+		// -div2
+		// --3
+		// --4
+		// --H1-stop (this stops collection)
+		// --5
+		//
+		// Tree After:
+		// root
+		// -div1
+		// --1
+		// --TH1
+		// ---newDiv1 (contains 2)
+		// ---newDiv2 (contains 3, 4)
+		// -div2
+		// --H1-stop
+		// --5
+
+		// given
+		sb := smarttest.New("root")
+		sb.AddBlock(simple.New(&model.Block{Id: "root", ChildrenIds: []string{"div1", "div2"}})).
+			AddBlock(newLayoutDivBlock("div1", "1", "H1", "2")).
+			AddBlock(newLayoutDivBlock("div2", "3", "4", "H1-stop", "5")).
+			AddBlock(newTextBlock("1", "before header")).
+			AddBlock(newTextBlock("H1", "header to convert")).
+			AddBlock(newTextBlock("2", "after header in div1")).
+			AddBlock(newTextBlock("3", "first in div2")).
+			AddBlock(newTextBlock("4", "second in div2")).
+			AddBlock(newTextBlockWithStyle("H1-stop", "stopping header", model.BlockContentText_Header1)).
+			AddBlock(newTextBlock("5", "after stopping header"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "H1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+
+		// Check toggle header style
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("H1").Model().GetText().Style)
+
+		// Check toggle header has 2 new div children
+		toggleChildren := r.Pick("H1").Model().ChildrenIds
+		require.Len(t, toggleChildren, 2)
+
+		// First new div should contain block "2"
+		newDiv1 := r.Pick(toggleChildren[0])
+		require.NotNil(t, newDiv1)
+		assert.Equal(t, model.BlockContentLayout_Div, newDiv1.Model().GetLayout().Style)
+		assert.Equal(t, []string{"2"}, newDiv1.Model().ChildrenIds)
+
+		// Second new div should contain blocks "3", "4"
+		newDiv2 := r.Pick(toggleChildren[1])
+		require.NotNil(t, newDiv2)
+		assert.Equal(t, model.BlockContentLayout_Div, newDiv2.Model().GetLayout().Style)
+		assert.Equal(t, []string{"3", "4"}, newDiv2.Model().ChildrenIds)
+
+		// Check div1 structure: should contain "1" and "H1" (toggle header)
+		assert.Equal(t, []string{"1", "H1"}, r.Pick("div1").Model().ChildrenIds)
+
+		// Check div2 structure: should contain "H1-stop" and "5"
+		assert.Equal(t, []string{"H1-stop", "5"}, r.Pick("div2").Model().ChildrenIds)
+	})
+
+	t.Run("collect entire sibling div when no stopping header", func(t *testing.T) {
+		// Tree Before:
+		// root
+		// -div1
+		// --H1
+		// --2
+		// -div2
+		// --3
+		// --4
+		//
+		// Tree After:
+		// root
+		// -div1
+		// --TH1
+		// ---newDiv1 (contains 2)
+		// ---newDiv2 (contains 3, 4)
+		// (div2 is removed as it becomes empty)
+
+		// given
+		sb := smarttest.New("root")
+		sb.AddBlock(simple.New(&model.Block{Id: "root", ChildrenIds: []string{"div1", "div2"}})).
+			AddBlock(newLayoutDivBlock("div1", "H1", "2")).
+			AddBlock(newLayoutDivBlock("div2", "3", "4")).
+			AddBlock(newTextBlock("H1", "header to convert")).
+			AddBlock(newTextBlock("2", "after header")).
+			AddBlock(newTextBlock("3", "first in div2")).
+			AddBlock(newTextBlock("4", "second in div2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "H1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+
+		// Check toggle header has 2 new div children
+		toggleChildren := r.Pick("H1").Model().ChildrenIds
+		require.Len(t, toggleChildren, 2)
+
+		// First new div should contain block "2"
+		newDiv1 := r.Pick(toggleChildren[0])
+		assert.Equal(t, []string{"2"}, newDiv1.Model().ChildrenIds)
+
+		// Second new div should contain blocks "3", "4"
+		newDiv2 := r.Pick(toggleChildren[1])
+		assert.Equal(t, []string{"3", "4"}, newDiv2.Model().ChildrenIds)
+
+		// div1 should only contain the toggle header
+		assert.Equal(t, []string{"H1"}, r.Pick("div1").Model().ChildrenIds)
+
+		// div2 should be unlinked (empty)
+		assert.False(t, r.Exists("div2") && len(r.Pick("div2").Model().ChildrenIds) > 0)
+	})
+
+	t.Run("stop at header in current div", func(t *testing.T) {
+		// Tree Before:
+		// root
+		// -div1
+		// --H1
+		// --2
+		// --H1-stop
+		// --3
+		// -div2
+		// --4
+		//
+		// Tree After:
+		// root
+		// -div1
+		// --TH1
+		// ---newDiv1 (contains 2)
+		// --H1-stop
+		// --3
+		// -div2
+		// --4
+
+		// given
+		sb := smarttest.New("root")
+		sb.AddBlock(simple.New(&model.Block{Id: "root", ChildrenIds: []string{"div1", "div2"}})).
+			AddBlock(newLayoutDivBlock("div1", "H1", "2", "H1-stop", "3")).
+			AddBlock(newLayoutDivBlock("div2", "4")).
+			AddBlock(newTextBlock("H1", "header to convert")).
+			AddBlock(newTextBlock("2", "content")).
+			AddBlock(newTextBlockWithStyle("H1-stop", "stopping header", model.BlockContentText_Header1)).
+			AddBlock(newTextBlock("3", "after stop")).
+			AddBlock(newTextBlock("4", "in div2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "H1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+
+		// Check toggle header has 1 new div child
+		toggleChildren := r.Pick("H1").Model().ChildrenIds
+		require.Len(t, toggleChildren, 1)
+
+		// New div should contain block "2"
+		newDiv := r.Pick(toggleChildren[0])
+		assert.Equal(t, []string{"2"}, newDiv.Model().ChildrenIds)
+
+		// div1 should contain TH1, H1-stop, 3
+		assert.Equal(t, []string{"H1", "H1-stop", "3"}, r.Pick("div1").Model().ChildrenIds)
+
+		// div2 should be unchanged
+		assert.Equal(t, []string{"4"}, r.Pick("div2").Model().ChildrenIds)
+	})
+
+	t.Run("no content to collect in div", func(t *testing.T) {
+		// Tree Before:
+		// root
+		// -div1
+		// --H1
+		// -div2
+		// --H1-stop
+		//
+		// Tree After: (unchanged except style)
+		// root
+		// -div1
+		// --TH1
+		// -div2
+		// --H1-stop
+
+		// given
+		sb := smarttest.New("root")
+		sb.AddBlock(simple.New(&model.Block{Id: "root", ChildrenIds: []string{"div1", "div2"}})).
+			AddBlock(newLayoutDivBlock("div1", "H1")).
+			AddBlock(newLayoutDivBlock("div2", "H1-stop")).
+			AddBlock(newTextBlock("H1", "header to convert")).
+			AddBlock(newTextBlockWithStyle("H1-stop", "stopping header", model.BlockContentText_Header1))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "H1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+
+		// Toggle header should have no children
+		assert.Empty(t, r.Pick("H1").Model().ChildrenIds)
+
+		// Structure should be preserved
+		assert.Equal(t, []string{"H1"}, r.Pick("div1").Model().ChildrenIds)
+		assert.Equal(t, []string{"H1-stop"}, r.Pick("div2").Model().ChildrenIds)
+	})
+
+	t.Run("H2 in div collects H3 but stops at H2", func(t *testing.T) {
+		// Test header level logic with div blocks
+
+		// given
+		sb := smarttest.New("root")
+		sb.AddBlock(simple.New(&model.Block{Id: "root", ChildrenIds: []string{"div1", "div2"}})).
+			AddBlock(newLayoutDivBlock("div1", "H2", "content1")).
+			AddBlock(newLayoutDivBlock("div2", "H3", "content2", "H2-stop", "content3")).
+			AddBlock(newTextBlock("H2", "H2 to convert")).
+			AddBlock(newTextBlock("content1", "content")).
+			AddBlock(newTextBlockWithStyle("H3", "H3 header", model.BlockContentText_Header3)).
+			AddBlock(newTextBlock("content2", "after H3")).
+			AddBlock(newTextBlockWithStyle("H2-stop", "stopping H2", model.BlockContentText_Header2)).
+			AddBlock(newTextBlock("content3", "after stop"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader2, "H2")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+
+		// Toggle header should have 2 div children
+		toggleChildren := r.Pick("H2").Model().ChildrenIds
+		require.Len(t, toggleChildren, 2)
+
+		// First div: content1
+		assert.Equal(t, []string{"content1"}, r.Pick(toggleChildren[0]).Model().ChildrenIds)
+
+		// Second div: H3, content2 (H3 is collected because it's lower level than H2)
+		assert.Equal(t, []string{"H3", "content2"}, r.Pick(toggleChildren[1]).Model().ChildrenIds)
+
+		// div2 should have H2-stop and content3
+		assert.Equal(t, []string{"H2-stop", "content3"}, r.Pick("div2").Model().ChildrenIds)
+	})
+}

--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -1100,8 +1100,9 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		// -div1
 		// --1
 		// --TH1
-		// ---newDiv1 (contains 2)
-		// ---newDiv2 (contains 3, 4)
+		// ---2
+		// ---3
+		// ---4
 		// -div2
 		// --H1-stop
 		// --5
@@ -1131,21 +1132,8 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		// Check toggle header style
 		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("H1").Model().GetText().Style)
 
-		// Check toggle header has 2 new div children
-		toggleChildren := r.Pick("H1").Model().ChildrenIds
-		require.Len(t, toggleChildren, 2)
-
-		// First new div should contain block "2"
-		newDiv1 := r.Pick(toggleChildren[0])
-		require.NotNil(t, newDiv1)
-		assert.Equal(t, model.BlockContentLayout_Div, newDiv1.Model().GetLayout().Style)
-		assert.Equal(t, []string{"2"}, newDiv1.Model().ChildrenIds)
-
-		// Second new div should contain blocks "3", "4"
-		newDiv2 := r.Pick(toggleChildren[1])
-		require.NotNil(t, newDiv2)
-		assert.Equal(t, model.BlockContentLayout_Div, newDiv2.Model().GetLayout().Style)
-		assert.Equal(t, []string{"3", "4"}, newDiv2.Model().ChildrenIds)
+		// Blocks are direct children of toggle header (no wrapper divs)
+		assert.Equal(t, []string{"2", "3", "4"}, r.Pick("H1").Model().ChildrenIds)
 
 		// Check div1 structure: should contain "1" and "H1" (toggle header)
 		assert.Equal(t, []string{"1", "H1"}, r.Pick("div1").Model().ChildrenIds)
@@ -1168,8 +1156,9 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		// root
 		// -div1
 		// --TH1
-		// ---newDiv1 (contains 2)
-		// ---newDiv2 (contains 3, 4)
+		// ---2
+		// ---3
+		// ---4
 		// (div2 is removed as it becomes empty)
 
 		// given
@@ -1191,17 +1180,8 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		require.NoError(t, err)
 		r := sb.NewState()
 
-		// Check toggle header has 2 new div children
-		toggleChildren := r.Pick("H1").Model().ChildrenIds
-		require.Len(t, toggleChildren, 2)
-
-		// First new div should contain block "2"
-		newDiv1 := r.Pick(toggleChildren[0])
-		assert.Equal(t, []string{"2"}, newDiv1.Model().ChildrenIds)
-
-		// Second new div should contain blocks "3", "4"
-		newDiv2 := r.Pick(toggleChildren[1])
-		assert.Equal(t, []string{"3", "4"}, newDiv2.Model().ChildrenIds)
+		// Blocks are direct children of toggle header
+		assert.Equal(t, []string{"2", "3", "4"}, r.Pick("H1").Model().ChildrenIds)
 
 		// div1 should only contain the toggle header
 		assert.Equal(t, []string{"H1"}, r.Pick("div1").Model().ChildrenIds)
@@ -1225,7 +1205,7 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		// root
 		// -div1
 		// --TH1
-		// ---newDiv1 (contains 2)
+		// ---2
 		// --H1-stop
 		// --3
 		// -div2
@@ -1251,13 +1231,8 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		require.NoError(t, err)
 		r := sb.NewState()
 
-		// Check toggle header has 1 new div child
-		toggleChildren := r.Pick("H1").Model().ChildrenIds
-		require.Len(t, toggleChildren, 1)
-
-		// New div should contain block "2"
-		newDiv := r.Pick(toggleChildren[0])
-		assert.Equal(t, []string{"2"}, newDiv.Model().ChildrenIds)
+		// Block "2" is a direct child of toggle header
+		assert.Equal(t, []string{"2"}, r.Pick("H1").Model().ChildrenIds)
 
 		// div1 should contain TH1, H1-stop, 3
 		assert.Equal(t, []string{"H1", "H1-stop", "3"}, r.Pick("div1").Model().ChildrenIds)
@@ -1330,17 +1305,70 @@ func TestTextImpl_TurnIntoToggleHeaderWithDivBlocks(t *testing.T) {
 		require.NoError(t, err)
 		r := sb.NewState()
 
-		// Toggle header should have 2 div children
-		toggleChildren := r.Pick("H2").Model().ChildrenIds
-		require.Len(t, toggleChildren, 2)
-
-		// First div: content1
-		assert.Equal(t, []string{"content1"}, r.Pick(toggleChildren[0]).Model().ChildrenIds)
-
-		// Second div: H3, content2 (H3 is collected because it's lower level than H2)
-		assert.Equal(t, []string{"H3", "content2"}, r.Pick(toggleChildren[1]).Model().ChildrenIds)
+		// Blocks are direct children: content1 from div1, H3 and content2 from div2
+		assert.Equal(t, []string{"content1", "H3", "content2"}, r.Pick("H2").Model().ChildrenIds)
 
 		// div2 should have H2-stop and content3
 		assert.Equal(t, []string{"H2-stop", "content3"}, r.Pick("div2").Model().ChildrenIds)
+	})
+
+	t.Run("collect from many sibling divs", func(t *testing.T) {
+		// Tree Before:
+		// root
+		// -div1
+		// --H1 (converting to TH1)
+		// --1
+		// -div2
+		// --2
+		// -div3
+		// --3
+		// -div4
+		// --4
+		// -div5
+		// --5
+		// -div6
+		// --6
+		//
+		// Tree After:
+		// root
+		// -div1
+		// --TH1
+		// ---1
+		// ---2
+		// ---3
+		// ---4
+		// ---5
+		// ---6
+		// (div2-div6 are removed as they become empty)
+
+		// given
+		sb := smarttest.New("root")
+		sb.AddBlock(simple.New(&model.Block{Id: "root", ChildrenIds: []string{"div1", "div2", "div3", "div4", "div5", "div6"}})).
+			AddBlock(newLayoutDivBlock("div1", "H1", "1")).
+			AddBlock(newLayoutDivBlock("div2", "2")).
+			AddBlock(newLayoutDivBlock("div3", "3")).
+			AddBlock(newLayoutDivBlock("div4", "4")).
+			AddBlock(newLayoutDivBlock("div5", "5")).
+			AddBlock(newLayoutDivBlock("div6", "6")).
+			AddBlock(newTextBlock("H1", "header to convert")).
+			AddBlock(newTextBlock("1", "in div1")).
+			AddBlock(newTextBlock("2", "in div2")).
+			AddBlock(newTextBlock("3", "in div3")).
+			AddBlock(newTextBlock("4", "in div4")).
+			AddBlock(newTextBlock("5", "in div5")).
+			AddBlock(newTextBlock("6", "in div6"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_ToggleHeader1, "H1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+
+		assert.Equal(t, model.BlockContentText_ToggleHeader1, r.Pick("H1").Model().GetText().Style)
+		assert.Equal(t, []string{"1", "2", "3", "4", "5", "6"}, r.Pick("H1").Model().ChildrenIds)
+		assert.Equal(t, []string{"H1"}, r.Pick("div1").Model().ChildrenIds)
 	})
 }

--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -896,6 +896,179 @@ func TestTextImpl_TurnIntoToggleHeader(t *testing.T) {
 	})
 }
 
+func TestTextImpl_TurnIntoHeaderFromToggleHeader(t *testing.T) {
+	t.Run("toggle header with children becomes header, children moved as siblings", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header", model.BlockContentText_ToggleHeader1, "2", "3")).
+			AddBlock(newTextBlock("2", "child1")).
+			AddBlock(newTextBlock("3", "child2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Header1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Header1, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "2", "3"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header 2 with children becomes header 2", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"0", "1", "4"}})).
+			AddBlock(newTextBlock("0", "before")).
+			AddBlock(newTextBlockWithStyle("1", "toggle header 2", model.BlockContentText_ToggleHeader2, "2", "3")).
+			AddBlock(newTextBlock("2", "child1")).
+			AddBlock(newTextBlock("3", "child2")).
+			AddBlock(newTextBlock("4", "after"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Header2, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Header2, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		// children should be placed right after the header, before "4"
+		assert.Equal(t, []string{"0", "1", "2", "3", "4"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header 3 with children becomes header 3", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header 3", model.BlockContentText_ToggleHeader3, "2")).
+			AddBlock(newTextBlock("2", "only child"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Header3, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Header3, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "2"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header without children becomes header without issues", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header", model.BlockContentText_ToggleHeader1))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Header1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Header1, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header with nested children becomes header, all children unindented", func(t *testing.T) {
+		// given: toggle header "1" has children "2" and "3", and "2" itself has child "2a"
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header", model.BlockContentText_ToggleHeader1, "2", "3")).
+			AddBlock(newTextBlock("2", "child with nested", "2a")).
+			AddBlock(newTextBlock("2a", "nested child")).
+			AddBlock(newTextBlock("3", "child2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Header1, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Header1, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		// Only direct children are moved up; nested children stay with their parent
+		assert.Equal(t, []string{"1", "2", "3"}, r.Pick("test").Model().ChildrenIds)
+		assert.Equal(t, []string{"2a"}, r.Pick("2").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header to different header level moves children", func(t *testing.T) {
+		// given: ToggleHeader1 with children is turned into Header3
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header 1", model.BlockContentText_ToggleHeader1, "2", "3")).
+			AddBlock(newTextBlock("2", "child1")).
+			AddBlock(newTextBlock("3", "child2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Header3, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Header3, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "2", "3"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header to paragraph keeps children", func(t *testing.T) {
+		// given: ToggleHeader1 with children is turned into Paragraph (which CAN have children)
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header", model.BlockContentText_ToggleHeader1, "2", "3")).
+			AddBlock(newTextBlock("2", "child1")).
+			AddBlock(newTextBlock("3", "child2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Paragraph, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Paragraph, r.Pick("1").Model().GetText().Style)
+		// Paragraph CAN have children, so they should remain
+		assert.Equal(t, []string{"2", "3"}, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1"}, r.Pick("test").Model().ChildrenIds)
+	})
+
+	t.Run("toggle header to code moves children", func(t *testing.T) {
+		// given: Code blocks also cannot have children
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"1"}})).
+			AddBlock(newTextBlockWithStyle("1", "toggle header", model.BlockContentText_ToggleHeader1, "2")).
+			AddBlock(newTextBlock("2", "child"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		// when
+		err := tb.TurnInto(nil, model.BlockContentText_Code, "1")
+
+		// then
+		require.NoError(t, err)
+		r := sb.NewState()
+		assert.Equal(t, model.BlockContentText_Code, r.Pick("1").Model().GetText().Style)
+		assert.Empty(t, r.Pick("1").Model().ChildrenIds)
+		assert.Equal(t, []string{"1", "2"}, r.Pick("test").Model().ChildrenIds)
+	})
+}
+
 func newLayoutDivBlock(id string, childrenIds ...string) simple.Block {
 	return simple.New(&model.Block{
 		Id:          id,


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6742/add-toggle-heading-block-styles-toggle-h1-h2-h3
https://linear.app/anytype/issue/GO-6833/conversion-to-toggle-heading-does-not-capture-blocks-until-the-next

Support TurnInto for Toggle Headers