### PR TITLE
GO-6630 Revert goheic lib switch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown v1.4.0
 	github.com/PuerkitoBio/goquery v1.10.2
 	github.com/VividCortex/ewma v1.2.0
+	github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
 	github.com/ahmetb/govvv v0.3.0
 	github.com/anyproto/any-store v0.4.4
 	github.com/anyproto/any-sync v0.11.9
@@ -63,7 +64,6 @@ require (
 	github.com/ipfs/go-ds-flatfs v0.5.5
 	github.com/ipfs/go-ipld-format v0.6.3
 	github.com/ipfs/go-log v1.0.5
-	github.com/jdeng/goheif v0.0.0-20251001174315-babb64285736
 	github.com/joho/godotenv v1.5.1
 	github.com/jsummers/gobmp v0.0.0-20230614200233-a9de23ed2e25
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786 h1:zvgtcRb2B5gynWjm+Fc9oJZPHXwmcgyH0xCcNm6Rmo4=
+github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ahmetb/govvv v0.3.0 h1:YGLGwEyiUwHFy5eh/RUhdupbuaCGBYn5T5GWXp+WJB0=
@@ -621,8 +623,6 @@ github.com/jarcoal/httpmock v1.0.4 h1:jp+dy/+nonJE4g4xbVtl9QdrUNbn6/3hDT5R4nDIZn
 github.com/jarcoal/httpmock v1.0.4/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-temp-err-catcher v0.1.0 h1:zpb3ZH6wIE8Shj2sKS+khgRvf7T7RABoLk/+KKHggpk=
 github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPwbGVtZVWC34vc5WLsDk=
-github.com/jdeng/goheif v0.0.0-20251001174315-babb64285736 h1:8p2uq8IfUtGXUYvV9EFpP5FQKgcXVcGoGjT/P8N4KoA=
-github.com/jdeng/goheif v0.0.0-20251001174315-babb64285736/go.mod h1:whEdtAJfm8ia675sbmIATUVAT/P9gnb7zHpR3hzqst0=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=

--- a/pkg/lib/mill/image_resize_heic.go
+++ b/pkg/lib/mill/image_resize_heic.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/jdeng/goheif"
-	"github.com/jdeng/goheif/heif"
+	"github.com/adrium/goheif"
+	"github.com/adrium/goheif/heif"
 	"github.com/kovidgoyal/imaging"
 )
 

--- a/pkg/lib/mill/testdata/images.go
+++ b/pkg/lib/mill/testdata/images.go
@@ -79,11 +79,12 @@ var Images = []TestImage{
 		Width:   1728,
 		Height:  2376,
 	},
-	{
-		Path:    "testdata/image_mdat_first.heic",
-		Format:  "heic",
-		HasExif: false,
-		Width:   1440,
-		Height:  960,
-	},
+	// TODO: GO-6630 Uncomment this when mdat-first heic images resize will be fixed
+	// {
+	// 	Path:    "testdata/image_mdat_first.heic",
+	// 	Format:  "heic",
+	// 	HasExif: false,
+	// 	Width:   1440,
+	// 	Height:  960,
+	// },
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6630/the-image-heic-format-is-broken

Jdeng/goheif library does not compile for Android. Let's revert changes until we find other solution to HEIC images resize for mdat box being first for Android files