### PR TITLE
GO-6868 Fix paste destroying styled block style

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -1272,6 +1272,90 @@ func TestPasteIntoEmptyStyledBlock(t *testing.T) {
 	}
 }
 
+func TestPasteIntoNonEmptyStyledBlock(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		style       model.BlockContentTextStyle
+		pasteBlocks []*model.Block
+		wantText    string
+	}{
+		{
+			name:  "single header paste into callout with all text selected",
+			style: model.BlockContentText_Callout,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Pasted Heading", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+			},
+			wantText: "Pasted Heading",
+		},
+		{
+			name:  "single paragraph paste into toggle with all text selected",
+			style: model.BlockContentText_Toggle,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Pasted Text", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+			wantText: "Pasted Text",
+		},
+		{
+			name:  "single header paste into checkbox with all text selected",
+			style: model.BlockContentText_Checkbox,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("Pasted Heading", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+			},
+			wantText: "Pasted Heading",
+		},
+		{
+			name:  "multi-block paste into callout with all text selected",
+			style: model.BlockContentText_Callout,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("First Line", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+				blockbuilder.Text("Second Line", blockbuilder.ID("p2"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+			wantText: "First Line",
+		},
+		{
+			name:  "multi-block paste into toggle with all text selected",
+			style: model.BlockContentText_Toggle,
+			pasteBlocks: []*model.Block{
+				blockbuilder.Text("First Line", blockbuilder.ID("p1"), blockbuilder.TextStyle(model.BlockContentText_Header1)).Block(),
+				blockbuilder.Text("Second Line", blockbuilder.ID("p2"), blockbuilder.TextStyle(model.BlockContentText_Paragraph)).Block(),
+			},
+			wantText: "First Line",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			existingText := "Existing content"
+			sb := smarttest.New("test")
+			sb.Doc = testutil.BuildStateFromAST(blockbuilder.Root(
+				blockbuilder.ID("root"),
+				blockbuilder.Children(
+					blockbuilder.Text(
+						existingText,
+						blockbuilder.ID("1"),
+						blockbuilder.TextStyle(tc.style),
+					),
+				)))
+
+			textLen := int32(textutil.UTF16RuneCountString(existingText))
+
+			// when
+			cb := newFixture(t, sb)
+			_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+				FocusedBlockId:    "1",
+				SelectedTextRange: &model.Range{From: 0, To: textLen},
+				AnySlot:           tc.pasteBlocks,
+			}, "")
+
+			// then
+			require.NoError(t, err)
+			targetBlock := sb.Doc.Pick("1")
+			require.NotNil(t, targetBlock, "target block should not be deleted")
+			assert.Equal(t, tc.style, targetBlock.Model().GetText().Style, "target block style should be preserved")
+			assert.Equal(t, tc.wantText, targetBlock.Model().GetText().Text, "target block text should match pasted content")
+		})
+	}
+}
+
 func Test_PasteText(t *testing.T) {
 
 	t.Run("paste", func(t *testing.T) {

--- a/core/block/editor/clipboard/paste.go
+++ b/core/block/editor/clipboard/paste.go
@@ -135,7 +135,8 @@ func (p *pasteCtrl) configure(req *pb.RpcBlockPasteRequest) (err error) {
 		}
 
 		selectedText := p.getFirstSelectedText()
-		p.mode.intoBlockCopyStyle = !(isSpecificStyle(p.getFirstPasteText()) || isRequiredBlock(selectedText))
+		targetIsStyled := selectedText != nil && selectedText.Model().GetText().Style != model.BlockContentText_Paragraph
+		p.mode.intoBlockCopyStyle = !(isSpecificStyle(p.getFirstPasteText()) || isRequiredBlock(selectedText) || targetIsStyled)
 
 		if selectedText != nil && textCount == 1 && nonTextCount == 0 && req.IsPartOfBlock {
 			p.mode.intoBlock = true
@@ -266,8 +267,13 @@ func (p *pasteCtrl) singleRange() (err error) {
 	}
 	if selText.GetText() == "" {
 		p.mode.removeSelection = true
-		if wasEmpty && firstPasteText != nil {
+		targetIsStyled := selText.Model().GetText().Style != model.BlockContentText_Paragraph
+		if (wasEmpty || targetIsStyled) && firstPasteText != nil {
 			p.mode.removeSelection = false
+			if targetIsStyled && !wasEmpty {
+				selText.SetText(firstPasteText.GetText(), firstPasteText.Model().GetText().Marks)
+				p.ps.Unlink(firstPasteText.Model().Id)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
## Summary
- Prevent paste from overwriting the style of non-Paragraph blocks (Callout, Toggle, Bullet, Checkbox, Highlight, etc.)
- Fix `intoBlock` path: disable style copying when target block has a non-Paragraph style, so single-block paste preserves the target's style
- Fix `singleRange` path: when a styled block becomes empty after `RangeSplit` (all text selected + replaced), preserve it by merging the first paste text content into it instead of deleting the block

## Linear
GO-6868

## Test plan
- [x] Existing `TestPasteIntoEmptyStyledBlock` tests pass (5 cases)
- [x] New `TestPasteIntoNonEmptyStyledBlock` tests pass (5 cases: single/multi-block paste into Callout, Toggle, Checkbox with all text selected)
- [x] Full clipboard test suite passes (`go test ./core/block/editor/clipboard/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)