### PR TITLE
GO-6415 Skip unnecessary IPFS block preloading during CFB SeekEnd

### DIFF
--- a/.run/Run.run.xml
+++ b/.run/Run.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Run" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="anytype-heart" />
     <working_directory value="$PROJECT_DIR$" />
-    <go_parameters value="-tags &quot;nomutexdeadlockdetector noauth nographviz appdebug&quot;" />
+    <go_parameters value="-tags &quot;nomutexdeadlockdetector noauth nographviz appdebug anydebug&quot;" />
     <envs>
       <env name="ANYDEBUG" value=":6061" />
       <env name="ANYPROF" value=":6060" />

--- a/pkg/lib/crypto/symmetric/cfb/cfb.go
+++ b/pkg/lib/crypto/symmetric/cfb/cfb.go
@@ -75,6 +75,18 @@ func (d *CFBDecryptor) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		if sizable, ok := cipherTextReader.(Sizable); ok {
 			newoffset = int64(sizable.Size()) + offset
+			if newoffset < 0 || newoffset > int64(sizable.Size()) {
+				return 0, fmt.Errorf("offset out of range")
+			}
+			if offset == 0 {
+				// Fast path for size queries: return file size without seeking the
+				// underlying reader. This avoids expensive IPFS block preloading
+				// (~10MB) that would be immediately discarded. http.ServeContent
+				// calls Seek(0, SeekEnd) to determine size, then always does
+				// Seek(start, SeekStart) before reading, which sets up cipher state.
+				d.currOffset = newoffset
+				return newoffset, nil
+			}
 		} else {
 			var err error
 			newoffset, err = cipherTextReader.Seek(offset, whence)

--- a/pkg/lib/crypto/symmetric/cfb/cfb_test.go
+++ b/pkg/lib/crypto/symmetric/cfb/cfb_test.go
@@ -8,10 +8,35 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/pkg/lib/crypto/symmetric"
 )
+
+// sizableReader wraps bytes.Reader and adds the Sizable interface.
+// It tracks whether Seek was called on the underlying reader.
+type sizableReader struct {
+	*bytes.Reader
+	size      uint64
+	seekCount int
+}
+
+func newSizableReader(data []byte) *sizableReader {
+	return &sizableReader{
+		Reader: bytes.NewReader(data),
+		size:   uint64(len(data)),
+	}
+}
+
+func (s *sizableReader) Size() uint64 {
+	return s.size
+}
+
+func (s *sizableReader) Seek(offset int64, whence int) (int64, error) {
+	s.seekCount++
+	return s.Reader.Seek(offset, whence)
+}
 
 var symmetricTestData = struct {
 	key        symmetric.Key
@@ -162,5 +187,122 @@ func TestDecryptReader(t *testing.T) {
 				})
 		}
 
+	})
+}
+
+func TestSeekEndSizableFastPath(t *testing.T) {
+	// Set up encryption
+	key, err := symmetric.NewRandom()
+	require.NoError(t, err)
+	iv := [aes.BlockSize]byte{}
+
+	plaintext := bytes.Repeat([]byte("abcdefghijklmnop"), 100) // 1600 bytes
+	enc := New(key, iv)
+
+	ciphertextReader, err := enc.EncryptReader(bytes.NewReader(plaintext))
+	require.NoError(t, err)
+	ciphertext, err := ioutil.ReadAll(ciphertextReader)
+	require.NoError(t, err)
+
+	t.Run("SeekEnd does not seek underlying sizable reader", func(t *testing.T) {
+		sr := newSizableReader(ciphertext)
+		dec, err := New(key, iv).DecryptReader(sr)
+		require.NoError(t, err)
+
+		sr.seekCount = 0
+
+		// Seek(0, SeekEnd) should return size without seeking underlying reader
+		pos, err := dec.Seek(0, io.SeekEnd)
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(ciphertext)), pos)
+		assert.Equal(t, 0, sr.seekCount, "Seek(0, SeekEnd) should not seek underlying sizable reader")
+	})
+
+	t.Run("SeekEnd then SeekStart then Read produces correct data", func(t *testing.T) {
+		// This simulates what http.ServeContent does:
+		// 1. Seek(0, SeekEnd) to get size
+		// 2. Seek(0, SeekStart) to reset
+		// 3. Read the data
+		sr := newSizableReader(ciphertext)
+		dec, err := New(key, iv).DecryptReader(sr)
+		require.NoError(t, err)
+
+		// Step 1: size determination
+		size, err := dec.Seek(0, io.SeekEnd)
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(plaintext)), size)
+
+		// Step 2: reset to start
+		pos, err := dec.Seek(0, io.SeekStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), pos)
+
+		// Step 3: read all
+		got, err := ioutil.ReadAll(dec)
+		require.NoError(t, err)
+		assert.Equal(t, plaintext, got)
+	})
+
+	t.Run("SeekEnd then range seek then Read produces correct data", func(t *testing.T) {
+		// Simulates http.ServeContent with Range header:
+		// 1. Seek(0, SeekEnd) to get size
+		// 2. Seek(rangeStart, SeekStart) to position
+		// 3. Read the range
+		sr := newSizableReader(ciphertext)
+		dec, err := New(key, iv).DecryptReader(sr)
+		require.NoError(t, err)
+
+		// Step 1: size determination
+		size, err := dec.Seek(0, io.SeekEnd)
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(plaintext)), size)
+
+		// Step 2: seek to mid-file range
+		rangeStart := int64(100)
+		pos, err := dec.Seek(rangeStart, io.SeekStart)
+		require.NoError(t, err)
+		assert.Equal(t, rangeStart, pos)
+
+		// Step 3: read range
+		rangeLen := 200
+		buf := make([]byte, rangeLen)
+		n, err := io.ReadFull(dec, buf)
+		require.NoError(t, err)
+		assert.Equal(t, rangeLen, n)
+		assert.Equal(t, plaintext[rangeStart:rangeStart+int64(rangeLen)], buf)
+	})
+
+	t.Run("SeekEnd with negative offset seeks underlying reader", func(t *testing.T) {
+		sr := newSizableReader(ciphertext)
+		dec, err := New(key, iv).DecryptReader(sr)
+		require.NoError(t, err)
+
+		sr.seekCount = 0
+
+		// Non-zero offset must go through the full cipher setup path
+		// so that Read after Seek produces correct data
+		pos, err := dec.Seek(-16, io.SeekEnd)
+		require.NoError(t, err)
+		assert.Equal(t, int64(len(ciphertext))-16, pos)
+		assert.Greater(t, sr.seekCount, 0, "Seek(-16, SeekEnd) should seek underlying reader to set up cipher state")
+
+		// Verify reading produces correct plaintext
+		buf := make([]byte, 16)
+		n, err := io.ReadFull(dec, buf)
+		require.NoError(t, err)
+		assert.Equal(t, 16, n)
+		assert.Equal(t, plaintext[len(plaintext)-16:], buf)
+	})
+
+	t.Run("SeekEnd out of range returns error", func(t *testing.T) {
+		sr := newSizableReader(ciphertext)
+		dec, err := New(key, iv).DecryptReader(sr)
+		require.NoError(t, err)
+
+		_, err = dec.Seek(1, io.SeekEnd)
+		assert.Error(t, err)
+
+		_, err = dec.Seek(-int64(len(ciphertext))-1, io.SeekEnd)
+		assert.Error(t, err)
 	})
 }

--- a/pkg/lib/gateway/gateway.go
+++ b/pkg/lib/gateway/gateway.go
@@ -252,8 +252,8 @@ func (g *gateway) fileHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", meta.Name))
 	w.Header().Set("Cache-Control", "max-age=31536000")
 
-	// todo: inside textile it still requires the file to be fully downloaded and decrypted(consuming 2xSize in ram) to provide the ReadSeeker interface
-	// 	need to find a way to use ReadSeeker all the way from downloading files from IPFS to writing the decrypted chunk to the HTTP
+	// Note: the DagReader is lazy and streams ~1MB blocks on demand. The CFBDecryptor.Seek
+	// fast-path avoids expensive IPFS block preloading during size determination (SeekEnd).
 	http.ServeContent(w, r, meta.Name, meta.Added, reader)
 }
 


### PR DESCRIPTION
## Summary

- Skip expensive IPFS DagReader seek during `Seek(0, SeekEnd)` size queries in the CFB decryptor
- When the underlying reader implements `Sizable`, return the precomputed file size without seeking the underlying reader, avoiding ~10MB of unnecessary IPFS block preloading per HTTP range request
- Add `anydebug` build tag to default run configuration

## Context

When iOS plays a ~250MB video via the gateway, `http.ServeContent` calls `Seek(0, SeekEnd)` on every range request to determine file size. The CFB decryptor was seeking the DagReader near the end of the file to read a 16-byte IV for cipher state setup — triggering IPFS `FetchChild` preloading of ~10 leaf blocks (~10MB). This cipher state was immediately discarded by the subsequent `Seek(start, SeekStart)` before any `Read`.

With up to 32 concurrent range requests, this caused ~320MB of wasted memory — enough to crash an iPhone 13 mini.

## Test plan

- [x] Existing CFB seek tests pass (all 24 cases including SeekEnd with non-zero offsets)
- [x] New `TestSeekEndSizableFastPath` tests verify:
  - `Seek(0, SeekEnd)` returns correct size without seeking underlying reader
  - `Seek(0, SeekEnd)` + `Seek(0, SeekStart)` + `Read` produces correct data
  - `Seek(0, SeekEnd)` + `Seek(rangeStart, SeekStart)` + `Read` produces correct range data
  - `Seek(-n, SeekEnd)` still goes through full cipher setup path
  - Out-of-range offsets return errors
- [x] Gateway tests pass
- [x] `go build ./core/...` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)