### PR TITLE
GO-6925 Fix repeated setDetails Null changes bloating spaceview trees

### DIFF
--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -258,11 +258,7 @@ func (s *State) changeBlockDetailsSet(set *pb.ChangeDetailsSet) error {
 	if s.details == nil {
 		s.details = det.Copy()
 	}
-	if set.Value != nil {
-		s.details.SetProtoValue(domain.RelationKey(set.Key), set.Value)
-	} else {
-		s.details.Delete(domain.RelationKey(set.Key))
-	}
+	s.details.SetProtoValue(domain.RelationKey(set.Key), set.Value)
 	return nil
 }
 

--- a/core/block/editor/state/details_test.go
+++ b/core/block/editor/state/details_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/relationutils/mock_relationutils"
+	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
@@ -204,5 +205,77 @@ func TestState_AllRelationKeys(t *testing.T) {
 
 		// then
 		assert.Len(t, keys, 5)
+	})
+}
+
+func TestState_ApplyNullDetailDoesNotGenerateDuplicateChange(t *testing.T) {
+	t.Run("apply detailsSet with nil proto value then SetDetail with Null should not produce change", func(t *testing.T) {
+		// given
+		// Simulate building state from changes: change sets iconOption to null (nil *types.Value in proto)
+		doc := NewDoc("root", nil).(*State)
+		doc.details = domain.NewDetails()
+		doc.details.Set("iconOption", domain.Int64(1))
+
+		// Apply a change that sets iconOption to null (nil proto value, as seen in the tree)
+		err := doc.ApplyChange(&pb.ChangeContent{
+			Value: &pb.ChangeContentValueOfDetailsSet{
+				DetailsSet: &pb.ChangeDetailsSet{
+					Key:   "iconOption",
+					Value: nil, // null in proto/JSON
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// After applying the change, iconOption should still be present as Null, not deleted
+		assert.True(t, doc.Details().Has("iconOption"), "iconOption should still be present in details after applying null change")
+		assert.True(t, doc.Details().Get("iconOption").IsNull(), "iconOption should be Null value")
+
+		// Now simulate what happens on startup: SetDetail is called with domain.Null()
+		s := doc.NewState()
+		s.SetDetail("iconOption", domain.Null())
+
+		// This should NOT produce any changes because the value is already Null
+		msgs, _, err := ApplyState("space1", s, false)
+		require.NoError(t, err)
+		assert.Empty(t, msgs, "setting Null on already-Null detail should not produce events")
+		assert.Empty(t, s.GetChanges(), "setting Null on already-Null detail should not produce changes")
+	})
+
+	t.Run("repeated null changes should not generate duplicate detailsSet", func(t *testing.T) {
+		// given
+		// Build state from a sequence of changes like seen in the bug report:
+		// change 608: detailsSet iconOption=null
+		// change 609: detailsSet iconOption=null (duplicate!)
+		doc := NewDoc("root", nil).(*State)
+		doc.details = domain.NewDetails()
+		doc.details.Set("iconOption", domain.Int64(5))
+
+		// First null change
+		err := doc.ApplyChange(&pb.ChangeContent{
+			Value: &pb.ChangeContentValueOfDetailsSet{
+				DetailsSet: &pb.ChangeDetailsSet{
+					Key:   "iconOption",
+					Value: nil,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// After first null change, SetDetail with Null should be a no-op
+		s := doc.NewState()
+		s.SetDetail("iconOption", domain.Null())
+
+		msgs, _, err := ApplyState("space1", s, false)
+		require.NoError(t, err)
+		assert.Empty(t, msgs, "first SetDetail(Null) after null change should not produce events")
+
+		// And again — still should be a no-op
+		s2 := doc.NewState()
+		s2.SetDetail("iconOption", domain.Null())
+
+		msgs, _, err = ApplyState("space1", s2, false)
+		require.NoError(t, err)
+		assert.Empty(t, msgs, "second SetDetail(Null) should not produce events")
 	})
 }

--- a/core/block/editor/state/state_test.go
+++ b/core/block/editor/state/state_test.go
@@ -2127,7 +2127,10 @@ func TestState_ApplyChangeIgnoreErrDetailsSet(t *testing.T) {
 		st.ApplyChangeIgnoreErr(change)
 
 		// then
-		assert.False(t, st.Details().Has("relationKey"))
+		// nil proto value is stored as domain.Null(), not deleted, to avoid
+		// generating duplicate changes on subsequent SetDetail(Null) calls
+		assert.True(t, st.Details().Has("relationKey"))
+		assert.True(t, st.Details().Get("relationKey").IsNull())
 	})
 }
 


### PR DESCRIPTION
## Summary
- Fixed a bug where `changeBlockDetailsSet` deleted keys on nil proto values instead of storing `domain.Null()`, causing an infinite cycle of duplicate `detailsSet` changes in one-to-one spaceview trees
- Added tests verifying null changes don't produce duplicates

## Test plan
- [x] All `core/block/editor/state` tests pass