### PR TITLE
GO-6664 Add spaceUxType to chat push notification payload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
 
+## Pull Requests
+
+Always create PRs targeting the `develop` branch by default.
+
 ## Commit Messages
 
 Every commit message must be prefixed with an issue number following this pattern:

--- a/core/block/chats/chatpush/push.go
+++ b/core/block/chats/chatpush/push.go
@@ -8,6 +8,7 @@ const ChatMessage Type = 1
 
 type Payload struct {
 	SpaceId           string             `json:"spaceId,omitempty"`
+	SpaceUxType       int                `json:"spaceUxType"`
 	SenderId          string             `json:"senderId"`
 	Type              Type               `json:"type"`
 	NewMessagePayload *NewMessagePayload `json:"newMessage,omitempty"`

--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -511,7 +511,11 @@ type pushNotificationRequest struct {
 
 func (s *service) buildPushPayload(req pushNotificationRequest) (*chatpush.Payload, error) {
 	accountId := s.accountService.AccountID()
-	spaceName := s.objectStore.GetSpaceName(req.spaceId)
+	spaceViewDetails, err := s.objectStore.GetSpaceViewDetails(req.spaceId)
+	if err != nil {
+		log.Warn("buildPushPayload: failed to get space view details", zap.Error(err))
+		spaceViewDetails = domain.NewDetails()
+	}
 	details, err := s.objectStore.SpaceIndex(req.spaceId).GetDetails(domain.NewParticipantId(req.spaceId, accountId))
 	var senderName string
 	if err != nil {
@@ -528,13 +532,14 @@ func (s *service) buildPushPayload(req pushNotificationRequest) (*chatpush.Paylo
 	text := applyEmojiMarks(req.message.Message.Text, req.message.Message.Marks)
 
 	return &chatpush.Payload{
-		SpaceId:  req.spaceId,
-		SenderId: accountId,
-		Type:     chatpush.ChatMessage,
+		SpaceId:     req.spaceId,
+		SpaceUxType: int(spaceViewDetails.GetInt64(bundle.RelationKeySpaceUxType)),
+		SenderId:    accountId,
+		Type:        chatpush.ChatMessage,
 		NewMessagePayload: &chatpush.NewMessagePayload{
 			ChatId:         req.chatObjectId,
 			MsgId:          req.messageId,
-			SpaceName:      spaceName,
+			SpaceName:      spaceViewDetails.GetString(bundle.RelationKeyName),
 			ChatName:       req.chatName,
 			SenderName:     senderName,
 			Text:           textUtil.Truncate(text, 1024, "..."),

--- a/core/block/chats/service_test.go
+++ b/core/block/chats/service_test.go
@@ -570,13 +570,14 @@ func TestBuildPushPayload(t *testing.T) {
 		senderName := "John Doe"
 		participantId := domain.NewParticipantId(spaceId, "testAccountId")
 
-		// Set up space name
+		// Set up space name and ux type
 		fx.objectStore.AddObjects(t, objectstore.TestTechSpaceId, []objectstore.TestObject{
 			{
 				bundle.RelationKeyId:             domain.String("spaceView1"),
 				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
 				bundle.RelationKeyTargetSpaceId:  domain.String(spaceId),
 				bundle.RelationKeyName:           domain.String(spaceName),
+				bundle.RelationKeySpaceUxType:    domain.Int64(int64(model.SpaceUxType_Chat)),
 			},
 		})
 
@@ -604,9 +605,10 @@ func TestBuildPushPayload(t *testing.T) {
 			},
 		}
 		want := &chatpush.Payload{
-			SpaceId:  spaceId,
-			SenderId: "testAccountId",
-			Type:     chatpush.ChatMessage,
+			SpaceId:     spaceId,
+			SpaceUxType: int(model.SpaceUxType_Chat),
+			SenderId:    "testAccountId",
+			Type:        chatpush.ChatMessage,
 			NewMessagePayload: &chatpush.NewMessagePayload{
 				ChatId:         "chat1",
 				MsgId:          "msg1",
@@ -772,6 +774,76 @@ func TestBuildPushPayload(t *testing.T) {
 				ChatName:       "",
 				SenderName:     "",
 				Text:           "Hello",
+				HasAttachments: false,
+				Attachments:    nil,
+			},
+		}
+
+		// when
+		got, err := fx.buildPushPayload(req)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("one-to-one space", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		spaceId := "space1"
+		spaceName := "Direct Chat"
+		participantId := domain.NewParticipantId(spaceId, "testAccountId")
+
+		// Set up space view with OneToOne ux type
+		fx.objectStore.AddObjects(t, objectstore.TestTechSpaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("spaceView1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
+				bundle.RelationKeyTargetSpaceId:  domain.String(spaceId),
+				bundle.RelationKeyName:           domain.String(spaceName),
+				bundle.RelationKeySpaceUxType:    domain.Int64(int64(model.SpaceUxType_OneToOne)),
+			},
+		})
+
+		// Set up sender name
+		fx.objectStore.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:   domain.String(participantId),
+				bundle.RelationKeyName: domain.String("Alice"),
+			},
+		})
+
+		fx.start(t)
+
+		req := pushNotificationRequest{
+			spaceId:      spaceId,
+			chatObjectId: "chat1",
+			chatName:     "Direct",
+			messageId:    "msg1",
+			message: &chatmodel.Message{
+				ChatMessage: &model.ChatMessage{
+					Message: &model.ChatMessageMessageContent{
+						Text: "Hey there",
+					},
+				},
+			},
+		}
+		want := &chatpush.Payload{
+			SpaceId:     spaceId,
+			SpaceUxType: int(model.SpaceUxType_OneToOne),
+			SenderId:    "testAccountId",
+			Type:        chatpush.ChatMessage,
+			NewMessagePayload: &chatpush.NewMessagePayload{
+				ChatId:         "chat1",
+				MsgId:          "msg1",
+				SpaceName:      spaceName,
+				ChatName:       "Direct",
+				SenderName:     "Alice",
+				Text:           "Hey there",
 				HasAttachments: false,
 				Attachments:    nil,
 			},

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -84,6 +84,7 @@ type ObjectStore interface {
 	SpaceIndex(spaceId string) spaceindex.Store
 
 	SpaceNameGetter
+	GetSpaceViewDetails(spaceId string) (*domain.Details, error)
 	spaceresolverstore.Store
 	CrossSpace
 

--- a/pkg/lib/localstore/objectstore/space.go
+++ b/pkg/lib/localstore/objectstore/space.go
@@ -1,6 +1,8 @@
 package objectstore
 
 import (
+	"fmt"
+
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
@@ -34,4 +36,28 @@ func (d *dsObjectStore) GetSpaceName(spaceId string) string {
 		spaceName = records[0].Details.GetString(bundle.RelationKeyName)
 	}
 	return spaceName
+}
+
+func (d *dsObjectStore) GetSpaceViewDetails(spaceId string) (*domain.Details, error) {
+	records, err := d.SpaceIndex(d.techSpaceId).Query(database.Query{
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyTargetSpaceId,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.String(spaceId),
+			},
+			{
+				RelationKey: bundle.RelationKeyResolvedLayout,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.Int64(int64(model.ObjectType_spaceView)),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(records) > 0 {
+		return records[0].Details, nil
+	}
+	return nil, fmt.Errorf("spaceView not found")
 }

--- a/pkg/lib/localstore/objectstore/space_test.go
+++ b/pkg/lib/localstore/objectstore/space_test.go
@@ -11,6 +11,65 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
+func TestGetSpaceViewDetails(t *testing.T) {
+	spaceId := "id"
+	spaceViewId := "spaceViewId"
+
+	t.Run("no space found returns error", func(t *testing.T) {
+		// given
+		s := NewStoreFixture(t)
+
+		// when
+		got, err := s.GetSpaceViewDetails(spaceId)
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("space with name and ux type", func(t *testing.T) {
+		// given
+		s := NewStoreFixture(t)
+
+		err := s.SpaceIndex(s.techSpaceId).UpdateObjectDetails(context.Background(), spaceViewId, domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:             domain.String(spaceViewId),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
+			bundle.RelationKeyTargetSpaceId:  domain.String(spaceId),
+			bundle.RelationKeyName:           domain.String("Test Space"),
+			bundle.RelationKeySpaceUxType:    domain.Int64(int64(model.SpaceUxType_OneToOne)),
+		}))
+		assert.Nil(t, err)
+
+		// when
+		got, err := s.GetSpaceViewDetails(spaceId)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, "Test Space", got.GetString(bundle.RelationKeyName))
+		assert.Equal(t, int64(model.SpaceUxType_OneToOne), got.GetInt64(bundle.RelationKeySpaceUxType))
+	})
+
+	t.Run("wrong spaceId returns error", func(t *testing.T) {
+		// given
+		s := NewStoreFixture(t)
+
+		err := s.SpaceIndex(s.techSpaceId).UpdateObjectDetails(context.Background(), spaceViewId, domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:             domain.String(spaceViewId),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
+			bundle.RelationKeyTargetSpaceId:  domain.String(spaceId),
+			bundle.RelationKeyName:           domain.String("Test Space"),
+		}))
+		assert.Nil(t, err)
+
+		// when
+		got, err := s.GetSpaceViewDetails("not exist")
+
+		// then
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
+}
+
 func TestGetSpaceName(t *testing.T) {
 	spaceId := "id"
 	spaceViewId := "spaceViewId"


### PR DESCRIPTION
## Summary
- Add `spaceUxType` field to chat push notification `Payload` so mobile clients can render 1-to-1 messages differently (no space name header)
- Add `GetSpaceViewDetails` method to objectstore that returns full space view details (or error if not found)
- Replace `GetSpaceName` usage in `buildPushPayload` with `GetSpaceViewDetails` to extract both space name and UX type

## Test plan
- [x] `TestGetSpaceViewDetails` — no space found returns error, space with name+uxType returns correct details, wrong spaceId returns error
- [x] `TestBuildPushPayload` — "basic message" updated to verify `SpaceUxType: Chat`, new "one-to-one space" test verifies `SpaceUxType: OneToOne`
- [x] `go build ./core/...` passes
- [x] `go test ./pkg/lib/localstore/objectstore/...` passes
- [x] `go test ./core/block/chats/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)