### PR TITLE
GO-7103 Switch CI to Android NDK 28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,12 @@ jobs:
           echo BUILD_TAG_NETWORK=envproduction >> $GITHUB_ENV
           echo MAVEN_ARTIFACT_VERSION=${VERSION} >> $GITHUB_ENV
           echo GOPRIVATE=github.com/anyproto >> $GITHUB_ENV
+          NDK28=$(ls -d ${ANDROID_HOME}/ndk/28.* 2>/dev/null | sort -V | tail -1)
+          if [ -z "$NDK28" ]; then echo "ERROR: NDK 28.x not found"; ls ${ANDROID_HOME}/ndk/; exit 1; fi
+          echo "Using NDK: $NDK28"
+          echo ANDROID_NDK=$NDK28 >> $GITHUB_ENV
+          echo ANDROID_NDK_HOME=$NDK28 >> $GITHUB_ENV
+          echo ANDROID_NDK_ROOT=$NDK28 >> $GITHUB_ENV
           echo $(pwd)/deps >> $GITHUB_PATH
           echo "${GOBIN}" >> $GITHUB_PATH
           git config --global url."https://${{ secrets.ANYTYPE_PAT }}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -164,6 +164,12 @@ jobs:
           echo BUILD_TAG_NETWORK=${{ github.event.inputs.build-tag-network || 'envproduction' }} >> $GITHUB_ENV
           echo MAVEN_ARTIFACT_VERSION=${VERSION} >> $GITHUB_ENV
           echo GOPRIVATE=github.com/anyproto >> $GITHUB_ENV
+          NDK28=$(ls -d ${ANDROID_HOME}/ndk/28.* 2>/dev/null | sort -V | tail -1)
+          if [ -z "$NDK28" ]; then echo "ERROR: NDK 28.x not found"; ls ${ANDROID_HOME}/ndk/; exit 1; fi
+          echo "Using NDK: $NDK28"
+          echo ANDROID_NDK=$NDK28 >> $GITHUB_ENV
+          echo ANDROID_NDK_HOME=$NDK28 >> $GITHUB_ENV
+          echo ANDROID_NDK_ROOT=$NDK28 >> $GITHUB_ENV
           echo $(pwd)/deps >> $GITHUB_PATH
           echo "${GOBIN}" >> $GITHUB_PATH
           git config --global url."https://${{ secrets.ANYTYPE_PAT }}@github.com/".insteadOf "https://github.com/"


### PR DESCRIPTION
## Summary
- Dynamically resolve the latest installed NDK 28.x on the CI runner instead of using the default NDK 27
- Overrides `ANDROID_NDK`, `ANDROID_NDK_HOME`, and `ANDROID_NDK_ROOT` env vars
- Fails fast with a clear error if NDK 28.x is not found on the runner
- Applied to both `build.yml` and `nightly.yml` workflows

## Test plan
- [ ] Trigger a build workflow and verify it picks up NDK 28.x
- [ ] Verify Android lib compiles successfully with the new NDK