### PR TITLE
GO-6736 Fix objectSetType change diff generating redundant adds

### DIFF
--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -780,6 +780,9 @@ func (s *State) makeObjectTypesChanges() (ch []*pb.ChangeContent) {
 	}
 
 	var prevMap = make(map[domain.TypeKey]struct{}, len(prev))
+	for _, v := range prev {
+		prevMap[v] = struct{}{}
+	}
 	var curMap = make(map[domain.TypeKey]struct{}, len(s.objectTypeKeys))
 
 	for _, v := range s.objectTypeKeys {

--- a/core/block/editor/state/change_test.go
+++ b/core/block/editor/state/change_test.go
@@ -1004,3 +1004,58 @@ func TestTableChanges(t *testing.T) {
 
 	})
 }
+
+func TestMakeObjectTypesChanges(t *testing.T) {
+	t.Run("no changes when types are the same", func(t *testing.T) {
+		// given
+		parent := &State{
+			objectTypeKeys: []domain.TypeKey{"ot-page", "ot-note"},
+		}
+		child := &State{
+			parent:         parent,
+			objectTypeKeys: []domain.TypeKey{"ot-page", "ot-note"},
+		}
+
+		// when
+		ch := child.makeObjectTypesChanges()
+
+		// then
+		assert.Empty(t, ch)
+	})
+	t.Run("add generates only ObjectTypeAdd for new type", func(t *testing.T) {
+		// given
+		parent := &State{
+			objectTypeKeys: []domain.TypeKey{"ot-page"},
+		}
+		child := &State{
+			parent:         parent,
+			objectTypeKeys: []domain.TypeKey{"ot-page", "ot-note"},
+		}
+
+		// when
+		ch := child.makeObjectTypesChanges()
+
+		// then
+		require.Len(t, ch, 1)
+		add := ch[0].GetValue().(*pb.ChangeContentValueOfObjectTypeAdd)
+		assert.Equal(t, domain.TypeKey("ot-note").URL(), add.ObjectTypeAdd.Url)
+	})
+	t.Run("remove generates only ObjectTypeRemove for removed type", func(t *testing.T) {
+		// given
+		parent := &State{
+			objectTypeKeys: []domain.TypeKey{"ot-page", "ot-note"},
+		}
+		child := &State{
+			parent:         parent,
+			objectTypeKeys: []domain.TypeKey{"ot-page"},
+		}
+
+		// when
+		ch := child.makeObjectTypesChanges()
+
+		// then
+		require.Len(t, ch, 1)
+		remove := ch[0].GetValue().(*pb.ChangeContentValueOfObjectTypeRemove)
+		assert.Equal(t, domain.TypeKey("ot-note").URL(), remove.ObjectTypeRemove.Url)
+	})
+}


### PR DESCRIPTION
## Summary
- Populate `prevMap` in `makeObjectTypesChanges()` — it was created but never filled, causing every current object type to be treated as newly added
- This produced redundant `ObjectTypeAdd` changes on every state apply, even when types hadn't changed

## Test plan
- [x] Added `TestMakeObjectTypesChanges` with 3 sub-tests: no changes when types match, only add for new type, only remove for removed type
- [x] All tests pass: `go test ./core/block/editor/state/... -run TestMakeObjectTypesChanges`

🤖 Generated with [Claude Code](https://claude.com/claude-code)