### PR TITLE
Preserve imported timestamps and attribution for file objects

### DIFF
--- a/core/block/import/common/objectid/oldfile.go
+++ b/core/block/import/common/objectid/oldfile.go
@@ -19,6 +19,16 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 )
 
+var importedFileDetailKeys = []domain.RelationKey{
+	bundle.RelationKeyName,
+	bundle.RelationKeyIsHiddenDiscovery,
+	bundle.RelationKeyCreatedDate,
+	bundle.RelationKeyLastModifiedDate,
+	bundle.RelationKeyAddedDate,
+	bundle.RelationKeyCreator,
+	bundle.RelationKeyLastModifiedBy,
+}
+
 // oldFile represents file in pre Files-as-Objects format
 type oldFile struct {
 	blockService      *block.Service
@@ -54,7 +64,11 @@ func (f *oldFile) GetIDAndPayload(ctx context.Context, spaceId string, sn *commo
 	if err != nil {
 		return "", treestorage.TreeStorageCreatePayload{}, fmt.Errorf("add file keys: %w", err)
 	}
-	objectId, err := f.fileObjectService.CreateFromImport(domain.FullFileId{SpaceId: spaceId, FileId: domain.FileId(fileId)}, origin, nil)
+	objectId, err := f.fileObjectService.CreateFromImport(
+		domain.FullFileId{SpaceId: spaceId, FileId: domain.FileId(fileId)},
+		origin,
+		sn.Snapshot.Data.Details.CopyOnlyKeys(importedFileDetailKeys...),
+	)
 	if err != nil {
 		return "", treestorage.TreeStorageCreatePayload{}, fmt.Errorf("create file object: %w", err)
 	}
@@ -71,7 +85,8 @@ func uploadFile(
 ) (string, error) {
 	params := pb.RpcFileUploadRequest{
 		SpaceId: spaceId,
-		Details: details.CopyOnlyKeys(bundle.RelationKeyName, bundle.RelationKeyIsHiddenDiscovery).ToProto(),
+		// Preserve file-object timestamps from imported snapshots.
+		Details: details.CopyOnlyKeys(importedFileDetailKeys...).ToProto(),
 	}
 
 	if strings.HasPrefix(filePath, "http://") || strings.HasPrefix(filePath, "https://") {
@@ -87,7 +102,7 @@ func uploadFile(
 
 	fileObjectId, _, _, err := blockService.UploadFile(ctx, spaceId, dto)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("upload file: %w", err)
 	}
 	return fileObjectId, nil
 }

--- a/core/files/fileobject/fileindex.go
+++ b/core/files/fileobject/fileindex.go
@@ -276,6 +276,28 @@ func (ind *indexer) injectMetadataToState(ctx context.Context, st *state.State, 
 	st.AddBundledRelationLinks(keys...)
 
 	details = prevDetails.Merge(details)
+	// Preserve explicitly provided import values. Metadata extraction can derive
+	// file-system-based times from temp files, which should not overwrite
+	// snapshot dates during restore/import. Creator and LastModifiedBy are
+	// included for the same reason: if metadata extraction ever starts setting
+	// these keys, import values would be silently lost.
+	for _, key := range []domain.RelationKey{
+		bundle.RelationKeyCreatedDate,
+		bundle.RelationKeyLastModifiedDate,
+		bundle.RelationKeyAddedDate,
+	} {
+		if v := prevDetails.GetInt64(key); v > 0 {
+			details.SetInt64(key, v)
+		}
+	}
+	for _, key := range []domain.RelationKey{
+		bundle.RelationKeyCreator,
+		bundle.RelationKeyLastModifiedBy,
+	} {
+		if v := prevDetails.Get(key); v.Ok() {
+			details.Set(key, v)
+		}
+	}
 	st.SetDetails(details)
 
 	err = fileblocks.AddFileBlocks(st, details, id.ObjectID)

--- a/core/files/fileobject/fileindex_test.go
+++ b/core/files/fileobject/fileindex_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/files/fileobject/fileblocks"
 	"github.com/anyproto/anytype-heart/core/files/mock_files"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
@@ -228,6 +230,52 @@ func TestIndexer_addFromObjectStore(t *testing.T) {
 		}
 
 		assert.ElementsMatch(t, want, got)
+	})
+}
+
+func TestIndexer_injectMetadataToState(t *testing.T) {
+	t.Run("imported dates and identity keys are preserved after metadata injection", func(t *testing.T) {
+		// given
+		fx := newIndexerFixture(t)
+		ctx := context.Background()
+
+		fileId := domain.FullFileId{SpaceId: "space1", FileId: testFileId}
+		objectId := domain.FullID{SpaceID: "space1", ObjectID: "obj1"}
+
+		// File infos with filesystem-derived timestamps that differ from import values.
+		infos := []*storage.FileInfo{
+			{
+				Name:             "name",
+				Media:            "application/pdf",
+				Mill:             mill.BlobId,
+				LastModifiedDate: 9000,
+				Added:            8000,
+			},
+		}
+
+		// Build a state with import-provided details already set (simulating what
+		// createInSpace does before calling injectMetadataToState).
+		st := state.NewDoc("root", nil).(*state.State)
+		fileblocks.InitEmptyFileState(st)
+		importDetails := domain.NewDetails()
+		importDetails.SetInt64(bundle.RelationKeyCreatedDate, 1000)
+		importDetails.SetInt64(bundle.RelationKeyLastModifiedDate, 2000)
+		importDetails.SetInt64(bundle.RelationKeyAddedDate, 3000)
+		importDetails.SetString(bundle.RelationKeyCreator, "importCreator")
+		importDetails.SetString(bundle.RelationKeyLastModifiedBy, "importEditor")
+		st.SetDetails(importDetails)
+
+		// when
+		err := fx.injectMetadataToState(ctx, st, infos, fileId, objectId)
+
+		// then
+		require.NoError(t, err)
+		got := st.CombinedDetails()
+		assert.Equal(t, int64(1000), got.GetInt64(bundle.RelationKeyCreatedDate))
+		assert.Equal(t, int64(2000), got.GetInt64(bundle.RelationKeyLastModifiedDate))
+		assert.Equal(t, int64(3000), got.GetInt64(bundle.RelationKeyAddedDate))
+		assert.Equal(t, "importCreator", got.GetString(bundle.RelationKeyCreator))
+		assert.Equal(t, "importEditor", got.GetString(bundle.RelationKeyLastModifiedBy))
 	})
 }
 

--- a/core/files/fileobject/service.go
+++ b/core/files/fileobject/service.go
@@ -454,6 +454,17 @@ func (s *service) createInSpace(ctx context.Context, space clientspace.Space, re
 			createState.SetDetailAndBundledRelation(k, v)
 		}
 	}
+	if req.ObjectOrigin.IsImported() && req.AdditionalDetails != nil {
+		// Preserve imported timestamps and creator attribution.
+		// ChangeTypeHistoryOperation prevents the apply layer from overwriting lastModified.
+		// Creator and LastModifiedBy are derived relations, so the
+		// SetDetailAndBundledRelation loop above already routes them to local
+		// details — no additional handling needed here.
+		createState.SetChangeType(domain.ChangeTypeHistoryOperation)
+		if created := req.AdditionalDetails.GetInt64(bundle.RelationKeyCreatedDate); created > 0 {
+			createState.SetOriginalCreatedTimestamp(created)
+		}
+	}
 
 	// Type will be changed after indexing, just use general type File for now
 	id, object, err = s.objectCreator.CreateSmartBlockFromStateInSpaceWithOptions(ctx, space, []domain.TypeKey{bundle.TypeKeyFile}, createState, objectcreator.WithPayload(&payload))

--- a/core/files/fileobject/service_test.go
+++ b/core/files/fileobject/service_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/anyproto/any-sync/accountservice/mock_accountservice"
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/commonfile/fileservice"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treestorage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -22,6 +25,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/object/idresolver/mock_idresolver"
 	"github.com/anyproto/anytype-heart/core/block/object/objectcreator"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/domain/objectorigin"
 	"github.com/anyproto/anytype-heart/core/event/mock_event"
 	"github.com/anyproto/anytype-heart/core/files"
 	"github.com/anyproto/anytype-heart/core/files/fileobject/filemodels"
@@ -253,4 +257,57 @@ func TestGetFileIdFromObjectWaitLoad(t *testing.T) {
 		})
 		require.ErrorIs(t, err, filemodels.ErrEmptyFileId)
 	})
+}
+
+func TestCreate_importedOriginPreservesTimestampsAndCreator(t *testing.T) {
+	fx := newFixture(t)
+	ctx := context.Background()
+	spaceId := "space1"
+
+	space := mock_clientspace.NewMockSpace(t)
+	space.EXPECT().Id().Return(spaceId).Maybe()
+	space.EXPECT().CreateTreePayload(mock.Anything, mock.Anything).Return(treestorage.TreeStorageCreatePayload{
+		RootRawChange: &treechangeproto.RawTreeChangeWithId{Id: "rootId"},
+	}, nil)
+	// The background indexer may pick up the queued file and try to index it.
+	space.EXPECT().Do(mock.Anything, mock.Anything).Return(fmt.Errorf("skip indexing in test")).Maybe()
+	fx.spaceService.EXPECT().Get(mock.Anything, spaceId).Return(space, nil)
+
+	fx.objectCreator.objectId = "fileObjId"
+	fx.objectCreator.details = domain.NewDetails()
+
+	origin := objectorigin.Import(model.Import_Pb)
+	additionalDetails := domain.NewDetails()
+	additionalDetails.SetInt64(bundle.RelationKeyCreatedDate, 1000)
+	additionalDetails.SetInt64(bundle.RelationKeyLastModifiedDate, 2000)
+	additionalDetails.SetString(bundle.RelationKeyCreator, "importCreator")
+	additionalDetails.SetString(bundle.RelationKeyLastModifiedBy, "importEditor")
+
+	id, _, err := fx.Create(ctx, spaceId, filemodels.CreateRequest{
+		FileId:                testFileId,
+		ObjectOrigin:          origin,
+		AdditionalDetails:     additionalDetails,
+		AsyncMetadataIndexing: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "fileObjId", id)
+
+	// Verify creation state captured by the stub.
+	st := fx.objectCreator.creationState
+	require.NotNil(t, st)
+
+	assert.Equal(t, domain.ChangeTypeHistoryOperation, st.GetChangeType())
+	assert.Equal(t, int64(1000), st.OriginalCreatedTimestamp())
+
+	// Creator is a derived relation, so SetDetailAndBundledRelation routes it
+	// to local details. The explicit SetLocalDetail call should also set it.
+	localDetails := st.LocalDetails()
+	require.NotNil(t, localDetails)
+	assert.Equal(t, "importCreator", localDetails.GetString(bundle.RelationKeyCreator))
+
+	// AdditionalDetails loop sets all keys via SetDetailAndBundledRelation.
+	combined := st.CombinedDetails()
+	assert.Equal(t, int64(1000), combined.GetInt64(bundle.RelationKeyCreatedDate))
+	assert.Equal(t, int64(2000), combined.GetInt64(bundle.RelationKeyLastModifiedDate))
+	assert.Equal(t, "importEditor", combined.GetString(bundle.RelationKeyLastModifiedBy))
 }


### PR DESCRIPTION

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### Description

During protobuf restore/import, file-object metadata indexing was overwriting snapshot-provided dates (CreatedDate, LastModifiedDate, AddedDate) with filesystem-derived timestamps from temp files.

Three associated fixes:
- Pass date and identity keys from import snapshots through to file object creation (oldfile.go)
- Set ChangeTypeHistoryOperation and OriginalCreatedTimestamp during creation to prevent the apply layer from overwriting timestamps (service.go)
- Restore import-provided dates and identity keys after metadata merge in the indexer (fileindex.go)

### What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix
- [X] ✅ Test

### Related Tickets & Documents

Fixes https://github.com/anyproto/anytype-heart/issues/2951

### Added tests?

- [X] 👍 yes
