### PR TITLE
GO-6615 Fix paste to toggled block

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -1245,7 +1245,7 @@ func TestPasteIntoEmptyStyledBlock(t *testing.T) {
 
 			// when
 			cb := newFixture(t, sb)
-			_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			blockIds, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
 				FocusedBlockId:    "1",
 				SelectedTextRange: &model.Range{From: 0, To: 0},
 				AnySlot:           tc.pasteBlocks,
@@ -1253,10 +1253,21 @@ func TestPasteIntoEmptyStyledBlock(t *testing.T) {
 
 			// then
 			require.NoError(t, err)
-			b := sb.Doc.Pick("1")
-			require.NotNil(t, b, "target block should not be deleted")
-			assert.Equal(t, tc.style, b.Model().GetText().Style, "target block style should be preserved")
-			assert.Equal(t, tc.pasteBlocks[0].GetText().Text, b.Model().GetText().Text, "first paste text should be merged into target")
+			targetBlock := sb.Doc.Pick("1")
+			require.NotNil(t, targetBlock, "target block should not be deleted")
+			assert.Equal(t, tc.style, targetBlock.Model().GetText().Style, "target block style should be preserved")
+			
+			// For multi-block paste: target stays empty, blocks inserted separately
+			// For single-block paste: text merges into target (intoBlock mode)
+			if len(tc.pasteBlocks) > 1 {
+				assert.Equal(t, "", targetBlock.Model().GetText().Text, "target block should remain empty for multi-block paste")
+				require.NotEmpty(t, blockIds, "pasted blocks should be inserted")
+				firstPasteBlock := sb.Doc.Pick(blockIds[0])
+				require.NotNil(t, firstPasteBlock, "first paste block should exist in state")
+				assert.Equal(t, tc.pasteBlocks[0].GetText().Text, firstPasteBlock.Model().GetText().Text, "first paste block text should be preserved")
+			} else {
+				assert.Equal(t, tc.pasteBlocks[0].GetText().Text, targetBlock.Model().GetText().Text, "single block text should merge into target")
+			}
 		})
 	}
 }

--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -399,10 +399,10 @@ func TestCommonSmart_RangeSplit(t *testing.T) {
 }
 
 func TestCommonSmart_TextSlot_RangeSplitCases(t *testing.T) {
-	t.Run("1. Cursor at the beginning, range == 0. Expected behavior: inserting blocks on top", func(t *testing.T) {
+	t.Run("1. Cursor at the beginning, range == 0. Expected behavior: paste text is merged into block at cursor position", func(t *testing.T) {
 		sb := createPage(t, createBlocks([]string{}, []string{"11111", "22222", "33333", "qwerty", "55555"}, emptyMarks))
 		pasteText(t, sb, "4", model.Range{From: 0, To: 0}, []string{}, "aaaaa\nbbbbb")
-		checkBlockText(t, sb, []string{"11111", "22222", "33333", "aaaaa\nbbbbb", "qwerty", "55555"})
+		checkBlockText(t, sb, []string{"11111", "22222", "33333", "aaaaa\nbbbbbqwerty", "55555"})
 	})
 
 	t.Run("2. Cursor in a middle, range == 0. Expected behaviour: split block top + bottom, insert in a middle", func(t *testing.T) {
@@ -1182,6 +1182,83 @@ func TestClipboard_PasteToTableCellBlock(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	assert.Equal(t, "text1\ntext2\ntabletable", sb.Doc.Pick("2-2").Model().GetText().Text)
+}
+
+func TestPasteIntoEmptyStyledBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		style      model.BlockContentTextStyle
+		pasteBlocks []*model.Block
+	}{
+		{
+			name:  "multi-block header paste into empty bullet",
+			style: model.BlockContentText_Marked,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Header Text", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+				blockbuilder.Text("Paragraph Text", blockbuilder.ID("p2"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+		},
+		{
+			name:  "multi-block header paste into empty toggle",
+			style: model.BlockContentText_Toggle,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Header Text", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+				blockbuilder.Text("Paragraph Text", blockbuilder.ID("p2"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+		},
+		{
+			name:  "multi-block header paste into empty callout",
+			style: model.BlockContentText_Callout,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Header Text", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+				blockbuilder.Text("Paragraph Text", blockbuilder.ID("p2"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+		},
+		{
+			name:  "single header paste into empty bullet",
+			style: model.BlockContentText_Marked,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Header Text", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+			},
+		},
+		{
+			name:  "multi-block paragraph paste into empty checkbox",
+			style: model.BlockContentText_Checkbox,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("First Line", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+				blockbuilder.Text("Second Line", blockbuilder.ID("p2"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			sb := smarttest.New("test")
+			sb.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+				blockbuilder.ID("root"),
+				blockbuilder.Children(
+					blockbuilder.Text(
+						"",
+						blockbuilder.ID("1"),
+						blockbuilder.TextStyle(tc.style),
+					),
+				)))
+
+			// when
+			cb := newFixture(t, sb)
+			_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+				FocusedBlockId:    "1",
+				SelectedTextRange: &model.Range{From: 0, To: 0},
+				AnySlot:           tc.pasteBlocks,
+			}, "")
+
+			// then
+			require.NoError(t, err)
+			b := sb.Doc.Pick("1")
+			require.NotNil(t, b, "target block should not be deleted")
+			assert.Equal(t, tc.style, b.Model().GetText().Style, "target block style should be preserved")
+			assert.Equal(t, tc.pasteBlocks[0].GetText().Text, b.Model().GetText().Text, "first paste text should be merged into target")
+		})
+	}
 }
 
 func Test_PasteText(t *testing.T) {

--- a/core/block/editor/clipboard/paste.go
+++ b/core/block/editor/clipboard/paste.go
@@ -268,8 +268,6 @@ func (p *pasteCtrl) singleRange() (err error) {
 		p.mode.removeSelection = true
 		if wasEmpty && firstPasteText != nil {
 			p.mode.removeSelection = false
-			selText.SetText(firstPasteText.GetText(), firstPasteText.Model().GetText().Marks)
-			p.ps.Unlink(firstPasteText.Model().Id)
 		}
 	}
 	return

--- a/core/block/editor/clipboard/paste.go
+++ b/core/block/editor/clipboard/paste.go
@@ -44,6 +44,10 @@ type pasteMode struct {
 	textBuf                    string
 }
 
+// Exec runs the paste operation: determines the paste mode via configure, executes the
+// mode-specific handler (multiRange / intoCodeBlock / intoBlock / singleRange), then
+// inserts remaining paste blocks under the selection, removes replaced blocks, normalizes
+// styles, and collects file upload requests.
 func (p *pasteCtrl) Exec(req *pb.RpcBlockPasteRequest) (err error) {
 	if err = p.configure(req); err != nil {
 		return
@@ -76,6 +80,17 @@ func (p *pasteCtrl) Exec(req *pb.RpcBlockPasteRequest) (err error) {
 	return
 }
 
+// configure determines the paste mode based on the request parameters:
+//   - FocusedBlockId set → singleRange mode (cursor is inside a block). Also sets
+//     IsPartOfBlock = true so that single-text-block paste routes to intoBlock.
+//     If the focused block is Code or a table cell, switches to intoBlockMergeWithoutStyle.
+//   - Multiple selIds → multiRange mode (several blocks selected for replacement).
+//   - Single text block in paste state + IsPartOfBlock → intoBlock mode (merge inline).
+//   - Otherwise stays in singleRange mode (split at cursor, insert paste blocks in between).
+//
+// intoBlockCopyStyle is set to true unless the paste content has Title/Description style
+// or the target is a required block (title, description), in which case the target's
+// style is preserved.
 func (p *pasteCtrl) configure(req *pb.RpcBlockPasteRequest) (err error) {
 	if req.SelectedTextRange != nil {
 		p.selRange = *req.SelectedTextRange
@@ -84,6 +99,7 @@ func (p *pasteCtrl) configure(req *pb.RpcBlockPasteRequest) (err error) {
 	if req.FocusedBlockId != "" {
 		p.selIds = append([]string{req.FocusedBlockId}, p.selIds...)
 		p.mode.singleRange = true
+		req.IsPartOfBlock = true
 		if firstSelText := p.getFirstSelectedText(); firstSelText != nil {
 			p.mode.intoBlockMergeWithoutStyle = firstSelText.Model().GetText().Style == model.BlockContentText_Code ||
 				table.IsTableCell(firstSelText.Model().Id)
@@ -132,6 +148,8 @@ func (p *pasteCtrl) configure(req *pb.RpcBlockPasteRequest) (err error) {
 	return
 }
 
+// isSpecificStyle returns true if the block has a Title or Description style.
+// Used to prevent copying these internal styles when pasting into regular blocks.
 func isSpecificStyle(block text.Block) bool {
 	if block == nil {
 		return false
@@ -190,6 +208,21 @@ func (p *pasteCtrl) getLastPasteText() (tb text.Block) {
 	return
 }
 
+// singleRange handles pasting when the cursor is inside a single block (FocusedBlockId set)
+// and the paste content has multiple blocks (so intoBlock mode was not chosen).
+//
+// It splits the focused block's text at the selection range via RangeSplit, producing:
+//   - selText: text before the range (runes[:from]) — stays in the original block
+//   - secondBlock: text after the range (runes[to:]) — inserted below
+//
+// Paste blocks from the paste state are then inserted between them by insertUnderSelection.
+//
+// Special cases:
+//   - Header blocks (title/description): merge first paste text into the header, return early.
+//   - Originally empty blocks (wasEmpty): merge first paste text content and marks into the
+//     block instead of deleting it. This preserves the block's style (bullet, toggle, etc.).
+//   - Blocks that became empty after split (had text, cursor at pos 0): mark for removal
+//     so the paste content replaces the block.
 func (p *pasteCtrl) singleRange() (err error) {
 	var (
 		selText     = p.getFirstSelectedText()
@@ -200,6 +233,7 @@ func (p *pasteCtrl) singleRange() (err error) {
 	}
 
 	targetId := selText.Model().Id
+	wasEmpty := selText.GetText() == ""
 	if secondBlock, err = selText.RangeSplit(p.selRange.From, p.selRange.To, false); err != nil {
 		return
 	}
@@ -221,8 +255,8 @@ func (p *pasteCtrl) singleRange() (err error) {
 	if secondBlock.Model().GetText().Text == "" {
 		p.s.Unlink(secondBlock.Model().Id)
 	}
+	firstPasteText := p.getFirstPasteText()
 	if isPasteToHeader && selText.GetText() == "" {
-		firstPasteText := p.getFirstPasteText()
 		if firstPasteText != nil {
 			selText.SetText(firstPasteText.GetText(), nil)
 			p.ps.Unlink(firstPasteText.Model().Id)
@@ -232,10 +266,20 @@ func (p *pasteCtrl) singleRange() (err error) {
 	}
 	if selText.GetText() == "" {
 		p.mode.removeSelection = true
+		if wasEmpty && firstPasteText != nil {
+			p.mode.removeSelection = false
+			selText.SetText(firstPasteText.GetText(), firstPasteText.Model().GetText().Marks)
+			p.ps.Unlink(firstPasteText.Model().Id)
+		}
 	}
 	return
 }
 
+// intoBlock handles pasting a single text block into the focused block inline.
+// It calls RangeTextPaste to insert the paste text at the selection range within the
+// existing block, then unlinks the paste text from the paste state.
+// When intoBlockCopyStyle is true and the paste replaces all text (or fills an empty
+// Paragraph block), the target block's style is overwritten with the paste block's style.
 func (p *pasteCtrl) intoBlock() (err error) {
 	var (
 		firstSelText   = p.getFirstSelectedText()
@@ -249,6 +293,10 @@ func (p *pasteCtrl) intoBlock() (err error) {
 	return
 }
 
+// multiRange handles pasting when multiple blocks are selected. It merges the first paste
+// text into the first selected block (if styles match), and the last paste text into the
+// last selected block (if styles match). The middle selected blocks are marked for removal
+// via removeSelection, and the paste blocks replace them via insertUnderSelection.
 func (p *pasteCtrl) multiRange() (err error) {
 	var (
 		firstSelText   = p.getFirstSelectedText()
@@ -283,6 +331,9 @@ func (p *pasteCtrl) multiRange() (err error) {
 	return
 }
 
+// insertUnderSelection moves all remaining blocks from the paste state into the document.
+// Non-root paste blocks are added to the doc state and their IDs collected in blockIds.
+// The paste root's children are inserted right after the first selected block (Block_Bottom).
 func (p *pasteCtrl) insertUnderSelection() (err error) {
 	var (
 		targetId  string
@@ -355,6 +406,9 @@ func (p *pasteCtrl) handleBase64(b simple.Block, file *model.BlockContentFile) e
 	return errors.New("invalid base64 image")
 }
 
+// normalize adjusts paste block styles that are only valid for specific system blocks:
+// Title style is converted to Header1, Description style is converted to Paragraph.
+// The original title/description blocks are exempt from conversion.
 func (p *pasteCtrl) normalize() {
 	p.ps.Iterate(func(b simple.Block) (isContinue bool) {
 		if txtBlock := b.Model().GetText(); txtBlock != nil {
@@ -368,6 +422,10 @@ func (p *pasteCtrl) normalize() {
 	})
 }
 
+// intoCodeBlock handles pasting into a Code block or table cell. All paste text blocks
+// are joined with newlines into a single string (or the TextSlot buffer is used directly),
+// then inserted via RangeTextPaste with style copying enabled. The paste state children
+// are cleared so insertUnderSelection does not duplicate them.
 func (p *pasteCtrl) intoCodeBlock() (err error) {
 	selText := p.getFirstSelectedText()
 	var txt = p.mode.textBuf


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6615/empty-toggle-becomes-overrided-by-clipboard-content-if-its-a-header

Fix pasting into empty toggled/bulleted block. We used to delete target block, but we need to preserve it