### PR TITLE
GO-6677 Preserve checkbox checked state on split

### DIFF
--- a/core/block/simple/text/text.go
+++ b/core/block/simple/text/text.go
@@ -432,10 +432,11 @@ func (t *Text) RangeSplit(from int32, to int32, top bool) (newBlock simple.Block
 	if top {
 		newBlock = simple.New(&model.Block{
 			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
-				Text:  textutil.UTF16ToStr(runes[:from]),
-				Style: t.content.Style,
-				Marks: oldMarks,
-				Color: t.content.Color,
+				Text:    textutil.UTF16ToStr(runes[:from]),
+				Style:   t.content.Style,
+				Marks:   oldMarks,
+				Checked: t.content.Checked,
+				Color:   t.content.Color,
 			}},
 			BackgroundColor: tBackgroundColor,
 			Align:           t.Align,
@@ -443,14 +444,13 @@ func (t *Text) RangeSplit(from int32, to int32, top bool) (newBlock simple.Block
 
 		t.content.Text = textutil.UTF16ToStr(runes[to:])
 		t.content.Marks = newMarks
-		t.content.Checked = false
 	} else {
 		newBlock = simple.New(&model.Block{
 			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
 				Text:    textutil.UTF16ToStr(runes[to:]),
 				Style:   t.content.Style,
 				Marks:   newMarks,
-				Checked: false,
+				Checked: t.content.Checked,
 				Color:   t.content.Color,
 			}},
 			BackgroundColor: tBackgroundColor,

--- a/core/block/simple/text/text_test.go
+++ b/core/block/simple/text/text_test.go
@@ -199,6 +199,68 @@ func TestText_RangeSplit(t *testing.T) {
 		_, err := b.RangeSplit(0, 11, false)
 		require.Equal(t, ErrOutOfRange, err)
 	})
+	t.Run("checked checkbox split at position 0 bottom preserves checked state", func(t *testing.T) {
+		b := NewText(&model.Block{
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				Text:    "checkbox text",
+				Style:   model.BlockContentText_Checkbox,
+				Checked: true,
+			}},
+		}).(*Text)
+		newBlock, err := b.RangeSplit(0, 0, false)
+		require.NoError(t, err)
+		nb := newBlock.(*Text)
+		assert.Equal(t, "checkbox text", nb.content.Text)
+		assert.True(t, nb.content.Checked, "new block should preserve checked state")
+		assert.Equal(t, "", b.content.Text)
+		assert.True(t, b.content.Checked, "original block should preserve checked state")
+	})
+	t.Run("checked checkbox split at position 0 top preserves checked state", func(t *testing.T) {
+		b := NewText(&model.Block{
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				Text:    "checkbox text",
+				Style:   model.BlockContentText_Checkbox,
+				Checked: true,
+			}},
+		}).(*Text)
+		newBlock, err := b.RangeSplit(0, 0, true)
+		require.NoError(t, err)
+		nb := newBlock.(*Text)
+		assert.Equal(t, "", nb.content.Text)
+		assert.True(t, nb.content.Checked, "new top block should preserve checked state")
+		assert.Equal(t, "checkbox text", b.content.Text)
+		assert.True(t, b.content.Checked, "original block should preserve checked state")
+	})
+	t.Run("checked checkbox mid-text split preserves checked state", func(t *testing.T) {
+		b := NewText(&model.Block{
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				Text:    "checkbox text",
+				Style:   model.BlockContentText_Checkbox,
+				Checked: true,
+			}},
+		}).(*Text)
+		newBlock, err := b.RangeSplit(8, 8, false)
+		require.NoError(t, err)
+		nb := newBlock.(*Text)
+		assert.Equal(t, " text", nb.content.Text)
+		assert.True(t, nb.content.Checked, "new block should preserve checked state")
+		assert.Equal(t, "checkbox", b.content.Text)
+		assert.True(t, b.content.Checked, "original block should preserve checked state")
+	})
+	t.Run("unchecked checkbox split does not set checked", func(t *testing.T) {
+		b := NewText(&model.Block{
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{
+				Text:    "unchecked",
+				Style:   model.BlockContentText_Checkbox,
+				Checked: false,
+			}},
+		}).(*Text)
+		newBlock, err := b.RangeSplit(0, 0, false)
+		require.NoError(t, err)
+		nb := newBlock.(*Text)
+		assert.False(t, nb.content.Checked)
+		assert.False(t, b.content.Checked)
+	})
 }
 
 func TestText_Merge(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `RangeSplit()` losing the `Checked` state when splitting a checkbox text block
- The bug caused checked checkboxes to become unchecked when pressing Enter at the start of the line (position-0 split)
- Root cause: both `top=true` and `top=false` branches unconditionally set `Checked` to `false`, unlike the simpler `Split()` method which correctly preserved it
- Now both branches use `Checked: t.content.Checked` to inherit the original state

## Test plan
- [x] Added test: checked checkbox split at position 0 (bottom mode) preserves checked state
- [x] Added test: checked checkbox split at position 0 (top mode) preserves checked state
- [x] Added test: checked checkbox mid-text split preserves checked state
- [x] Added test: unchecked checkbox split does not incorrectly set checked
- [x] All existing `RangeSplit` tests pass
- [x] All `stext` editor tests pass