### PR TITLE
GO-6932 Fix forward compatibility for any-store objects

### DIFF
--- a/core/block/editor/chatobject/chathandler.go
+++ b/core/block/editor/chatobject/chathandler.go
@@ -207,7 +207,7 @@ func (d *ChatHandler) UpgradeKeyModifier(ch storestate.ChangeOp, key *pb.KeyModi
 			case chatmodel.PinnedKey:
 				d.subscription.UpdatePinned(msg)
 			default:
-				return nil, false, fmt.Errorf("invalid key path %s", key.KeyPath)
+				// Forward compatibility: unknown key path, skip side effects
 			}
 		}
 

--- a/core/block/editor/chatobject/chathandler.go
+++ b/core/block/editor/chatobject/chathandler.go
@@ -207,7 +207,7 @@ func (d *ChatHandler) UpgradeKeyModifier(ch storestate.ChangeOp, key *pb.KeyModi
 			case chatmodel.PinnedKey:
 				d.subscription.UpdatePinned(msg)
 			default:
-				// Forward compatibility: unknown key path, skip side effects
+				return nil, false, fmt.Errorf("invalid key path %s", key.KeyPath)
 			}
 		}
 

--- a/core/block/editor/chatobject/chatobject_test.go
+++ b/core/block/editor/chatobject/chatobject_test.go
@@ -461,6 +461,44 @@ func TestEditMessage(t *testing.T) {
 
 }
 
+func TestDeleteMessage(t *testing.T) {
+	t.Run("delete own message", func(t *testing.T) {
+		ctx := context.Background()
+		fx := newFixture(t)
+
+		inputMessage := givenComplexMessage()
+		messageId, err := fx.AddMessage(ctx, nil, inputMessage)
+		require.NoError(t, err)
+
+		err = fx.DeleteMessage(ctx, messageId)
+		require.NoError(t, err)
+
+		messagesResp, err := fx.GetMessages(ctx, chatrepository.GetMessagesRequest{})
+		require.NoError(t, err)
+		require.Len(t, messagesResp.Messages, 0)
+	})
+
+	t.Run("delete other's message", func(t *testing.T) {
+		ctx := context.Background()
+		fx := newFixture(t)
+
+		inputMessage := givenComplexMessage()
+		messageId, err := fx.AddMessage(ctx, nil, inputMessage)
+		require.NoError(t, err)
+
+		fx.sourceCreator = "maliciousPerson"
+
+		err = fx.DeleteMessage(ctx, messageId)
+		require.Error(t, err)
+
+		// Check that message is not deleted
+		fx.sourceCreator = testCreator
+		messagesResp, err := fx.GetMessages(ctx, chatrepository.GetMessagesRequest{})
+		require.NoError(t, err)
+		require.Len(t, messagesResp.Messages, 1)
+	})
+}
+
 func TestToggleReaction(t *testing.T) {
 	ctx := context.Background()
 	fx := newFixture(t)

--- a/core/block/editor/chatobject/chatobject_test.go
+++ b/core/block/editor/chatobject/chatobject_test.go
@@ -444,9 +444,9 @@ func TestEditMessage(t *testing.T) {
 		fx.sourceCreator = "maliciousPerson"
 
 		err = fx.EditMessage(ctx, messageId, editedMessage)
-		require.NoError(t, err)
+		require.Error(t, err)
 
-		// Check that nothing is changed (validation error is skipped, but modification is not applied)
+		// Check that nothing is changed
 		messagesResp, err := fx.GetMessages(ctx, chatrepository.GetMessagesRequest{})
 		require.NoError(t, err)
 		require.Len(t, messagesResp.Messages, 1)
@@ -500,10 +500,8 @@ func TestToggleReaction(t *testing.T) {
 	t.Run("can't toggle someone else's reactions", func(t *testing.T) {
 		fx.sourceCreator = testCreator
 		fx.accountServiceStub.accountId = anotherPerson
-		added, err := fx.ToggleMessageReaction(ctx, messageId, "🐻")
-		require.NoError(t, err)
-		// Validation error is skipped for forward compatibility, but the reaction is not actually applied
-		assert.True(t, added)
+		_, err := fx.ToggleMessageReaction(ctx, messageId, "🐻")
+		require.Error(t, err)
 	})
 	t.Run("can toggle reactions on someone else's messages", func(t *testing.T) {
 		fx.sourceCreator = anotherPerson
@@ -565,7 +563,7 @@ func (fx *fixture) applyToStore(ctx context.Context, params source.PushStoreChan
 		_ = tx.Rollback()
 	}()
 	order := fx.generateOrderId(tx)
-	err = tx.ApplyChangeSet(storestate.ChangeSet{
+	err = tx.ApplyChangeSetReturnAllErrors(storestate.ChangeSet{
 		Id:        changeId,
 		Order:     order,
 		Changes:   params.Changes,

--- a/core/block/editor/chatobject/chatobject_test.go
+++ b/core/block/editor/chatobject/chatobject_test.go
@@ -444,9 +444,9 @@ func TestEditMessage(t *testing.T) {
 		fx.sourceCreator = "maliciousPerson"
 
 		err = fx.EditMessage(ctx, messageId, editedMessage)
-		require.Error(t, err)
+		require.NoError(t, err)
 
-		// Check that nothing is changed
+		// Check that nothing is changed (validation error is skipped, but modification is not applied)
 		messagesResp, err := fx.GetMessages(ctx, chatrepository.GetMessagesRequest{})
 		require.NoError(t, err)
 		require.Len(t, messagesResp.Messages, 1)
@@ -501,8 +501,9 @@ func TestToggleReaction(t *testing.T) {
 		fx.sourceCreator = testCreator
 		fx.accountServiceStub.accountId = anotherPerson
 		added, err := fx.ToggleMessageReaction(ctx, messageId, "🐻")
-		require.Error(t, err)
-		assert.False(t, added)
+		require.NoError(t, err)
+		// Validation error is skipped for forward compatibility, but the reaction is not actually applied
+		assert.True(t, added)
 	})
 	t.Run("can toggle reactions on someone else's messages", func(t *testing.T) {
 		fx.sourceCreator = anotherPerson

--- a/core/block/editor/storestate/error.go
+++ b/core/block/editor/storestate/error.go
@@ -6,6 +6,7 @@ var (
 	ErrIgnore            = errors.New("ignore")
 	ErrValidation        = errors.New("validation")
 	ErrCritical          = errors.New("critical")
+	errModifier          = errors.New("modifier")
 	ErrUnexpectedHandler = errors.New("unexpected handler")
 	ErrOrderNotFound     = errors.New("order not found")
 )

--- a/core/block/editor/storestate/error.go
+++ b/core/block/editor/storestate/error.go
@@ -5,7 +5,7 @@ import "errors"
 var (
 	ErrIgnore            = errors.New("ignore")
 	ErrValidation        = errors.New("validation")
-	ErrLog               = errors.New("log")
+	ErrCritical          = errors.New("critical")
 	ErrUnexpectedHandler = errors.New("unexpected handler")
 	ErrOrderNotFound     = errors.New("order not found")
 )

--- a/core/block/editor/storestate/modifier.go
+++ b/core/block/editor/storestate/modifier.go
@@ -13,6 +13,18 @@ import (
 
 const ordersKey = "_o"
 
+// wrapModifierErrors wraps a modifier so that any error it returns is tagged with errModifier.
+// This allows callers to distinguish modifier errors (from handler logic) from DB-level errors.
+func wrapModifierErrors(mod query.Modifier) query.Modifier {
+	return query.ModifyFunc(func(a *anyenc.Arena, v *anyenc.Value) (result *anyenc.Value, modified bool, err error) {
+		result, modified, err = mod.Modify(a, v)
+		if err != nil {
+			err = fmt.Errorf("%w: %w", errModifier, err)
+		}
+		return
+	})
+}
+
 func makeModifier(ch ChangeOp, h Handler) (modifier query.Modifier, err error) {
 	m := ch.Change.Change.GetModify()
 	chain := make(query.ModifierChain, 0, len(m.Keys))

--- a/core/block/editor/storestate/state.go
+++ b/core/block/editor/storestate/state.go
@@ -206,14 +206,14 @@ func (ss *StoreState) applyCreate(ctx context.Context, ch Change) (err error) {
 	// insert
 	coll, err := ss.Collection(ctx, create.Collection)
 	if err != nil {
-		return fmt.Errorf("get collection: %w", errors.Join(ErrCritical, err))
+		return errors.Join(ErrCritical, fmt.Errorf("get collection: %w", err))
 	}
 
 	if err = coll.Insert(ctx, value); err != nil {
 		if errors.Is(err, anystore.ErrDocExists) {
 			return ErrIgnore
 		}
-		return fmt.Errorf("insert document: %w", errors.Join(ErrCritical, err))
+		return errors.Join(ErrCritical, fmt.Errorf("insert document: %w", err))
 	}
 	return
 }
@@ -240,7 +240,7 @@ func (ss *StoreState) applyModify(ctx context.Context, ch Change) (err error) {
 
 	coll, err := ss.Collection(ctx, modify.Collection)
 	if err != nil {
-		return fmt.Errorf("get collection: %w", errors.Join(ErrCritical, err))
+		return errors.Join(ErrCritical, fmt.Errorf("get collection: %w", err))
 	}
 
 	var exec func(ctx context.Context, id any, m query.Modifier) (anystore.ModifyResult, error)
@@ -260,7 +260,7 @@ func (ss *StoreState) applyModify(ctx context.Context, ch Change) (err error) {
 			return err
 		}
 		// An error from any-store
-		return fmt.Errorf("modify document: %w", errors.Join(ErrCritical, err))
+		return errors.Join(ErrCritical, fmt.Errorf("modify document: %w", err))
 	}
 	return nil
 }
@@ -280,14 +280,14 @@ func (ss *StoreState) applyDelete(ctx context.Context, ch Change) (err error) {
 
 	coll, err := ss.Collection(ctx, del.Collection)
 	if err != nil {
-		return fmt.Errorf("get collection: %w", errors.Join(ErrCritical, err))
+		return errors.Join(ErrCritical, fmt.Errorf("get collection: %w", err))
 	}
 	switch mode {
 	case DeleteModeMark:
 		payload := ss.newDeleteMark(del.DocumentId)
 		fillRootOrder(ss.arena, payload, ch.Order)
 		if err = coll.UpdateOne(ctx, payload); err != nil {
-			return fmt.Errorf("update document: %w", errors.Join(ErrCritical, err))
+			return errors.Join(ErrCritical, fmt.Errorf("update document: %w", err))
 		}
 		return nil
 	case DeleteModeDelete:
@@ -296,7 +296,7 @@ func (ss *StoreState) applyDelete(ctx context.Context, ch Change) (err error) {
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("delete document: %w", errors.Join(ErrCritical, err))
+			return errors.Join(ErrCritical, fmt.Errorf("delete document: %w", err))
 		}
 		return nil
 	}

--- a/core/block/editor/storestate/state.go
+++ b/core/block/editor/storestate/state.go
@@ -136,7 +136,7 @@ func (ss *StoreState) Collection(ctx context.Context, name string) (anystore.Col
 	return ss.db.Collection(ctx, ss.id+name)
 }
 
-func (ss *StoreState) applyChangeSet(ctx context.Context, set ChangeSet) (err error) {
+func (ss *StoreState) applyChangeSet(ctx context.Context, set ChangeSet, returnAllErrors bool) (err error) {
 	for _, ch := range set.Changes {
 		applyErr := ss.applyChange(ctx, Change{
 			Id:        set.Id,
@@ -149,6 +149,10 @@ func (ss *StoreState) applyChangeSet(ctx context.Context, set ChangeSet) (err er
 			continue
 		}
 		if errors.Is(applyErr, ErrCritical) {
+			err = applyErr
+			break
+		}
+		if returnAllErrors {
 			err = applyErr
 			break
 		}

--- a/core/block/editor/storestate/state.go
+++ b/core/block/editor/storestate/state.go
@@ -148,16 +148,16 @@ func (ss *StoreState) applyChangeSet(ctx context.Context, set ChangeSet) (err er
 		if applyErr == nil || errors.Is(applyErr, ErrIgnore) {
 			continue
 		}
-		if errors.Is(applyErr, ErrLog) {
-			log.Warn("change apply error",
-				zap.Error(applyErr),
-				zap.String("changeId", set.Id),
-				zap.String("order", set.Order),
-			)
-			continue
+		if errors.Is(applyErr, ErrCritical) {
+			err = applyErr
+			break
 		}
-		err = applyErr
-		break
+		// Default: log and skip for forward compatibility
+		log.Warn("change apply error",
+			zap.Error(applyErr),
+			zap.String("changeId", set.Id),
+			zap.String("order", set.Order),
+		)
 	}
 	return
 }
@@ -206,14 +206,14 @@ func (ss *StoreState) applyCreate(ctx context.Context, ch Change) (err error) {
 	// insert
 	coll, err := ss.Collection(ctx, create.Collection)
 	if err != nil {
-		return err
+		return fmt.Errorf("get collection: %w", errors.Join(ErrCritical, err))
 	}
 
 	if err = coll.Insert(ctx, value); err != nil {
 		if errors.Is(err, anystore.ErrDocExists) {
 			return ErrIgnore
 		}
-		return
+		return fmt.Errorf("insert document: %w", errors.Join(ErrCritical, err))
 	}
 	return
 }
@@ -240,7 +240,7 @@ func (ss *StoreState) applyModify(ctx context.Context, ch Change) (err error) {
 
 	coll, err := ss.Collection(ctx, modify.Collection)
 	if err != nil {
-		return
+		return fmt.Errorf("get collection: %w", errors.Join(ErrCritical, err))
 	}
 
 	var exec func(ctx context.Context, id any, m query.Modifier) (anystore.ModifyResult, error)
@@ -252,13 +252,6 @@ func (ss *StoreState) applyModify(ctx context.Context, ch Change) (err error) {
 
 	// TODO: check result?
 	_, err = exec(ctx, modify.DocumentId, mod)
-	if err != nil {
-		if errors.Is(err, anystore.ErrDocNotFound) {
-			return ErrLog
-		} else {
-			return
-		}
-	}
 	return
 }
 
@@ -277,19 +270,25 @@ func (ss *StoreState) applyDelete(ctx context.Context, ch Change) (err error) {
 
 	coll, err := ss.Collection(ctx, del.Collection)
 	if err != nil {
-		return
+		return fmt.Errorf("get collection: %w", errors.Join(ErrCritical, err))
 	}
 	switch mode {
 	case DeleteModeMark:
 		payload := ss.newDeleteMark(del.DocumentId)
 		fillRootOrder(ss.arena, payload, ch.Order)
-		return coll.UpdateOne(ctx, payload)
+		if err = coll.UpdateOne(ctx, payload); err != nil {
+			return fmt.Errorf("update document: %w", errors.Join(ErrCritical, err))
+		}
+		return nil
 	case DeleteModeDelete:
 		err = coll.DeleteId(ctx, del.DocumentId)
 		if errors.Is(err, anystore.ErrDocNotFound) {
 			return nil
 		}
-		return err
+		if err != nil {
+			return fmt.Errorf("delete document: %w", errors.Join(ErrCritical, err))
+		}
+		return nil
 	}
 	return
 }
@@ -314,5 +313,5 @@ func (ss *StoreState) getHandler(collection string) (Handler, error) {
 	if h, ok := ss.handlers[collection]; ok {
 		return h, nil
 	}
-	return nil, errors.Join(ErrLog, ErrUnexpectedHandler, fmt.Errorf("'%s'", collection))
+	return nil, errors.Join(ErrUnexpectedHandler, fmt.Errorf("'%s'", collection))
 }

--- a/core/block/editor/storestate/state.go
+++ b/core/block/editor/storestate/state.go
@@ -250,9 +250,19 @@ func (ss *StoreState) applyModify(ctx context.Context, ch Change) (err error) {
 		exec = coll.UpdateId
 	}
 
-	// TODO: check result?
-	_, err = exec(ctx, modify.DocumentId, mod)
-	return
+	_, err = exec(ctx, modify.DocumentId, wrapModifierErrors(mod))
+	if err != nil {
+		if errors.Is(err, anystore.ErrDocNotFound) {
+			return nil
+		}
+		// An error from the modifier
+		if errors.Is(err, errModifier) {
+			return err
+		}
+		// An error from any-store
+		return fmt.Errorf("modify document: %w", errors.Join(ErrCritical, err))
+	}
+	return nil
 }
 
 func (ss *StoreState) applyDelete(ctx context.Context, ch Change) (err error) {

--- a/core/block/editor/storestate/state_test.go
+++ b/core/block/editor/storestate/state_test.go
@@ -246,6 +246,53 @@ func TestApplyChangeSetErrorHandling(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tx.Commit())
 	})
+
+	t.Run("ApplyChangeSetReturnAllErrors returns validation error", func(t *testing.T) {
+		handler := &errorHandler{
+			Name:      "testColl",
+			createErr: fmt.Errorf("validation failed: %w", ErrValidation),
+		}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		build := &Builder{}
+		assert.NoError(t, build.Create("testColl", "1", `{"key":"value1"}`))
+
+		err = tx.ApplyChangeSetReturnAllErrors(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrValidation)
+	})
+
+	t.Run("ApplyChangeSetReturnAllErrors returns unknown handler error", func(t *testing.T) {
+		handler := &errorHandler{
+			Name:      "testColl",
+			createErr: fmt.Errorf("some unknown error from handler"),
+		}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		build := &Builder{}
+		assert.NoError(t, build.Create("testColl", "1", `{"key":"value1"}`))
+
+		err = tx.ApplyChangeSetReturnAllErrors(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.Error(t, err)
+	})
 }
 
 // errorHandler is a test handler that returns configurable errors

--- a/core/block/editor/storestate/state_test.go
+++ b/core/block/editor/storestate/state_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-store/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -126,6 +127,135 @@ func TestStoreStateTx_ApplyChangeSet(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
+}
+
+func TestApplyChangeSetErrorHandling(t *testing.T) {
+	t.Run("unknown handler error is logged and skipped", func(t *testing.T) {
+		handler := &errorHandler{
+			Name:      "testColl",
+			createErr: fmt.Errorf("some unknown error from handler"),
+		}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+
+		build := &Builder{}
+		// First change will fail with unknown error (should be skipped)
+		assert.NoError(t, build.Create("testColl", "1", `{"key":"value1"}`))
+		// Second change should still be applied
+		handler.createErr = nil
+		assert.NoError(t, build.Create("testColl", "2", `{"key":"value2"}`))
+
+		err = tx.ApplyChangeSet(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+
+		// Only second document should exist
+		coll, err := fx.Collection(ctx, "testColl")
+		require.NoError(t, err)
+		_, err = coll.FindId(ctx, "2")
+		require.NoError(t, err)
+	})
+
+	t.Run("ErrCritical breaks the loop", func(t *testing.T) {
+		handler := &errorHandler{
+			Name:      "testColl",
+			createErr: fmt.Errorf("db failure: %w", ErrCritical),
+		}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+		defer func() {
+			_ = tx.Rollback()
+		}()
+
+		build := &Builder{}
+		assert.NoError(t, build.Create("testColl", "1", `{"key":"value1"}`))
+		assert.NoError(t, build.Create("testColl", "2", `{"key":"value2"}`))
+
+		err = tx.ApplyChangeSet(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrCritical)
+	})
+
+	t.Run("ErrIgnore continues silently", func(t *testing.T) {
+		handler := &errorHandler{
+			Name:      "testColl",
+			createErr: ErrIgnore,
+		}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+
+		build := &Builder{}
+		assert.NoError(t, build.Create("testColl", "1", `{"key":"value1"}`))
+
+		err = tx.ApplyChangeSet(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	})
+
+	t.Run("ErrValidation is logged and skipped", func(t *testing.T) {
+		handler := &errorHandler{
+			Name:      "testColl",
+			createErr: fmt.Errorf("validation failed: %w", ErrValidation),
+		}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+
+		build := &Builder{}
+		assert.NoError(t, build.Create("testColl", "1", `{"key":"value1"}`))
+
+		err = tx.ApplyChangeSet(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	})
+}
+
+// errorHandler is a test handler that returns configurable errors
+type errorHandler struct {
+	Name      string
+	createErr error
+}
+
+func (h *errorHandler) CollectionName() string { return h.Name }
+
+func (h *errorHandler) Init(ctx context.Context, s *StoreState) error {
+	_, err := s.Collection(ctx, h.Name)
+	return err
+}
+
+func (h *errorHandler) BeforeCreate(_ context.Context, _ ChangeOp) error {
+	return h.createErr
+}
+
+func (h *errorHandler) BeforeModify(_ context.Context, _ ChangeOp) (ModifyMode, error) {
+	return ModifyModeUpdate, nil
+}
+
+func (h *errorHandler) BeforeDelete(_ context.Context, _ ChangeOp) (DeleteMode, error) {
+	return DeleteModeDelete, nil
+}
+
+func (h *errorHandler) UpgradeKeyModifier(_ ChangeOp, _ *pb.KeyModify, mod query.Modifier) query.Modifier {
+	return mod
 }
 
 func TestBenchCreate(t *testing.T) {

--- a/core/block/editor/storestate/state_test.go
+++ b/core/block/editor/storestate/state_test.go
@@ -207,6 +207,25 @@ func TestApplyChangeSetErrorHandling(t *testing.T) {
 		require.NoError(t, tx.Commit())
 	})
 
+	t.Run("modify on non-existent document is skipped", func(t *testing.T) {
+		handler := DefaultHandler{Name: "testColl"}
+		fx := newFixture(t, "objId", handler)
+		tx, err := fx.NewTx(ctx)
+		require.NoError(t, err)
+
+		build := &Builder{}
+		// Modify a document that doesn't exist
+		assert.NoError(t, build.Modify("testColl", "nonexistent", nil, pb.ModifyOp_Set, nil))
+
+		err = tx.ApplyChangeSet(ChangeSet{
+			Id:      "1",
+			Order:   "1",
+			Changes: build.ChangeSet,
+		})
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit())
+	})
+
 	t.Run("ErrValidation is logged and skipped", func(t *testing.T) {
 		handler := &errorHandler{
 			Name:      "testColl",

--- a/core/block/editor/storestate/tx.go
+++ b/core/block/editor/storestate/tx.go
@@ -72,10 +72,18 @@ func (stx *StoreStateTx) checkMaxOrder(order string) {
 }
 
 func (stx *StoreStateTx) ApplyChangeSet(ch ChangeSet) (err error) {
+	return stx.applyChangeSet(ch, false)
+}
+
+func (stx *StoreStateTx) ApplyChangeSetReturnAllErrors(ch ChangeSet) (err error) {
+	return stx.applyChangeSet(ch, true)
+}
+
+func (stx *StoreStateTx) applyChangeSet(ch ChangeSet, returnAllErrors bool) (err error) {
 	if err = stx.SetOrder(ch.Id, ch.Order); err != nil && !errors.Is(err, anystore.ErrDocExists) {
 		return
 	}
-	err = stx.state.applyChangeSet(stx.ctx, ch)
+	err = stx.state.applyChangeSet(stx.ctx, ch, returnAllErrors)
 	return err
 }
 

--- a/core/block/source/sourceimpl/store.go
+++ b/core/block/source/sourceimpl/store.go
@@ -268,7 +268,7 @@ func (s *store) PushStoreChange(ctx context.Context, params source.PushStoreChan
 		DataType:          dataType,
 		Timestamp:         params.Time.Unix(),
 	}, func(change objecttree.StorageChange) error {
-		err = tx.ApplyChangeSet(storestate.ChangeSet{
+		err = tx.ApplyChangeSetReturnAllErrors(storestate.ChangeSet{
 			Id:        change.Id,
 			Order:     change.OrderId,
 			Changes:   params.Changes,


### PR DESCRIPTION
## Summary
- Fix forward compatibility for any-store objects by properly categorizing errors in `applyChangeSet`: critical DB errors break processing, validation/unknown errors are logged and skipped
- Wrap modifier errors with `errModifier` sentinel to distinguish handler errors from DB errors in `applyModify`
- Place `ErrCritical` as top-level sentinel in `errors.Join` for reliable detection
- Add `ApplyChangeSetReturnAllErrors` to return validation errors for user actions (`PushStoreChange`), so edit/react/delete operations on other users' messages properly fail
- Add comprehensive tests for error handling tiers and chat validation scenarios

## Test plan
- [x] `TestApplyChangeSetErrorHandling` covers all error tiers: unknown errors logged/skipped, `ErrCritical` breaks loop, `ErrIgnore` continues, `ErrValidation` logged/skipped, `ApplyChangeSetReturnAllErrors` returns all errors
- [x] `TestEditMessage/edit other's message` verifies editing another user's message returns error
- [x] `TestToggleReaction/can't toggle someone else's reactions` verifies toggling another user's reactions returns error
- [x] `TestDeleteMessage/delete other's message` verifies deleting another user's message returns error
- [x] Full `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)