### PR TITLE
Fix import replace for file objects, archive state, and metadata

### DIFF
--- a/core/block/import/common/objectcreator/objectcreator.go
+++ b/core/block/import/common/objectcreator/objectcreator.go
@@ -91,6 +91,10 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 	newID := oldIDtoNew[sn.Id]
 
 	if sn.Snapshot.SbType == coresb.SmartBlockTypeFile {
+		// Legacy file snapshots resolve to file-object ids via object-id providers.
+		// Apply imported details directly to the resolved file object so replace/import
+		// keeps snapshot metadata (for example name and dates).
+		oc.restoreLegacyFileDetails(snapshot, newID)
 		return nil, newID, nil
 	}
 
@@ -144,7 +148,10 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 	if err != nil {
 		log.With("objectID", newID).Errorf("failed to install bundled relations and types: %s", err)
 	}
-	var respDetails *domain.Details
+	var (
+		respDetails *domain.Details
+		isExisting  bool
+	)
 	if payload := dataObject.createPayloads[newID]; payload.RootRawChange != nil {
 		respDetails, err = oc.createNewObject(ctx, spaceID, payload, st, newID, oldIDtoNew)
 		if err != nil {
@@ -152,15 +159,29 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 			return nil, "", err
 		}
 	} else {
+		isExisting = true
 		if canUpdateObject(sn.Snapshot.SbType) {
 			respDetails = oc.updateExistingObject(st, oldIDtoNew, newID)
 		}
 	}
 	oc.setFavorite(snapshot, newID)
 
-	oc.setArchived(ctx, snapshot, newID)
+	wasUnarchived := oc.setArchived(ctx, snapshot, newID)
 
 	syncErr := oc.syncFilesAndLinks(dataObject.newIdsSet, domain.FullID{SpaceID: spaceID, ObjectID: newID}, origin)
+	if isExisting || wasUnarchived {
+		// Keep backup timestamp semantics for replace/existing-object import after
+		// archive/sync side-effects that can bump modified time.
+		// wasUnarchived covers the create-but-tree-exists path: the payload has
+		// RootRawChange so isExisting is false, yet the object may already exist
+		// (ErrTreeExists fallback) and have been archived before this import.
+		oc.restoreLastModifiedDate(snapshot, newID)
+	}
+	if isExisting && sn.Snapshot.SbType == coresb.SmartBlockTypeFileObject {
+		// File objects can retain runtime metadata despite resetState; re-apply
+		// imported file details explicitly for replace on existing objects.
+		oc.restoreLegacyFileDetails(snapshot, newID)
+	}
 	if syncErr != nil {
 		if errors.Is(syncErr, common.ErrFileLoad) {
 			return respDetails, newID, syncErr
@@ -172,7 +193,6 @@ func (oc *ObjectCreator) Create(dataObject *DataObject, sn *common.Snapshot) (*d
 func canUpdateObject(sbType coresb.SmartBlockType) bool {
 	return sbType != coresb.SmartBlockTypeRelation &&
 		sbType != coresb.SmartBlockTypeRelationOption &&
-		sbType != coresb.SmartBlockTypeFileObject &&
 		sbType != coresb.SmartBlockTypeParticipant
 }
 
@@ -403,15 +423,102 @@ func (oc *ObjectCreator) setFavorite(snapshot *common.StateSnapshot, newID strin
 	}
 }
 
-func (oc *ObjectCreator) setArchived(ctx context.Context, snapshot *common.StateSnapshot, newID string) {
-	isArchive := snapshot.Details.GetBool(bundle.RelationKeyIsArchived)
-	if isArchive {
-		err := oc.detailsService.SetIsArchived(ctx, newID, true)
-		if err != nil {
-			log.With(zap.String("object id", newID)).
-				Errorf("failed to set isFavorite when importing object %s: %s", newID, err)
+func (oc *ObjectCreator) setArchived(ctx context.Context, snapshot *common.StateSnapshot, newID string) bool {
+	desiredArchived := snapshot.Details.GetBool(bundle.RelationKeyIsArchived)
+	currentArchived, err := oc.isArchived(newID)
+	if err != nil {
+		log.With(zap.String("object id", newID)).
+			Errorf("failed to get current archived status during import %s: %s", newID, err)
+		return false
+	}
+	if desiredArchived == currentArchived {
+		return false
+	}
+	err = oc.detailsService.SetIsArchived(ctx, newID, desiredArchived)
+	if err != nil {
+		log.With(zap.String("object id", newID)).
+			Errorf("failed to set isArchived when importing object %s: %s", newID, err)
+		return false
+	}
+	return !desiredArchived && currentArchived
+}
+
+func (oc *ObjectCreator) restoreLastModifiedDate(snapshot *common.StateSnapshot, objectID string) {
+	if !snapshot.Details.Has(bundle.RelationKeyLastModifiedDate) {
+		return
+	}
+	err := cache.Do(oc.objectGetterDeleter, objectID, func(b smartblock.SmartBlock) error {
+		st := b.NewState()
+		st.SetLocalDetail(bundle.RelationKeyLastModifiedDate, snapshot.Details.Get(bundle.RelationKeyLastModifiedDate))
+		return b.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.NoRestrictions, smartblock.KeepInternalFlags)
+	})
+	if err != nil {
+		log.With(zap.String("object id", objectID)).
+			Errorf("failed to restore lastModifiedDate after import: %s", err)
+	}
+}
+
+func (oc *ObjectCreator) isArchived(objectID string) (bool, error) {
+	var archived bool
+	err := cache.Do(oc.objectGetterDeleter, objectID, func(b smartblock.SmartBlock) error {
+		archived = b.CombinedDetails().GetBool(bundle.RelationKeyIsArchived)
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("get object details: %w", err)
+	}
+	return archived, nil
+}
+
+func (oc *ObjectCreator) restoreLegacyFileDetails(snapshot *common.StateSnapshot, objectID string) {
+	keys := []domain.RelationKey{
+		bundle.RelationKeyName,
+		bundle.RelationKeyIsHiddenDiscovery,
+		bundle.RelationKeyCreatedDate,
+		bundle.RelationKeyLastModifiedDate,
+		bundle.RelationKeyAddedDate,
+		bundle.RelationKeyCreator,
+		bundle.RelationKeyLastModifiedBy,
+	}
+	restoredFileName := snapshot.Details.GetString(bundle.RelationKeyName)
+	if restoredFileName == "" {
+		restoredFileName = firstSnapshotFileBlockName(snapshot)
+	}
+	err := cache.Do(oc.objectGetterDeleter, objectID, func(b smartblock.SmartBlock) error {
+		st := b.NewState()
+		for _, key := range keys {
+			if snapshot.Details.Has(key) {
+				st.SetLocalDetail(key, snapshot.Details.Get(key))
+			}
+		}
+		if restoredFileName != "" {
+			// File-object reads can use the file block caption/name; keep it in sync with
+			// restored details for replace/updateExisting import.
+			if iterErr := st.Iterate(func(bl simple.Block) (isContinue bool) {
+				if file := bl.Model().GetFile(); file != nil {
+					file.Name = restoredFileName
+					return false
+				}
+				return true
+			}); iterErr != nil {
+				return iterErr
+			}
+		}
+		return b.Apply(st, smartblock.NoHistory, smartblock.NoEvent, smartblock.NoRestrictions, smartblock.KeepInternalFlags)
+	})
+	if err != nil {
+		log.With(zap.String("object id", objectID)).
+			Errorf("failed to restore legacy file details after import: %s", err)
+	}
+}
+
+func firstSnapshotFileBlockName(snapshot *common.StateSnapshot) string {
+	for _, block := range snapshot.Blocks {
+		if file := block.GetFile(); file != nil && file.Name != "" {
+			return file.Name
 		}
 	}
+	return ""
 }
 
 func (oc *ObjectCreator) syncFilesAndLinks(newIdsSet map[string]struct{}, id domain.FullID, origin objectorigin.ObjectOrigin) error {

--- a/core/block/import/common/objectcreator/objectcreator_test.go
+++ b/core/block/import/common/objectcreator/objectcreator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/tree/treestorage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/block/detailservice/mock_detailservice"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
@@ -99,6 +100,54 @@ func TestObjectCreator_Create(t *testing.T) {
 		assert.Equal(t, participantId, id)
 		assert.Equal(t, testDetails, testParticipant.CombinedDetails())
 	})
+	t.Run("legacy file snapshot updates existing file object details", func(t *testing.T) {
+		spaceID := "spaceId"
+		fileObjectID := "fileObjectId"
+		fileName := "imported-file-name.png"
+		detailsService := mock_detailservice.NewMockService(t)
+
+		oldToNew := map[string]string{"oldFile": fileObjectID}
+		dataObject := NewDataObject(context.Background(), oldToNew, nil, nil, objectorigin.Import(model.Import_Pb), spaceID)
+		sn := &common.Snapshot{
+			Id: "oldFile",
+			Snapshot: &common.SnapshotModel{
+				SbType: coresb.SmartBlockTypeFile,
+				Data: &common.StateSnapshot{
+					Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+						bundle.RelationKeyName:             domain.String(fileName),
+						bundle.RelationKeyLastModifiedDate: domain.Int64(123),
+					}),
+				},
+			},
+		}
+
+		testFile := smarttest.New(fileObjectID)
+		st := testFile.NewState()
+		st.SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:   domain.String(fileObjectID),
+			bundle.RelationKeyName: domain.String("old-name.png"),
+		}))
+		err := testFile.Apply(st)
+		require.NoError(t, err)
+
+		getter := newDumbObjectGetter(map[string]smartblock.SmartBlock{
+			fileObjectID: testFile,
+		})
+
+		fetcher := mock_relationutils.NewMockRelationFormatFetcher(t)
+		service := New(detailsService, nil, nil, nil, nil, objectcreator.NewCreator(), getter, fetcher)
+
+		create, id, err := service.Create(dataObject, sn)
+		require.NoError(t, err)
+		assert.Nil(t, create)
+		assert.Equal(t, fileObjectID, id)
+		assert.Equal(t, fileName, testFile.CombinedDetails().GetString(bundle.RelationKeyName))
+		assert.Equal(
+			t,
+			int64(123),
+			testFile.CombinedDetails().GetInt64(bundle.RelationKeyLastModifiedDate),
+		)
+	})
 }
 
 func TestObjectCreator_updateKeys(t *testing.T) {
@@ -165,6 +214,46 @@ func TestObjectCreator_updateKeys(t *testing.T) {
 		assert.Equal(t, "test", doc.Details().GetString("key"))
 		assert.True(t, doc.HasRelation("key"))
 	})
+}
+
+func TestCanUpdateObject(t *testing.T) {
+	tests := []struct {
+		name   string
+		sbType coresb.SmartBlockType
+		want   bool
+	}{
+		{
+			name:   "page can be updated",
+			sbType: coresb.SmartBlockTypePage,
+			want:   true,
+		},
+		{
+			name:   "file object can be updated",
+			sbType: coresb.SmartBlockTypeFileObject,
+			want:   true,
+		},
+		{
+			name:   "relation cannot be updated",
+			sbType: coresb.SmartBlockTypeRelation,
+			want:   false,
+		},
+		{
+			name:   "relation option cannot be updated",
+			sbType: coresb.SmartBlockTypeRelationOption,
+			want:   false,
+		},
+		{
+			name:   "participant cannot be updated",
+			sbType: coresb.SmartBlockTypeParticipant,
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canUpdateObject(tt.sbType))
+		})
+	}
 }
 
 type dumbObjectGetter struct {

--- a/core/block/import/common/objectid/existingobject.go
+++ b/core/block/import/common/objectid/existingobject.go
@@ -24,15 +24,33 @@ func newExistingObject(objectStore objectstore.ObjectStore) *existingObject {
 }
 
 func (e *existingObject) GetIDAndPayload(_ context.Context, spaceID string, sn *common.Snapshot, getExisting bool) (string, treestorage.TreeStorageCreatePayload, error) {
-	id, err := e.getObjectByOldAnytypeID(spaceID, sn)
-	if err != nil {
-		return "", treestorage.TreeStorageCreatePayload{}, fmt.Errorf("get object by old anytype id: %w", err)
-	}
-	if id != "" {
-		return id, treestorage.TreeStorageCreatePayload{}, nil
-	}
+	var (
+		id  string
+		err error
+	)
 	if getExisting {
+		// For updateExisting/replace import we must target the current object id first.
+		// Otherwise oldAnytypeID can match a previously imported clone and skip in-place replace.
+		id = e.getExistingObjectByID(spaceID, sn)
+		if id != "" {
+			return id, treestorage.TreeStorageCreatePayload{}, nil
+		}
+		id, err = e.getObjectByOldAnytypeID(spaceID, sn)
+		if err != nil {
+			return "", treestorage.TreeStorageCreatePayload{}, fmt.Errorf("get object by old anytype id: %w", err)
+		}
+		if id != "" {
+			return id, treestorage.TreeStorageCreatePayload{}, nil
+		}
 		id = e.getExistingObject(spaceID, sn)
+		if id != "" {
+			return id, treestorage.TreeStorageCreatePayload{}, nil
+		}
+	} else {
+		id, err = e.getObjectByOldAnytypeID(spaceID, sn)
+		if err != nil {
+			return "", treestorage.TreeStorageCreatePayload{}, fmt.Errorf("get object by old anytype id: %w", err)
+		}
 		if id != "" {
 			return id, treestorage.TreeStorageCreatePayload{}, nil
 		}
@@ -51,51 +69,64 @@ func (e *existingObject) GetIDAndPayload(_ context.Context, spaceID string, sn *
 
 func (e *existingObject) getObjectByOldAnytypeID(spaceID string, sn *common.Snapshot) (string, error) {
 	oldAnytypeID := sn.Snapshot.Data.Details.GetString(bundle.RelationKeyOldAnytypeID)
+	if oldAnytypeID == "" {
+		return "", nil
+	}
 
 	// Check for imported objects
-	ids, _, err := e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeyOldAnytypeID,
-				Value:       domain.String(oldAnytypeID),
-			},
-		},
-	})
-	if err == nil && len(ids) > 0 {
-		return ids[0], nil
+	records, err := e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyOldAnytypeID,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(oldAnytypeID),
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId), nil
 	}
 
 	// Check for derived objects
-	ids, _, err = e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeyUniqueKey,
-				Value:       domain.String(oldAnytypeID), // Old id equals to unique key
-			},
-		},
-	})
-	if err == nil && len(ids) > 0 {
-		return ids[0], nil
+	records, err = e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyUniqueKey,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(oldAnytypeID), // Old id equals to unique key
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId), nil
 	}
 
 	return "", err
 }
 
+func (e *existingObject) getExistingObjectByID(spaceID string, sn *common.Snapshot) string {
+	oldAnytypeID := sn.Snapshot.Data.Details.GetString(bundle.RelationKeyOldAnytypeID)
+	if oldAnytypeID == "" {
+		oldAnytypeID = sn.Snapshot.Data.Details.GetString(bundle.RelationKeyId)
+	}
+	if oldAnytypeID == "" {
+		return ""
+	}
+	records, err := e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeyId,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(oldAnytypeID),
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId)
+	}
+	return ""
+}
+
 func (e *existingObject) getExistingObject(spaceID string, sn *common.Snapshot) string {
 	source := sn.Snapshot.Data.Details.GetString(bundle.RelationKeySourceFilePath)
-	ids, _, err := e.objectStore.SpaceIndex(spaceID).QueryObjectIds(database.Query{
-		Filters: []database.FilterRequest{
-			{
-				Condition:   model.BlockContentDataviewFilter_Equal,
-				RelationKey: bundle.RelationKeySourceFilePath,
-				Value:       domain.String(source),
-			},
-		},
-	})
-	if err == nil && len(ids) > 0 {
-		return ids[0]
+	if source == "" {
+		return ""
+	}
+	records, err := e.objectStore.SpaceIndex(spaceID).QueryRaw(&database.Filters{FilterObj: database.FilterEq{
+		Key:   bundle.RelationKeySourceFilePath,
+		Cond:  model.BlockContentDataviewFilter_Equal,
+		Value: domain.String(source),
+	}}, 1, 0)
+	if err == nil && len(records) > 0 {
+		return records[0].Details.GetString(bundle.RelationKeyId)
 	}
 	return ""
 }

--- a/core/block/import/common/objectid/existingobject_test.go
+++ b/core/block/import/common/objectid/existingobject_test.go
@@ -1,0 +1,120 @@
+package objectid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/import/common"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+)
+
+func TestExistingObject_GetIDAndPayload_MatchByIDOnlyWhenGetExisting(t *testing.T) {
+	setup := func(t *testing.T) (*existingObject, *common.Snapshot) {
+		sf := objectstore.NewStoreFixture(t)
+		existing := newExistingObject(sf)
+
+		sf.AddObjects(t, "spaceId", []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:      domain.String("obj1"),
+				bundle.RelationKeyName:    domain.String("name"),
+				bundle.RelationKeySpaceId: domain.String("spaceId"),
+			},
+		})
+
+		sn := &common.Snapshot{
+			Snapshot: &common.SnapshotModel{
+				SbType: coresb.SmartBlockTypePage,
+				Data: &common.StateSnapshot{
+					Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+						bundle.RelationKeyOldAnytypeID: domain.String("obj1"),
+					}),
+				},
+			},
+		}
+		return existing, sn
+	}
+
+	t.Run("getExisting false does not match by object id", func(t *testing.T) {
+		existing, sn := setup(t)
+
+		id, _, err := existing.GetIDAndPayload(context.Background(), "spaceId", sn, false)
+		require.NoError(t, err)
+		assert.Equal(t, "", id)
+	})
+
+	t.Run("getExisting true matches by object id", func(t *testing.T) {
+		existing, sn := setup(t)
+
+		id, _, err := existing.GetIDAndPayload(context.Background(), "spaceId", sn, true)
+		require.NoError(t, err)
+		assert.Equal(t, "obj1", id)
+	})
+}
+
+func TestExistingObject_GetIDAndPayload_MatchBySnapshotIDWhenOldAnytypeIDMissing(t *testing.T) {
+	sf := objectstore.NewStoreFixture(t)
+	existing := newExistingObject(sf)
+
+	sf.AddObjects(t, "spaceId", []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:      domain.String("obj1"),
+			bundle.RelationKeyName:    domain.String("name"),
+			bundle.RelationKeySpaceId: domain.String("spaceId"),
+		},
+	})
+
+	sn := &common.Snapshot{
+		Snapshot: &common.SnapshotModel{
+			SbType: coresb.SmartBlockTypeFileObject,
+			Data: &common.StateSnapshot{
+				Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId: domain.String("obj1"),
+				}),
+			},
+		},
+	}
+
+	id, _, err := existing.GetIDAndPayload(context.Background(), "spaceId", sn, true)
+	require.NoError(t, err)
+	assert.Equal(t, "obj1", id)
+}
+
+func TestExistingObject_GetIDAndPayload_GetExistingPrefersObjectIDOverOldAnytypeID(t *testing.T) {
+	sf := objectstore.NewStoreFixture(t)
+	existing := newExistingObject(sf)
+
+	// Simulate a prior import-created clone that references original id via oldAnytypeID.
+	sf.AddObjects(t, "spaceId", []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:      domain.String("original-file-object-id"),
+			bundle.RelationKeySpaceId: domain.String("spaceId"),
+		},
+		{
+			bundle.RelationKeyId:           domain.String("imported-clone-id"),
+			bundle.RelationKeyOldAnytypeID: domain.String("original-file-object-id"),
+			bundle.RelationKeySpaceId:      domain.String("spaceId"),
+		},
+	})
+
+	sn := &common.Snapshot{
+		Snapshot: &common.SnapshotModel{
+			SbType: coresb.SmartBlockTypeFileObject,
+			Data: &common.StateSnapshot{
+				Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId:           domain.String("original-file-object-id"),
+					bundle.RelationKeyOldAnytypeID: domain.String("original-file-object-id"),
+				}),
+			},
+		},
+	}
+
+	id, _, err := existing.GetIDAndPayload(context.Background(), "spaceId", sn, true)
+	require.NoError(t, err)
+	assert.Equal(t, "original-file-object-id", id)
+}

--- a/core/block/import/common/objectid/fileobject.go
+++ b/core/block/import/common/objectid/fileobject.go
@@ -27,6 +27,11 @@ func (o *fileObject) GetIDAndPayload(ctx context.Context, spaceId string, sn *co
 
 	filePath := sn.Snapshot.Data.Details.GetString(bundle.RelationKeySource)
 	if filePath != "" {
+		// On replace/updateExisting import, preserve the already matched file-object id.
+		// Re-upload can hit dedup "existing object" short-circuit and bypass state reset.
+		if getExisting && id != "" {
+			return id, payload, nil
+		}
 		var encryptionKeys map[string]string
 		if sn.Snapshot.Data.FileInfo != nil {
 			encryptionKeys = make(map[string]string, len(sn.Snapshot.Data.FileInfo.EncryptionKeys))

--- a/core/block/import/common/objectid/fileobject_test.go
+++ b/core/block/import/common/objectid/fileobject_test.go
@@ -1,0 +1,68 @@
+package objectid
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/import/common"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/domain/objectorigin"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func TestFileObject_GetIDAndPayload_KeepExistingIDOnReplace(t *testing.T) {
+	sf := objectstore.NewStoreFixture(t)
+	spaceID := "spaceId"
+	oldAnytypeID := "old-file-object-id"
+	existingID := "existing-file-object-id"
+
+	sf.AddObjects(t, spaceID, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:           domain.String(existingID),
+			bundle.RelationKeyOldAnytypeID: domain.String(oldAnytypeID),
+			bundle.RelationKeySpaceId:      domain.String(spaceID),
+			bundle.RelationKeyResolvedLayout: domain.Int64(
+				int64(model.ObjectType_file),
+			),
+		},
+	})
+
+	sn := &common.Snapshot{
+		Id: oldAnytypeID,
+		Snapshot: &common.SnapshotModel{
+			SbType: coresb.SmartBlockTypeFileObject,
+			Data: &common.StateSnapshot{
+				Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+					bundle.RelationKeyId:           domain.String(oldAnytypeID),
+					bundle.RelationKeyOldAnytypeID: domain.String(oldAnytypeID),
+					bundle.RelationKeySource:       domain.String("/tmp/backup-file.png"),
+				}),
+			},
+		},
+	}
+
+	f := &fileObject{
+		treeObject:   newTreeObject(newExistingObject(sf), nil),
+		blockService: nil,
+	}
+
+	gotID, _, err := f.GetIDAndPayload(
+		context.Background(),
+		spaceID,
+		sn,
+		time.Now(),
+		true,
+		objectorigin.Import(model.Import_Pb),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, existingID, gotID)
+}
+


### PR DESCRIPTION
### Description

During replace/update-existing import, three issues caused incorrect object targeting and metadata loss:

1. ID resolution matched imported clones via OldAnytypeID instead of the original object. Prioritize direct object-ID lookup when getExisting is true to ensure in-place replace targets the correct object.

2. File object re-upload could hit dedup and return a different file-object ID, bypassing state reset on the matched existing object. Short-circuit when the existing ID is already resolved.

3. Archive/unarchive and file sync side-effects bump lastModifiedDate. Restore the snapshot's original timestamp after these operations. Also restore legacy file details (name, dates, creator) for both SmartBlockTypeFile snapshots and existing SmartBlockTypeFileObject objects during replace import.

Remove SmartBlockTypeFileObject from canUpdateObject exclusion list so file objects participate in resetState during replace. Change setArchived to bidirectional (archive and unarchive) and return whether an unarchive occurred for timestamp restoration.


Note: this PR changes some of the same files as two other PRs.

Recommended merge order to minimize rebase effort:

1. https://github.com/anyproto/anytype-heart/pull/2955
2. https://github.com/anyproto/anytype-heart/pull/2956
3. This one

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---


### What type of PR is this? (check all applicable)

- [X] 🐛 Bug Fix
- [X] ✅ Test

### Added tests?

- [X] 👍 yes

### [optional] Are there any post-deployment tasks we need to perform?

See note above about merge order
