### PR TITLE
GO-7110 Use order ID instead of diffmanager for chat sync status

### DIFF
--- a/core/block/chats/chatrepository/repository.go
+++ b/core/block/chats/chatrepository/repository.go
@@ -179,7 +179,7 @@ type Repository interface {
 	HasMyReaction(ctx context.Context, myIdentity string, messageId string, emoji string) (bool, error)
 	GetMessagesByIds(ctx context.Context, messageIds []string) ([]*chatmodel.Message, error)
 	GetLastMessages(ctx context.Context, limit uint) ([]*chatmodel.Message, error)
-	SetSyncedFlag(ctx context.Context, chatObjectId string, msgIds []string, value bool) ([]string, error)
+	SetSyncedByMaxOrderId(ctx context.Context, maxOrderId string) ([]string, error)
 	// GetAllMessageAttachments returns attachment info from all messages, optionally filtered by afterOrderId.
 	GetAllMessageAttachments(ctx context.Context, afterOrderId string) ([]MessageAttachmentInfo, error)
 	GetPinnedMessages(ctx context.Context) ([]*chatmodel.Message, error)
@@ -476,50 +476,20 @@ func (r *repository) setReadFlag(ctx context.Context, arena *anyenc.Arena, handl
 	return mod.getModifiedIds(), nil
 }
 
-func (r *repository) SetSyncedFlag(ctx context.Context, chatObjectId string, msgIds []string, value bool) ([]string, error) {
-	arena := r.arenaPool.Get()
-	defer func() {
-		r.arenaPool.Put(arena)
-	}()
-
-	var idsModified []string
-
-	chunks := lo.Chunk(msgIds, 100)
-	for _, chunk := range chunks {
-		modified, err := r.setSyncedFlag(ctx, arena, chunk, value)
-		if err != nil {
-			return nil, err
-		}
-		idsModified = append(idsModified, modified...)
+func (r *repository) SetSyncedByMaxOrderId(ctx context.Context, maxOrderId string) ([]string, error) {
+	if maxOrderId == "" {
+		return nil, nil
 	}
 
-	return idsModified, nil
-}
-
-func (r *repository) setSyncedFlag(ctx context.Context, arena *anyenc.Arena, msgIds []string, value bool) ([]string, error) {
-	arena.Reset()
-	encIds := make([]*anyenc.Value, 0, len(msgIds))
-	for _, id := range msgIds {
-		encIds = append(encIds, arena.NewString(id))
+	filter := query.And{
+		filterSyncedFalse,
+		query.Key{Path: []string{chatmodel.OrderKey, "id"}, Filter: query.NewComp(query.CompOpLte, maxOrderId)},
 	}
 
-	var syncedFilter query.Filter
-	if value {
-		syncedFilter = filterSyncedFalse
-	} else {
-		syncedFilter = filterSyncedTrue
-	}
-
-	mod := &syncedModifier{value: value}
-	_, err := r.collection.Find(query.And{
-		syncedFilter,
-		query.Key{
-			Path:   []string{"id"},
-			Filter: query.NewInValue(encIds...),
-		},
-	}).Update(ctx, mod)
+	mod := &syncedModifier{value: true}
+	_, err := r.collection.Find(filter).Update(ctx, mod)
 	if err != nil {
-		return nil, fmt.Errorf("update synced flag: %w", err)
+		return nil, fmt.Errorf("set synced by max order id: %w", err)
 	}
 	return mod.getModifiedIds(), nil
 }

--- a/core/block/chats/chatrepository/repository_test.go
+++ b/core/block/chats/chatrepository/repository_test.go
@@ -218,35 +218,20 @@ func TestSetReadFlag(t *testing.T) {
 	})
 }
 
-func TestSetSyncedFlag(t *testing.T) {
-	chatObjectId := "chatObj1"
-
-	t.Run("mark unsynced messages as synced", func(t *testing.T) {
+func TestSetSyncedByMaxOrderId(t *testing.T) {
+	t.Run("mark unsynced messages up to max order id", func(t *testing.T) {
 		fx := newFixture(t)
 		fx.addMessageWithSynced(t, "msg1", "order1", false)
 		fx.addMessageWithSynced(t, "msg2", "order2", false)
 		fx.addMessageWithSynced(t, "msg3", "order3", false)
 
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, []string{"msg1", "msg2", "msg3"}, true)
-		require.NoError(t, err)
-
-		assert.ElementsMatch(t, []string{"msg1", "msg2", "msg3"}, modified)
-		assert.True(t, fx.getMessage(t, "msg1").Synced)
-		assert.True(t, fx.getMessage(t, "msg2").Synced)
-		assert.True(t, fx.getMessage(t, "msg3").Synced)
-	})
-
-	t.Run("mark synced messages as unsynced", func(t *testing.T) {
-		fx := newFixture(t)
-		fx.addMessageWithSynced(t, "msg1", "order1", true)
-		fx.addMessageWithSynced(t, "msg2", "order2", true)
-
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, []string{"msg1", "msg2"}, false)
+		modified, err := fx.repo.SetSyncedByMaxOrderId(context.Background(), "order2")
 		require.NoError(t, err)
 
 		assert.ElementsMatch(t, []string{"msg1", "msg2"}, modified)
-		assert.False(t, fx.getMessage(t, "msg1").Synced)
-		assert.False(t, fx.getMessage(t, "msg2").Synced)
+		assert.True(t, fx.getMessage(t, "msg1").Synced)
+		assert.True(t, fx.getMessage(t, "msg2").Synced)
+		assert.False(t, fx.getMessage(t, "msg3").Synced)
 	})
 
 	t.Run("skip already synced messages", func(t *testing.T) {
@@ -254,71 +239,30 @@ func TestSetSyncedFlag(t *testing.T) {
 		fx.addMessageWithSynced(t, "msg1", "order1", true)
 		fx.addMessageWithSynced(t, "msg2", "order2", false)
 
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, []string{"msg1", "msg2"}, true)
+		modified, err := fx.repo.SetSyncedByMaxOrderId(context.Background(), "order2")
 		require.NoError(t, err)
 
 		assert.Equal(t, []string{"msg2"}, modified)
 	})
 
-	t.Run("skip already unsynced messages", func(t *testing.T) {
-		fx := newFixture(t)
-		fx.addMessageWithSynced(t, "msg1", "order1", false)
-		fx.addMessageWithSynced(t, "msg2", "order2", true)
-
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, []string{"msg1", "msg2"}, false)
-		require.NoError(t, err)
-
-		assert.Equal(t, []string{"msg2"}, modified)
-	})
-
-	t.Run("skip missing messages", func(t *testing.T) {
-		fx := newFixture(t)
-		fx.addMessageWithSynced(t, "msg1", "order1", false)
-
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, []string{"msg1", "nonexistent"}, true)
-		require.NoError(t, err)
-
-		assert.Equal(t, []string{"msg1"}, modified)
-	})
-
-	t.Run("empty input returns nil", func(t *testing.T) {
+	t.Run("empty max order id returns nil", func(t *testing.T) {
 		fx := newFixture(t)
 
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, nil, true)
+		modified, err := fx.repo.SetSyncedByMaxOrderId(context.Background(), "")
 		require.NoError(t, err)
 
 		assert.Nil(t, modified)
 	})
 
-	t.Run("more than 100 messages are chunked", func(t *testing.T) {
+	t.Run("no unsynced messages in range", func(t *testing.T) {
 		fx := newFixture(t)
-		var ids []string
-		for i := range 150 {
-			id := fmt.Sprintf("msg%03d", i)
-			fx.addMessageWithSynced(t, id, fmt.Sprintf("order%03d", i), false)
-			ids = append(ids, id)
-		}
+		fx.addMessageWithSynced(t, "msg1", "order1", true)
+		fx.addMessageWithSynced(t, "msg2", "order2", true)
 
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, ids, true)
+		modified, err := fx.repo.SetSyncedByMaxOrderId(context.Background(), "order2")
 		require.NoError(t, err)
 
-		assert.Len(t, modified, 150)
-		for _, id := range ids {
-			assert.True(t, fx.getMessage(t, id).Synced, id)
-		}
-	})
-
-	t.Run("updates are committed", func(t *testing.T) {
-		fx := newFixture(t)
-		fx.addMessageWithSynced(t, "msg1", "order1", false)
-		fx.addMessageWithSynced(t, "msg2", "order2", false)
-
-		modified, err := fx.repo.SetSyncedFlag(context.Background(), chatObjectId, []string{"msg1", "msg2"}, true)
-		require.NoError(t, err)
-		assert.Len(t, modified, 2)
-
-		assert.True(t, fx.getMessage(t, "msg1").Synced)
-		assert.True(t, fx.getMessage(t, "msg2").Synced)
+		assert.Empty(t, modified)
 	})
 }
 

--- a/core/block/editor/chatobject/chatobject.go
+++ b/core/block/editor/chatobject/chatobject.go
@@ -41,8 +41,7 @@ const (
 	EditorCollectionName  = "editor"
 	diffManagerMessages   = "messages"
 	diffManagerMentions   = "mentions"
-	diffManagerSyncStatus = "syncStatus"
-	diffManagerReactions  = "reactions"
+	diffManagerReactions = "reactions"
 )
 
 var log = logging.Logger("core.block.editor.chatobject").Desugar()
@@ -228,12 +227,6 @@ func (s *storeObject) Init(ctx *smartblock.InitContext) error {
 		markErr := s.markReadReactions(removed)
 		if markErr != nil {
 			log.Error("mark read reactions", zap.Error(markErr))
-		}
-	})
-	storeSource.RegisterDiffManager(diffManagerSyncStatus, func(removed []string) {
-		updateErr := s.setMessagesSyncStatus(removed)
-		if updateErr != nil {
-			log.Error("set sync status", zap.Error(updateErr))
 		}
 	})
 	err = s.SmartBlock.Init(ctx)
@@ -547,11 +540,35 @@ func (s *storeObject) Close() error {
 }
 
 func (s *storeObject) HandleSyncStatusUpdate(heads []string, status domain.ObjectSyncStatus, syncError domain.SyncError) {
-	if status == (domain.ObjectSyncStatusSynced) {
-		err := s.storeSource.MarkSeenHeads(s.componentCtx, diffManagerSyncStatus, heads)
+	if status != domain.ObjectSyncStatusSynced {
+		return
+	}
+
+	var maxOrderId string
+	for _, head := range heads {
+		ch, err := s.Tree().GetChange(head)
 		if err != nil {
-			log.Error("mark sync status heads", zap.Error(err))
+			continue
 		}
+		if ch.OrderId > maxOrderId {
+			maxOrderId = ch.OrderId
+		}
+	}
+	if maxOrderId == "" {
+		return
+	}
+
+	idsModified, err := s.repository.SetSyncedByMaxOrderId(s.componentCtx, maxOrderId)
+	if err != nil {
+		log.Error("set synced by max order id", zap.Error(err))
+		return
+	}
+
+	if len(idsModified) > 0 {
+		s.subscription.Lock()
+		defer s.subscription.Unlock()
+		s.subscription.UpdateSyncStatus(idsModified, true)
+		s.subscription.Flush(false)
 	}
 }
 

--- a/core/block/editor/chatobject/reading.go
+++ b/core/block/editor/chatobject/reading.go
@@ -227,21 +227,3 @@ func (h *readStoreTreeHook) AfterDiffManagersInit(ctx context.Context) error {
 	return nil
 }
 
-func (s *storeObject) setMessagesSyncStatus(changeIds []string) error {
-	if len(changeIds) == 0 {
-		return nil
-	}
-
-	idsModified, err := s.repository.SetSyncedFlag(s.componentCtx, s.Id(), changeIds, true)
-	if err != nil {
-		return fmt.Errorf("set synced flag: %w", err)
-	}
-
-	if len(idsModified) > 0 {
-		s.subscription.Lock()
-		defer s.subscription.Unlock()
-		s.subscription.UpdateSyncStatus(idsModified, true)
-		s.subscription.Flush(false)
-	}
-	return nil
-}


### PR DESCRIPTION
## Summary
- Replace `diffManagerSyncStatus` with order ID-based approach for tracking chat message sync status
- Find max order ID from synced tree heads and mark all messages up to that point as synced via new `SetSyncedByMaxOrderId` repository method
- Remove unused `SetSyncedFlag` method and its diff manager registration

## Test plan
- [x] `go build ./core/...` compiles
- [x] `go test ./core/block/chats/chatrepository/...` passes
- [x] `go test ./core/block/editor/chatobject/...` passes
- [ ] Verify chat messages show correct sync status in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)