### PR TITLE
GO-7041 Fix block duplication after indentation in batch move

### DIFF
--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -382,9 +382,32 @@ func (s *State) changeBlockUpdate(update *pb.ChangeBlockUpdate) error {
 
 func (s *State) changeBlockMove(move *pb.ChangeBlockMove) error {
 	for _, id := range move.Ids {
-		s.Unlink(id)
+		if !s.Unlink(id) {
+			// The block's parent may have been unlinked earlier in this batch,
+			// making the block unreachable from root. Search among co-moved
+			// blocks for the actual parent and remove the child reference.
+			s.unlinkFromCoMovedBlocks(id, move.Ids)
+		}
 	}
 	return s.InsertTo(move.TargetId, move.Position, move.Ids...)
+}
+
+// unlinkFromCoMovedBlocks removes id from the ChildrenIds of any block in batchIds.
+// This handles the case where a block's parent was unlinked earlier in the same
+// batch move operation, making the block unreachable via root traversal.
+func (s *State) unlinkFromCoMovedBlocks(id string, batchIds []string) {
+	for _, otherId := range batchIds {
+		if otherId == id {
+			continue
+		}
+		if b := s.Pick(otherId); b != nil {
+			if slice.FindPos(b.Model().ChildrenIds, id) != -1 {
+				parent := s.Get(otherId)
+				s.removeChildren(parent.Model(), id)
+				return
+			}
+		}
+	}
 }
 
 func (s *State) changeStoreKeySet(set *pb.ChangeStoreKeySet) error {

--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -381,33 +381,8 @@ func (s *State) changeBlockUpdate(update *pb.ChangeBlockUpdate) error {
 }
 
 func (s *State) changeBlockMove(move *pb.ChangeBlockMove) error {
-	for _, id := range move.Ids {
-		if !s.Unlink(id) {
-			// The block's parent may have been unlinked earlier in this batch,
-			// making the block unreachable from root. Search among co-moved
-			// blocks for the actual parent and remove the child reference.
-			s.unlinkFromCoMovedBlocks(id, move.Ids)
-		}
-	}
+	s.UnlinkAll(move.Ids)
 	return s.InsertTo(move.TargetId, move.Position, move.Ids...)
-}
-
-// unlinkFromCoMovedBlocks removes id from the ChildrenIds of any block in batchIds.
-// This handles the case where a block's parent was unlinked earlier in the same
-// batch move operation, making the block unreachable via root traversal.
-func (s *State) unlinkFromCoMovedBlocks(id string, batchIds []string) {
-	for _, otherId := range batchIds {
-		if otherId == id {
-			continue
-		}
-		if b := s.Pick(otherId); b != nil {
-			if slice.FindPos(b.Model().ChildrenIds, id) != -1 {
-				parent := s.Get(otherId)
-				s.removeChildren(parent.Model(), id)
-				return
-			}
-		}
-	}
 }
 
 func (s *State) changeStoreKeySet(set *pb.ChangeStoreKeySet) error {

--- a/core/block/editor/state/change_test.go
+++ b/core/block/editor/state/change_test.go
@@ -1116,3 +1116,43 @@ func TestMakeObjectTypesChanges(t *testing.T) {
 		assert.Equal(t, domain.TypeKey("ot-note").URL(), remove.ObjectTypeRemove.Url)
 	})
 }
+
+func TestState_ChangeBlockMove_BatchWithParentAndChildren(t *testing.T) {
+	t.Run("parent and children moved together - no duplication", func(t *testing.T) {
+		// Reproduces GO-7041: indent on iOS generates a single Move change
+		// containing [B, B1, B2] where B was parent of B1, B2
+		d := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"A", "B"}}),
+			"A":    simple.New(&model.Block{Id: "A"}),
+			"B":    simple.New(&model.Block{Id: "B", ChildrenIds: []string{"B1", "B2"}}),
+			"B1":   simple.New(&model.Block{Id: "B1"}),
+			"B2":   simple.New(&model.Block{Id: "B2"}),
+		})
+		s := d.NewState()
+
+		err := s.ApplyChange(newMoveChange("A", model.Block_Inner, "B", "B1", "B2"))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"B", "B1", "B2"}, s.Pick("A").Model().ChildrenIds)
+		assert.Empty(t, s.Pick("B").Model().ChildrenIds)
+		assert.Equal(t, []string{"A"}, s.Pick("root").Model().ChildrenIds)
+		require.NoError(t, s.Validate())
+	})
+
+	t.Run("siblings moved together - no regression", func(t *testing.T) {
+		d := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"A", "B", "C"}}),
+			"A":    simple.New(&model.Block{Id: "A"}),
+			"B":    simple.New(&model.Block{Id: "B"}),
+			"C":    simple.New(&model.Block{Id: "C"}),
+		})
+		s := d.NewState()
+
+		err := s.ApplyChange(newMoveChange("A", model.Block_Inner, "B", "C"))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"B", "C"}, s.Pick("A").Model().ChildrenIds)
+		assert.Equal(t, []string{"A"}, s.Pick("root").Model().ChildrenIds)
+		require.NoError(t, s.Validate())
+	})
+}


### PR DESCRIPTION
## Summary
- Fix block duplication when a parent block and its children are moved together in a single batched Move change (e.g. indent on iOS)
- Use 'UnlinkAll' instead of 'Unlink' to handle the cases we already unlink the parent of next moving block, so new iteration cycle could not find it in invalid state
- Add tests covering the batch parent+children move scenario and a siblings regression test

## Test plan
- [x] New unit tests pass: `TestState_ChangeBlockMove_BatchWithParentAndChildren`
- [x] All state package tests pass: `go test ./core/block/editor/state/...`
- [x] Move/indent/outdent tests pass: `go test ./core/block/editor/basic/... -run TestBasic_Move`
- [x] Stext merge tests pass: `go test ./core/block/editor/stext/...`
- [x] Manual verification: indent blocks on iOS, verify no duplication on Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)