### PR TITLE
GO-6812 Add description on note conversion

### DIFF
--- a/core/block/editor/converter/layout.go
+++ b/core/block/editor/converter/layout.go
@@ -291,7 +291,11 @@ func (c *layoutConverter) fromAnyToCollection(st *state.State) error {
 }
 
 func (c *layoutConverter) fromNoteToAny(st *state.State) error {
-	template.InitTemplate(st, template.WithNameFromFirstBlock)
+	templates := []template.StateTransformer{template.WithNameFromFirstBlock}
+	if st.Details().GetString(bundle.RelationKeyDescription) != "" {
+		templates = append(templates, template.WithDescription)
+	}
+	template.InitTemplate(st, templates...)
 	return nil
 }
 

--- a/core/block/editor/smartblock/detailsinject.go
+++ b/core/block/editor/smartblock/detailsinject.go
@@ -322,7 +322,11 @@ func convertLayoutBlocks(st *state.State, oldLayout, newLayout domain.Value) {
 			return
 		}
 		log.With("objectId", st.RootId()).Infof("convert layout: %s -> %s", oldLayout, newLayout)
-		template.InitTemplate(st, template.WithNameFromFirstBlock, template.WithTitle)
+		templates := []template.StateTransformer{template.WithNameFromFirstBlock, template.WithTitle}
+		if st.Details().GetString(bundle.RelationKeyDescription) != "" {
+			templates = append(templates, template.WithDescription)
+		}
+		template.InitTemplate(st, templates...)
 	} else if newLayout.Int64() == int64(model.ObjectType_note) {
 		if !st.Exists(state.TitleBlockID) {
 			return

--- a/core/block/editor/smartblock/detailsinject_test.go
+++ b/core/block/editor/smartblock/detailsinject_test.go
@@ -288,7 +288,7 @@ func TestInjectLinksDetails_filterOutRelations(t *testing.T) {
 		fx := newFixture(id, t)
 
 		st := state.NewDoc(id, map[string]simple.Block{
-			id:     simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
+			id:      simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
 			"link1": simple.New(&model.Block{Id: "link1", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj1"}}}),
 			"link2": simple.New(&model.Block{Id: "link2", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "iconImageId"}}}),
 		}).NewState()
@@ -308,7 +308,7 @@ func TestInjectLinksDetails_filterOutRelations(t *testing.T) {
 		fx := newFixture(id, t)
 
 		st := state.NewDoc(id, map[string]simple.Block{
-			id:     simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
+			id:      simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
 			"link1": simple.New(&model.Block{Id: "link1", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj1"}}}),
 			"link2": simple.New(&model.Block{Id: "link2", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "pictureId"}}}),
 		}).NewState()
@@ -328,7 +328,7 @@ func TestInjectLinksDetails_filterOutRelations(t *testing.T) {
 		fx := newFixture(id, t)
 
 		st := state.NewDoc(id, map[string]simple.Block{
-			id:     simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
+			id:      simple.New(&model.Block{Id: id, ChildrenIds: []string{"link1", "link2"}}),
 			"link1": simple.New(&model.Block{Id: "link1", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj1"}}}),
 			"link2": simple.New(&model.Block{Id: "link2", Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "obj2"}}}),
 		}).NewState()
@@ -471,6 +471,34 @@ func TestResolveLayout(t *testing.T) {
 		assert.Equal(t, int64(model.ObjectType_todo), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
 		assert.Equal(t, "First note block", st.Details().GetString(bundle.RelationKeyName))
 		assert.NotNil(t, st.Pick(state.TitleBlockID))
+	})
+	t.Run("conversion from note adds Description if it is not empty", func(t *testing.T) {
+		// given
+		fx := newFixture(id, t)
+
+		st := state.NewDoc("id", map[string]simple.Block{
+			"id":   simple.New(&model.Block{Id: id, ChildrenIds: []string{state.HeaderLayoutID, "text"}}),
+			"text": simple.New(&model.Block{Id: "text", Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: "First note block"}}}),
+		}).NewState()
+		st.SetLocalDetail(bundle.RelationKeyType, domain.String(bundle.TypeKeyTask.URL()))
+		st.SetLocalDetail(bundle.RelationKeyResolvedLayout, domain.Int64(model.ObjectType_note))
+		st.SetDetail(bundle.RelationKeyDescription, domain.String("description"))
+
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{{
+			bundle.RelationKeyId:                domain.String(bundle.TypeKeyTask.URL()),
+			bundle.RelationKeyRecommendedLayout: domain.Int64(model.ObjectType_todo),
+		}})
+
+		// when
+		fx.resolveLayout(st)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_todo), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
+		assert.Equal(t, "First note block", st.Details().GetString(bundle.RelationKeyName))
+		assert.NotNil(t, st.Pick(state.TitleBlockID))
+		assert.NotNil(t, st.Pick(state.DescriptionBlockID))
+		require.True(t, st.Details().Has(bundle.RelationKeyFeaturedRelations))
+		assert.Contains(t, st.Details().GetStringList(bundle.RelationKeyFeaturedRelations), "description")
 	})
 	t.Run("conversion from note works on sb.Init", func(t *testing.T) {
 		// given


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6812/objects-of-custom-type-no-longer-show-description

Add description block on Note->NotNote conversion