### PR TITLE
GO-6743 Skip reactions counters for changes before epoch

### DIFF
--- a/core/block/editor/chatobject/chathandler.go
+++ b/core/block/editor/chatobject/chathandler.go
@@ -29,6 +29,8 @@ type ChatHandler struct {
 	chatFullId      domain.FullID
 	currentIdentity string
 	myParticipantId string
+	// reactionsCounterEpoch is the unix timestamp after which reactions counters are tracked
+	reactionsCounterEpoch int64
 	// forceNotRead forces handler to mark all messages as not read. It's useful for unit testing
 	forceNotRead bool
 }
@@ -228,8 +230,10 @@ func (d *ChatHandler) handleReactionsModify(
 	}
 	// TODO Count validation
 
+	reactionsCounterEnabled := ch.Change.Timestamp > d.reactionsCounterEpoch
+
 	// Track unread reaction changes on current user's messages from other users
-	if msg.Creator == d.currentIdentity && ch.Change.Creator != d.currentIdentity && len(key.KeyPath) > 1 {
+	if reactionsCounterEnabled && msg.Creator == d.currentIdentity && ch.Change.Creator != d.currentIdentity && len(key.KeyPath) > 1 {
 		emoji := key.KeyPath[1]
 		wasPresent := isIdentityInReactions(oldReactions, emoji, identity)
 		isPresent := isIdentityInReactions(msg.GetReactions(), emoji, identity)

--- a/core/block/editor/chatobject/chatobject.go
+++ b/core/block/editor/chatobject/chatobject.go
@@ -40,8 +40,8 @@ const (
 	EditorCollectionName  = "editor"
 	diffManagerMessages   = "messages"
 	diffManagerMentions   = "mentions"
-	diffManagerSyncStatus  = "syncStatus"
-	diffManagerReactions   = "reactions"
+	diffManagerSyncStatus = "syncStatus"
+	diffManagerReactions  = "reactions"
 )
 
 var log = logging.Logger("core.block.editor.chatobject").Desugar()
@@ -96,6 +96,8 @@ type storeObject struct {
 	detailsComponent        *detailsComponent
 	statService             debugstat.StatService
 	indexerStore            objectstore.IndexerStore
+
+	reactionsCounterEpoch int64
 
 	arenaPool          *anyenc.ArenaPool
 	componentCtx       context.Context
@@ -171,6 +173,7 @@ func New(
 		crdtDb:                  crdtDb,
 		repositoryService:       repositoryService,
 		indexerStore:            indexerStore,
+		reactionsCounterEpoch:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Unix(),
 		componentCtx:            ctx,
 		componentCtxCancel:      cancel,
 		chatSubscriptionService: chatSubscriptionService,
@@ -231,12 +234,13 @@ func (s *storeObject) Init(ctx *smartblock.InitContext) error {
 	}
 
 	s.chatHandler = &ChatHandler{
-		repository:      s.repository,
-		subscription:    s.subscription,
-		indexerStore:    s.indexerStore,
-		chatFullId:      domain.FullID{ObjectID: storeSource.Id(), SpaceID: storeSource.SpaceID()},
-		currentIdentity: s.accountService.AccountID(),
-		myParticipantId: myParticipantId,
+		repository:            s.repository,
+		subscription:          s.subscription,
+		indexerStore:          s.indexerStore,
+		chatFullId:            domain.FullID{ObjectID: storeSource.Id(), SpaceID: storeSource.SpaceID()},
+		currentIdentity:       s.accountService.AccountID(),
+		myParticipantId:       myParticipantId,
+		reactionsCounterEpoch: s.reactionsCounterEpoch,
 	}
 
 	stateStore, err := storestate.New(ctx.Ctx, s.Id(), s.crdtDb, s.chatHandler, storestate.DefaultHandler{Name: EditorCollectionName, ModifyMode: storestate.ModifyModeUpsert})

--- a/core/block/editor/chatobject/chatobject_test.go
+++ b/core/block/editor/chatobject/chatobject_test.go
@@ -100,7 +100,15 @@ const (
 	chatId      = "chatId1"
 )
 
-func newFixture(t *testing.T) *fixture {
+type fixtureOption func(fx *fixture)
+
+func withReactionsCounterEpoch(epoch int64) fixtureOption {
+	return func(fx *fixture) {
+		fx.reactionsCounterEpoch = epoch
+	}
+}
+
+func newFixture(t *testing.T, opts ...fixtureOption) *fixture {
 	ctx := context.Background()
 
 	a := &app.App{}
@@ -201,6 +209,10 @@ func newFixture(t *testing.T) *fixture {
 	}).Maybe()
 
 	fx.source = source
+
+	for _, opt := range opts {
+		opt(fx)
+	}
 
 	err = object.Init(&smartblock.InitContext{
 		Ctx:    ctx,

--- a/core/block/editor/chatobject/reading_test.go
+++ b/core/block/editor/chatobject/reading_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -439,5 +440,29 @@ func TestUnreadReactionTracking(t *testing.T) {
 		msg, err := fx.GetMessageById(ctx, messageId)
 		require.NoError(t, err)
 		assert.False(t, msg.UnreadReaction)
+	})
+
+	t.Run("reaction before epoch does not track unread", func(t *testing.T) {
+		ctx := context.Background()
+		// Set epoch far in the future so current time is before it
+		fx := newFixture(t, withReactionsCounterEpoch(time.Now().Add(time.Hour).Unix()))
+
+		// testCreator creates a message
+		messageId, err := fx.AddMessage(ctx, nil, givenSimpleMessage("my message"))
+		require.NoError(t, err)
+
+		// Another person adds a reaction (timestamp is before epoch)
+		fx.sourceCreator = anotherPerson
+		fx.accountServiceStub.accountId = anotherPerson
+		added, err := fx.ToggleMessageReaction(ctx, messageId, "👍")
+		require.NoError(t, err)
+		assert.True(t, added)
+
+		// Reaction should be applied but not tracked as unread
+		fx.sourceCreator = testCreator
+		fx.accountServiceStub.accountId = testCreator
+		msg, err := fx.GetMessageById(ctx, messageId)
+		require.NoError(t, err)
+		assert.False(t, msg.UnreadReaction, "reactions before epoch should not be tracked as unread")
 	})
 }


### PR DESCRIPTION
## Summary
- Add a reactions counter epoch (March 1, 2026) to skip unread reaction tracking for old changes
- The epoch is configured as a field on `storeObject`, flowing through to `ChatHandler` during init
- Add test verifying reactions before epoch are not tracked as unread

## Test plan
- [x] Existing reaction tracking tests pass
- [x] New test: `TestUnreadReactionTracking/reaction_before_epoch_does_not_track_unread`
- [x] Subscription reaction counter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)