### PR TITLE
GO-6879 Downgrade spammy relation format log to Debug

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1489,7 +1489,7 @@ func (sb *smartBlock) collectLinksFromRelations(st *state.State, objectId string
 		}
 		format, err := sb.formatFetcher.GetRelationFormatByKey(sb.SpaceID(), key)
 		if err != nil {
-			log.Warnf("failed to get relation format for key %s: %v", key, err)
+			log.Debugf("failed to get relation format for key %s: %v", key, err)
 			format = guessRelationFormatFromValue(val)
 		}
 


### PR DESCRIPTION
## Summary
- Downgrade the "failed to get relation format for key" log message from `Warnf` to `Debugf` in `collectLinksFromRelations`
- This message fires very frequently during object indexing for custom (user-created) relations that may not be available in the local subscription yet (e.g., during sync)
- The code already has a graceful fallback via `guessRelationFormatFromValue()`, so this is informational, not a warning

## Test plan
- [x] `go build ./core/...` passes
- [x] `go test ./core/block/editor/smartblock/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)