### PR TITLE
GO-6861 Fix inverted condition in links detail filtering

### DIFF
--- a/core/block/editor/smartblock/detailsinject_test.go
+++ b/core/block/editor/smartblock/detailsinject_test.go
@@ -280,6 +280,71 @@ func TestInjectDerivedDetails(t *testing.T) {
 	})
 }
 
+func TestInjectLinksDetails_filterOutRelations(t *testing.T) {
+	const id = "id"
+
+	t.Run("string relation value is filtered out from links", func(t *testing.T) {
+		// given
+		fx := newFixture(id, t)
+
+		st := state.NewDoc(id, map[string]simple.Block{
+			id:     simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
+			"link1": simple.New(&model.Block{Id: "link1", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj1"}}}),
+			"link2": simple.New(&model.Block{Id: "link2", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "iconImageId"}}}),
+		}).NewState()
+		st.SetDetail(bundle.RelationKeyIconImage, domain.String("iconImageId"))
+
+		// when
+		fx.injectLinksDetails(st)
+
+		// then
+		links := st.LocalDetails().GetStringList(bundle.RelationKeyLinks)
+		assert.Contains(t, links, "obj1")
+		assert.NotContains(t, links, "iconImageId")
+	})
+
+	t.Run("string list relation value is filtered out from links", func(t *testing.T) {
+		// given
+		fx := newFixture(id, t)
+
+		st := state.NewDoc(id, map[string]simple.Block{
+			id:     simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
+			"link1": simple.New(&model.Block{Id: "link1", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj1"}}}),
+			"link2": simple.New(&model.Block{Id: "link2", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "pictureId"}}}),
+		}).NewState()
+		st.SetDetail(bundle.RelationKeyPicture, domain.StringList([]string{"pictureId", "otherPic"}))
+
+		// when
+		fx.injectLinksDetails(st)
+
+		// then
+		links := st.LocalDetails().GetStringList(bundle.RelationKeyLinks)
+		assert.Contains(t, links, "obj1")
+		assert.NotContains(t, links, "pictureId")
+	})
+
+	t.Run("links are preserved when filter relations are set but do not match", func(t *testing.T) {
+		// given
+		fx := newFixture(id, t)
+
+		st := state.NewDoc(id, map[string]simple.Block{
+			id:     simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
+			"link1": simple.New(&model.Block{Id: "link1", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj1"}}}),
+			"link2": simple.New(&model.Block{Id: "link2", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj2"}}}),
+		}).NewState()
+		st.SetDetail(bundle.RelationKeyIconImage, domain.String("someImage"))
+		st.SetDetail(bundle.RelationKeyCoverId, domain.String("someCover"))
+
+		// when
+		fx.injectLinksDetails(st)
+
+		// then
+		links := st.LocalDetails().GetStringList(bundle.RelationKeyLinks)
+		assert.Contains(t, links, "obj1")
+		assert.Contains(t, links, "obj2")
+	})
+}
+
 func TestResolveLayout(t *testing.T) {
 	const id = "id"
 	t.Run("resolved layout is injected from layout detail", func(t *testing.T) {

--- a/core/block/editor/smartblock/links.go
+++ b/core/block/editor/smartblock/links.go
@@ -70,7 +70,7 @@ func (sb *smartBlock) injectLinksDetails(s *state.State) {
 			}
 			val := s.Details().Get(rel)
 			if val.IsString() {
-				if val.String() != link {
+				if val.String() == link {
 					return false
 				}
 				continue

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -63,7 +63,7 @@ const (
 	// ForceInvalidateObjectsIndexCounter clears all indexed heads hashes, causing reindexOutdatedObjects
 	// to reindex all objects. This is more efficient than ForceObjectsReindexCounter because it
 	// reindexes objects asynchronously and continue reindex after app F
-	ForceInvalidateObjectsIndexCounter int32 = 2
+	ForceInvalidateObjectsIndexCounter int32 = 3
 )
 
 type allDeletedIdsProvider interface {


### PR DESCRIPTION
## Summary
- Fixed inverted condition (`!=` → `==`) in `injectLinksDetails` filter that was incorrectly removing all links not matching iconImage/picture/fileId/coverId relation values, resulting in empty `links` property for objects
- Added tests for both string and string list relation filtering in links injection

## Test plan
- [x] New unit tests for string relation filtering (iconImage)
- [x] New unit tests for string list relation filtering (picture)
- [x] New unit tests verifying links are preserved when filter relations don't match
- [x] Existing `TestInjectDerivedDetails` still passes