### PR TITLE
GO-7030 Bump Go version to 1.25 in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'mac-mini-runner-') }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - name: Setup GO

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'mac-mini-runner-') }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - name: Setup GO

--- a/.github/workflows/perftests-grafana.yml
+++ b/.github/workflows/perftests-grafana.yml
@@ -37,7 +37,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'mac-mini-runner-') }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - name: Setup GO

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
 
       - name: Clone anytype-heart with specified branch


### PR DESCRIPTION
## Summary
- Bump Go version from 1.24 to 1.25 in `build`, `nightly`, `perftests-grafana`, and `smoke-tests` CI workflows
- `test.yml` and `golangci-lint.yml` were already at 1.25

## Test plan
- [ ] Verify CI workflows run successfully with Go 1.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)