### PR TITLE
GO-6570: Fix unread counters

### DIFF
--- a/core/block/chats/chatsubscription/manager.go
+++ b/core/block/chats/chatsubscription/manager.go
@@ -2,6 +2,7 @@ package chatsubscription
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 
@@ -135,16 +136,24 @@ func (s *subscriptionManager) ForceSendingChatState() {
 	s.chatStateUpdated = true
 }
 
-func (s *subscriptionManager) GetLastMessage() (*model.ChatMessage, bool) {
+func (s *subscriptionManager) GetLastMessage() (*model.ChatMessage, bool, error) {
 	// get the last message from any subscription. It works because we don't have offsets for subscriptions, so
 	// it's guaranteed for the last message in a subscription to be the last message in a set of all messages.
 	for _, sub := range s.subscriptions {
 		last := sub.state.messages.Back()
 		if last != nil {
-			return last.Value.(*stateEntry).msg, true
+			return proto.Clone(last.Value.(*stateEntry).msg).(*model.ChatMessage), true, nil
 		}
 	}
-	return nil, false
+
+	msgs, err := s.repository.GetLastMessages(s.componentCtx, 1)
+	if err != nil {
+		return nil, false, fmt.Errorf("get last message from repository: %w", err)
+	}
+	if len(msgs) > 0 {
+		return msgs[0].ChatMessage, true, nil
+	}
+	return nil, false, nil
 }
 
 // Flush is called after committing changes. If reloadStateIfNeeded is true and s.needReloadState is true, it reloads state

--- a/core/block/chats/chatsubscription/manager_test.go
+++ b/core/block/chats/chatsubscription/manager_test.go
@@ -419,27 +419,39 @@ func TestGetLastMessage(t *testing.T) {
 	mngr, err := fx.GetManager(testSpaceId, chatId)
 	require.NoError(t, err)
 
-	t.Run("with no subscriptions", func(t *testing.T) {
-		_, ok := mngr.GetLastMessage()
+	t.Run("with no subscriptions and no messages in db", func(t *testing.T) {
+		_, ok, err := mngr.GetLastMessage()
+		require.NoError(t, err)
 		assert.False(t, ok)
 	})
 
+	t.Run("with no subscriptions, fallback to repository", func(t *testing.T) {
+		repo, err := fx.repo.Repository(testSpaceId, chatId)
+		require.NoError(t, err)
+		dbMsg := givenSimpleMessage("dbMsg1", "from db", "o0")
+		err = repo.AddTestMessage(ctx, dbMsg)
+		require.NoError(t, err)
+
+		got, ok, err := mngr.GetLastMessage()
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, dbMsg.Id, got.Id)
+		assert.Equal(t, dbMsg.ChatMessage.Message.Text, got.Message.Text)
+	})
+
+	// Subscribe after messages are already in db — subscription will load them
 	_, err = fx.SubscribeLastMessages(ctx, SubscribeLastMessagesRequest{
 		ChatObjectId: chatId,
 		SubId:        subId,
 	})
 	require.NoError(t, err)
 
-	t.Run("with no messages", func(t *testing.T) {
-		_, ok := mngr.GetLastMessage()
-		assert.False(t, ok)
-	})
-
 	msg := givenComplexMessage("msg1", "text", "o1")
 	mngr.Add("", msg)
 
 	t.Run("with only one message", func(t *testing.T) {
-		got, ok := mngr.GetLastMessage()
+		got, ok, err := mngr.GetLastMessage()
+		require.NoError(t, err)
 		assert.True(t, ok)
 		assert.Equal(t, msg.ChatMessage, got)
 	})
@@ -448,7 +460,8 @@ func TestGetLastMessage(t *testing.T) {
 	mngr.Add("o1", msg2)
 
 	t.Run("with multiple messages", func(t *testing.T) {
-		got, ok := mngr.GetLastMessage()
+		got, ok, err := mngr.GetLastMessage()
+		require.NoError(t, err)
 		assert.True(t, ok)
 		assert.Equal(t, msg2.ChatMessage, got)
 	})

--- a/core/block/chats/chatsubscription/mock_chatsubscription/mock_Manager.go
+++ b/core/block/chats/chatsubscription/mock_chatsubscription/mock_Manager.go
@@ -205,7 +205,7 @@ func (_c *MockManager_GetChatState_Call) RunAndReturn(run func() *model.ChatStat
 }
 
 // GetLastMessage provides a mock function with given fields:
-func (_m *MockManager) GetLastMessage() (*model.ChatMessage, bool) {
+func (_m *MockManager) GetLastMessage() (*model.ChatMessage, bool, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
@@ -214,7 +214,8 @@ func (_m *MockManager) GetLastMessage() (*model.ChatMessage, bool) {
 
 	var r0 *model.ChatMessage
 	var r1 bool
-	if rf, ok := ret.Get(0).(func() (*model.ChatMessage, bool)); ok {
+	var r2 error
+	if rf, ok := ret.Get(0).(func() (*model.ChatMessage, bool, error)); ok {
 		return rf()
 	}
 	if rf, ok := ret.Get(0).(func() *model.ChatMessage); ok {
@@ -231,7 +232,13 @@ func (_m *MockManager) GetLastMessage() (*model.ChatMessage, bool) {
 		r1 = ret.Get(1).(bool)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func() error); ok {
+		r2 = rf()
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // MockManager_GetLastMessage_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLastMessage'
@@ -251,12 +258,12 @@ func (_c *MockManager_GetLastMessage_Call) Run(run func()) *MockManager_GetLastM
 	return _c
 }
 
-func (_c *MockManager_GetLastMessage_Call) Return(_a0 *model.ChatMessage, _a1 bool) *MockManager_GetLastMessage_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockManager_GetLastMessage_Call) Return(_a0 *model.ChatMessage, _a1 bool, _a2 error) *MockManager_GetLastMessage_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *MockManager_GetLastMessage_Call) RunAndReturn(run func() (*model.ChatMessage, bool)) *MockManager_GetLastMessage_Call {
+func (_c *MockManager_GetLastMessage_Call) RunAndReturn(run func() (*model.ChatMessage, bool, error)) *MockManager_GetLastMessage_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/block/chats/chatsubscription/service.go
+++ b/core/block/chats/chatsubscription/service.go
@@ -51,7 +51,7 @@ type Manager interface {
 
 	IsActive() bool
 	GetChatState() *model.ChatState
-	GetLastMessage() (*model.ChatMessage, bool)
+	GetLastMessage() (*model.ChatMessage, bool, error)
 	SetSessionContext(ctx session.Context)
 	UpdateReactions(message *chatmodel.Message)
 	UpdatePinned(message *chatmodel.Message)

--- a/core/block/editor/chatobject/chatobject.go
+++ b/core/block/editor/chatobject/chatobject.go
@@ -278,7 +278,31 @@ func (s *storeObject) Init(ctx *smartblock.InitContext) error {
 	s.seenHeadsCollector = newTreeSeenHeadsCollector(s.Tree())
 	s.statService.AddProvider(s)
 
+	s.onInit(ctx)
+
 	return nil
+}
+
+func (s *storeObject) onInit(ctx *smartblock.InitContext) {
+	s.subscription.Lock()
+	defer s.subscription.Unlock()
+
+	s.subscription.Flush(true)
+
+	last, ok := s.subscription.GetLastMessage()
+	if !ok {
+		msgs, err := s.repository.GetLastMessages(s.componentCtx, 1)
+		if err != nil {
+			log.Error("onUpdate: get last message", zap.Error(err))
+		}
+		if len(msgs) > 0 {
+			last = msgs[0].ChatMessage
+		}
+	}
+
+	if last != nil {
+		ctx.State.SetDetailAndBundledRelation(bundle.RelationKeyLastMessageDate, domain.Int64(last.CreatedAt))
+	}
 }
 
 func (s *storeObject) onUpdate() {

--- a/core/block/editor/chatobject/chatobject.go
+++ b/core/block/editor/chatobject/chatobject.go
@@ -287,20 +287,15 @@ func (s *storeObject) onInit(ctx *smartblock.InitContext) {
 	s.subscription.Lock()
 	defer s.subscription.Unlock()
 
+	// It's important to flush updates to subscriptions after reading a store document, or we can lose some important
+	// updates such as unread counters state
 	s.subscription.Flush(true)
 
-	last, ok := s.subscription.GetLastMessage()
-	if !ok {
-		msgs, err := s.repository.GetLastMessages(s.componentCtx, 1)
-		if err != nil {
-			log.Error("onUpdate: get last message", zap.Error(err))
-		}
-		if len(msgs) > 0 {
-			last = msgs[0].ChatMessage
-		}
+	last, ok, err := s.subscription.GetLastMessage()
+	if err != nil {
+		log.Error("onInit: get last message", zap.Error(err))
 	}
-
-	if last != nil {
+	if ok && last != nil {
 		ctx.State.SetDetailAndBundledRelation(bundle.RelationKeyLastMessageDate, domain.Int64(last.CreatedAt))
 	}
 }
@@ -316,18 +311,11 @@ func (s *storeObject) onUpdate() {
 
 	s.subscription.Flush(true)
 
-	last, ok := s.subscription.GetLastMessage()
-	if !ok {
-		msgs, err := s.repository.GetLastMessages(s.componentCtx, 1)
-		if err != nil {
-			log.Error("onUpdate: get last message", zap.Error(err))
-		}
-		if len(msgs) > 0 {
-			last = msgs[0].ChatMessage
-		}
+	last, ok, err := s.subscription.GetLastMessage()
+	if err != nil {
+		log.Error("onUpdate: get last message", zap.Error(err))
 	}
-
-	if last != nil {
+	if ok && last != nil {
 		st := s.NewState()
 		st.SetDetailAndBundledRelation(bundle.RelationKeyLastMessageDate, domain.Int64(last.CreatedAt))
 		err = s.Apply(st, smartblock.NotPushChanges)


### PR DESCRIPTION
## Summary
- Moved repository fallback logic for `GetLastMessage` from `chatobject.go` into `subscriptionManager`, eliminating duplicate code in both `onInit` and `onUpdate`
- Changed `Manager.GetLastMessage()` signature to return an error, enabling proper error propagation
- Clone the message returned from subscription memory to avoid exposing internal state
- Fixed copy-paste bug where `onInit` logged `"onUpdate"` in error messages
- Added flush comment explaining why flush is needed after reading store doc

## Test plan
- [x] `go test ./core/block/chats/chatsubscription/...` passes
- [x] `go test ./core/block/editor/chatobject/...` passes
- [x] Added test case for repository fallback when no active subscriptions exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)