### PR TITLE
GO-6816 Replace FeaturedRelation methods with DescriptionShow/Hide

### DIFF
--- a/core/block/editor.go
+++ b/core/block/editor.go
@@ -328,15 +328,15 @@ func (s *Service) SetLayout(ctx session.Context, contextId string, layout model.
 	})
 }
 
-func (s *Service) FeaturedRelationAdd(ctx session.Context, contextId string, relations ...string) error {
+func (s *Service) DescriptionShow(ctx session.Context, contextId string) error {
 	return cache.Do(s, contextId, func(b basic.CommonOperations) error {
-		return b.FeaturedRelationAdd(ctx, relations...)
+		return b.DescriptionShow(ctx)
 	})
 }
 
-func (s *Service) FeaturedRelationRemove(ctx session.Context, contextId string, relations ...string) error {
+func (s *Service) DescriptionHide(ctx session.Context, contextId string) error {
 	return cache.Do(s, contextId, func(b basic.CommonOperations) error {
-		return b.FeaturedRelationRemove(ctx, relations...)
+		return b.DescriptionHide(ctx)
 	})
 }
 

--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -49,8 +49,8 @@ type CommonOperations interface {
 
 	SetRelationKey(ctx session.Context, req pb.RpcBlockRelationSetKeyRequest) error
 	AddRelationAndSet(ctx session.Context, req pb.RpcBlockRelationAddRequest) error
-	FeaturedRelationAdd(ctx session.Context, relations ...string) error
-	FeaturedRelationRemove(ctx session.Context, relations ...string) error
+	DescriptionShow(ctx session.Context) error
+	DescriptionHide(ctx session.Context) error
 
 	ExtractBlocksToObjects(ctx session.Context, oc ObjectCreator, tsc templateSvc.Service, req pb.RpcBlockListConvertToObjectsRequest) (linkIds []string, err error)
 
@@ -506,53 +506,41 @@ func (bs *basic) AddRelationAndSet(ctx session.Context, req pb.RpcBlockRelationA
 	return bs.Apply(s)
 }
 
-func (bs *basic) FeaturedRelationAdd(ctx session.Context, relations ...string) (err error) {
+func (bs *basic) DescriptionShow(ctx session.Context) error {
 	s := bs.NewStateCtx(ctx)
+
 	fr := s.Details().GetStringList(bundle.RelationKeyFeaturedRelations)
-	frc := make([]string, len(fr))
-	copy(frc, fr)
-	for _, r := range relations {
-		if slice.FindPos(frc, r) == -1 {
-			// special case
-			if r == bundle.RelationKeyDescription.String() {
-				// todo: looks like it's not ok to use templates here but it has a lot of logic inside
-				template.WithForcedDescription(s)
-			}
-			frc = append(frc, r)
-			key := domain.RelationKey(r)
-			if !s.HasRelation(key) {
-				// TODO: GO-4284 remove
-				err = bs.addRelationLink(s, key)
-				if err != nil {
-					return fmt.Errorf("failed to add relation link on adding featured relation '%s': %w", r, err)
-				}
-			}
+	descKey := bundle.RelationKeyDescription.String()
+	if slice.FindPos(fr, descKey) != -1 {
+		return nil // noop
+	}
+
+	template.WithForcedDescription(s)
+
+	if !s.HasRelation(bundle.RelationKeyDescription) {
+		// TODO: GO-4284 remove
+		if err := bs.addRelationLink(s, bundle.RelationKeyDescription); err != nil {
+			return fmt.Errorf("add description relation link: %w", err)
 		}
 	}
-	if len(frc) != len(fr) {
-		s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList(frc))
-	}
+
+	s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList(append(fr, descKey)))
+	s.SetChangeType(domain.ChangeTypeDescriptionToggle)
 	return bs.Apply(s, smartblock.NoRestrictions)
 }
 
-func (bs *basic) FeaturedRelationRemove(ctx session.Context, relations ...string) (err error) {
+func (bs *basic) DescriptionHide(ctx session.Context) error {
 	s := bs.NewStateCtx(ctx)
+
 	fr := s.Details().GetStringList(bundle.RelationKeyFeaturedRelations)
-	frc := make([]string, len(fr))
-	copy(frc, fr)
-	for _, r := range relations {
-		if slice.FindPos(frc, r) != -1 {
-			// special cases
-			switch r {
-			case bundle.RelationKeyDescription.String():
-				s.Unlink(state.DescriptionBlockID)
-			}
-			frc = slice.RemoveMut(frc, r)
-		}
+	descKey := bundle.RelationKeyDescription.String()
+	if slice.FindPos(fr, descKey) == -1 {
+		return nil // noop
 	}
-	if len(frc) != len(fr) {
-		s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList(frc))
-	}
+
+	s.Unlink(state.DescriptionBlockID)
+	s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList(slice.RemoveMut(append([]string{}, fr...), descKey)))
+	s.SetChangeType(domain.ChangeTypeDescriptionToggle)
 	return bs.Apply(s, smartblock.NoRestrictions)
 }
 

--- a/core/block/editor/basic/basic_test.go
+++ b/core/block/editor/basic/basic_test.go
@@ -941,36 +941,65 @@ func TestBasic_SetRelationKey(t *testing.T) {
 	})
 }
 
-func TestBasic_FeaturedRelationAdd(t *testing.T) {
-	sb := smarttest.New("test")
-	s := sb.NewState()
-	template.WithTitle(s)
-	s.AddBundledRelationLinks(bundle.RelationKeyName)
-	s.AddBundledRelationLinks(bundle.RelationKeyDescription)
-	require.NoError(t, sb.Apply(s))
+func TestBasic_DescriptionShow(t *testing.T) {
+	t.Run("show description adds to featured", func(t *testing.T) {
+		sb := smarttest.New("test")
+		s := sb.NewState()
+		template.WithTitle(s)
+		s.AddBundledRelationLinks(bundle.RelationKeyDescription)
+		require.NoError(t, sb.Apply(s))
 
-	store := objectstore.NewStoreFixture(t)
+		store := objectstore.NewStoreFixture(t)
 
-	b := NewBasic(sb, store.SpaceIndex("spc"), converter.NewLayoutConverter(), nil)
-	newRel := []string{bundle.RelationKeyDescription.String(), bundle.RelationKeyName.String()}
-	require.NoError(t, b.FeaturedRelationAdd(nil, newRel...))
+		b := NewBasic(sb, store.SpaceIndex("spc"), converter.NewLayoutConverter(), nil)
+		require.NoError(t, b.DescriptionShow(nil))
 
-	res := sb.NewState()
-	assert.Equal(t, newRel, res.Details().GetStringList(bundle.RelationKeyFeaturedRelations))
-	assert.NotNil(t, res.Pick(template.DescriptionBlockId))
+		res := sb.NewState()
+		assert.Equal(t, []string{bundle.RelationKeyDescription.String()}, res.Details().GetStringList(bundle.RelationKeyFeaturedRelations))
+		assert.NotNil(t, res.Pick(template.DescriptionBlockId))
+	})
+
+	t.Run("show description when already shown is no-op", func(t *testing.T) {
+		sb := smarttest.New("test")
+		s := sb.NewState()
+		template.WithTitle(s)
+		s.AddBundledRelationLinks(bundle.RelationKeyDescription)
+		s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList([]string{bundle.RelationKeyDescription.String()}))
+		require.NoError(t, sb.Apply(s))
+
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		require.NoError(t, b.DescriptionShow(nil))
+
+		res := sb.NewState()
+		assert.Equal(t, []string{bundle.RelationKeyDescription.String()}, res.Details().GetStringList(bundle.RelationKeyFeaturedRelations))
+	})
 }
 
-func TestBasic_FeaturedRelationRemove(t *testing.T) {
-	sb := smarttest.New("test")
-	s := sb.NewState()
-	s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList([]string{bundle.RelationKeyDescription.String(), bundle.RelationKeyName.String()}))
-	template.WithDescription(s)
-	require.NoError(t, sb.Apply(s))
+func TestBasic_DescriptionHide(t *testing.T) {
+	t.Run("hide description removes from featured", func(t *testing.T) {
+		sb := smarttest.New("test")
+		s := sb.NewState()
+		s.SetDetail(bundle.RelationKeyFeaturedRelations, domain.StringList([]string{bundle.RelationKeyDescription.String()}))
+		template.WithDescription(s)
+		require.NoError(t, sb.Apply(s))
 
-	b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
-	require.NoError(t, b.FeaturedRelationRemove(nil, bundle.RelationKeyDescription.String()))
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		require.NoError(t, b.DescriptionHide(nil))
 
-	res := sb.NewState()
-	assert.Equal(t, []string{bundle.RelationKeyName.String()}, res.Details().GetStringList(bundle.RelationKeyFeaturedRelations))
-	assert.Nil(t, res.PickParentOf(template.DescriptionBlockId))
+		res := sb.NewState()
+		assert.Empty(t, res.Details().GetStringList(bundle.RelationKeyFeaturedRelations))
+		assert.Nil(t, res.PickParentOf(template.DescriptionBlockId))
+	})
+
+	t.Run("hide description when already hidden is no-op", func(t *testing.T) {
+		sb := smarttest.New("test")
+		s := sb.NewState()
+		require.NoError(t, sb.Apply(s))
+
+		b := NewBasic(sb, nil, converter.NewLayoutConverter(), nil)
+		require.NoError(t, b.DescriptionHide(nil))
+
+		res := sb.NewState()
+		assert.Empty(t, res.Details().GetStringList(bundle.RelationKeyFeaturedRelations))
+	})
 }

--- a/core/domain/types.go
+++ b/core/domain/types.go
@@ -47,6 +47,7 @@ const (
 	ChangeTypeObjectReinstall
 	ChangeTypeIndexing
 	ChangeTypeSystemObjectReviserMigration
+	ChangeTypeDescriptionToggle
 )
 
 func (c ChangeType) String() string {
@@ -71,6 +72,8 @@ func (c ChangeType) String() string {
 		return "Indexing"
 	case ChangeTypeSystemObjectReviserMigration:
 		return "SystemObjectReviserMigration"
+	case ChangeTypeDescriptionToggle:
+		return "DescriptionToggle"
 	default:
 		return "Unknown"
 	}

--- a/core/object.go
+++ b/core/object.go
@@ -527,6 +527,7 @@ func (mw *Middleware) ObjectSetLayout(cctx context.Context, req *pb.RpcObjectSet
 	return response(pb.RpcObjectSetLayoutResponseError_NULL, nil)
 }
 
+// ObjectRelationAddFeatured used to set featuredRelations value, that is now outdated and is used only for storing 'description' value
 func (mw *Middleware) ObjectRelationAddFeatured(cctx context.Context, req *pb.RpcObjectRelationAddFeaturedRequest) *pb.RpcObjectRelationAddFeaturedResponse {
 	ctx := mw.newContext(cctx)
 	response := func(code pb.RpcObjectRelationAddFeaturedResponseErrorCode, err error) *pb.RpcObjectRelationAddFeaturedResponse {
@@ -538,8 +539,13 @@ func (mw *Middleware) ObjectRelationAddFeatured(cctx context.Context, req *pb.Rp
 		}
 		return m
 	}
+	for _, r := range req.Relations {
+		if r != bundle.RelationKeyDescription.String() {
+			return response(pb.RpcObjectRelationAddFeaturedResponseError_UNKNOWN_ERROR, fmt.Errorf("only description relation is supported"))
+		}
+	}
 	err := mw.doBlockService(func(bs *block.Service) (err error) {
-		return bs.FeaturedRelationAdd(ctx, req.ContextId, req.Relations...)
+		return bs.DescriptionShow(ctx, req.ContextId)
 	})
 	if err != nil {
 		return response(pb.RpcObjectRelationAddFeaturedResponseError_UNKNOWN_ERROR, err)
@@ -547,6 +553,7 @@ func (mw *Middleware) ObjectRelationAddFeatured(cctx context.Context, req *pb.Rp
 	return response(pb.RpcObjectRelationAddFeaturedResponseError_NULL, nil)
 }
 
+// ObjectRelationRemoveFeatured is used only to remove 'description' value. See comment on ObjectRelationRemoveFeatured
 func (mw *Middleware) ObjectRelationRemoveFeatured(cctx context.Context, req *pb.RpcObjectRelationRemoveFeaturedRequest) *pb.RpcObjectRelationRemoveFeaturedResponse {
 	ctx := mw.newContext(cctx)
 	response := func(code pb.RpcObjectRelationRemoveFeaturedResponseErrorCode, err error) *pb.RpcObjectRelationRemoveFeaturedResponse {
@@ -558,8 +565,13 @@ func (mw *Middleware) ObjectRelationRemoveFeatured(cctx context.Context, req *pb
 		}
 		return m
 	}
+	for _, r := range req.Relations {
+		if r != bundle.RelationKeyDescription.String() {
+			return response(pb.RpcObjectRelationRemoveFeaturedResponseError_UNKNOWN_ERROR, fmt.Errorf("only description relation is supported"))
+		}
+	}
 	err := mw.doBlockService(func(bs *block.Service) (err error) {
-		return bs.FeaturedRelationRemove(ctx, req.ContextId, req.Relations...)
+		return bs.DescriptionHide(ctx, req.ContextId)
 	})
 	if err != nil {
 		return response(pb.RpcObjectRelationRemoveFeaturedResponseError_UNKNOWN_ERROR, err)


### PR DESCRIPTION
## Summary
- Replace generic `FeaturedRelationAdd`/`FeaturedRelationRemove` with dedicated `DescriptionShow`/`DescriptionHide` methods in `basic.CommonOperations` and `block.Service`
- Set `ChangeTypeDescriptionToggle` so `lastModifiedDate` is not updated when toggling description visibility
- Move validation to MW layer: only `description` relation is accepted through the featured relation RPCs
- Add `ChangeTypeDescriptionToggle` constant to `domain.ChangeType`

## Test plan
- [x] Unit tests pass (`go test ./core/block/editor/basic/... -run "Description(Show|Hide)"`)
- [x] Manual verification: toggling description visibility does not update Modified Date
- [x] Verify objects sorted by Modified Date are not reordered on description toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)