### PR TITLE
GO-6828 Fix bulleted list indentation on block merge

### DIFF
--- a/core/block/editor/stext/text.go
+++ b/core/block/editor/stext/text.go
@@ -185,8 +185,33 @@ func (t *textImpl) Merge(ctx session.Context, firstId, secondId string) (err err
 	if err = first.Merge(second, mergeOpts...); err != nil {
 		return
 	}
+	// Before unlinking, find second's previous sibling in its parent so we can
+	// re-parent its children at the correct indentation level (GO-6828)
+	secondChildren := second.Model().ChildrenIds
+	secondParent := s.GetParentOf(secondId)
+	var prevSiblingId string
+	if secondParent != nil {
+		secondPos := slice.FindPos(secondParent.Model().ChildrenIds, secondId)
+		if secondPos > 0 {
+			prevSiblingId = secondParent.Model().ChildrenIds[secondPos-1]
+		}
+	}
+
 	s.Unlink(second.Model().Id)
-	first.Model().ChildrenIds = append(first.Model().ChildrenIds, second.Model().ChildrenIds...)
+
+	// Append second's children to its previous sibling so they maintain
+	// their indentation level. If there is no previous sibling, fall back
+	// to appending to the first (target) block.
+	if len(secondChildren) > 0 {
+		if prevSiblingId != "" {
+			prevSibling := s.Get(prevSiblingId)
+			if prevSibling != nil {
+				prevSibling.Model().ChildrenIds = append(prevSibling.Model().ChildrenIds, secondChildren...)
+			}
+		} else {
+			first.Model().ChildrenIds = append(first.Model().ChildrenIds, secondChildren...)
+		}
+	}
 	if err = t.Apply(s); err != nil {
 		return
 	}

--- a/core/block/editor/stext/text_test.go
+++ b/core/block/editor/stext/text_test.go
@@ -211,6 +211,41 @@ func TestTextImpl_Merge(t *testing.T) {
 		assert.Equal(t, []string{"ch1", "ch2"}, r.Pick("1").Model().ChildrenIds)
 	})
 
+	t.Run("should keep children indentation when first is deeper than second", func(t *testing.T) {
+		// Structure:
+		//   root
+		//   ├── A
+		//   │   └── SubA (first - visually above B)
+		//   └── B (second - being merged into SubA)
+		//       ├── Ch1
+		//       └── Ch2
+		//
+		// After merge B into SubA, Ch1 and Ch2 should become children of A
+		// (B's previous sibling) to retain their indentation level.
+		sb := smarttest.New("test")
+		subA := newTextBlock("subA", "sub")
+		b := newTextBlock("B", "two")
+		b.Model().ChildrenIds = []string{"ch1", "ch2"}
+		sb.AddBlock(simple.New(&model.Block{Id: "test", ChildrenIds: []string{"A", "B"}})).
+			AddBlock(simple.New(&model.Block{Id: "A", ChildrenIds: []string{"subA"}})).
+			AddBlock(subA).
+			AddBlock(b).
+			AddBlock(newTextBlock("ch1", "child1")).
+			AddBlock(newTextBlock("ch2", "child2"))
+		sender := mock_event.NewMockSender(t)
+		tb := NewText(sb, nil, sender)
+
+		err := tb.Merge(nil, "subA", "B")
+		require.NoError(t, err)
+
+		r := sb.NewState()
+		assert.False(t, r.Exists("B"))
+		assert.Equal(t, "subtwo", r.Pick("subA").Model().GetText().Text)
+		// Ch1 and Ch2 should be children of A (B's previous sibling), not subA
+		assert.Equal(t, []string{"subA", "ch1", "ch2"}, r.Pick("A").Model().ChildrenIds)
+		assert.Empty(t, r.Pick("subA").Model().ChildrenIds)
+	})
+
 	t.Run("shouldn't merge blocks inside header block", func(t *testing.T) {
 		sb := smarttest.New("test")
 		tb1 := newTextBlock("1", "one")


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6828/bulleted-list-indentation-strange-behaviour

## Summary
- When backspacing to merge a bullet block into the block above, the merged block's children were incorrectly appended to the target block — increasing their indentation when the target was at a deeper nesting level
- Now children are appended to the merged block's previous sibling in its parent, preserving their original indentation level
- Added test for the cross-depth merge scenario (target block deeper than source)

## Test plan
- [x] Unit tests pass (`go test ./core/block/editor/... -count=1`)
- [x] Manual verification: create a bulleted list with sub-bullets, backspace to merge a parent bullet into the block above, verify sub-bullets stay at the same indentation level (yes, I have tested in manually true-true-true!)

