### PR TITLE
GO-6968 Revert anystore autocheckpoint to 10000

### DIFF
--- a/pkg/lib/datastore/anystoreprovider/provider.go
+++ b/pkg/lib/datastore/anystoreprovider/provider.go
@@ -233,7 +233,7 @@ func (s *provider) setDefaultConfig() {
 	}
 	s.anyStoreConfig.SQLiteConnectionOptions = maps.Clone(s.anyStoreConfig.SQLiteConnectionOptions)
 	s.anyStoreConfig.SQLiteConnectionOptions["synchronous"] = "normal"
-	s.anyStoreConfig.SQLiteConnectionOptions["wal_autocheckpoint"] = "0"
+	s.anyStoreConfig.SQLiteConnectionOptions["wal_autocheckpoint"] = "10000"
 
 }
 

--- a/space/spacecore/storage/anystorage/storageservice.go
+++ b/space/spacecore/storage/anystorage/storageservice.go
@@ -224,7 +224,7 @@ func (s *storageService) anyStoreConfig() *anystore.Config {
 		opts = make(map[string]string)
 	}
 	opts["synchronous"] = "normal"
-	opts["wal_autocheckpoint"] = "0" // we will flush on idle
+	opts["wal_autocheckpoint"] = "10000"
 
 	return &anystore.Config{
 		ReadConnections:                           4,


### PR DESCRIPTION
## Summary
- Set `wal_autocheckpoint` to `10000` (~40MB) instead of `0` (disabled) for both spacestorage and objectstore SQLite databases
- Restores SQLite auto-checkpoint behavior to prevent unbounded WAL growth

## Test plan
- [ ] Verify WAL files don't grow unbounded during heavy writes
- [ ] Check no performance regression on space open/sync operations