### PR TITLE
GO-6866 Fix file sync limited -> syncing -> limited status cycle

### DIFF
--- a/core/files/filesync/batchuploader.go
+++ b/core/files/filesync/batchuploader.go
@@ -34,6 +34,11 @@ func (s *fileSync) addToLimitedQueue(objectId string) error {
 			return FileInfo{}, false, nil
 		}
 
+		space, spaceErr := s.limitManager.getSpace(info.SpaceId)
+		if spaceErr == nil {
+			space.deallocateFile(info.Key())
+		}
+
 		err := s.handleLimitReached(s.loopCtx, info)
 		if err != nil {
 			info.State = FileStatePendingUpload

--- a/core/files/filesync/nodeusage.go
+++ b/core/files/filesync/nodeusage.go
@@ -164,7 +164,7 @@ func (s *spaceUsage) update(ctx context.Context) error {
 	}
 
 	newLimit := int(info.LimitBytes)
-	newUsageFromNode := int(info.SpaceUsageBytes)
+	newUsageFromNode := int(info.TotalUsageBytes)
 
 	s.limit = newLimit
 	s.usageFromNode = newUsageFromNode

--- a/core/files/filesync/nodeusage_test.go
+++ b/core/files/filesync/nodeusage_test.go
@@ -72,7 +72,8 @@ func TestSpaceLimit(t *testing.T) {
 					return &fileproto.SpaceInfoResponse{
 						SpaceId:         spaceId,
 						LimitBytes:      uint64(tc.limit),
-						SpaceUsageBytes: uint64(tc.usage),
+						SpaceUsageBytes: 0,
+						TotalUsageBytes: uint64(tc.usage),
 					}, nil
 				})
 

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -212,7 +212,6 @@ func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *
 		return it, nil
 	}
 
-	// Set Syncing status only after blocks have been successfully queued
 	if it.ObjectId != "" {
 		err := s.updateStatus(it, filesyncstatus.Syncing)
 		if isObjectDeletedError(err) {

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -221,7 +221,7 @@ func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *
 		return it, nil
 	}
 
-	if it.ObjectId != "" {
+	if it.ObjectId != "" && it.State != FileStateLimited {
 		err := s.updateStatus(it, filesyncstatus.Syncing)
 		if isObjectDeletedError(err) {
 			it.State = FileStatePendingDeletion

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -177,17 +177,6 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 }
 
 func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *blocksAvailabilityResponse) (FileInfo, error) {
-	if it.ObjectId != "" {
-		err := s.updateStatus(it, filesyncstatus.Syncing)
-		if isObjectDeletedError(err) {
-			it.State = FileStatePendingDeletion
-			return it, nil
-		}
-		if err != nil {
-			return it, fmt.Errorf("update status: %w", err)
-		}
-	}
-
 	var totalBytesToUpload int
 	err := s.walkFileBlocks(ctx, it.SpaceId, it.FileId, it.Variants, func(fileBlocks []blocks.Block) error {
 		bytesToUpload, err := s.uploadOrBindBlocks(ctx, it, fileBlocks, blocksAvailability.cidsToBind)
@@ -221,6 +210,18 @@ func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *
 		}
 		it.State = FileStateDone
 		return it, nil
+	}
+
+	// Set Syncing status only after blocks have been successfully queued
+	if it.ObjectId != "" {
+		err := s.updateStatus(it, filesyncstatus.Syncing)
+		if isObjectDeletedError(err) {
+			it.State = FileStatePendingDeletion
+			return it, nil
+		}
+		if err != nil {
+			return it, fmt.Errorf("update status: %w", err)
+		}
 	}
 
 	it.State = FileStateUploading

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -173,6 +173,15 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		it = it.Reschedule()
 		return it, err
 	}
+
+	switch it.State {
+	case FileStateLimited, FileStatePendingDeletion:
+		spaceLimits.deallocateFile(it.Key())
+	case FileStateDone:
+		spaceLimits.markFileUploaded(it.Key())
+	default:
+	}
+
 	return it, nil
 }
 

--- a/core/files/filesync/upload_test.go
+++ b/core/files/filesync/upload_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/files/filesync/filequeue"
+	"github.com/anyproto/anytype-heart/core/syncstatus/filesyncstatus"
 )
 
 func TestFileSync_AddFile(t *testing.T) {
@@ -207,6 +208,47 @@ func TestFileSync_AddFile(t *testing.T) {
 			},
 		}, currentUsage.Spaces)
 	})
+}
+
+func TestFileSync_NoSyncingStatusWhenLimitReached(t *testing.T) {
+	fx := newFixtureNotStarted(t, 1024)
+	spaceId := "space1"
+
+	var mu sync.Mutex
+	statuses := map[string][]filesyncstatus.Status{}
+	fx.OnStatusUpdated(func(objectId string, _ domain.FullFileId, status filesyncstatus.Status) error {
+		mu.Lock()
+		statuses[objectId] = append(statuses[objectId], status)
+		mu.Unlock()
+		return nil
+	})
+
+	require.NoError(t, fx.a.Start(ctx))
+	defer fx.Finish(t)
+
+	fileId, _ := fx.givenFileAddedToDAG(t, 1024)
+	objectId := "limitedObject"
+	require.NoError(t, fx.AddFile(AddFileRequest{
+		FileObjectId:   objectId,
+		FileId:         domain.FullFileId{SpaceId: spaceId, FileId: fileId},
+		UploadedByUser: true,
+	}))
+
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	it, err := fx.queue.GetNext(waitCtx, filequeue.GetNextRequest[FileInfo]{
+		Subscribe:   true,
+		StoreFilter: filterByState(FileStateLimited),
+		Filter:      func(info FileInfo) bool { return info.ObjectId == objectId && info.State == FileStateLimited },
+	})
+	require.NoError(t, err)
+	require.NoError(t, fx.queue.ReleaseAndUpdate(it.ObjectId, it))
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, s := range statuses[objectId] {
+		assert.NotEqual(t, filesyncstatus.Syncing, s, "limited file should never get Syncing status")
+	}
 }
 
 func (fx *fixture) assertFileUploadedToRemoteNode(t *testing.T, fileNode ipld.Node, wantSize int) []cid.Cid {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/adrium/goheif v0.0.0-20230113233934-ca402e77a786
 	github.com/ahmetb/govvv v0.3.0
 	github.com/anyproto/any-store v0.4.4
-	github.com/anyproto/any-sync v0.11.10
+	github.com/anyproto/any-sync v0.11.14
 	github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb
 	github.com/anyproto/anytype-push-server/pushclient v0.0.0-20250801122506-553f6c085a23
 	github.com/anyproto/go-chash v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/anyproto/any-store v0.4.4 h1:OcRFOYIqY/LqiAxjPyM9bVXyTxBdwo3jvu4vAnDa4cE=
 github.com/anyproto/any-store v0.4.4/go.mod h1:Npi35qMUVZ8ouiV4o9AqpZDs6LbDOF+5ZLlVijXofFM=
-github.com/anyproto/any-sync v0.11.10 h1:HVRHoom1wHX3RniSMOyOiPiHYF+Qh4lTNcsY8HEkyO0=
-github.com/anyproto/any-sync v0.11.10/go.mod h1:DHuR/dILpIaZSGSUCFwjZrleUkXMJ97cIBq4aYXWCHQ=
 github.com/anyproto/any-sync v0.11.14 h1:hcsyf+bkzHQ0VZe7YOcSVaR2gVaSn2eAP37PulnmadE=
 github.com/anyproto/any-sync v0.11.14/go.mod h1:DHuR/dILpIaZSGSUCFwjZrleUkXMJ97cIBq4aYXWCHQ=
 github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb h1:X1os44y0QWf1mYGj8BOoYKlXwY5xb94xTQIw1IIKJbY=

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/anyproto/any-store v0.4.4 h1:OcRFOYIqY/LqiAxjPyM9bVXyTxBdwo3jvu4vAnDa
 github.com/anyproto/any-store v0.4.4/go.mod h1:Npi35qMUVZ8ouiV4o9AqpZDs6LbDOF+5ZLlVijXofFM=
 github.com/anyproto/any-sync v0.11.10 h1:HVRHoom1wHX3RniSMOyOiPiHYF+Qh4lTNcsY8HEkyO0=
 github.com/anyproto/any-sync v0.11.10/go.mod h1:DHuR/dILpIaZSGSUCFwjZrleUkXMJ97cIBq4aYXWCHQ=
+github.com/anyproto/any-sync v0.11.14 h1:hcsyf+bkzHQ0VZe7YOcSVaR2gVaSn2eAP37PulnmadE=
+github.com/anyproto/any-sync v0.11.14/go.mod h1:DHuR/dILpIaZSGSUCFwjZrleUkXMJ97cIBq4aYXWCHQ=
 github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb h1:X1os44y0QWf1mYGj8BOoYKlXwY5xb94xTQIw1IIKJbY=
 github.com/anyproto/anytype-publish-server/publishclient v0.0.0-20250716122732-cdcfe3a126bb/go.mod h1:OzzODq4OigiRVD2lSOX1iHAoLcxhJDRbZb8n5PLG3WE=
 github.com/anyproto/anytype-push-server/pushclient v0.0.0-20250801122506-553f6c085a23 h1:jXAjKY4g9ec7lDtayIlzM9u0/b3xGS9YgGA6JtRhHfU=


### PR DESCRIPTION
## Summary
- Move `updateStatus(Syncing)` in `upload()` to after `walkFileBlocks` succeeds, preventing the `Limited -> Syncing -> Limited` cycle that wrote new tree versions on every retry
- Skip `Syncing` status update entirely for limited file retries via the batch uploader path
- Use `TotalUsageBytes` instead of `SpaceUsageBytes` in `spaceUsage.update` so `allocateFile` checks against the account-wide limit
- Fix missing space deallocation in `processFilePendingUpload`: when `upload()` returns a non-uploading state (Limited, PendingDeletion, Done) without error, properly deallocate or mark uploaded so `allocatedUsage` doesn't inflate
- Deallocate space in `addToLimitedQueue` when the batch uploader hits a node limit
- Bump any-sync to v0.11.14

## Test plan
- [x] Existing upload tests pass
- [x] `TestFileSync_NoSyncingStatusWhenLimitReached` verifies no Syncing status is emitted for limited files