### PR TITLE
GO-6848 Add in-memory cache for node usage

### DIFF
--- a/core/files/filesync/service.go
+++ b/core/files/filesync/service.go
@@ -119,7 +119,9 @@ type fileSync struct {
 	eventSender     event.Sender
 	onStatusUpdated []StatusCallback
 
-	nodeUsageCache keyvaluestore.Store[NodeUsage]
+	nodeUsageStore keyvaluestore.Store[NodeUsage]
+	nodeUsageLock  sync.RWMutex
+	nodeUsage      *NodeUsage
 
 	limitManager    *spaceUsageManager
 	requestsBatcher *requestsBatcher
@@ -171,7 +173,7 @@ func (s *fileSync) Init(a *app.App) (err error) {
 		return info
 	})
 
-	s.nodeUsageCache = keyvaluestore.NewJsonFromCollection[NodeUsage](provider.GetSystemCollection())
+	s.nodeUsageStore = keyvaluestore.NewJsonFromCollection[NodeUsage](provider.GetSystemCollection())
 
 	s.requestsCh = make(chan blockPushManyRequest, 10)
 	s.requestsBatcher = newRequestsBatcher(1024*1024+14, 100*time.Millisecond, s.requestsCh)

--- a/core/files/filesync/stats.go
+++ b/core/files/filesync/stats.go
@@ -135,12 +135,14 @@ func (s *fileSync) precacheNodeUsage() {
 	_, ok, err := s.getCachedNodeUsage()
 	// Init cache with default limits
 	if !ok || err != nil {
-		err = s.nodeUsageCache.Set(context.Background(), "node_usage", NodeUsage{
+		defaultUsage := NodeUsage{
 			AccountBytesLimit: 100 * 1024 * 1024, // 100 MB
-		})
+		}
+		err = s.nodeUsageStore.Set(context.Background(), anystoreprovider.SystemKeys.NodeUsage(), defaultUsage)
 		if err != nil {
 			log.Error("can't set default limits", zap.Error(err))
 		}
+		s.setNodeUsageInMemory(defaultUsage)
 	}
 
 	// Load actual node usage
@@ -169,14 +171,29 @@ func (s *fileSync) UpdateNodeUsage(ctx context.Context) error {
 }
 
 func (s *fileSync) getCachedNodeUsage() (NodeUsage, bool, error) {
-	usage, err := s.nodeUsageCache.Get(context.Background(), anystoreprovider.SystemKeys.NodeUsage())
+	s.nodeUsageLock.RLock()
+	if s.nodeUsage != nil {
+		usage := *s.nodeUsage
+		s.nodeUsageLock.RUnlock()
+		return usage, true, nil
+	}
+	s.nodeUsageLock.RUnlock()
+
+	usage, err := s.nodeUsageStore.Get(context.Background(), anystoreprovider.SystemKeys.NodeUsage())
 	if errors.Is(err, anystore.ErrDocNotFound) {
 		return NodeUsage{}, false, nil
 	}
 	if err != nil {
 		return NodeUsage{}, false, err
 	}
+	s.setNodeUsageInMemory(usage)
 	return usage, true, nil
+}
+
+func (s *fileSync) setNodeUsageInMemory(usage NodeUsage) {
+	s.nodeUsageLock.Lock()
+	s.nodeUsage = &usage
+	s.nodeUsageLock.Unlock()
 }
 
 func (s *fileSync) getAndUpdateNodeUsage(ctx context.Context) (NodeUsage, error) {
@@ -218,10 +235,11 @@ func (s *fileSync) getAndUpdateNodeUsage(ctx context.Context) (NodeUsage, error)
 	if prevUsage.Equal(usage) {
 		return usage, nil
 	}
-	err = s.nodeUsageCache.Set(context.Background(), anystoreprovider.SystemKeys.NodeUsage(), usage)
+	err = s.nodeUsageStore.Set(context.Background(), anystoreprovider.SystemKeys.NodeUsage(), usage)
 	if err != nil {
 		return NodeUsage{}, fmt.Errorf("save node usage info to store: %w", err)
 	}
+	s.setNodeUsageInMemory(usage)
 
 	if !prevUsageFound || prevUsage.AccountBytesLimit != usage.AccountBytesLimit {
 		s.sendLimitUpdatedEvent(uint64(usage.AccountBytesLimit))


### PR DESCRIPTION
## Summary
- Add an in-memory cache for `NodeUsage` to avoid redundant anystore reads on every access
- The cache is protected by `sync.RWMutex` and lazily populated on first read from store
- Store writes also update the in-memory cache, keeping it consistent

## Test plan
- [ ] Verify node usage limits are correctly applied after restart
- [ ] Verify file sync still respects storage limits
- [ ] Verify no regression in file upload/download behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)