### PR TITLE
fix: ExactIn filter string support

### DIFF
--- a/pkg/lib/database/filter.go
+++ b/pkg/lib/database/filter.go
@@ -763,8 +763,17 @@ func (exIn *FilterOptionsEqual) Ok(v *anyenc.Value, docBuf *syncpool.DocBuffer) 
 	defer exIn.arena.Reset()
 
 	arr := v.GetArray(string(exIn.Key))
-	// Just fall back to precompiled filter
 	if len(arr) == 0 {
+		// Handle single string value (not array) - mirrors FilterObject() logic
+		optionId := string(v.GetStringBytes(string(exIn.Key)))
+		if optionId != "" {
+			_, isValidOption := exIn.Options[optionId]
+			if !isValidOption {
+				return false
+			}
+			return slices.Contains(exIn.Value, optionId)
+		}
+		// Fall back to precompiled filter for other non-array types
 		return exIn.valueFilter.Ok(v.Get(string(exIn.Key)), docBuf)
 	}
 

--- a/pkg/lib/database/filter_test.go
+++ b/pkg/lib/database/filter_test.go
@@ -563,6 +563,29 @@ func TestFilterOptionsEqual(t *testing.T) {
 		obj := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{"k": domain.StringList([]string{"optionId1", "optionId2", "optionId3"})})
 		assertFilter(t, eq, obj, false)
 	})
+	t.Run("one option as single string, ok", func(t *testing.T) {
+		eq := newFilterOptionsEqual(&anyenc.Arena{}, "k", []string{"optionId1"}, optionIdToName)
+		obj := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{"k": domain.String("optionId1")})
+		assertFilter(t, eq, obj, true)
+	})
+	t.Run("one option as single string, not ok - wrong value", func(t *testing.T) {
+		eq := newFilterOptionsEqual(&anyenc.Arena{}, "k", []string{"optionId1"}, optionIdToName)
+		obj := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{"k": domain.String("optionId2")})
+		assertFilter(t, eq, obj, false)
+	})
+	t.Run("one option as single string, not ok - not in options", func(t *testing.T) {
+		eq := newFilterOptionsEqual(&anyenc.Arena{}, "k", []string{"optionId1"}, optionIdToName)
+		obj := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{"k": domain.String("unknownOption")})
+		assertFilter(t, eq, obj, false)
+	})
+	t.Run("single string matching one of two filter values - allowed for backward compatibility", func(t *testing.T) {
+		// Note: This behavior matches FilterObject() for single strings
+		// In board view, filters always have a single value, so this case shouldn't occur
+		eq := newFilterOptionsEqual(&anyenc.Arena{}, "k", []string{"optionId1", "optionId2"}, optionIdToName)
+		obj := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{"k": domain.String("optionId1")})
+		// Single string is treated as a valid match if it's in the filter values
+		assertFilter(t, eq, obj, true)
+	})
 }
 
 func TestMakeFilters(t *testing.T) {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

Fixed missing objects by supporting single-string values in ExactIn filter. My old notes use single-string values, seems like this is a valid fix.

Same board before/after the fix
<img width="3503" height="1210" alt="image" src="https://github.com/user-attachments/assets/63eff374-a414-45e6-bd57-a750d38ce1fb" />

This was a regression, it worked before and broke only in latest releases.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
