### PR TITLE
GO-6838 Fix date filter in advanced/nested filters

### DIFF
--- a/pkg/lib/database/filter.go
+++ b/pkg/lib/database/filter.go
@@ -71,6 +71,13 @@ func makeFilter(spaceID string, rawFilter FilterRequest, store ObjectStore) (Fil
 	if rawFilter.Condition == model.BlockContentDataviewFilter_None {
 		return nil, nil
 	}
+	// model.RelationFormat_longtext may be a default value, so we try to get the actual value. It's important to use
+	// proper format for all filters to work correctly. Date filter is a good example.
+	if rawFilter.Format == model.RelationFormat_longtext && rawFilter.RelationKey != "" {
+		if format, err := store.GetRelationFormatByKey(rawFilter.RelationKey); err == nil {
+			rawFilter.Format = format
+		}
+	}
 	rawFilters := transformDateFilter(rawFilter, time.Now())
 
 	if len(rawFilters) == 1 {

--- a/pkg/lib/database/filter_test.go
+++ b/pkg/lib/database/filter_test.go
@@ -899,6 +899,55 @@ func TestMakeFilters(t *testing.T) {
 		assert.NotNil(t, filters.(FiltersOr)[0].(FilterEq))
 		assert.NotNil(t, filters.(FiltersOr)[1].(FilterEq))
 	})
+	t.Run("nested date filter with unset format resolves from store", func(t *testing.T) {
+		// given
+		store := &stubSpaceObjectStore{}
+
+		now := time.Now()
+		yesterday := now.Add(-24 * time.Hour)
+		tomorrow := now.Add(24 * time.Hour)
+
+		// Nested/advanced filter: Format is not set (zero value) by the client
+		filter := []FilterRequest{
+			{
+				Operator: model.BlockContentDataviewFilter_And,
+				NestedFilters: []FilterRequest{
+					{
+						RelationKey: bundle.RelationKeyDueDate,
+						Condition:   model.BlockContentDataviewFilter_LessOrEqual,
+						QuickOption: model.BlockContentDataviewFilter_Today,
+						// Format intentionally omitted — this is what the client sends for advanced filters
+					},
+					{
+						RelationKey: bundle.RelationKeyName,
+						Condition:   model.BlockContentDataviewFilter_NotEmpty,
+					},
+				},
+			},
+		}
+
+		// when
+		f, err := MakeFilters(filter, store)
+		require.NoError(t, err)
+
+		// then
+		objYesterday := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyDueDate: domain.Int64(yesterday.Unix()),
+			bundle.RelationKeyName:    domain.String("task1"),
+		})
+		objToday := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyDueDate: domain.Int64(now.Unix()),
+			bundle.RelationKeyName:    domain.String("task2"),
+		})
+		objTomorrow := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyDueDate: domain.Int64(tomorrow.Unix()),
+			bundle.RelationKeyName:    domain.String("task3"),
+		})
+
+		assertFilter(t, f, objYesterday, true)
+		assertFilter(t, f, objToday, true)
+		assertFilter(t, f, objTomorrow, false)
+	})
 }
 
 func TestFilter2ValuesComp_FilterObject(t *testing.T) {
@@ -1054,5 +1103,33 @@ func TestFilterDate(t *testing.T) {
 		assertFilter(t, f, obj2, false)
 		assertFilter(t, f, obj3, true)
 		assertFilter(t, f, obj4, false)
+	})
+	t.Run("date filter with unset format resolves format from store", func(t *testing.T) {
+		// given
+		store := &stubSpaceObjectStore{}
+
+		now := time.Now()
+		yesterday := now.Add(-24 * time.Hour)
+		tomorrow := now.Add(24 * time.Hour)
+
+		// when - Format is 0 (unset), simulating advanced/nested filter behavior
+		f, err := MakeFilter("spaceId", FilterRequest{
+			RelationKey: bundle.RelationKeyDueDate,
+			Condition:   model.BlockContentDataviewFilter_LessOrEqual,
+			QuickOption: model.BlockContentDataviewFilter_Today,
+		}, store)
+		require.NoError(t, err)
+
+		// then
+		objYesterday := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{bundle.RelationKeyDueDate: domain.Int64(yesterday.Unix())})
+		objToday := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{bundle.RelationKeyDueDate: domain.Int64(now.Unix())})
+		objTomorrow := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{bundle.RelationKeyDueDate: domain.Int64(tomorrow.Unix())})
+		objNoDate := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{})
+
+		assertFilter(t, f, objYesterday, true)
+		assertFilter(t, f, objToday, true)
+		assertFilter(t, f, objTomorrow, false)
+		// Object with no date has zero value which is less than today's end timestamp
+		assertFilter(t, f, objNoDate, true)
 	})
 }


### PR DESCRIPTION
## Summary
- When using advanced (nested) filters, the client doesn't set the `Format` field on leaf filters, leaving it at the zero value (`longtext`). This caused `transformDateFilter` to skip `QuickOption` resolution (e.g., "Today"), so date conditions like "due date is on or before today" compared against 0 instead of an actual timestamp — showing only objects without a date.
- Resolve the relation format from the object store when `Format` is unset (zero value) in `makeFilter()`, so date filters work correctly in advanced filter mode.
- Added tests for both direct and nested date filters with unset format.

## Test plan
- [x] `go test ./pkg/lib/database/... -run TestFilterDate` — verifies date filter with unset format resolves correctly
- [x] `go test ./pkg/lib/database/... -run TestMakeFilters/nested_date_filter` — verifies nested/advanced filter end-to-end
- [x] `go test ./pkg/lib/database/...` — full database package tests pass
- [x] `go build ./core/...` — compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)