### PR TITLE
GO-6032 Protect angle brackets in HTML-to-blocks pipeline

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -2027,6 +2027,61 @@ func TestProcessFileBlock(t *testing.T) {
 	})
 }
 
+func TestClipboard_PasteHtmlWithAngleBrackets(t *testing.T) {
+	t.Run("HTML-only paste into code block preserves angle brackets", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithTitle))
+		s := sb.NewState()
+		codeBlock := simple.New(&model.Block{
+			Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Style: model.BlockContentText_Code,
+					Text:  "",
+				},
+			},
+		})
+		s.Add(codeBlock)
+		s.InsertTo("", model.Block_Inner, codeBlock.Model().Id)
+		require.NoError(t, sb.Apply(s))
+
+		// when
+		cb := newFixture(t, sb)
+		_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    codeBlock.Model().Id,
+			SelectedTextRange: &model.Range{From: 0, To: 0},
+			HtmlSlot:          `<pre><code>fmt.Println(&lt;T&gt;)</code></pre>`,
+		}, "")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "fmt.Println(<T>)\n", sb.Doc.Pick(codeBlock.Model().Id).Model().GetText().Text)
+		assert.Equal(t, model.BlockContentText_Code, sb.Doc.Pick(codeBlock.Model().Id).Model().GetText().Style)
+	})
+
+	t.Run("HTML paste with angle brackets into paragraph", func(t *testing.T) {
+		// given
+		sb := createPage(t, createBlocks([]string{}, []string{}, emptyMarks))
+
+		// when
+		pasteHtml(t, sb, "", model.Range{From: 0, To: 0}, []string{}, `<p>const fn = (x) =&gt; x + 1</p>`)
+
+		// then
+		checkBlockText(t, sb, []string{"const fn = (x) => x + 1"})
+	})
+
+	t.Run("HTML paste with generics preserves angle brackets", func(t *testing.T) {
+		// given
+		sb := createPage(t, createBlocks([]string{}, []string{}, emptyMarks))
+
+		// when
+		pasteHtml(t, sb, "", model.Range{From: 0, To: 0}, []string{}, `<p>List&lt;String&gt; items</p>`)
+
+		// then
+		checkBlockText(t, sb, []string{"List<String> items"})
+	})
+}
+
 func TestPasteEmptyFileBlock(t *testing.T) {
 	t.Run("empty file placeholder pastes without error", func(t *testing.T) {
 		// given

--- a/core/block/import/markdown/anymark/blocks_test.go
+++ b/core/block/import/markdown/anymark/blocks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/globalsign/mgo/bson"
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/text"
 
@@ -129,6 +130,65 @@ func TestPreprocessBlocksThreeCodeBlock(t *testing.T) {
 
 	assert.Equal(t, blocks[0].GetText().GetText(), bl.GetText().GetText())
 	assert.Equal(t, blocks[1].GetText().GetText(), bl2.GetText().GetText()+"\n"+bl3.GetText().GetText())
+}
+
+func TestEscapeUnescapeAngleBrackets(t *testing.T) {
+	input := "List<String> a = new ArrayList<>()"
+	escaped := Escape(input)
+
+	assert.NotContains(t, escaped, "<")
+	assert.NotContains(t, escaped, ">")
+	assert.Equal(t, input, Unescape(escaped))
+}
+
+func TestHTMLToBlocks_AngleBrackets(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected string
+	}{
+		{
+			name:     "HTML entities in paragraph",
+			html:     `<p>fmt.Println(&lt;T&gt;)</p>`,
+			expected: "fmt.Println(<T>)",
+		},
+		{
+			name:     "arrow function in span",
+			html:     `<p>const fn = (x) =&gt; x + 1</p>`,
+			expected: "const fn = (x) => x + 1",
+		},
+		{
+			name:     "JSX-like content",
+			html:     `<p>&lt;div className=&quot;test&quot;&gt;Hello&lt;/div&gt;</p>`,
+			expected: `<div className="test">Hello</div>`,
+		},
+		{
+			name:     "generics in code block",
+			html:     `<pre><code>List&lt;String&gt; items = new ArrayList&lt;&gt;();</code></pre>`,
+			expected: "List<String> items = new ArrayList<>();\n",
+		},
+		{
+			name:     "comparison operators",
+			html:     `<p>if a &lt; b &amp;&amp; c &gt; d</p>`,
+			expected: "if a < b && c > d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks, _, err := HTMLToBlocks([]byte(tt.html), "")
+			require.NoError(t, err)
+
+			var textContent string
+			for _, b := range blocks {
+				if b.GetText() != nil {
+					textContent = b.GetText().GetText()
+					break
+				}
+			}
+			assert.Equal(t, tt.expected, textContent)
+		})
+	}
 }
 
 func TestCloseTextBlock(t *testing.T) {

--- a/core/block/import/markdown/anymark/escape.go
+++ b/core/block/import/markdown/anymark/escape.go
@@ -12,6 +12,8 @@ var protectedRunes = []rune{
 	'`', // Markdown code opener
 	'_', // Markdown em opener
 	'|', // Markdown table column separator
+	'<', // HTML tag opener — prevents goldmark from treating literal < as HTML
+	'>', // HTML tag closer — prevents goldmark from treating literal > as HTML
 }
 
 // Starting at the first BMP PUA code point (U+E000)


### PR DESCRIPTION
## Summary
- Add `<` and `>` to the `protectedRunes` escape list in `anymark/escape.go`
- When pasting HTML containing `&lt;`/`&gt;` entities (e.g. from CodeMirror copy buttons, ViolentMonkey, IDE copy buttons), the html-to-markdown library decodes them to bare `<`/`>`, which goldmark then misinterprets as HTML tags and silently drops
- The existing PUA sentinel escape mechanism already protects markdown-special characters (`[`, `]`, `*`, etc.) — this extends it to also protect angle brackets
- Fixes the issue for all paste targets (code blocks, paragraphs, etc.) since the fix is in the shared conversion pipeline

## Test plan
- [x] `TestEscapeUnescapeAngleBrackets` — round-trip escape/unescape preserves `<` and `>`
- [x] `TestHTMLToBlocks_AngleBrackets` — HTML entities, arrow functions, JSX, generics, comparison operators all preserved through `HTMLToBlocks`
- [x] `TestClipboard_PasteHtmlWithAngleBrackets` — end-to-end paste into code blocks and paragraphs preserves angle brackets
- [x] All existing `TestConvertHTMLToBlocks` JSON test cases still pass (including underline `<u>` tags)
- [x] All existing clipboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
