### PR TITLE
Fix restore (import with UpdateExistingObjects) of archived object and existing object lookup

### DIFF
--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -158,9 +158,15 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 	}
 	oc.setFavorite(snapshot, newID)
 
-	oc.setArchived(ctx, snapshot, newID)
+	wasUnarchived := oc.setArchived(ctx, snapshot, newID)
 
 	syncErr := oc.syncFilesAndLinks(dataObject.newIdsSet, domain.FullID{SpaceID: spaceID, ObjectID: newID}, origin)
+	if wasUnarchived {
+		// Unarchive mutates archive collection links and bumps modified time.
+		// For import with UpdateExistingObjects=true we must keep snapshot
+		// lastModifiedDate, so we re-apply it after archive+sync side effects finish.
+		oc.restoreLastModifiedDate(snapshot, newID)
+	}
 	if syncErr != nil {
 		if errors.Is(syncErr, common.ErrFileLoad) {
 			return respDetails, newID, syncErr
@@ -403,15 +409,54 @@ func (oc *ObjectCreator) setFavorite(snapshot *common.StateSnapshot, newID strin
 	}
 }
 
-func (oc *ObjectCreator) setArchived(ctx context.Context, snapshot *common.StateSnapshot, newID string) {
-	isArchive := snapshot.Details.GetBool(bundle.RelationKeyIsArchived)
-	if isArchive {
-		err := oc.detailsService.SetIsArchived(ctx, newID, true)
-		if err != nil {
-			log.With(zap.String("object id", newID)).
-				Errorf("failed to set isFavorite when importing object %s: %s", newID, err)
-		}
+func (oc *ObjectCreator) setArchived(ctx context.Context, snapshot *common.StateSnapshot, newID string) bool {
+	desiredArchived := snapshot.Details.GetBool(bundle.RelationKeyIsArchived)
+	currentArchived, err := oc.isArchived(newID)
+	if err != nil {
+		log.With(zap.String("object id", newID)).
+			Errorf("failed to get current archived status during import %s: %s", newID, err)
+		return false
 	}
+	if desiredArchived == currentArchived {
+		return false
+	}
+	err = oc.detailsService.SetIsArchived(ctx, newID, desiredArchived)
+	if err != nil {
+		log.With(zap.String("object id", newID)).
+			Errorf("failed to set isArchived when importing object %s: %s", newID, err)
+		return false
+	}
+	return !desiredArchived && currentArchived
+}
+
+func (oc *ObjectCreator) restoreLastModifiedDate(snapshot *common.StateSnapshot, objectID string) {
+	if !snapshot.Details.Has(bundle.RelationKeyLastModifiedDate) {
+		return
+	}
+	err := cache.Do(oc.objectGetterDeleter, objectID, func(b smartblock.SmartBlock) error {
+		st := b.NewState()
+		st.SetLocalDetail(bundle.RelationKeyLastModifiedDate, snapshot.Details.Get(bundle.RelationKeyLastModifiedDate))
+		// Use local details + NoHistory here to avoid generating a new user
+		// change that would overwrite lastModifiedDate with "now". Do not change
+		// global SetIsArchived semantics; keep this scoped to restore flow.
+		return b.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.NoRestrictions, smartblock.KeepInternalFlags)
+	})
+	if err != nil {
+		log.With(zap.String("object id", objectID)).
+			Errorf("failed to restore lastModifiedDate after unarchive: %s", err)
+	}
+}
+
+func (oc *ObjectCreator) isArchived(objectID string) (bool, error) {
+	var archived bool
+	err := cache.Do(oc.objectGetterDeleter, objectID, func(b smartblock.SmartBlock) error {
+		archived = b.CombinedDetails().GetBool(bundle.RelationKeyIsArchived)
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("get object details: %w", err)
+	}
+	return archived, nil
 }
 
 func (oc *ObjectCreator) syncFilesAndLinks(newIdsSet map[string]struct{}, id domain.FullID, origin objectorigin.ObjectOrigin) error {

--- a/core/block/import/common/objectcreator/objectcreator_test.go
+++ b/core/block/import/common/objectcreator/objectcreator_test.go
@@ -101,6 +101,90 @@ func TestObjectCreator_Create(t *testing.T) {
 	})
 }
 
+func TestObjectCreator_setArchived(t *testing.T) {
+	t.Run("detail missing keeps false and does not update", func(t *testing.T) {
+		detailsService := mock_detailservice.NewMockService(t)
+		testObject := smarttest.New("obj1")
+		st := testObject.NewState()
+		st.SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String("obj1"),
+			bundle.RelationKeyIsArchived: domain.Bool(false),
+		}))
+		assert.NoError(t, testObject.Apply(st))
+		getter := newDumbObjectGetter(map[string]smartblock.SmartBlock{"obj1": testObject})
+		oc := &ObjectCreator{detailsService: detailsService, objectGetterDeleter: getter}
+		snapshot := &common.StateSnapshot{Details: domain.NewDetails()}
+		oc.setArchived(context.Background(), snapshot, "obj1")
+	})
+
+	t.Run("detail set false unarchives archived object", func(t *testing.T) {
+		detailsService := mock_detailservice.NewMockService(t)
+		detailsService.EXPECT().SetIsArchived(mock.Anything, "obj1", false).Return(nil).Once()
+		testObject := smarttest.New("obj1")
+		st := testObject.NewState()
+		st.SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:               domain.String("obj1"),
+			bundle.RelationKeyIsArchived:       domain.Bool(true),
+			bundle.RelationKeyLastModifiedDate: domain.Int64(999),
+		}))
+		assert.NoError(t, testObject.Apply(st))
+		getter := newDumbObjectGetter(map[string]smartblock.SmartBlock{"obj1": testObject})
+		oc := &ObjectCreator{detailsService: detailsService, objectGetterDeleter: getter}
+		snapshot := &common.StateSnapshot{
+			Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyLastModifiedDate: domain.Int64(123),
+			}),
+		}
+		wasUnarchived := oc.setArchived(context.Background(), snapshot, "obj1")
+		assert.True(t, wasUnarchived)
+		oc.restoreLastModifiedDate(snapshot, "obj1")
+		assert.Equal(
+			t,
+			int64(123),
+			testObject.CombinedDetails().GetInt64(bundle.RelationKeyLastModifiedDate),
+		)
+	})
+
+	t.Run("detail set false does not update when already false", func(t *testing.T) {
+		detailsService := mock_detailservice.NewMockService(t)
+		testObject := smarttest.New("obj1")
+		st := testObject.NewState()
+		st.SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String("obj1"),
+			bundle.RelationKeyIsArchived: domain.Bool(false),
+		}))
+		assert.NoError(t, testObject.Apply(st))
+		getter := newDumbObjectGetter(map[string]smartblock.SmartBlock{"obj1": testObject})
+		oc := &ObjectCreator{detailsService: detailsService, objectGetterDeleter: getter}
+		snapshot := &common.StateSnapshot{
+			Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyIsArchived: domain.Bool(false),
+			}),
+		}
+		oc.setArchived(context.Background(), snapshot, "obj1")
+	})
+
+	t.Run("detail set true archives when currently false", func(t *testing.T) {
+		detailsService := mock_detailservice.NewMockService(t)
+		detailsService.EXPECT().SetIsArchived(mock.Anything, "obj1", true).Return(nil).Once()
+		testObject := smarttest.New("obj1")
+		st := testObject.NewState()
+		st.SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String("obj1"),
+			bundle.RelationKeyIsArchived: domain.Bool(false),
+		}))
+		assert.NoError(t, testObject.Apply(st))
+		getter := newDumbObjectGetter(map[string]smartblock.SmartBlock{"obj1": testObject})
+		oc := &ObjectCreator{detailsService: detailsService, objectGetterDeleter: getter}
+		snapshot := &common.StateSnapshot{
+			Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyIsArchived: domain.Bool(true),
+			}),
+		}
+		oc.setArchived(context.Background(), snapshot, "obj1")
+	})
+}
+
 func TestObjectCreator_updateKeys(t *testing.T) {
 	t.Run("updateKeys - update relation key", func(t *testing.T) {
 		// given

--- a/core/block/import/common/objectid/existingobject.go
+++ b/core/block/import/common/objectid/existingobject.go
@@ -32,6 +32,10 @@ func (e *existingObject) GetIDAndPayload(_ context.Context, spaceID string, sn *
 		return id, treestorage.TreeStorageCreatePayload{}, nil
 	}
 	if getExisting {
+		id = e.getExistingObjectByID(spaceID, sn)
+		if id != "" {
+			return id, treestorage.TreeStorageCreatePayload{}, nil
+		}
 		id = e.getExistingObject(spaceID, sn)
 		if id != "" {
 			return id, treestorage.TreeStorageCreatePayload{}, nil
@@ -51,51 +55,61 @@ func (e *existingObject) GetIDAndPayload(_ context.Context, spaceID string, sn *
 
 func (e *existingObject) getObjectByOldAnytypeID(spaceID string, sn *common.Snapshot) (string, error) {
 	oldAnytypeID := sn.Snapshot.Data.Details.GetString(bundle.RelationKeyOldAnytypeID)
+	if oldAnytypeID == "" {
+		return "", nil
+	}
 
 	// Check for imported objects
-	ids, _, err := e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeyOldAnytypeID,
-				Value:       domain.String(oldAnytypeID),
-			},
-		},
-	})
-	if err == nil && len(ids) > 0 {
-		return ids[0], nil
+	records, err := e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyOldAnytypeID,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(oldAnytypeID),
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId), nil
 	}
 
 	// Check for derived objects
-	ids, _, err = e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeyUniqueKey,
-				Value:       domain.String(oldAnytypeID), // Old id equals to unique key
-			},
-		},
-	})
-	if err == nil && len(ids) > 0 {
-		return ids[0], nil
+	records, err = e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyUniqueKey,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(oldAnytypeID), // Old id equals to unique key
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId), nil
 	}
 
 	return "", err
 }
 
+func (e *existingObject) getExistingObjectByID(spaceID string, sn *common.Snapshot) string {
+	oldAnytypeID := sn.Snapshot.Data.Details.GetString(bundle.RelationKeyOldAnytypeID)
+	if oldAnytypeID == "" {
+		return ""
+	}
+	records, err := e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyId,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(oldAnytypeID),
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId)
+	}
+	return ""
+}
+
 func (e *existingObject) getExistingObject(spaceID string, sn *common.Snapshot) string {
 	source := sn.Snapshot.Data.Details.GetString(bundle.RelationKeySourceFilePath)
-	ids, _, err := e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeySourceFilePath,
-				Value:       domain.String(source),
-			},
-		},
-	})
-	if err == nil && len(ids) > 0 {
-		return ids[0]
+	if source == "" {
+		return ""
+	}
+	records, err := e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeySourceFilePath,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(source),
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId)
 	}
 	return ""
 }

--- a/core/block/import/common/objectid/existingobject_test.go
+++ b/core/block/import/common/objectid/existingobject_test.go
@@ -1,0 +1,46 @@
+package objectid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/import/common"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+)
+
+func TestExistingObject_GetIDAndPayload_MatchByIDOnlyWhenGetExisting(t *testing.T) {
+	sf := objectstore.NewStoreFixture(t)
+	existing := newExistingObject(sf)
+
+	sf.AddObjects(t, "spaceId", []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:      domain.String("obj1"),
+			bundle.RelationKeyName:    domain.String("name"),
+			bundle.RelationKeySpaceId: domain.String("spaceId"),
+		},
+	})
+
+	sn := &common.Snapshot{
+		Snapshot: &common.SnapshotModel{
+			SbType: coresb.SmartBlockTypePage,
+			Data: &common.StateSnapshot{
+				Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyOldAnytypeID: domain.String("obj1"),
+				}),
+			},
+		},
+	}
+
+	id, _, err := existing.GetIDAndPayload(context.Background(), "spaceId", sn, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "", id)
+
+	id, _, err = existing.GetIDAndPayload(context.Background(), "spaceId", sn, true)
+	assert.NoError(t, err)
+	assert.Equal(t, "obj1", id)
+}


### PR DESCRIPTION
### Description

Fix restore (import with UpdateExistingObjects) of archived object
- archive toggle was one-dirrectional (archive only)
- archive overwrote lastModifiedDate as a side-effect of un-archiving

Compare current vs desired archived state and restore the snapshot lastModifiedDate after unarchive.

Also add direct ID matching via oldAnytypeID when getExisting is true, migrate store queries from QueryObjectIds to QueryRaw with limit=1, and skip queries on empty filter values.

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix
- [X] ✅ Test

### Added tests?

- [X] 👍 yes