### PR TITLE
GO-6810 Return error instead of silently skipping restricted objects …

### DIFF
--- a/core/block/detailservice/service_test.go
+++ b/core/block/detailservice/service_test.go
@@ -547,4 +547,28 @@ func TestService_SetListIsArchived(t *testing.T) {
 		// then
 		assert.Error(t, err)
 	})
+
+	t.Run("error on archiving restricted objects", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		sb := smarttest.New(binId)
+		sb.AddBlock(simple.New(&model.Block{Id: binId, ChildrenIds: []string{}}))
+		fx.store.AddObjects(t, spaceId, objects)
+		fx.space.EXPECT().DerivedIDs().Return(threads.DerivedSmartblockIds{Archive: binId})
+		fx.getter.EXPECT().GetObject(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, objectId string) (smartblock.SmartBlock, error) {
+			if objectId == binId {
+				return editor.NewArchive(sb, fx.store.SpaceIndex(spaceId)), nil
+			}
+			restrictedSb := smarttest.New(objectId)
+			restrictedSb.SetType(coresb.SmartBlockTypeParticipant)
+			return restrictedSb, nil
+		})
+
+		// when
+		err := fx.SetListIsArchived(context.Background(), []string{"obj1", "obj2", "obj3"}, true)
+
+		// then
+		assert.Error(t, err)
+		assert.Len(t, sb.Blocks(), 1) // nothing was archived
+	})
 }

--- a/core/block/detailservice/set_details.go
+++ b/core/block/detailservice/set_details.go
@@ -221,14 +221,11 @@ func (s *service) setIsArchivedForObjects(ctx context.Context, spaceId string, o
 			return err
 		}
 
+		archiveId := spc.DerivedIDs().Archive
 		ids = slice.Filter(ids, func(id string) bool {
-			for _, objId := range spc.DerivedIDs().IDsWithSystemTypesAndRelations() {
-				if id == objId {
-					// avoid archive system objects including archive itself
-					return false
-				}
-			}
-			return true
+			// Skip the archive object itself to prevent deadlock:
+			// we're already inside cache.Do for this object
+			return id != archiveId
 		})
 		anySucceed, err := s.modifyArchiveLinks(ctx, archive, isArchived, ids...)
 


### PR DESCRIPTION
## Summary
- Replaced broad pre-filter in `setIsArchivedForObjects` that silently removed all system types/relations from the archive list (`IDsWithSystemTypesAndRelations()`) with a narrow filter that only skips the archive object itself (to prevent deadlock)
- All other restricted objects (system types, system relations, infrastructure objects) now reach `checkArchivedRestriction` which returns proper restriction errors instead of silently succeeding
- Added test verifying that batch-archiving restricted objects returns an error

## Test plan
- [x] Unit tests pass (`go test ./core/block/detailservice/... -v -count=1`)
- [ ] Manual verification: right-click delete on a system type/relation from sidebar should show an error instead of silently failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
