### PR TITLE
GO-7054 Fix chat message validation for nil fields and empty content

### DIFF
--- a/core/block/chats/chatmodel/chatmodel.go
+++ b/core/block/chats/chatmodel/chatmodel.go
@@ -250,14 +250,24 @@ func (m *Message) MentionIdentities(ctx context.Context, repo MessagesGetter) ([
 }
 
 func (m *Message) Validate() error {
-	utf16text := textUtil.StrToUTF16(m.Message.Text)
+	var utf16text []uint16
+	if m.Message != nil {
+		utf16text = textUtil.StrToUTF16(m.Message.Text)
 
-	if len(utf16text) > MaxMessageLength {
-		return fmt.Errorf("message text exceeds maximum length of %d characters", MaxMessageLength)
+		if len(utf16text) > MaxMessageLength {
+			return fmt.Errorf("message text exceeds maximum length of %d characters", MaxMessageLength)
+		}
+
+		if err := validateMarks(m.Message.Marks, utf16text); err != nil {
+			return err
+		}
 	}
 
-	if err := validateMarks(m.Message.Marks, utf16text); err != nil {
-		return err
+	hasText := len(utf16text) > 0
+	hasAttachments := len(m.Attachments) > 0
+	hasBlocks := len(m.ChatMessage.Blocks) > 0
+	if !hasText && !hasAttachments && !hasBlocks {
+		return fmt.Errorf("message must have at least one of: text, attachments, or blocks")
 	}
 
 	for _, att := range m.Attachments {
@@ -302,6 +312,9 @@ func (m *Message) Validate() error {
 
 func validateMarks(marks []*model.BlockContentTextMark, utf16text []uint16) error {
 	for _, mark := range marks {
+		if mark.Range == nil {
+			return fmt.Errorf("mark range is nil")
+		}
 		if mark.Range.From < 0 {
 			return fmt.Errorf("invalid range.from")
 		}

--- a/core/block/chats/chatmodel/chatmodel_test.go
+++ b/core/block/chats/chatmodel/chatmodel_test.go
@@ -235,6 +235,68 @@ func TestValidate(t *testing.T) {
 
 		assert.Error(t, msg.Validate())
 	})
+
+	t.Run("nil message field with attachments is valid", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{
+				Attachments: []*model.ChatMessageAttachment{
+					{Target: "file1", Type: model.ChatMessageAttachment_FILE},
+				},
+			},
+		}
+
+		assert.NoError(t, msg.Validate())
+	})
+
+	t.Run("nil message field with blocks is valid", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{
+				Blocks: []*model.ChatMessageMessageBlock{
+					{Content: &model.ChatMessageMessageBlockContentOfText{
+						Text: &model.ChatMessageMessageBlockText{Text: "hello"},
+					}},
+				},
+			},
+		}
+
+		assert.NoError(t, msg.Validate())
+	})
+
+	t.Run("no content at all is invalid", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{},
+		}
+
+		assert.Error(t, msg.Validate())
+	})
+
+	t.Run("empty message with no attachments or blocks is invalid", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{
+				Message: &model.ChatMessageMessageContent{},
+			},
+		}
+
+		assert.Error(t, msg.Validate())
+	})
+
+	t.Run("mark with nil range is invalid", func(t *testing.T) {
+		msg := &Message{
+			ChatMessage: &model.ChatMessage{
+				Message: &model.ChatMessageMessageContent{
+					Text: "hello",
+					Marks: []*model.BlockContentTextMark{
+						{
+							Type:  model.BlockContentTextMark_Bold,
+							Range: nil,
+						},
+					},
+				},
+			},
+		}
+
+		assert.Error(t, msg.Validate())
+	})
 }
 
 func TestBlocksRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add nil guard for `Message` field in `Validate()` to prevent panic when optional proto field is nil
- Add nil guard for `mark.Range` in `validateMarks()` to prevent panic on nil range
- Add content validation: message must have at least one of text, attachments, or blocks

## Test plan
- [x] Added test: nil `Message` with attachments — valid
- [x] Added test: nil `Message` with blocks — valid
- [x] Added test: no content at all — invalid
- [x] Added test: empty `Message` with no attachments/blocks — invalid
- [x] Added test: mark with nil `Range` — invalid
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)