### PR TITLE
GO-6967: Fix full-text crash recovery reindexing

### DIFF
--- a/core/indexer/indexer_test.go
+++ b/core/indexer/indexer_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/threads"
 	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
@@ -89,6 +92,71 @@ func TestIndexer(t *testing.T) {
 			assert.Equal(t, 1, len(count))
 		})
 	}
+
+	t.Run("ftQueueCtr is saved when object is added to fulltext queue", func(t *testing.T) {
+		// given
+		indexerFx := newFixture(t)
+		smartTest := smarttest.New("objectId1")
+		smartTest.SetSpaceId("spaceId1")
+		smartTest.SetSpace(space)
+		smartTest.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+			blockbuilder.ID("root"),
+			blockbuilder.Children(
+				blockbuilder.Text(
+					"to index",
+					blockbuilder.ID("blockId1"),
+				),
+			)))
+
+		smartTest.SetType(coresb.SmartBlockTypePage)
+		info := smartTest.GetDocInfo()
+		info.Details = domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyName: domain.String("test"),
+		})
+
+		// when
+		err := indexerFx.Index(info)
+
+		// then
+		assert.NoError(t, err)
+		entries, err := indexerFx.store.SpaceIndex("spaceId1").GetHeadsWithFtQueueCtrGreaterThan(ctx, 0)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "objectId1", entries[0].ObjectID)
+		assert.Greater(t, entries[0].FTQueueCtr, uint64(0))
+	})
+
+	t.Run("ftQueueCtr is not saved when object is not added to fulltext queue", func(t *testing.T) {
+		// given
+		indexerFx := newFixture(t)
+		smartTest := smarttest.New("objectId1")
+		smartTest.SetSpaceId("spaceId1")
+		smartTest.SetSpace(space)
+		smartTest.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+			blockbuilder.ID("root"),
+			blockbuilder.Children(
+				blockbuilder.Text(
+					"to index",
+					blockbuilder.ID("blockId1"),
+				),
+			)))
+
+		// SmartBlockTypeWorkspace has fulltext=false, so it won't be added to FT queue
+		smartTest.SetType(coresb.SmartBlockTypeWorkspace)
+		info := smartTest.GetDocInfo()
+		info.Details = domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyName: domain.String("test"),
+		})
+
+		// when
+		err := indexerFx.Index(info)
+
+		// then
+		assert.NoError(t, err)
+		entries, err := indexerFx.store.SpaceIndex("spaceId1").GetHeadsWithFtQueueCtrGreaterThan(ctx, 0)
+		require.NoError(t, err)
+		assert.Len(t, entries, 0)
+	})
 
 	t.Run("index has started - when hashes match and options are not provided", func(t *testing.T) {
 		// given

--- a/core/indexer/spaceindexer.go
+++ b/core/indexer/spaceindexer.go
@@ -165,13 +165,13 @@ func (i *spaceIndexer) index(ctx context.Context, ftQueueCounter uint64, info sm
 
 	headHashToIndex := headsHash(info.Heads)
 
-	saveIndexedHash := func() {
+	saveIndexedHash := func(updateFtCounter bool) {
 		if headHashToIndex == "" {
 			return
 		}
 
 		// If we have ftQueueCtr, use the method that saves it for crash recovery
-		if ftQueueCounter > 0 {
+		if ftQueueCounter > 0 && updateFtCounter {
 			err = i.spaceIndex.SaveLastIndexedHeadsHashWithFtQueueCtr(ctx, info.Id, headHashToIndex, ftQueueCounter)
 		} else {
 			err = i.spaceIndex.SaveLastIndexedHeadsHash(ctx, info.Id, headHashToIndex)
@@ -255,7 +255,7 @@ func (i *spaceIndexer) index(ctx context.Context, ftQueueCounter uint64, info sm
 	}
 
 	if !hasError {
-		saveIndexedHash()
+		saveIndexedHash(addToFulltextQueue)
 	}
 
 	return addToFulltextQueue, nil


### PR DESCRIPTION
## Summary
- Fix `saveIndexedHash` to only persist `ftQueueCtr` when the object is actually added to the fulltext queue, preventing unnecessary crash recovery reindexing for non-fulltext objects
- Add tests verifying `ftQueueCtr` is saved only when appropriate

## Test plan
- [x] `TestIndexer/ftQueueCtr_is_saved_when_object_is_added_to_fulltext_queue` — verifies counter is persisted for fulltext-enabled types
- [x] `TestIndexer/ftQueueCtr_is_not_saved_when_object_is_not_added_to_fulltext_queue` — verifies counter is NOT persisted for non-fulltext types

🤖 Generated with [Claude Code](https://claude.com/claude-code)