### PR TITLE
GO-6696 deprecate OldAccountIdentity

### DIFF
--- a/core/application/account_create_from_export.go
+++ b/core/application/account_create_from_export.go
@@ -82,7 +82,7 @@ func (s *Service) RecoverFromLegacy(req *pb.RpcAccountRecoverFromLegacyExportReq
 		return RecoverFromLegacyResponse{}, ErrWalletNotInitialized
 	}
 	address := s.derivedKeys.Identity.GetPublic().Account()
-	if profile.Address != s.derivedKeys.OldAccountKey.GetPublic().Account() && profile.Address != address {
+	if profile.Address != address {
 		return RecoverFromLegacyResponse{}, ErrAccountMismatch
 	}
 	s.rootPath = req.RootPath

--- a/core/configfetcher/configfetcher.go
+++ b/core/configfetcher/configfetcher.go
@@ -29,7 +29,6 @@ import (
 	"github.com/anyproto/any-sync/util/periodicsync"
 
 	"github.com/anyproto/anytype-heart/core/event"
-	"github.com/anyproto/anytype-heart/core/wallet"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -66,8 +65,7 @@ type configFetcher struct {
 	client       coordinatorclient.CoordinatorClient
 	spaceService spacecore.SpaceCoreService
 	getter       techSpaceGetter
-	wallet       wallet.Wallet
-	lastStatus   model.AccountStatusType
+	lastStatus model.AccountStatusType
 	mutex        sync.Mutex
 }
 
@@ -81,7 +79,6 @@ func (c *configFetcher) Run(context.Context) error {
 }
 
 func (c *configFetcher) Init(a *app.App) (err error) {
-	c.wallet = a.MustComponent(wallet.CName).(wallet.Wallet)
 	c.eventSender = a.MustComponent(event.CName).(event.Sender)
 	c.periodicSync = periodicsync.NewPeriodicSync(refreshIntervalSecs, timeout, c.updateStatus, logger.CtxLogger{Logger: log.Desugar()})
 	c.client = a.MustComponent(coordinatorclient.CName).(coordinatorclient.CoordinatorClient)
@@ -106,8 +103,6 @@ func (c *configFetcher) updateStatus(ctx context.Context) (err error) {
 		payload := coordinatorclient.SpaceSignPayload{
 			SpaceId:     techSpace.Id(),
 			SpaceHeader: state.SpaceHeader,
-			OldAccount:  c.wallet.GetOldAccountKey(),
-			Identity:    c.wallet.GetAccountPrivkey(),
 		}
 		// registering space inside coordinator
 		_, err = c.client.SpaceSign(ctx, payload)

--- a/core/wallet/mock_wallet/mock_Wallet.go
+++ b/core/wallet/mock_wallet/mock_Wallet.go
@@ -355,53 +355,6 @@ func (_c *MockWallet_GetMasterKey_Call) RunAndReturn(run func() crypto.PrivKey) 
 	return _c
 }
 
-// GetOldAccountKey provides a mock function with given fields:
-func (_m *MockWallet) GetOldAccountKey() crypto.PrivKey {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOldAccountKey")
-	}
-
-	var r0 crypto.PrivKey
-	if rf, ok := ret.Get(0).(func() crypto.PrivKey); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(crypto.PrivKey)
-		}
-	}
-
-	return r0
-}
-
-// MockWallet_GetOldAccountKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOldAccountKey'
-type MockWallet_GetOldAccountKey_Call struct {
-	*mock.Call
-}
-
-// GetOldAccountKey is a helper method to define mock.On call
-func (_e *MockWallet_Expecter) GetOldAccountKey() *MockWallet_GetOldAccountKey_Call {
-	return &MockWallet_GetOldAccountKey_Call{Call: _e.mock.On("GetOldAccountKey")}
-}
-
-func (_c *MockWallet_GetOldAccountKey_Call) Run(run func()) *MockWallet_GetOldAccountKey_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockWallet_GetOldAccountKey_Call) Return(_a0 crypto.PrivKey) *MockWallet_GetOldAccountKey_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockWallet_GetOldAccountKey_Call) RunAndReturn(run func() crypto.PrivKey) *MockWallet_GetOldAccountKey_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Init provides a mock function with given fields: a
 func (_m *MockWallet) Init(a *app.App) error {
 	ret := _m.Called(a)

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -40,8 +40,6 @@ type wallet struct {
 	accountKey    crypto.PrivKey
 	deviceKey     crypto.PrivKey
 	masterKey     crypto.PrivKey
-	oldAccountKey crypto.PrivKey
-
 	// this key is used to sign ethereum transactions
 	// and use Any Naming Service
 	ethereumKey ecdsa.PrivateKey
@@ -56,10 +54,6 @@ func (r *wallet) GetAccountPrivkey() crypto.PrivKey {
 
 func (r *wallet) GetDevicePrivkey() crypto.PrivKey {
 	return r.accountData.PeerKey
-}
-
-func (r *wallet) GetOldAccountKey() crypto.PrivKey {
-	return r.oldAccountKey
 }
 
 func (r *wallet) GetMasterKey() crypto.PrivKey {
@@ -193,9 +187,8 @@ func NewWithAccountRepo(rootPath string, derivationResult crypto.DerivationResul
 		rootPath:      rootPath,
 		repoPath:      repoPath,
 		lang:          lang,
-		masterKey:     derivationResult.MasterKey,
-		oldAccountKey: derivationResult.OldAccountKey,
-		accountKey:    derivationResult.Identity,
+		masterKey:  derivationResult.MasterKey,
+		accountKey: derivationResult.Identity,
 		deviceKeyPath: filepath.Join(repoPath, keyFileDevice),
 		ethereumKey:   derivationResult.EthereumIdentity,
 	}
@@ -221,7 +214,6 @@ type Wallet interface {
 	FtsPrimaryLang() string
 	GetAccountPrivkey() crypto.PrivKey
 	GetDevicePrivkey() crypto.PrivKey
-	GetOldAccountKey() crypto.PrivKey
 	GetMasterKey() crypto.PrivKey
 
 	GetAccountEthPrivkey() EthPrivateKey

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0
 	github.com/ahmetb/govvv v0.3.0
 	github.com/anyproto/any-store v0.4.4
-	github.com/anyproto/any-sync v0.11.9
+	github.com/anyproto/any-sync v0.11.10
 	github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb
 	github.com/anyproto/anytype-push-server/pushclient v0.0.0-20250801122506-553f6c085a23
 	github.com/anyproto/go-chash v0.1.0
@@ -221,7 +221,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect
-	github.com/libp2p/go-libp2p v0.46.0 // indirect
+	github.com/libp2p/go-libp2p v0.47.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/anyproto/any-store v0.4.4 h1:OcRFOYIqY/LqiAxjPyM9bVXyTxBdwo3jvu4vAnDa4cE=
 github.com/anyproto/any-store v0.4.4/go.mod h1:Npi35qMUVZ8ouiV4o9AqpZDs6LbDOF+5ZLlVijXofFM=
-github.com/anyproto/any-sync v0.11.9 h1:KS0+CFQZndCzaW67EPkHu9OKzUfMyoJsYQ1JIUNQm3k=
-github.com/anyproto/any-sync v0.11.9/go.mod h1:gNZdrslSXcW5OM3n3RG7fFURlJ8wqBOfXOrWKf3qhfY=
+github.com/anyproto/any-sync v0.11.10 h1:HVRHoom1wHX3RniSMOyOiPiHYF+Qh4lTNcsY8HEkyO0=
+github.com/anyproto/any-sync v0.11.10/go.mod h1:DHuR/dILpIaZSGSUCFwjZrleUkXMJ97cIBq4aYXWCHQ=
 github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb h1:X1os44y0QWf1mYGj8BOoYKlXwY5xb94xTQIw1IIKJbY=
 github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb/go.mod h1:OzzODq4OigiRVD2lSOX1iHAoLcxhJDRbZb8n5PLG3WE=
 github.com/anyproto/anytype-push-server/pushclient v0.0.0-20250801122506-553f6c085a23 h1:jXAjKY4g9ec7lDtayIlzM9u0/b3xGS9YgGA6JtRhHfU=
@@ -691,8 +691,8 @@ github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6
 github.com/libp2p/go-buffer-pool v0.1.0/go.mod h1:N+vh8gMqimBzdKkSMVuydVDq+UV5QTWy5HSiZacSbPg=
 github.com/libp2p/go-flow-metrics v0.3.0 h1:q31zcHUvHnwDO0SHaukewPYgwOBSxtt830uJtUx6784=
 github.com/libp2p/go-flow-metrics v0.3.0/go.mod h1:nuhlreIwEguM1IvHAew3ij7A8BMlyHQJ279ao24eZZo=
-github.com/libp2p/go-libp2p v0.46.0 h1:0T2yvIKpZ3DVYCuPOFxPD1layhRU486pj9rSlGWYnDM=
-github.com/libp2p/go-libp2p v0.46.0/go.mod h1:TbIDnpDjBLa7isdgYpbxozIVPBTmM/7qKOJP4SFySrQ=
+github.com/libp2p/go-libp2p v0.47.0 h1:qQpBjSCWNQFF0hjBbKirMXE9RHLtSuzTDkTfr1rw0yc=
+github.com/libp2p/go-libp2p v0.47.0/go.mod h1:s8HPh7mMV933OtXzONaGFseCg/BE//m1V34p3x4EUOY=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
 github.com/libp2p/go-libp2p-record v0.3.1 h1:cly48Xi5GjNw5Wq+7gmjfBiG9HCzQVkiZOUZ8kUl+Fg=

--- a/space/spacecore/credentialprovider/credentialprovider.go
+++ b/space/spacecore/credentialprovider/credentialprovider.go
@@ -9,7 +9,6 @@ import (
 	"github.com/anyproto/any-sync/coordinator/coordinatorclient"
 	"github.com/gogo/protobuf/proto"
 
-	"github.com/anyproto/anytype-heart/core/wallet"
 )
 
 func New() app.Component {
@@ -18,12 +17,10 @@ func New() app.Component {
 
 type credentialProvider struct {
 	client coordinatorclient.CoordinatorClient
-	wallet wallet.Wallet
 }
 
 func (c *credentialProvider) Init(a *app.App) (err error) {
 	c.client = a.MustComponent(coordinatorclient.CName).(coordinatorclient.CoordinatorClient)
-	c.wallet = a.MustComponent(wallet.CName).(wallet.Wallet)
 	return
 }
 
@@ -35,8 +32,6 @@ func (c *credentialProvider) GetCredential(ctx context.Context, spaceHeader *spa
 	payload := coordinatorclient.SpaceSignPayload{
 		SpaceId:     spaceHeader.Id,
 		SpaceHeader: spaceHeader.RawHeader,
-		OldAccount:  c.wallet.GetOldAccountKey(),
-		Identity:    c.wallet.GetAccountPrivkey(),
 	}
 	receipt, err := c.client.SpaceSign(ctx, payload)
 	if err != nil {


### PR DESCRIPTION
Bumps any-sync to v0.11.10 (which includes https://github.com/anyproto/any-sync/pull/607) and removes all usages of the deprecated old identity mechanism from heart.