### PR TITLE
GO-6630 Use goheif fork with mdat fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/JohannesKaufmann/html-to-markdown v1.4.0
 	github.com/PuerkitoBio/goquery v1.10.2
 	github.com/VividCortex/ewma v1.2.0
-	github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
 	github.com/ahmetb/govvv v0.3.0
 	github.com/anyproto/any-store v0.4.4
 	github.com/anyproto/any-sync v0.11.10
@@ -17,6 +16,7 @@ require (
 	github.com/anyproto/go-chash v0.1.0
 	github.com/anyproto/go-naturaldate/v2 v2.0.2-0.20230524105841-9829cfd13438
 	github.com/anyproto/go-slip10 v1.0.1
+	github.com/anyproto/goheif v0.0.0-20260216083627-c3efd00cd92e
 	github.com/anyproto/lexid v0.0.6
 	github.com/anyproto/tantivy-go v1.0.6
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
@@ -328,5 +328,3 @@ replace google.golang.org/genproto/googleapis/rpc => google.golang.org/genproto/
 replace github.com/btcsuite/btcutil => github.com/btcsuite/btcd/btcutil v1.1.5
 
 replace github.com/dsoprea/go-jpeg-image-structure/v2 => github.com/dchesterton/go-jpeg-image-structure/v2 v2.0.0-20240318203529-c3eea088bd38
-
-replace github.com/adrium/goheif => github.com/anyproto/goheif v0.0.0-20260215190623-db9edcf185bb

--- a/go.mod
+++ b/go.mod
@@ -328,3 +328,5 @@ replace google.golang.org/genproto/googleapis/rpc => google.golang.org/genproto/
 replace github.com/btcsuite/btcutil => github.com/btcsuite/btcd/btcutil v1.1.5
 
 replace github.com/dsoprea/go-jpeg-image-structure/v2 => github.com/dchesterton/go-jpeg-image-structure/v2 v2.0.0-20240318203529-c3eea088bd38
+
+replace github.com/adrium/goheif => github.com/anyproto/goheif v0.0.0-20260215190623-db9edcf185bb

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/anyproto/go-slip21 v1.0.0 h1:CI7lUqTIwmPOEGVAj4jyNLoICvueh++0U2HoAi3m
 github.com/anyproto/go-slip21 v1.0.0/go.mod h1:gbIJt7HAdr5DuT4f2pFTKCBSUWYsm/fysHBNqgsuxT0=
 github.com/anyproto/go-sqlite v1.4.2-any h1:ZTIcq/u2mYYJ6rJB4I3Ds5QH/7IlONebMiG14FyZcD4=
 github.com/anyproto/go-sqlite v1.4.2-any/go.mod h1:nW7TvS+4bzPU2vNaPlPFNPYcejK5RdjH6qZY2kjT3Io=
-github.com/anyproto/goheif v0.0.0-20260215190623-db9edcf185bb h1:6cCQ/XaCnZ8ww5lVfelZ8OO++rM3pYe09mDGo4J5I8U=
-github.com/anyproto/goheif v0.0.0-20260215190623-db9edcf185bb/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
+github.com/anyproto/goheif v0.0.0-20260216083627-c3efd00cd92e h1:m6MvomLslQN8dHmlKvfiZCaQmbckH5l9l0C2boKeZ5U=
+github.com/anyproto/goheif v0.0.0-20260216083627-c3efd00cd92e/go.mod h1:SZgKWZ226XERv6MVcvJUgj7MEMzOU37RX76F8HD+2Xg=
 github.com/anyproto/html-to-markdown v0.0.0-20231025221133-830bf0a6f139 h1:Wp9z0Q2kAstznWUmTZyOb9UgpVmUgYt1LXRvK/cg10E=
 github.com/anyproto/html-to-markdown v0.0.0-20231025221133-830bf0a6f139/go.mod h1:1zaDDQVWTRwNksmTUTkcVXqgNF28YHiEUIm8FL9Z+II=
 github.com/anyproto/lexid v0.0.6 h1:lTJd9K11vU1xoBs1dkZVv8VtYfCBo373lNd9kAgXEio=

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786 h1:zvgtcRb2B5gynWjm+Fc9oJZPHXwmcgyH0xCcNm6Rmo4=
-github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ahmetb/govvv v0.3.0 h1:YGLGwEyiUwHFy5eh/RUhdupbuaCGBYn5T5GWXp+WJB0=
@@ -110,6 +108,8 @@ github.com/anyproto/go-slip21 v1.0.0 h1:CI7lUqTIwmPOEGVAj4jyNLoICvueh++0U2HoAi3m
 github.com/anyproto/go-slip21 v1.0.0/go.mod h1:gbIJt7HAdr5DuT4f2pFTKCBSUWYsm/fysHBNqgsuxT0=
 github.com/anyproto/go-sqlite v1.4.2-any h1:ZTIcq/u2mYYJ6rJB4I3Ds5QH/7IlONebMiG14FyZcD4=
 github.com/anyproto/go-sqlite v1.4.2-any/go.mod h1:nW7TvS+4bzPU2vNaPlPFNPYcejK5RdjH6qZY2kjT3Io=
+github.com/anyproto/goheif v0.0.0-20260215190623-db9edcf185bb h1:6cCQ/XaCnZ8ww5lVfelZ8OO++rM3pYe09mDGo4J5I8U=
+github.com/anyproto/goheif v0.0.0-20260215190623-db9edcf185bb/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
 github.com/anyproto/html-to-markdown v0.0.0-20231025221133-830bf0a6f139 h1:Wp9z0Q2kAstznWUmTZyOb9UgpVmUgYt1LXRvK/cg10E=
 github.com/anyproto/html-to-markdown v0.0.0-20231025221133-830bf0a6f139/go.mod h1:1zaDDQVWTRwNksmTUTkcVXqgNF28YHiEUIm8FL9Z+II=
 github.com/anyproto/lexid v0.0.6 h1:lTJd9K11vU1xoBs1dkZVv8VtYfCBo373lNd9kAgXEio=

--- a/pkg/lib/mill/image_resize_heic.go
+++ b/pkg/lib/mill/image_resize_heic.go
@@ -9,8 +9,9 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/adrium/goheif"
-	"github.com/adrium/goheif/heif"
+	"github.com/anyproto/goheif"
+	"github.com/anyproto/goheif/heif"
+
 	"github.com/kovidgoyal/imaging"
 )
 

--- a/pkg/lib/mill/testdata/images.go
+++ b/pkg/lib/mill/testdata/images.go
@@ -79,7 +79,6 @@ var Images = []TestImage{
 		Width:   1728,
 		Height:  2376,
 	},
-	// TODO: GO-6630 Uncomment this when mdat-first heic images resize will be fixed
 	{
 		Path:    "testdata/image_mdat_first.heic",
 		Format:  "heic",

--- a/pkg/lib/mill/testdata/images.go
+++ b/pkg/lib/mill/testdata/images.go
@@ -80,11 +80,11 @@ var Images = []TestImage{
 		Height:  2376,
 	},
 	// TODO: GO-6630 Uncomment this when mdat-first heic images resize will be fixed
-	// {
-	// 	Path:    "testdata/image_mdat_first.heic",
-	// 	Format:  "heic",
-	// 	HasExif: false,
-	// 	Width:   1440,
-	// 	Height:  960,
-	// },
+	{
+		Path:    "testdata/image_mdat_first.heic",
+		Format:  "heic",
+		HasExif: false,
+		Width:   1440,
+		Height:  960,
+	},
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6630/the-image-heic-format-is-broken

Use fork of goheif library that include fix for HEIC images resize from original library: https://github.com/jdeng/goheif/commit/dc779c2c6b801b600d697917ac47f848b849b4a1

In case mdat box goes first in byte representation of file adrium/goheif fails to resize image