### PR TITLE
Enable backup and restore of custom properties and types

### DIFF
--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -170,8 +170,7 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 }
 
 func canUpdateObject(sbType coresb.SmartBlockType) bool {
-	return sbType != coresb.SmartBlockTypeRelation &&
-		sbType != coresb.SmartBlockTypeRelationOption &&
+	return sbType != coresb.SmartBlockTypeRelationOption &&
 		sbType != coresb.SmartBlockTypeFileObject &&
 		sbType != coresb.SmartBlockTypeParticipant
 }

--- a/core/block/import/common/objectcreator/objectcreator_test.go
+++ b/core/block/import/common/objectcreator/objectcreator_test.go
@@ -167,6 +167,26 @@ func TestObjectCreator_updateKeys(t *testing.T) {
 	})
 }
 
+func TestCanUpdateObject(t *testing.T) {
+	tests := []struct {
+		name   string
+		sbType coresb.SmartBlockType
+		want   bool
+	}{
+		{"page is updatable", coresb.SmartBlockTypePage, true},
+		{"relation is updatable", coresb.SmartBlockTypeRelation, true},
+		{"object type is updatable", coresb.SmartBlockTypeObjectType, true},
+		{"relation option is not updatable", coresb.SmartBlockTypeRelationOption, false},
+		{"file object is not updatable", coresb.SmartBlockTypeFileObject, false},
+		{"participant is not updatable", coresb.SmartBlockTypeParticipant, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canUpdateObject(tt.sbType))
+		})
+	}
+}
+
 type dumbObjectGetter struct {
 	objects map[string]smartblock.SmartBlock
 }


### PR DESCRIPTION
### Description

Previously, relation objects were excluded from the update path during import, which meant changes to custom relation properties (name, format, description) were silently dropped when re-importing.

Bundled relations remain protected by the existing revision guard in resetState.

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

### What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix
- [X] ✅ Test

### Added tests?

- [X] 👍 yes