### PR TITLE
GO-6609 Fix image position when copying content to clipboard

### DIFF
--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -98,13 +98,15 @@ func (cb *clipboard) Paste(ctx session.Context, req *pb.RpcBlockPasteRequest, gr
 }
 
 func (cb *clipboard) Copy(ctx session.Context, req pb.RpcBlockCopyRequest) (textSlot string, htmlSlot string, anySlot []*model.Block, err error) {
-	anySlot = req.Blocks
 	textSlot = ""
 	htmlSlot = ""
 
 	if len(req.Blocks) == 0 {
 		return textSlot, htmlSlot, anySlot, fmt.Errorf("copy: no blocks")
 	}
+
+	req.Blocks = cb.reorderBlocksByDocumentOrder(req.Blocks)
+	anySlot = req.Blocks
 
 	s := cb.blocksToState(req.Blocks)
 
@@ -165,6 +167,8 @@ func (cb *clipboard) Cut(ctx session.Context, req pb.RpcBlockCutRequest) (textSl
 	if err != nil {
 		return textSlot, htmlSlot, anySlot, err
 	}
+
+	req.Blocks = cb.reorderBlocksByDocumentOrder(req.Blocks)
 
 	var firstTextBlock, lastTextBlock *model.Block
 	for _, b := range req.Blocks {
@@ -471,6 +475,45 @@ func (cb *clipboard) pasteAny(
 	blockIds = ctrl.blockIds
 
 	return blockIds, uploadArr, caretPosition, isSameBlockCaret, cb.Apply(s)
+}
+
+// reorderBlocksByDocumentOrder reorders the given blocks to match their position
+// in the document tree. This ensures correct block ordering when the client sends
+// blocks in an order that doesn't match the document structure.
+func (cb *clipboard) reorderBlocksByDocumentOrder(blocks []*model.Block) []*model.Block {
+	if len(blocks) <= 1 {
+		return blocks
+	}
+
+	blockByID := make(map[string]*model.Block, len(blocks))
+	for _, b := range blocks {
+		blockByID[b.Id] = b
+	}
+
+	var ordered []*model.Block
+	// DFS pre-order traversal of the document tree to get top-to-bottom document order
+	var walk func(id string)
+	walk = func(id string) {
+		if b, ok := blockByID[id]; ok {
+			ordered = append(ordered, b)
+			delete(blockByID, id)
+		}
+		if block := cb.Pick(id); block != nil {
+			for _, childID := range block.Model().ChildrenIds {
+				walk(childID)
+			}
+		}
+	}
+	walk(cb.RootId())
+
+	// Append any blocks not found in the document tree, preserving their original order
+	for _, b := range blocks {
+		if _, ok := blockByID[b.Id]; ok {
+			ordered = append(ordered, b)
+		}
+	}
+
+	return ordered
 }
 
 func (cb *clipboard) blocksToState(blocks []*model.Block) (cbs *state.State) {

--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
@@ -1059,9 +1060,10 @@ func TestClipboard_TitleOps(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, result, textSlot)
 		assert.Len(t, anySlot, 3)
+		// Blocks are reordered to document order: firstText, lastText, bookmark
 		assert.Equal(t, firstTextBlockId, anySlot[0].Id)
-		assert.Equal(t, bookmarkId, anySlot[1].Id)
-		assert.Equal(t, lastTextBlockId, anySlot[2].Id)
+		assert.Equal(t, lastTextBlockId, anySlot[1].Id)
+		assert.Equal(t, bookmarkId, anySlot[2].Id)
 		assert.Contains(t, htmlSlot, firstText)
 		assert.Contains(t, htmlSlot, url)
 		assert.Contains(t, htmlSlot, secondText)
@@ -2024,6 +2026,130 @@ func TestProcessFileBlock(t *testing.T) {
 
 		// then
 		assert.Nil(t, fb.File)
+	})
+}
+
+func TestCopy_BlockOrdering(t *testing.T) {
+	t.Run("copy reorders blocks to match document order", func(t *testing.T) {
+		// given: document with blocks in order: text1, file, text2
+		sb := smarttest.New("test")
+		sb.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+			blockbuilder.ID("test"),
+			blockbuilder.Children(
+				blockbuilder.Text("first paragraph",
+					blockbuilder.ID("text1"),
+				),
+				blockbuilder.File("img1",
+					blockbuilder.ID("file1"),
+					blockbuilder.FileType(model.BlockContentFile_Image),
+				),
+				blockbuilder.Text("second paragraph",
+					blockbuilder.ID("text2"),
+				),
+			),
+		))
+
+		cb := newFixture(t, sb)
+
+		// when: copy with blocks in wrong order (file first)
+		_, htmlSlot, anySlot, err := cb.Copy(nil, pb.RpcBlockCopyRequest{
+			Blocks: []*model.Block{
+				sb.Pick("file1").Model(),
+				sb.Pick("text1").Model(),
+				sb.Pick("text2").Model(),
+			},
+		})
+
+		// then: anySlot should be reordered to document order
+		require.NoError(t, err)
+		require.Len(t, anySlot, 3)
+		assert.Equal(t, "text1", anySlot[0].Id)
+		assert.Equal(t, "file1", anySlot[1].Id)
+		assert.Equal(t, "text2", anySlot[2].Id)
+
+		// HTML should contain text1 before text2
+		text1Pos := strings.Index(htmlSlot, "first paragraph")
+		text2Pos := strings.Index(htmlSlot, "second paragraph")
+		assert.Greater(t, text1Pos, -1, "first paragraph should be in HTML")
+		assert.Greater(t, text2Pos, -1, "second paragraph should be in HTML")
+		assert.Less(t, text1Pos, text2Pos, "first paragraph should appear before second paragraph in HTML")
+	})
+
+	t.Run("cut reorders blocks to match document order", func(t *testing.T) {
+		// given: document with blocks in order: text1, file, text2
+		sb := smarttest.New("test")
+		sb.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+			blockbuilder.ID("test"),
+			blockbuilder.Children(
+				blockbuilder.Text("first paragraph",
+					blockbuilder.ID("text1"),
+				),
+				blockbuilder.File("img1",
+					blockbuilder.ID("file1"),
+					blockbuilder.FileType(model.BlockContentFile_Image),
+				),
+				blockbuilder.Text("second paragraph",
+					blockbuilder.ID("text2"),
+				),
+			),
+		))
+
+		cb := newFixture(t, sb)
+
+		// when: cut with blocks in wrong order (file first)
+		_, htmlSlot, anySlot, err := cb.Cut(session.NewContext(), pb.RpcBlockCutRequest{
+			SelectedTextRange: &model.Range{},
+			Blocks: []*model.Block{
+				sb.Pick("file1").Model(),
+				sb.Pick("text1").Model(),
+				sb.Pick("text2").Model(),
+			},
+		})
+
+		// then: anySlot should be reordered to document order
+		require.NoError(t, err)
+		require.Len(t, anySlot, 3)
+		assert.Equal(t, "text1", anySlot[0].Id)
+		assert.Equal(t, "file1", anySlot[1].Id)
+		assert.Equal(t, "text2", anySlot[2].Id)
+
+		// HTML should contain text1 before text2
+		text1Pos := strings.Index(htmlSlot, "first paragraph")
+		text2Pos := strings.Index(htmlSlot, "second paragraph")
+		assert.Greater(t, text1Pos, -1)
+		assert.Greater(t, text2Pos, -1)
+		assert.Less(t, text1Pos, text2Pos)
+	})
+
+	t.Run("already correctly ordered blocks remain unchanged", func(t *testing.T) {
+		// given
+		sb := smarttest.New("test")
+		sb.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+			blockbuilder.ID("test"),
+			blockbuilder.Children(
+				blockbuilder.Text("aaa", blockbuilder.ID("a")),
+				blockbuilder.Text("bbb", blockbuilder.ID("b")),
+				blockbuilder.Text("ccc", blockbuilder.ID("c")),
+			),
+		))
+
+		cb := newFixture(t, sb)
+
+		// when: copy with blocks already in correct order
+		_, _, anySlot, err := cb.Copy(nil, pb.RpcBlockCopyRequest{
+			Blocks: []*model.Block{
+				sb.Pick("a").Model(),
+				sb.Pick("b").Model(),
+				sb.Pick("c").Model(),
+			},
+		})
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, anySlot, 3)
+		assert.Equal(t, "a", anySlot[0].Id)
+		assert.Equal(t, "b", anySlot[1].Id)
+		assert.Equal(t, "c", anySlot[2].Id)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `reorderBlocksByDocumentOrder()` method that uses DFS pre-order traversal of the document tree to sort blocks by their actual position
- Apply block reordering in `Copy()` and `Cut()` before generating clipboard HTML, ensuring images and other blocks maintain their correct position relative to text
- When blocks are sent by the client in an order that doesn't match the document structure (e.g., image blocks before text blocks), the generated HTML now has correct block ordering

## Test plan
- [x] All existing clipboard tests pass (`go test ./core/block/editor/clipboard/...`)
- [x] All HTML converter tests pass (`go test ./core/converter/html/...`)
- [x] New `TestCopy_BlockOrdering` tests verify correct reordering for Copy, Cut, and no-op cases
- [ ] Manual verification: copy mixed text+image content from Anytype and paste into Linear/Notion/Google Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)