### PR TITLE
Fix do not close update channel in filesync

### DIFF
--- a/core/files/filesync/spaceusage.go
+++ b/core/files/filesync/spaceusage.go
@@ -224,5 +224,4 @@ func (m *spaceUsageManager) close() {
 	if m.ctxCancel != nil {
 		m.ctxCancel()
 	}
-	close(m.updateCh)
 }


### PR DESCRIPTION
https://github.com/anyproto/anytype-heart/actions/runs/22900770868/job/66446435783?pr=3009

 Root cause: In spaceUsageManager.close() (line 223-228), context cancellation and close(m.updateCh) happen in       
  sequence. The goroutine in setupUpdateCh (line 178-191) can receive from the per-space channel and then enter the
  inner select where both m.ctx.Done() and m.updateCh <- update are candidates. Since Go's select picks randomly among
   ready cases, if it picks the send to the already-closed m.updateCh, it panics.                                     

  The timeline:
  1. close() calls m.ctxCancel() — marks context as done
  2. close() calls close(m.updateCh) — closes the channel
  3. The setupUpdateCh goroutine already received from the per-space channel and enters the inner select
  4. Both m.ctx.Done() (ready) and m.updateCh <- update (closed channel → panic) are available
  5. If select picks the send case → panic: send on closed channel

  This is flaky because locally the timing may differ (faster machine, less contention), so it passes. On CI with more
   load, the race window opens up.

  Fix: Remove close(m.updateCh). Context cancellation alone is sufficient to stop all goroutines. The consumer
  runLimitedUploader already checks ctx.Done() via its own loopCtx.
