### PR TITLE
GO-7038 Strip trailing newlines when pasting over selection at end of…

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -1142,6 +1142,98 @@ func TestClipboard_PasteToCodeBlock(t *testing.T) {
 	assert.Equal(t, model.BlockContentText_Code, sb.Doc.Pick(codeBlock.Model().Id).Model().GetText().Style)
 }
 
+func TestClipboard_PasteToCodeBlock_TrailingNewline(t *testing.T) {
+	t.Run("strip trailing newline when selection extends to end", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithTitle))
+		s := sb.NewState()
+		codeBlock := simple.New(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Style: model.BlockContentText_Code,
+					Text:  "some code",
+				},
+			},
+		})
+		s.Add(codeBlock)
+		s.InsertTo("", model.Block_Inner, codeBlock.Model().Id)
+		require.NoError(t, sb.Apply(s))
+
+		// when — select " code" (positions 4..9, end of text) and paste with trailing \n
+		cb := newFixture(t, sb)
+		_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    codeBlock.Model().Id,
+			SelectedTextRange: rng(4, 9),
+			TextSlot:          " replacement\n",
+		}, "")
+
+		// then — trailing newline should be stripped
+		require.NoError(t, err)
+		assert.Equal(t, "some replacement", sb.Doc.Pick(codeBlock.Model().Id).Model().GetText().Text)
+	})
+
+	t.Run("full text replacement strips trailing newline", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithTitle))
+		s := sb.NewState()
+		codeBlock := simple.New(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Style: model.BlockContentText_Code,
+					Text:  "hello world",
+				},
+			},
+		})
+		s.Add(codeBlock)
+		s.InsertTo("", model.Block_Inner, codeBlock.Model().Id)
+		require.NoError(t, sb.Apply(s))
+
+		// when — select all text and paste with trailing \n
+		cb := newFixture(t, sb)
+		_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    codeBlock.Model().Id,
+			SelectedTextRange: rng(0, 11),
+			TextSlot:          "replacement\n",
+		}, "")
+
+		// then — no blank line at the end
+		require.NoError(t, err)
+		assert.Equal(t, "replacement", sb.Doc.Pick(codeBlock.Model().Id).Model().GetText().Text)
+	})
+
+	t.Run("preserve trailing newline when selection is in the middle", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithTitle))
+		s := sb.NewState()
+		codeBlock := simple.New(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Style: model.BlockContentText_Code,
+					Text:  "some code here",
+				},
+			},
+		})
+		s.Add(codeBlock)
+		s.InsertTo("", model.Block_Inner, codeBlock.Model().Id)
+		require.NoError(t, sb.Apply(s))
+
+		// when — select "code" (positions 5..9, NOT end of text) and paste with trailing \n
+		cb := newFixture(t, sb)
+		_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    codeBlock.Model().Id,
+			SelectedTextRange: rng(5, 9),
+			TextSlot:          "block\n",
+		}, "")
+
+		// then — trailing newline should be preserved as a separator
+		require.NoError(t, err)
+		assert.Equal(t, "some block\n here", sb.Doc.Pick(codeBlock.Model().Id).Model().GetText().Text)
+	})
+}
+
 func TestClipboard_PasteToTableCellBlock(t *testing.T) {
 	// given
 	sb := smarttest.New("text")

--- a/core/block/editor/clipboard/paste.go
+++ b/core/block/editor/clipboard/paste.go
@@ -437,6 +437,13 @@ func (p *pasteCtrl) intoCodeBlock() (err error) {
 		})
 		txt = strings.Join(txtArr, "\n")
 	}
+	// Strip trailing newlines when selection reaches the end of the code block,
+	// because there is no text after the selection to absorb them. This prevents
+	// clipboard artifacts (trailing \n or \r\n) from adding blank lines.
+	textLen := int32(textutil.UTF16RuneCountString(selText.GetText()))
+	if p.selRange.To >= textLen {
+		txt = strings.TrimRight(txt, "\n\r")
+	}
 	tb := &model.Block{
 		Content: &model.BlockContentOfText{
 			Text: &model.BlockContentText{


### PR DESCRIPTION
## Summary
- Fix extra blank line appearing when pasting text over a selection that extends to the end of a code block
- Clipboard content typically includes a trailing `\n` which, when there's no text after the selection to absorb it, creates blank lines that accumulate with each paste
- Strip trailing newlines from paste text only when the selection reaches the end of the code block; mid-text pastes preserve trailing newlines as separators

## Test plan
- [x] Unit tests pass (`TestClipboard_PasteToCodeBlock_TrailingNewline` — 3 subtests)
- [x] Existing `TestClipboard_PasteToCodeBlock` still passes (no regression)
- [x] Full clipboard test suite passes
- [ ] Manual verification: paste over selection at end of code block, no extra blank line (QA is needed, as fix should be verified on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
