### PR TITLE
GO-5860 Remove FileHashes and ImageHashes from converter.Converter

### DIFF
--- a/core/converter/converter.go
+++ b/core/converter/converter.go
@@ -11,8 +11,6 @@ import (
 type Converter interface {
 	Convert(sbType model.SmartBlockType) (result []byte)
 	SetKnownDocs(docs map[string]*domain.Details) Converter
-	FileHashes() []string
-	ImageHashes() []string
 	Ext() string
 }
 

--- a/core/converter/dot/dot.go
+++ b/core/converter/dot/dot.go
@@ -48,8 +48,6 @@ type dot struct {
 	graph        *cgraph.Graph
 	graphviz     *graphviz.Graphviz
 	knownDocs    map[string]*domain.Details
-	fileHashes   []string
-	imageHashes  []string
 	exportFormat graphviz.Format
 	nodes        map[string]*cgraph.Node
 	linksByNode  map[string][]linkInfo
@@ -84,14 +82,6 @@ func NewMultiConverter(
 func (d *dot) SetKnownDocs(docs map[string]*domain.Details) converter.Converter {
 	d.knownDocs = docs
 	return d
-}
-
-func (d *dot) FileHashes() []string {
-	return d.fileHashes
-}
-
-func (d *dot) ImageHashes() []string {
-	return d.imageHashes
 }
 
 func (d *dot) Add(space smartblock.Space, st *state.State, fetcher relationutils.RelationFormatFetcher) error {

--- a/core/converter/dot/dot_notsupported.go
+++ b/core/converter/dot/dot_notsupported.go
@@ -36,14 +36,6 @@ func (d *dot) SetKnownDocs(docs map[string]*domain.Details) converter.Converter 
 	return d
 }
 
-func (d *dot) FileHashes() []string {
-	return nil
-}
-
-func (d *dot) ImageHashes() []string {
-	return nil
-}
-
 func (d *dot) Add(space smartblock.Space, st *state.State, fetcher relationutils.RelationFormatFetcher) error {
 	return nil
 }

--- a/core/converter/graphjson/graphjson.go
+++ b/core/converter/graphjson/graphjson.go
@@ -46,8 +46,6 @@ type Graph struct {
 
 type graphjson struct {
 	knownDocs   map[string]*domain.Details
-	fileHashes  []string
-	imageHashes []string
 	nodes       map[string]*Node
 	linksByNode map[string][]*Edge
 
@@ -67,14 +65,6 @@ func NewMultiConverter(
 func (g *graphjson) SetKnownDocs(docs map[string]*domain.Details) converter.Converter {
 	g.knownDocs = docs
 	return g
-}
-
-func (g *graphjson) FileHashes() []string {
-	return g.fileHashes
-}
-
-func (g *graphjson) ImageHashes() []string {
-	return g.imageHashes
 }
 
 func (g *graphjson) Add(space smartblock.Space, st *state.State, fetcher relationutils.RelationFormatFetcher) error {

--- a/core/converter/md/md.go
+++ b/core/converter/md/md.go
@@ -60,9 +60,6 @@ func NewMDConverterWithResolver(s *state.State, fn FileNamer, includeRelations b
 type MD struct {
 	s *state.State
 
-	fileHashes  []string
-	imageHashes []string
-
 	knownDocs map[string]*domain.Details
 	resolver  ObjectResolver
 
@@ -271,13 +268,6 @@ func (h *MD) processFileId(fileId string) string {
 	_, filename, _ := h.getLinkInfo(fileId)
 	if filename == "" {
 		return ""
-	}
-
-	// Track file hashes
-	if layout == int64(model.ObjectType_image) {
-		h.imageHashes = append(h.imageHashes, fileId)
-	} else {
-		h.fileHashes = append(h.fileHashes, fileId)
 	}
 
 	return filename
@@ -636,10 +626,8 @@ func (h *MD) renderFile(buf writer, in *renderState, b *model.Block) {
 	buf.WriteString(in.indent)
 	if file.Type != model.BlockContentFile_Image {
 		fmt.Fprintf(buf, "[%s](%s)    \n", title, filename)
-		h.fileHashes = append(h.fileHashes, file.TargetObjectId)
 	} else {
 		fmt.Fprintf(buf, "![%s](%s)    \n", title, filename)
-		h.imageHashes = append(h.imageHashes, file.TargetObjectId)
 	}
 }
 
@@ -779,14 +767,6 @@ func (h *MD) renderTable(buf writer, in *renderState, b *model.Block) {
 	if err != nil {
 		fmt.Fprintf(buf, "error while rendering table: %s", err)
 	}
-}
-
-func (h *MD) FileHashes() []string {
-	return h.fileHashes
-}
-
-func (h *MD) ImageHashes() []string {
-	return h.imageHashes
 }
 
 func (h *MD) marksWriter(text *model.BlockContentText) *marksWriter {

--- a/core/converter/md/md_test.go
+++ b/core/converter/md/md_test.go
@@ -1060,11 +1060,6 @@ func TestMD_FileFormatRelations(t *testing.T) {
 		assert.Contains(t, resultStr, "- files/file789_data.xlsx")
 		assert.Contains(t, resultStr, "- files/pdf012_manual.pdf")
 
-		// Check that file hashes were recorded
-		assert.Contains(t, conv.fileHashes, "file123")
-		assert.Contains(t, conv.fileHashes, "file789")
-		assert.Contains(t, conv.fileHashes, "pdf012")
-		assert.Contains(t, conv.imageHashes, "image456")
 	})
 }
 

--- a/core/converter/pbc/pbc.go
+++ b/core/converter/pbc/pbc.go
@@ -67,10 +67,3 @@ func (p *pbc) SetKnownDocs(map[string]*domain.Details) converter.Converter {
 	return p
 }
 
-func (p *pbc) FileHashes() []string {
-	return nil
-}
-
-func (p *pbc) ImageHashes() []string {
-	return nil
-}

--- a/core/converter/pbjson/pbjson.go
+++ b/core/converter/pbjson/pbjson.go
@@ -53,10 +53,3 @@ func (p *pbj) SetKnownDocs(map[string]*domain.Details) converter.Converter {
 	return p
 }
 
-func (p *pbj) FileHashes() []string {
-	return nil
-}
-
-func (p *pbj) ImageHashes() []string {
-	return nil
-}


### PR DESCRIPTION
## Summary
- Remove `FileHashes()` and `ImageHashes()` methods from the `converter.Converter` interface
- Remove associated fields and hash accumulation logic from all converter implementations (MD, DOT, GraphJSON, Protobuf, Protobuf JSON)
- These methods were never called by any consumer — dead code adding unnecessary complexity

## Test plan
- [x] `go build ./core/converter/...` — all converter packages compile
- [x] `go build ./core/block/export/...` — export package compiles
- [x] `go test ./core/converter/...` — all converter tests pass
- [x] `go test ./core/block/export/...` — export tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)