### PR TITLE
Add swag dev dependency installation to make openapi

### DIFF
--- a/makefiles/setup.mk
+++ b/makefiles/setup.mk
@@ -35,4 +35,9 @@ setup-protoc-js:
 	@echo 'Setting up js protobuf plugins...'
 	@npm -D install
 
+setup-swag:
+	@echo 'Setting up swag...'
+	# -mod=mod allows go to auto-add swag's transitive deps to go.sum (they get stripped by go mod tidy since the main module doesn't import them directly)
+	@GOFLAGS=-mod=mod go build -o deps github.com/swaggo/swag/v2/cmd/swag
+
 setup-protoc: setup-protoc-go

--- a/makefiles/tools.mk
+++ b/makefiles/tools.mk
@@ -6,11 +6,11 @@ fmt:
 
 lint: run-linter
 
-openapi:
+openapi: setup-swag
 	@echo 'Generating openapi docs...'
-	@swag init --v3.1 -q -d core/api -g service.go -o $(OPENAPI_DOCS_DIR)
+	@deps/swag init --v3.1 -q -d core/api -g service.go -o $(OPENAPI_DOCS_DIR)
 	@echo 'Removing package prefixes from definitions...'
 	@jq '.components.schemas |= with_entries(.key |= (gsub("apimodel\\."; "") | gsub("apimodel_"; "") | gsub("pagination\\."; "") | gsub("pagination_"; "") | gsub("util\\."; "") | gsub("util_"; ""))) | walk(if type == "string" then (gsub("apimodel\\."; "") | gsub("apimodel_"; "") | gsub("pagination\\."; "") | gsub("pagination_"; "") | gsub("util\\."; "") | gsub("util_"; "")) else . end)' "$(OPENAPI_DOCS_DIR)/swagger.json" > "$(OPENAPI_DOCS_DIR)/openapi.json" && rm "$(OPENAPI_DOCS_DIR)/swagger.json"
 	@sed -i.bak 's/apimodel[._]//g; s/pagination[._]//g; s/util[._]//g' "$(OPENAPI_DOCS_DIR)/swagger.yaml" && rm -f "$(OPENAPI_DOCS_DIR)/swagger.yaml.bak" && mv "$(OPENAPI_DOCS_DIR)/swagger.yaml" "$(OPENAPI_DOCS_DIR)/openapi.yaml"
 	@echo 'Formatting openapi docs...'
-	@swag fmt -d core/api
+	@deps/swag fmt -d core/api


### PR DESCRIPTION
## Summary
- Add `setup-swag` target in `makefiles/setup.mk` that installs the `swag` binary into `deps/`, following the same pattern as other dev tools (govvv, goderive, mockery)
- Make `openapi` target depend on `setup-swag` so the binary is installed automatically when running `make openapi`
- Use `deps/swag` instead of global `swag` in the `openapi` target for consistency

## Test plan
- [x] Run `rm -f deps/swag && make openapi` — swag should be installed and docs generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)