### PR TITLE
GO-7019 Fix discussion being duplicated in another object

### DIFF
--- a/core/block/create.go
+++ b/core/block/create.go
@@ -37,6 +37,7 @@ func (s *Service) ObjectDuplicate(ctx context.Context, id string) (objectID stri
 		}
 		st = b.NewState().Copy()
 		st.SetLocalDetails(nil)
+		st.RemoveDetail(bundle.RelationKeyDiscussionId)
 		st.SetDetail(bundle.RelationKeySourceObject, domain.String(id))
 		return nil
 	}); err != nil {

--- a/core/block/template/templateimpl/impl.go
+++ b/core/block/template/templateimpl/impl.go
@@ -220,6 +220,7 @@ func (s *service) buildState(sb smartblock.SmartBlock) (st *state.State, err err
 		bundle.RelationKeyOrigin,
 		bundle.RelationKeyAddedDate,
 		bundle.RelationKeyFeaturedRelations,
+		bundle.RelationKeyDiscussionId,
 	}
 
 	// Only remove template name if prefill type is Empty (default)
@@ -488,6 +489,8 @@ func (s *service) buildTemplateStateFromObject(sb smartblock.SmartBlock) (*state
 			st.RemoveDetail(domain.RelationKey(rel.Key))
 		}
 	}
+	// Discussion-related details are hidden but should not be inherited by templates
+	st.RemoveDetail(bundle.RelationKeyDiscussionId)
 	flags := internalflag.NewFromState(st)
 	flags.Remove(model.InternalFlag_editorDeleteEmpty)
 	flags.AddToState(st)

--- a/core/block/template/templateimpl/impl_test.go
+++ b/core/block/template/templateimpl/impl_test.go
@@ -183,6 +183,22 @@ func TestService_CreateTemplateStateWithDetails(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("discussionId is removed from template state", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTest(templateName, "")
+		_ = tmpl.(*smarttest.SmartTest).SetDetails(nil, []domain.Detail{
+			{Key: bundle.RelationKeyDiscussionId, Value: domain.String("disc1")},
+		}, false)
+		s := service{picker: &testPicker{sb: tmpl}}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{TemplateId: templateName})
+
+		// then
+		assert.NoError(t, err)
+		assert.False(t, st.Details().Has(bundle.RelationKeyDiscussionId))
+	})
+
 	t.Run("template typeKey is removed", func(t *testing.T) {
 		// given
 		tmpl := newTemplateTest(templateName, bundle.TypeKeyGoal.String())
@@ -378,6 +394,33 @@ func assertLayoutBlocks(t *testing.T, st *state.State, layout model.ObjectTypeLa
 }
 
 func TestBuildTemplateStateFromObject(t *testing.T) {
+	t.Run("discussionId is removed from template state built from object", func(t *testing.T) {
+		// given
+		obj := smarttest.New("object")
+		err := obj.SetDetails(nil, []domain.Detail{
+			{Key: bundle.RelationKeyDiscussionId, Value: domain.String("disc1")},
+		}, false)
+		assert.NoError(t, err)
+
+		obj.SetObjectTypes([]domain.TypeKey{bundle.TypeKeyNote})
+
+		sp := mock_clientspace.NewMockSpace(t)
+		sp.EXPECT().GetTypeIdByKey(mock.Anything, mock.Anything).Times(1).Return(bundle.TypeKeyNote.String(), nil)
+		obj.SetSpace(sp)
+		obj.SetSpaceId("space1")
+
+		s := service{
+			store: objectstore.NewStoreFixture(t),
+		}
+
+		// when
+		st, err := s.buildTemplateStateFromObject(obj)
+
+		// then
+		assert.NoError(t, err)
+		assert.Empty(t, st.Details().GetString(bundle.RelationKeyDiscussionId))
+	})
+
 	t.Run("building state for new template", func(t *testing.T) {
 		// given
 		obj := smarttest.New("object")


### PR DESCRIPTION
## Summary
- Strip `discussionId` from object state during duplication (`ObjectDuplicate`) so discussions are not inherited by duplicated objects
- Strip `discussionId` from template state in `buildState` and `buildTemplateStateFromObject` so objects created from templates don't inherit the template's discussion
- Add tests for both template-related paths

## Test plan
- [x] Existing template tests pass
- [x] New tests verify `discussionId` is removed when building state from template
- [x] New tests verify `discussionId` is removed when creating template from object
- [ ] Manual: create object with discussion, duplicate it — duplicate should have no discussion
- [ ] Manual: create template from object with discussion, create object from that template — new object should have no discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)