### PR TITLE
GO-6789 Save all cids on image upload

### DIFF
--- a/core/files/filesync/fileinfo.go
+++ b/core/files/filesync/fileinfo.go
@@ -83,6 +83,7 @@ func marshalFileInfo(arena *anyenc.Arena, info FileInfo) *anyenc.Value {
 	var i int
 	for c := range info.CidsToUpload {
 		cidsToUpload.SetArrayItem(i, arena.NewString(c.String()))
+		i++
 	}
 	obj.Set("cidsToUpload", cidsToUpload)
 
@@ -90,6 +91,7 @@ func marshalFileInfo(arena *anyenc.Arena, info FileInfo) *anyenc.Value {
 	i = 0
 	for c := range info.CidsToBind {
 		cidsToBind.SetArrayItem(i, arena.NewString(c.String()))
+		i++
 	}
 	obj.Set("cidsToBind", cidsToBind)
 	return obj

--- a/core/files/filesync/fileinfo_test.go
+++ b/core/files/filesync/fileinfo_test.go
@@ -28,6 +28,8 @@ func TestMarshalUnmarshal(t *testing.T) {
 func givenFileInfo() FileInfo {
 
 	testFileId := domain.FileId("bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")
+	testCid2 := cid.MustParse("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+	testCid3 := cid.MustParse("bafybeie5gq4jxvzmsym6hjlwxej4rwdoxt7wadqvmmwbqi7r27irfvnfza")
 
 	return FileInfo{
 		FileId:              testFileId,
@@ -41,9 +43,13 @@ func givenFileInfo() FileInfo {
 		BytesToUploadOrBind: 123,
 		CidsToBind: map[cid.Cid]struct{}{
 			cid.MustParse(testFileId.String()): {},
+			testCid2:                           {},
+			testCid3:                           {},
 		},
 		CidsToUpload: map[cid.Cid]struct{}{
 			cid.MustParse(testFileId.String()): {},
+			testCid2:                           {},
+			testCid3:                           {},
 		},
 	}
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6789/profile-images-uploaded-to-ios-are-not-displayed-on-the-desktop

On file marshalling while saving to queue on file syncing we used to iterate over CIDs of file blocks, but saved only last one to anystore