### PR TITLE
GO-6612 Handle outdent operation on move

### DIFF
--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -274,7 +274,7 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 		return err
 	}
 
-	var ctx outdentOpContext
+	var opCtx *outdentOpContext
 	var replacementCandidate simple.Block
 	for i, id := range blockIds {
 		if b := srcState.Pick(id); b != nil {
@@ -287,7 +287,7 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 
 			// Capture outdent context of last moving block before unlinking
 			if i == len(blockIds)-1 {
-				ctx = collectOutdentContext(srcState, id)
+				opCtx = collectOutdentContext(srcState, id)
 			}
 
 			srcState.Unlink(id)
@@ -331,15 +331,15 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 		return err
 	}
 
-	return processOutdentOperation(ctx, srcState, targetBlockId, position)
+	return processOutdentOperation(opCtx, srcState, targetBlockId, position)
 }
 
-func collectOutdentContext(srcState *state.State, blockId string) outdentOpContext {
+func collectOutdentContext(srcState *state.State, blockId string) *outdentOpContext {
 	parent := srcState.GetParentOf(blockId)
 	if parent == nil {
-		return outdentOpContext{}
+		return nil
 	}
-	ctx := outdentOpContext{
+	ctx := &outdentOpContext{
 		blockId:          blockId,
 		originalParent:   parent,
 		positionInParent: slice.FindPos(parent.Model().ChildrenIds, blockId),
@@ -353,19 +353,19 @@ func collectOutdentContext(srcState *state.State, blockId string) outdentOpConte
 	return ctx
 }
 
-func processOutdentOperation(ctx outdentOpContext, srcState *state.State, targetBlockId string, pos model.BlockPosition) error {
-	if ctx.originalParent == nil || len(ctx.followingSiblings) == 0 {
+func processOutdentOperation(opCtx *outdentOpContext, srcState *state.State, targetBlockId string, pos model.BlockPosition) error {
+	if opCtx == nil || opCtx.originalParent == nil || len(opCtx.followingSiblings) == 0 {
 		return nil
 	}
 
 	// Detect outdent: moving to be sibling of a current parent
 	// This happens when target is the current parent and position is Top/Bottom
-	if targetBlockId == "" || ctx.originalParent.Model().Id != targetBlockId || (pos != model.Block_Top && pos != model.Block_Bottom) {
+	if targetBlockId == "" || opCtx.originalParent.Model().Id != targetBlockId || (pos != model.Block_Top && pos != model.Block_Bottom) {
 		return nil
 	}
 
 	// Validate moved block can have children
-	movedBlock := srcState.Get(ctx.blockId)
+	movedBlock := srcState.Get(opCtx.blockId)
 	if movedBlock != nil {
 		if textContent, ok := movedBlock.Model().Content.(*model.BlockContentOfText); ok {
 			if textContent.Text != nil && !canHaveChildren(textContent.Text.Style) {
@@ -375,10 +375,10 @@ func processOutdentOperation(ctx outdentOpContext, srcState *state.State, target
 	}
 
 	// Reassign siblings as children
-	for _, siblingId := range ctx.followingSiblings {
+	for _, siblingId := range opCtx.followingSiblings {
 		srcState.Unlink(siblingId)
 	}
-	if err := srcState.InsertTo(ctx.blockId, model.Block_Inner, ctx.followingSiblings...); err != nil {
+	if err := srcState.InsertTo(opCtx.blockId, model.Block_Inner, opCtx.followingSiblings...); err != nil {
 		return fmt.Errorf("reassign siblings during outdent: %w", err)
 	}
 	return nil

--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -331,7 +331,10 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 		return err
 	}
 
-	return processOutdentOperation(opCtx, srcState, targetBlockId, position)
+	if opCtx != nil {
+		return processOutdentOperation(opCtx, srcState, targetBlockId, position)
+	}
+	return nil
 }
 
 func collectOutdentContext(srcState *state.State, blockId string) *outdentOpContext {
@@ -354,7 +357,7 @@ func collectOutdentContext(srcState *state.State, blockId string) *outdentOpCont
 }
 
 func processOutdentOperation(opCtx *outdentOpContext, srcState *state.State, targetBlockId string, pos model.BlockPosition) error {
-	if opCtx == nil || opCtx.originalParent == nil || len(opCtx.followingSiblings) == 0 {
+	if opCtx.originalParent == nil || len(opCtx.followingSiblings) == 0 {
 		return nil
 	}
 

--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -96,6 +96,13 @@ type Updatable interface {
 	Update(ctx session.Context, apply func(b simple.Block) error, blockIds ...string) (err error)
 }
 
+type outdentOpContext struct {
+	blockId           string
+	originalParent    simple.Block
+	positionInParent  int
+	followingSiblings []string
+}
+
 func NewBasic(
 	sb smartblock.SmartBlock,
 	objectStore spaceindex.Store,
@@ -267,8 +274,9 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 		return err
 	}
 
+	var ctx outdentOpContext
 	var replacementCandidate simple.Block
-	for _, id := range blockIds {
+	for i, id := range blockIds {
 		if b := srcState.Pick(id); b != nil {
 			if replacementCandidate == nil {
 				replacementCandidate = srcState.Get(id)
@@ -276,6 +284,12 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 			if slices.Contains(b.Model().ChildrenIds, targetBlockId) {
 				return fmt.Errorf("cannot move block to its child")
 			}
+
+			// Capture outdent context of last moving block before unlinking
+			if i == len(blockIds)-1 {
+				ctx = collectOutdentContext(srcState, id)
+			}
+
 			srcState.Unlink(id)
 		}
 	}
@@ -313,7 +327,61 @@ func (bs *basic) Move(srcState, destState *state.State, targetBlockId string, po
 		}
 	}
 
-	return srcState.InsertTo(targetBlockId, position, blockIds...)
+	if err = srcState.InsertTo(targetBlockId, position, blockIds...); err != nil {
+		return err
+	}
+
+	return processOutdentOperation(ctx, srcState, targetBlockId, position)
+}
+
+func collectOutdentContext(srcState *state.State, blockId string) outdentOpContext {
+	parent := srcState.GetParentOf(blockId)
+	if parent == nil {
+		return outdentOpContext{}
+	}
+	ctx := outdentOpContext{
+		blockId:          blockId,
+		originalParent:   parent,
+		positionInParent: slice.FindPos(parent.Model().ChildrenIds, blockId),
+	}
+	// Get siblings after this position - make a copy to avoid slice aliasing
+	if ctx.positionInParent != -1 && ctx.positionInParent < len(parent.Model().ChildrenIds)-1 {
+		siblings := parent.Model().ChildrenIds[ctx.positionInParent+1:]
+		ctx.followingSiblings = make([]string, len(siblings))
+		copy(ctx.followingSiblings, siblings)
+	}
+	return ctx
+}
+
+func processOutdentOperation(ctx outdentOpContext, srcState *state.State, targetBlockId string, pos model.BlockPosition) error {
+	if ctx.originalParent == nil || len(ctx.followingSiblings) == 0 {
+		return nil
+	}
+
+	// Detect outdent: moving to be sibling of a current parent
+	// This happens when target is the current parent and position is Top/Bottom
+	if targetBlockId == "" || ctx.originalParent.Model().Id != targetBlockId || (pos != model.Block_Top && pos != model.Block_Bottom) {
+		return nil
+	}
+
+	// Validate moved block can have children
+	movedBlock := srcState.Get(ctx.blockId)
+	if movedBlock != nil {
+		if textContent, ok := movedBlock.Model().Content.(*model.BlockContentOfText); ok {
+			if textContent.Text != nil && !canHaveChildren(textContent.Text.Style) {
+				return nil // Skip if block can't have children
+			}
+		}
+	}
+
+	// Reassign siblings as children
+	for _, siblingId := range ctx.followingSiblings {
+		srcState.Unlink(siblingId)
+	}
+	if err := srcState.InsertTo(ctx.blockId, model.Block_Inner, ctx.followingSiblings...); err != nil {
+		return fmt.Errorf("reassign siblings during outdent: %w", err)
+	}
+	return nil
 }
 
 func (bs *basic) Replace(ctx session.Context, id string, block *model.Block) (newId string, err error) {

--- a/core/block/editor/basic/basic_test.go
+++ b/core/block/editor/basic/basic_test.go
@@ -427,6 +427,226 @@ func TestBasic_Move(t *testing.T) {
 	})
 }
 
+func TestBasic_MoveOutdent(t *testing.T) {
+	t.Run("basic outdent with siblings - siblings become children", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B", "C"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"})).
+			AddBlock(simple.New(&model.Block{Id: "C"}))
+
+		// when - move A to be sibling after parent (outdent)
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_Bottom, []string{"A"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"parent", "A"}, newState.Pick("test").Model().ChildrenIds, "A should be sibling of parent")
+		assert.Equal(t, []string{"B", "C"}, newState.Pick("A").Model().ChildrenIds, "B and C should be children of A")
+		assert.Empty(t, newState.Pick("parent").Model().ChildrenIds, "parent should have no children")
+	})
+
+	t.Run("outdent last block - no siblings to capture", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"}))
+
+		// when - move B to be sibling after parent (outdent)
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_Bottom, []string{"B"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"parent", "B"}, newState.Pick("test").Model().ChildrenIds, "B should be sibling of parent")
+		assert.Empty(t, newState.Pick("B").Model().ChildrenIds, "B should have no children")
+		assert.Equal(t, []string{"A"}, newState.Pick("parent").Model().ChildrenIds, "parent should still have A")
+	})
+
+	t.Run("regular move within same parent - not outdent", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B", "C"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"})).
+			AddBlock(simple.New(&model.Block{Id: "C"}))
+
+		// when - move B to top position within same parent
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_InnerFirst, []string{"B"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"B", "A", "C"}, newState.Pick("parent").Model().ChildrenIds, "B should be first, A and C still siblings")
+		assert.Empty(t, newState.Pick("B").Model().ChildrenIds, "B should NOT capture siblings")
+	})
+
+	t.Run("outdent block that cannot have children - header block", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B", "C"}})).
+			AddBlock(newTextBlockWithStyle("A", "block A", model.BlockContentText_Header1)).
+			AddBlock(simple.New(&model.Block{Id: "B"})).
+			AddBlock(simple.New(&model.Block{Id: "C"}))
+
+		// when - move A to be sibling after parent (outdent)
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_Bottom, []string{"A"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"parent", "A"}, newState.Pick("test").Model().ChildrenIds, "A should be sibling of parent")
+		assert.Empty(t, newState.Pick("A").Model().ChildrenIds, "A should NOT capture siblings (cannot have children)")
+		assert.Equal(t, []string{"B", "C"}, newState.Pick("parent").Model().ChildrenIds, "B and C should remain with parent")
+	})
+
+	t.Run("outdent with Top position", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"}))
+
+		// when - move A to be sibling before parent (outdent with Top)
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_Top, []string{"A"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"A", "parent"}, newState.Pick("test").Model().ChildrenIds, "A should be before parent")
+		assert.Equal(t, []string{"B"}, newState.Pick("A").Model().ChildrenIds, "B should be child of A")
+		assert.Empty(t, newState.Pick("parent").Model().ChildrenIds, "parent should have no children")
+	})
+
+	t.Run("outdent with numbered list items", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(newTextBlockWithStyle("parent", "parent", model.BlockContentText_Numbered)).
+			AddBlock(newTextBlockWithStyle("A", "block A", model.BlockContentText_Numbered)).
+			AddBlock(newTextBlockWithStyle("B", "block B", model.BlockContentText_Numbered)).
+			AddBlock(newTextBlockWithStyle("C", "block C", model.BlockContentText_Numbered))
+
+		st := sb.NewState()
+		st.Get("parent").Model().ChildrenIds = []string{"A", "B", "C"}
+
+		require.NoError(t, sb.Apply(st))
+
+		// when - move A to be sibling after parent (outdent)
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st2 := sb.NewState()
+		err := b.Move(st2, st2, "parent", model.Block_Bottom, []string{"A"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st2))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"parent", "A"}, newState.Pick("test").Model().ChildrenIds, "A should be sibling of parent")
+		assert.Equal(t, []string{"B", "C"}, newState.Pick("A").Model().ChildrenIds, "B and C should be children of A")
+	})
+
+	t.Run("outdent middle block with siblings before and after", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B", "C", "D"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"})).
+			AddBlock(simple.New(&model.Block{Id: "C"})).
+			AddBlock(simple.New(&model.Block{Id: "D"}))
+
+		// when - outdent B to be sibling after parent
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_Bottom, []string{"B"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"parent", "B"}, newState.Pick("test").Model().ChildrenIds, "B should be sibling of parent")
+		assert.Equal(t, []string{"C", "D"}, newState.Pick("B").Model().ChildrenIds, "only C and D (after B) should be children of B")
+		assert.Equal(t, []string{"A"}, newState.Pick("parent").Model().ChildrenIds, "A (before B) should remain with parent")
+	})
+
+	t.Run("move to Inner position - not outdent", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent", "target"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"})).
+			AddBlock(simple.New(&model.Block{Id: "target"}))
+
+		// when - move A to Inner of target (not grandparent)
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "target", model.Block_Inner, []string{"A"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"A"}, newState.Pick("target").Model().ChildrenIds, "A should be child of target")
+		assert.Empty(t, newState.Pick("A").Model().ChildrenIds, "A should NOT capture siblings (Inner position)")
+	})
+
+	t.Run("multiple blocks moving - only last captures siblings", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"parent"}})).
+			AddBlock(simple.New(&model.Block{Id: "parent", ChildrenIds: []string{"A", "B", "C", "D"}})).
+			AddBlock(simple.New(&model.Block{Id: "A"})).
+			AddBlock(simple.New(&model.Block{Id: "B"})).
+			AddBlock(simple.New(&model.Block{Id: "C"})).
+			AddBlock(simple.New(&model.Block{Id: "D"}))
+
+		// when - move both A and B together to be siblings after parent
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		st := sb.NewState()
+		err := b.Move(st, st, "parent", model.Block_Bottom, []string{"A", "B"})
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, sb.Apply(st))
+
+		newState := sb.NewState()
+		assert.Equal(t, []string{"parent", "A", "B"}, newState.Pick("test").Model().ChildrenIds, "A and B should be siblings of parent")
+		assert.Empty(t, newState.Pick("A").Model().ChildrenIds, "A should NOT capture siblings (not last in selection)")
+		assert.Equal(t, []string{"C", "D"}, newState.Pick("B").Model().ChildrenIds, "B (last in selection) should capture C and D")
+	})
+}
+
 func TestBasic_MoveTableBlocks(t *testing.T) {
 	getSB := func() *smarttest.SmartTest {
 		sb := smarttest.New("test")


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6612/single-change-outdent-operation-for-list-blocks

Support outdent (opposite to indent) operations on blocks move. In this case sibling blocks that go after the moved one should become children of the moved one:

Example

Before outdent:

Parent Block
├── Block A (target for outdent)
├── Block B
└── Block C


After outdent of Block A:

Parent Block
Block A
├── Block B
└── Block C