### PR TITLE
GO-6955 Rephrase space not ready error for local-only mode

### DIFF
--- a/core/workspace.go
+++ b/core/workspace.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gogo/protobuf/types"
 
 	"github.com/anyproto/anytype-heart/core/anytype/account"
+	"github.com/anyproto/anytype-heart/core/anytype/config"
 	"github.com/anyproto/anytype-heart/core/block"
 	"github.com/anyproto/anytype-heart/core/block/cache"
 	"github.com/anyproto/anytype-heart/core/block/detailservice"
@@ -107,6 +108,10 @@ func (mw *Middleware) WorkspaceOpen(cctx context.Context, req *pb.RpcWorkspaceOp
 	info, err := mustService[account.Service](mw).GetSpaceInfo(ctx, req.SpaceId)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
+			cfg := mustService[*config.Config](mw)
+			if cfg.IsLocalOnlyMode() {
+				return response(nil, pb.RpcWorkspaceOpenResponseError_FAILED_TO_LOAD, errors.New("space is not ready: please try again later"))
+			}
 			return response(nil, pb.RpcWorkspaceOpenResponseError_FAILED_TO_LOAD, errors.New("space is not ready: check your internet connection and try again later"))
 		}
 		return response(info, pb.RpcWorkspaceOpenResponseError_UNKNOWN_ERROR, err)


### PR DESCRIPTION
## Summary
- In local-only mode, the "space is not ready" timeout error no longer tells users to "check your internet connection" since network connectivity is irrelevant
- Local-only mode now shows: "space is not ready: please try again later"
- Network mode keeps the existing message unchanged

## Test plan
- [ ] Open a space in local-only mode when space loading times out — verify error says "space is not ready: please try again later"
- [ ] Open a space in default network mode when space loading times out — verify error still says "space is not ready: check your internet connection and try again later"

🤖 Generated with [Claude Code](https://claude.com/claude-code)