### PR TITLE
GO-5707 Exclude non-existent objects and raw files from graph

### DIFF
--- a/core/block/object/objectgraph/graph.go
+++ b/core/block/object/objectgraph/graph.go
@@ -157,6 +157,9 @@ func (gr *Builder) buildGraph(
 ) ([]*domain.Details, []*pb.RpcObjectGraphEdge) {
 	existedNodes := fillExistedNodes(records)
 	for _, rec := range records {
+		if isExcludedFromGraph(rec) {
+			continue
+		}
 		sourceId := rec.GetString(bundle.RelationKeyId)
 
 		if len(req.Keys) == 0 {
@@ -218,10 +221,31 @@ func (gr *Builder) appendRelations(
 func fillExistedNodes(records []*domain.Details) map[string]struct{} {
 	existedNodes := make(map[string]struct{}, len(records))
 	for _, rec := range records {
-		id := rec.GetString(bundle.RelationKeyId)
-		existedNodes[id] = struct{}{}
+		if isExcludedFromGraph(rec) {
+			continue
+		}
+		existedNodes[rec.GetString(bundle.RelationKeyId)] = struct{}{}
 	}
 	return existedNodes
+}
+
+func isExcludedFromGraph(details *domain.Details) bool {
+	n := details.Len()
+	// Empty details or containing only id
+	if n <= 1 {
+		return true
+	}
+	// Details only with id + backlinks should be discarded
+	if n == 2 && details.Has(bundle.RelationKeyBacklinks) {
+		return true
+	}
+
+	id := details.GetString(bundle.RelationKeyId)
+	if domain.IsFileId(id) {
+		return true
+	}
+
+	return false
 }
 
 func isExcludedRelation(rel *relationutils.Relation) bool {

--- a/core/block/object/objectgraph/graph_test.go
+++ b/core/block/object/objectgraph/graph_test.go
@@ -89,6 +89,106 @@ func Test(t *testing.T) {
 		assert.Empty(t, edges)
 	})
 
+	t.Run("old file objects are excluded from graph", func(t *testing.T) {
+		fx := newFixture(t)
+		spaceId := "space1"
+		fileId := "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku"
+		fx.objectStoreMock.AddObjects(t, spaceId, []spaceindex.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("rel1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_relation)),
+				bundle.RelationKeyRelationKey:    domain.String(bundle.RelationKeyId.String()),
+				bundle.RelationKeyRelationFormat: domain.Int64(int64(model.RelationFormat_object)),
+			},
+		})
+		fx.subscriptionServiceMock.EXPECT().Search(mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{
+				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId:    domain.String("id1"),
+					bundle.RelationKeyLinks: domain.StringList([]string{fileId}),
+				}),
+				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId: domain.String(fileId),
+				}),
+			},
+		}, nil)
+		fx.subscriptionServiceMock.EXPECT().Unsubscribe(mock.Anything).Return(nil)
+		fx.sbtProviderMock.EXPECT().Type(mock.Anything, mock.Anything).Return(smartblock.SmartBlockTypePage, nil).Maybe()
+
+		graph, edges, err := fx.ObjectGraph(ObjectGraphRequest{SpaceId: spaceId})
+		assert.NoError(t, err)
+		require.Len(t, graph, 1)
+		assert.Equal(t, "id1", graph[0].GetString(bundle.RelationKeyId))
+		assert.Empty(t, edges)
+	})
+
+	t.Run("objects with only id are excluded from graph", func(t *testing.T) {
+		fx := newFixture(t)
+		spaceId := "space1"
+		fx.objectStoreMock.AddObjects(t, spaceId, []spaceindex.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("rel1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_relation)),
+				bundle.RelationKeyRelationKey:    domain.String(bundle.RelationKeyId.String()),
+				bundle.RelationKeyRelationFormat: domain.Int64(int64(model.RelationFormat_object)),
+			},
+		})
+		fx.subscriptionServiceMock.EXPECT().Search(mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{
+				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId:   domain.String("id1"),
+					bundle.RelationKeyName: domain.String("name1"),
+				}),
+				// object with only id should be excluded
+				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId: domain.String("id2"),
+				}),
+			},
+		}, nil)
+		fx.subscriptionServiceMock.EXPECT().Unsubscribe(mock.Anything).Return(nil)
+		fx.sbtProviderMock.EXPECT().Type(mock.Anything, mock.Anything).Return(smartblock.SmartBlockTypePage, nil).Maybe()
+
+		graph, edges, err := fx.ObjectGraph(ObjectGraphRequest{SpaceId: spaceId})
+		assert.NoError(t, err)
+		require.Len(t, graph, 1)
+		assert.Equal(t, "id1", graph[0].GetString(bundle.RelationKeyId))
+		assert.Empty(t, edges)
+	})
+
+	t.Run("objects with only id and backlinks are excluded from graph", func(t *testing.T) {
+		fx := newFixture(t)
+		spaceId := "space1"
+		fx.objectStoreMock.AddObjects(t, spaceId, []spaceindex.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("rel1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_relation)),
+				bundle.RelationKeyRelationKey:    domain.String(bundle.RelationKeyId.String()),
+				bundle.RelationKeyRelationFormat: domain.Int64(int64(model.RelationFormat_object)),
+			},
+		})
+		fx.subscriptionServiceMock.EXPECT().Search(mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{
+				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId:   domain.String("id1"),
+					bundle.RelationKeyName: domain.String("name1"),
+				}),
+				// object with only id and backlinks should be excluded
+				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId:        domain.String("id2"),
+					bundle.RelationKeyBacklinks: domain.StringList([]string{"id1"}),
+				}),
+			},
+		}, nil)
+		fx.subscriptionServiceMock.EXPECT().Unsubscribe(mock.Anything).Return(nil)
+		fx.sbtProviderMock.EXPECT().Type(mock.Anything, mock.Anything).Return(smartblock.SmartBlockTypePage, nil).Maybe()
+
+		graph, edges, err := fx.ObjectGraph(ObjectGraphRequest{SpaceId: spaceId})
+		assert.NoError(t, err)
+		require.Len(t, graph, 1)
+		assert.Equal(t, "id1", graph[0].GetString(bundle.RelationKeyId))
+		assert.Empty(t, edges)
+	})
+
 	t.Run("graph", func(t *testing.T) {
 		fx := newFixture(t)
 		spaceId := "space1"
@@ -133,10 +233,12 @@ func Test(t *testing.T) {
 					bundle.RelationKeyLinks:    domain.StringList([]string{"id2", "id3", dateObject.Id()}),
 				}),
 				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-					bundle.RelationKeyId: domain.String("id2"),
+					bundle.RelationKeyId:   domain.String("id2"),
+					bundle.RelationKeyName: domain.String("name2"),
 				}),
 				domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-					bundle.RelationKeyId: domain.String("id3"),
+					bundle.RelationKeyId:   domain.String("id3"),
+					bundle.RelationKeyName: domain.String("name3"),
 				}),
 			},
 		}, nil)


### PR DESCRIPTION
## Summary
- Rewrite `isExcludedFromGraph` to accept `*domain.Details` and filter out objects with no meaningful data
- Exclude file objects (existing behavior), objects with only an `id`, and objects with only `id` + `backlinks`
- Prevents untitled/deleted types from appearing as ghost nodes in the graph

## Test plan
- [x] Added test: objects with only `id` are excluded
- [x] Added test: objects with only `id` + `backlinks` are excluded
- [x] Existing file exclusion test still passes
- [x] Full graph test updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)