### PR TITLE
GO-7133 Add _final_score field blending BM25 score with recency decay and name boost

### DIFF
--- a/core/block/detailservice/mock_detailservice/mock_Service.go
+++ b/core/block/detailservice/mock_detailservice/mock_Service.go
@@ -29,6 +29,52 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 	return &MockService_Expecter{mock: &_m.Mock}
 }
 
+// Close provides a mock function with given fields: ctx
+func (_m *MockService) Close(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Close")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockService_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type MockService_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockService_Expecter) Close(ctx interface{}) *MockService_Close_Call {
+	return &MockService_Close_Call{Call: _e.mock.On("Close", ctx)}
+}
+
+func (_c *MockService_Close_Call) Run(run func(ctx context.Context)) *MockService_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockService_Close_Call) Return(err error) *MockService_Close_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockService_Close_Call) RunAndReturn(run func(context.Context) error) *MockService_Close_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Init provides a mock function with given fields: a
 func (_m *MockService) Init(a *app.App) error {
 	ret := _m.Called(a)
@@ -522,6 +568,52 @@ func (_c *MockService_ObjectTypeSetRelations_Call) RunAndReturn(run func(string,
 	return _c
 }
 
+// Run provides a mock function with given fields: ctx
+func (_m *MockService) Run(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Run")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockService_Run_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Run'
+type MockService_Run_Call struct {
+	*mock.Call
+}
+
+// Run is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockService_Expecter) Run(ctx interface{}) *MockService_Run_Call {
+	return &MockService_Run_Call{Call: _e.mock.On("Run", ctx)}
+}
+
+func (_c *MockService_Run_Call) Run(run func(ctx context.Context)) *MockService_Run_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockService_Run_Call) Return(err error) *MockService_Run_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockService_Run_Call) RunAndReturn(run func(context.Context) error) *MockService_Run_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SetDetails provides a mock function with given fields: ctx, objectId, details
 func (_m *MockService) SetDetails(ctx session.Context, objectId string, details []domain.Detail) error {
 	ret := _m.Called(ctx, objectId, details)
@@ -851,64 +943,6 @@ func (_c *MockService_SetSpaceInfo_Call) Return(_a0 error) *MockService_SetSpace
 }
 
 func (_c *MockService_SetSpaceInfo_Call) RunAndReturn(run func(string, *domain.GenericMap[domain.RelationKey]) error) *MockService_SetSpaceInfo_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// SetWorkspaceDashboardId provides a mock function with given fields: ctx, workspaceId, id
-func (_m *MockService) SetWorkspaceDashboardId(ctx session.Context, workspaceId string, id string) (string, error) {
-	ret := _m.Called(ctx, workspaceId, id)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SetWorkspaceDashboardId")
-	}
-
-	var r0 string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(session.Context, string, string) (string, error)); ok {
-		return rf(ctx, workspaceId, id)
-	}
-	if rf, ok := ret.Get(0).(func(session.Context, string, string) string); ok {
-		r0 = rf(ctx, workspaceId, id)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	if rf, ok := ret.Get(1).(func(session.Context, string, string) error); ok {
-		r1 = rf(ctx, workspaceId, id)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockService_SetWorkspaceDashboardId_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetWorkspaceDashboardId'
-type MockService_SetWorkspaceDashboardId_Call struct {
-	*mock.Call
-}
-
-// SetWorkspaceDashboardId is a helper method to define mock.On call
-//   - ctx session.Context
-//   - workspaceId string
-//   - id string
-func (_e *MockService_Expecter) SetWorkspaceDashboardId(ctx interface{}, workspaceId interface{}, id interface{}) *MockService_SetWorkspaceDashboardId_Call {
-	return &MockService_SetWorkspaceDashboardId_Call{Call: _e.mock.On("SetWorkspaceDashboardId", ctx, workspaceId, id)}
-}
-
-func (_c *MockService_SetWorkspaceDashboardId_Call) Run(run func(ctx session.Context, workspaceId string, id string)) *MockService_SetWorkspaceDashboardId_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(session.Context), args[1].(string), args[2].(string))
-	})
-	return _c
-}
-
-func (_c *MockService_SetWorkspaceDashboardId_Call) Return(setId string, err error) *MockService_SetWorkspaceDashboardId_Call {
-	_c.Call.Return(setId, err)
-	return _c
-}
-
-func (_c *MockService_SetWorkspaceDashboardId_Call) RunAndReturn(run func(session.Context, string, string) (string, error)) *MockService_SetWorkspaceDashboardId_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/block/editor/smartblock/mock_Space.go
+++ b/core/block/editor/smartblock/mock_Space.go
@@ -10,6 +10,8 @@ import (
 
 	objecttreebuilder "github.com/anyproto/any-sync/commonspace/objecttreebuilder"
 
+	spacedomain "github.com/anyproto/anytype-heart/space/spacedomain"
+
 	threads "github.com/anyproto/anytype-heart/pkg/lib/threads"
 )
 
@@ -513,6 +515,51 @@ func (_c *MockSpace_RefreshObjects_Call) Return(err error) *MockSpace_RefreshObj
 }
 
 func (_c *MockSpace_RefreshObjects_Call) RunAndReturn(run func([]string) error) *MockSpace_RefreshObjects_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SpaceType provides a mock function with no fields
+func (_m *MockSpace) SpaceType() spacedomain.SpaceType {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for SpaceType")
+	}
+
+	var r0 spacedomain.SpaceType
+	if rf, ok := ret.Get(0).(func() spacedomain.SpaceType); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(spacedomain.SpaceType)
+	}
+
+	return r0
+}
+
+// MockSpace_SpaceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SpaceType'
+type MockSpace_SpaceType_Call struct {
+	*mock.Call
+}
+
+// SpaceType is a helper method to define mock.On call
+func (_e *MockSpace_Expecter) SpaceType() *MockSpace_SpaceType_Call {
+	return &MockSpace_SpaceType_Call{Call: _e.mock.On("SpaceType")}
+}
+
+func (_c *MockSpace_SpaceType_Call) Run(run func()) *MockSpace_SpaceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSpace_SpaceType_Call) Return(_a0 spacedomain.SpaceType) *MockSpace_SpaceType_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSpace_SpaceType_Call) RunAndReturn(run func() spacedomain.SpaceType) *MockSpace_SpaceType_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "33b752b3618688fb548408b767bccf5376a33033d855edf5642cdf8dc3496a91"
+const RelationChecksum = "4f675d5d6482e6a8445fa623b8d611fc6dd9f6db95695dab8e1b394891290406"
 const (
 	RelationKeyTag                                  domain.RelationKey = "tag"
 	RelationKeyCamera                               domain.RelationKey = "camera"
@@ -194,6 +194,7 @@ const (
 	RelationKeyAnalyticsChatId                      domain.RelationKey = "analyticsChatId"
 	RelationKeyAnalyticsSpaceId                     domain.RelationKey = "analyticsSpaceId"
 	RelationKey_score                               domain.RelationKey = "_score"
+	RelationKey_final_score                         domain.RelationKey = "_final_score"
 	RelationKeyMigrationObjectContext               domain.RelationKey = "migrationObjectContext"
 	RelationKeyTemplateNamePrefillType              domain.RelationKey = "templateNamePrefillType"
 	RelationKeySpaceType                            domain.RelationKey = "spaceType"
@@ -2762,6 +2763,20 @@ var (
 			Key:              "writersLimit",
 			MaxCount:         1,
 			Name:             "Writers limit",
+			ReadOnly:         true,
+			ReadOnlyRelation: true,
+			Scope:            model.Relation_type,
+		},
+		RelationKey_final_score: {
+
+			DataSource:       model.Relation_derived,
+			Description:      "Fulltext search final score (BM25 + recency + name boost)",
+			Format:           model.RelationFormat_number,
+			Hidden:           true,
+			Id:               "_br_final_score",
+			Key:              "_final_score",
+			MaxCount:         1,
+			Name:             "Final Score",
 			ReadOnly:         true,
 			ReadOnlyRelation: true,
 			Scope:            model.Relation_type,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1878,6 +1878,16 @@
     "source": "derived"
   },
   {
+    "description": "Fulltext search final score (BM25 + recency + name boost)",
+    "format": "number",
+    "hidden": true,
+    "key": "_final_score",
+    "maxCount": 1,
+    "name": "Final Score",
+    "readonly": true,
+    "source": "derived"
+  },
+  {
     "description": "Version of file context migration completed for this space",
     "format": "number",
     "hidden": true,

--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -19,9 +19,7 @@ import (
 var log = logging.Logger("anytype-database")
 
 const (
-	RecordScoreField      = "_score"
-	RecordFinalScoreField = "_final_score"
-	secondsPerDay         = 86400.0
+	secondsPerDay = 86400.0
 )
 
 type Record struct {
@@ -172,13 +170,13 @@ func injectDefaultOrder(qry Query, sorts []SortRequest) []SortRequest {
 	}
 
 	for _, sort := range sorts {
-		if sort.RelationKey == RecordScoreField || sort.RelationKey == RecordFinalScoreField {
+		if sort.RelationKey == bundle.RelationKey_score || sort.RelationKey == bundle.RelationKey_final_score {
 			hasScoreSort = true
 		}
 	}
 
 	if !hasScoreSort {
-		sorts = append([]SortRequest{{RelationKey: RecordFinalScoreField, Type: model.BlockContentDataviewSort_Desc}}, sorts...)
+		sorts = append([]SortRequest{{RelationKey: bundle.RelationKey_final_score, Type: model.BlockContentDataviewSort_Desc}}, sorts...)
 	}
 
 	return sorts
@@ -411,7 +409,12 @@ func ComputeFinalScore(bm25Score float64, details *domain.Details, nameMatch boo
 	now := time.Now().Unix()
 	lastOpened := details.GetInt64(bundle.RelationKeyLastOpenedDate)
 	lastModified := details.GetInt64(bundle.RelationKeyLastModifiedDate)
-	recency := math.Max(recencyDecay(now, lastOpened), recencyDecay(now, lastModified))
+	var recency float64
+	if lastOpened > lastModified {
+		recency = recencyDecay(now, lastOpened)
+	} else {
+		recency = recencyDecay(now, lastModified)
+	}
 	nameBoost := 0.0
 	if nameMatch {
 		nameBoost = 1.0

--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"fmt"
+	"math"
+	"time"
 
 	"github.com/anyproto/any-store/anyenc"
 	"golang.org/x/text/collate"
@@ -17,7 +19,9 @@ import (
 var log = logging.Logger("anytype-database")
 
 const (
-	RecordScoreField = "_score"
+	RecordScoreField      = "_score"
+	RecordFinalScoreField = "_final_score"
+	secondsPerDay         = 86400.0
 )
 
 type Record struct {
@@ -168,14 +172,13 @@ func injectDefaultOrder(qry Query, sorts []SortRequest) []SortRequest {
 	}
 
 	for _, sort := range sorts {
-		// include archived objects if we have explicit filter about it
-		if sort.RelationKey == RecordScoreField {
+		if sort.RelationKey == RecordScoreField || sort.RelationKey == RecordFinalScoreField {
 			hasScoreSort = true
 		}
 	}
 
 	if !hasScoreSort {
-		sorts = append([]SortRequest{{RelationKey: RecordScoreField, Type: model.BlockContentDataviewSort_Desc}}, sorts...)
+		sorts = append([]SortRequest{{RelationKey: RecordFinalScoreField, Type: model.BlockContentDataviewSort_Desc}}, sorts...)
 	}
 
 	return sorts
@@ -393,4 +396,35 @@ func convertToHighlightRanges(ranges [][]int, highlight string) []*model.Range {
 type Filters struct {
 	FilterObj Filter
 	Order     Order
+}
+
+// ComputeFinalScore blends a Tantivy BM25 score with two additive signals:
+//   - recency: exponential decay on the more-recent of lastOpenedDate / lastModifiedDate (30-day half-life, [0,1])
+//   - nameBoost: 1.0 when the fulltext match landed in the "name" relation field, 0 otherwise
+//
+// Formula: ln(1+bm25) + recency + nameBoost
+// Log-compressing the BM25 score keeps recency and nameBoost as equal-weight additive signals.
+func ComputeFinalScore(bm25Score float64, details *domain.Details, nameMatch bool) float64 {
+	if details == nil {
+		return math.Log1p(bm25Score)
+	}
+	now := time.Now().Unix()
+	lastOpened := details.GetInt64(bundle.RelationKeyLastOpenedDate)
+	lastModified := details.GetInt64(bundle.RelationKeyLastModifiedDate)
+	recency := math.Max(recencyDecay(now, lastOpened), recencyDecay(now, lastModified))
+	nameBoost := 0.0
+	if nameMatch {
+		nameBoost = 1.0
+	}
+	return math.Log1p(bm25Score) + recency + nameBoost
+}
+
+// recencyDecay returns exp(-ln(2)/30 * age_in_days) clamped to [0,1].
+// Returns 0 when ts is zero (never opened/modified).
+func recencyDecay(nowUnix, ts int64) float64 {
+	if ts == 0 {
+		return 0
+	}
+	ageDays := float64(nowUnix-ts) / secondsPerDay
+	return math.Min(1.0, math.Exp(-math.Log(2)/30.0*ageDays))
 }

--- a/pkg/lib/database/database_test.go
+++ b/pkg/lib/database/database_test.go
@@ -1,7 +1,9 @@
 package database
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/anyproto/any-store/anyenc"
 	"github.com/stretchr/testify/assert"
@@ -831,5 +833,146 @@ func TestFTDocumentMatchToFulltextResult(t *testing.T) {
 		assert.Len(t, result.HighlightRanges, 1)
 		assert.Equal(t, int32(0), result.HighlightRanges[0].From)
 		assert.Equal(t, int32(6), result.HighlightRanges[0].To) // 6 UTF-16 runes
+	})
+}
+
+func TestRecencyDecay(t *testing.T) {
+	now := time.Now().Unix()
+
+	t.Run("zero timestamp returns 0", func(t *testing.T) {
+		// when
+		got := recencyDecay(now, 0)
+
+		// then
+		assert.Equal(t, 0.0, got)
+	})
+
+	t.Run("ts equal to now returns 1", func(t *testing.T) {
+		// when
+		got := recencyDecay(now, now)
+
+		// then
+		assert.InDelta(t, 1.0, got, 1e-9)
+	})
+
+	t.Run("ts 30 days ago returns ~0.5 (half-life)", func(t *testing.T) {
+		// given
+		thirtyDaysAgo := now - 30*86400
+
+		// when
+		got := recencyDecay(now, thirtyDaysAgo)
+
+		// then
+		assert.InDelta(t, 0.5, got, 0.001)
+	})
+
+	t.Run("future timestamp is clamped to 1", func(t *testing.T) {
+		// when
+		got := recencyDecay(now, now+86400)
+
+		// then
+		assert.Equal(t, 1.0, got)
+	})
+}
+
+func TestComputeFinalScore(t *testing.T) {
+	t.Run("zero dates and no name match gives ln(1+score)", func(t *testing.T) {
+		// given
+		details := domain.NewDetails()
+		score := 2.77
+
+		// when
+		got := ComputeFinalScore(score, details, false)
+
+		// then
+		assert.InDelta(t, math.Log1p(score), got, 1e-9)
+	})
+
+	t.Run("name match adds 1.0 on top of log-score", func(t *testing.T) {
+		// given
+		details := domain.NewDetails()
+		score := 2.77
+
+		// when
+		withoutBoost := ComputeFinalScore(score, details, false)
+		withBoost := ComputeFinalScore(score, details, true)
+
+		// then
+		assert.InDelta(t, withoutBoost+1.0, withBoost, 1e-9)
+	})
+
+	t.Run("fresh open adds recency on top of log-score", func(t *testing.T) {
+		// given
+		details := domain.NewDetails()
+		now := time.Now().Unix()
+		details.SetInt64(bundle.RelationKeyLastOpenedDate, now)
+		score := 2.77
+
+		// when
+		got := ComputeFinalScore(score, details, false)
+
+		// then
+		want := math.Log1p(score) + 1.0 // recency == 1.0 when opened right now
+		assert.InDelta(t, want, got, 0.01)
+	})
+
+	t.Run("lastModified dominates lastOpened when more recent", func(t *testing.T) {
+		// given
+		details := domain.NewDetails()
+		now := time.Now().Unix()
+		thirtyDaysAgo := now - 30*86400
+		details.SetInt64(bundle.RelationKeyLastOpenedDate, thirtyDaysAgo) // recency ~0.5
+		details.SetInt64(bundle.RelationKeyLastModifiedDate, now)          // recency ~1.0
+		score := 1.0
+
+		// when
+		got := ComputeFinalScore(score, details, false)
+
+		// then
+		want := math.Log1p(score) + 1.0 // picks modified (more recent)
+		assert.InDelta(t, want, got, 0.01)
+	})
+
+	t.Run("lastOpened dominates lastModified when more recent", func(t *testing.T) {
+		// given
+		details := domain.NewDetails()
+		now := time.Now().Unix()
+		thirtyDaysAgo := now - 30*86400
+		details.SetInt64(bundle.RelationKeyLastOpenedDate, now)             // recency ~1.0
+		details.SetInt64(bundle.RelationKeyLastModifiedDate, thirtyDaysAgo) // recency ~0.5
+		score := 1.0
+
+		// when
+		got := ComputeFinalScore(score, details, false)
+
+		// then
+		want := math.Log1p(score) + 1.0 // picks opened (more recent)
+		assert.InDelta(t, want, got, 0.01)
+	})
+
+	t.Run("all three signals combine additively", func(t *testing.T) {
+		// given
+		details := domain.NewDetails()
+		now := time.Now().Unix()
+		details.SetInt64(bundle.RelationKeyLastOpenedDate, now) // recency == 1.0
+		score := 3.0
+
+		// when
+		got := ComputeFinalScore(score, details, true) // nameMatch = true
+
+		// then
+		want := math.Log1p(score) + 1.0 + 1.0 // log + recency + nameBoost
+		assert.InDelta(t, want, got, 0.01)
+	})
+
+	t.Run("nil details returns ln(1+score)", func(t *testing.T) {
+		// given
+		score := 2.77
+
+		// when
+		got := ComputeFinalScore(score, nil, false)
+
+		// then
+		assert.InDelta(t, math.Log1p(score), got, 1e-9)
 	})
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -127,6 +127,7 @@ func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, par
 				}
 				details.SetString(bundle.RelationKeyId, res.Path.ObjectId)
 				details.SetFloat64(database.RecordScoreField, res.Score)
+				details.SetFloat64(database.RecordFinalScoreField, database.ComputeFinalScore(res.Score, details, res.Path.RelationKey == bundle.RelationKeyName.String()))
 				rec := database.Record{Details: details}
 				if params.FilterObj == nil || params.FilterObj.FilterObject(rec.Details) {
 					resultObjectMap[res.Path.ObjectId] = struct{}{}
@@ -146,6 +147,7 @@ func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, par
 			continue
 		}
 		details.SetFloat64(database.RecordScoreField, res.Score)
+		details.SetFloat64(database.RecordFinalScoreField, database.ComputeFinalScore(res.Score, details, res.Path.RelationKey == bundle.RelationKeyName.String()))
 
 		rec := database.Record{Details: details}
 		if params.FilterObj == nil || params.FilterObj.FilterObject(rec.Details) {
@@ -273,6 +275,9 @@ func (s *dsObjectStore) getObjectsWithObjectInRelation(details *domain.Details, 
 		detailsCopy := rec.Details.Copy()
 		// set the same score as original object
 		detailsCopy.SetFloat64(database.RecordScoreField, score)
+		// nameMatch=false: injected objects are found via relation (links/type/priority),
+		// not because their own name matched the query.
+		detailsCopy.SetFloat64(database.RecordFinalScoreField, database.ComputeFinalScore(score, detailsCopy, false))
 		injectedResults = append(injectedResults, database.Record{
 			Details: detailsCopy,
 			Meta:    metaInj,

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -126,8 +126,8 @@ func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, par
 					continue
 				}
 				details.SetString(bundle.RelationKeyId, res.Path.ObjectId)
-				details.SetFloat64(database.RecordScoreField, res.Score)
-				details.SetFloat64(database.RecordFinalScoreField, database.ComputeFinalScore(res.Score, details, res.Path.RelationKey == bundle.RelationKeyName.String()))
+				details.SetFloat64(bundle.RelationKey_score, res.Score)
+				details.SetFloat64(bundle.RelationKey_final_score, database.ComputeFinalScore(res.Score, details, res.Path.RelationKey == bundle.RelationKeyName.String()))
 				rec := database.Record{Details: details}
 				if params.FilterObj == nil || params.FilterObj.FilterObject(rec.Details) {
 					resultObjectMap[res.Path.ObjectId] = struct{}{}
@@ -146,8 +146,8 @@ func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, par
 			log.Errorf("QueryByIds failed to extract details: %s", res.Path.ObjectId)
 			continue
 		}
-		details.SetFloat64(database.RecordScoreField, res.Score)
-		details.SetFloat64(database.RecordFinalScoreField, database.ComputeFinalScore(res.Score, details, res.Path.RelationKey == bundle.RelationKeyName.String()))
+		details.SetFloat64(bundle.RelationKey_score, res.Score)
+		details.SetFloat64(bundle.RelationKey_final_score, database.ComputeFinalScore(res.Score, details, res.Path.RelationKey == bundle.RelationKeyName.String()))
 
 		rec := database.Record{Details: details}
 		if params.FilterObj == nil || params.FilterObj.FilterObject(rec.Details) {
@@ -274,10 +274,10 @@ func (s *dsObjectStore) getObjectsWithObjectInRelation(details *domain.Details, 
 
 		detailsCopy := rec.Details.Copy()
 		// set the same score as original object
-		detailsCopy.SetFloat64(database.RecordScoreField, score)
+		detailsCopy.SetFloat64(bundle.RelationKey_score, score)
 		// nameMatch=false: injected objects are found via relation (links/type/priority),
 		// not because their own name matched the query.
-		detailsCopy.SetFloat64(database.RecordFinalScoreField, database.ComputeFinalScore(score, detailsCopy, false))
+		detailsCopy.SetFloat64(bundle.RelationKey_final_score, database.ComputeFinalScore(score, detailsCopy, false))
 		injectedResults = append(injectedResults, database.Record{
 			Details: detailsCopy,
 			Meta:    metaInj,

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
@@ -145,7 +145,7 @@ func TestGetObjectsWithObjectInRelation(t *testing.T) {
 
 		// verify score is propagated
 		for _, rec := range result {
-			assert.Equal(t, 0.8, rec.Details.GetFloat64(database.RecordScoreField))
+			assert.Equal(t, 0.8, rec.Details.GetFloat64(bundle.RelationKey_score))
 		}
 
 		// verify meta
@@ -466,7 +466,7 @@ func TestGetObjectsWithObjectInRelation(t *testing.T) {
 
 		// then
 		require.Len(t, result, 1)
-		assert.Equal(t, 1.5, result[0].Details.GetFloat64(database.RecordScoreField))
+		assert.Equal(t, 1.5, result[0].Details.GetFloat64(bundle.RelationKey_score))
 	})
 
 	t.Run("sets correct meta with filtered relation details", func(t *testing.T) {
@@ -987,7 +987,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		require.Len(t, recs, 1)
-		assert.InDelta(t, 3.14, recs[0].Details.GetFloat64(database.RecordScoreField), 0.001)
+		assert.InDelta(t, 3.14, recs[0].Details.GetFloat64(bundle.RelationKey_score), 0.001)
 	})
 
 	t.Run("highlight is generated from title when not provided", func(t *testing.T) {
@@ -1348,7 +1348,7 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		require.Len(t, records, 1)
-		assert.InDelta(t, math.Log1p(score), records[0].Details.GetFloat64(database.RecordFinalScoreField), 1e-9)
+		assert.InDelta(t, math.Log1p(score), records[0].Details.GetFloat64(bundle.RelationKey_final_score), 1e-9)
 	})
 
 	t.Run("_final_score gets name_boost when match is in name field", func(t *testing.T) {
@@ -1378,8 +1378,8 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		// then
 		require.Len(t, nameRecords, 1)
 		require.Len(t, otherRecords, 1)
-		nameScore := nameRecords[0].Details.GetFloat64(database.RecordFinalScoreField)
-		otherScore := otherRecords[0].Details.GetFloat64(database.RecordFinalScoreField)
+		nameScore := nameRecords[0].Details.GetFloat64(bundle.RelationKey_final_score)
+		otherScore := otherRecords[0].Details.GetFloat64(bundle.RelationKey_final_score)
 		assert.InDelta(t, otherScore+1.0, nameScore, 1e-9, "name match should add exactly 1.0 to _final_score")
 	})
 
@@ -1419,7 +1419,7 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		byId := map[string]float64{}
 		for _, r := range records {
 			id := r.Details.GetString(bundle.RelationKeyId)
-			byId[id] = r.Details.GetFloat64(database.RecordFinalScoreField)
+			byId[id] = r.Details.GetFloat64(bundle.RelationKey_final_score)
 		}
 		assert.Greater(t, byId["fresh"], byId["stale"], "fresh object should outscore stale one with same BM25")
 	})

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
@@ -1,7 +1,9 @@
 package spaceindex
 
 import (
+	"math"
 	"testing"
+	"time"
 
 	"github.com/anyproto/any-store/anyenc"
 	"github.com/stretchr/testify/assert"
@@ -1317,5 +1319,108 @@ func TestQueryFromFulltext(t *testing.T) {
 		for _, rec := range recs {
 			assert.NotEqual(t, "obj1", rec.Details.GetString(bundle.RelationKeyId))
 		}
+	})
+}
+
+func TestQueryFromFulltext_FinalScore(t *testing.T) {
+	t.Run("_final_score equals ln(1+score) when dates are zero and no name match", func(t *testing.T) {
+		// given
+		s := NewStoreFixture(t)
+		obj := TestObject{
+			bundle.RelationKeyId:             domain.String("obj1"),
+			bundle.RelationKeyName:           domain.String("Test Object"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			// no date fields set, so recency contribution is zero
+		}
+		s.AddObjects(t, []TestObject{obj})
+
+		score := 2.77
+		results := []database.FulltextResult{
+			{
+				Path:  domain.ObjectPath{ObjectId: "obj1", RelationKey: "description"}, // not "name"
+				Score: score,
+			},
+		}
+
+		// when
+		records, err := s.QueryFromFulltext(results, emptyFilters(t, s), 10, 0, "test")
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		assert.InDelta(t, math.Log1p(score), records[0].Details.GetFloat64(database.RecordFinalScoreField), 1e-9)
+	})
+
+	t.Run("_final_score gets name_boost when match is in name field", func(t *testing.T) {
+		// given
+		s := NewStoreFixture(t)
+		obj := TestObject{
+			bundle.RelationKeyId:             domain.String("obj1"),
+			bundle.RelationKeyName:           domain.String("Test Object"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+		}
+		s.AddObjects(t, []TestObject{obj})
+
+		score := 2.77
+		nameResults := []database.FulltextResult{
+			{Path: domain.ObjectPath{ObjectId: "obj1", RelationKey: bundle.RelationKeyName.String()}, Score: score},
+		}
+		otherResults := []database.FulltextResult{
+			{Path: domain.ObjectPath{ObjectId: "obj1", RelationKey: "description"}, Score: score},
+		}
+
+		// when
+		nameRecords, err := s.QueryFromFulltext(nameResults, emptyFilters(t, s), 10, 0, "test")
+		require.NoError(t, err)
+		otherRecords, err := s.QueryFromFulltext(otherResults, emptyFilters(t, s), 10, 0, "test")
+		require.NoError(t, err)
+
+		// then
+		require.Len(t, nameRecords, 1)
+		require.Len(t, otherRecords, 1)
+		nameScore := nameRecords[0].Details.GetFloat64(database.RecordFinalScoreField)
+		otherScore := otherRecords[0].Details.GetFloat64(database.RecordFinalScoreField)
+		assert.InDelta(t, otherScore+1.0, nameScore, 1e-9, "name match should add exactly 1.0 to _final_score")
+	})
+
+	t.Run("recently opened object scores higher than stale with same BM25", func(t *testing.T) {
+		// given
+		s := NewStoreFixture(t)
+		now := time.Now().Unix()
+		sixtyDaysAgo := now - 60*86400
+
+		fresh := TestObject{
+			bundle.RelationKeyId:             domain.String("fresh"),
+			bundle.RelationKeyName:           domain.String("Object"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			bundle.RelationKeyLastOpenedDate: domain.Int64(now),
+		}
+		stale := TestObject{
+			bundle.RelationKeyId:             domain.String("stale"),
+			bundle.RelationKeyName:           domain.String("Object"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			bundle.RelationKeyLastOpenedDate: domain.Int64(sixtyDaysAgo),
+		}
+		// lastModifiedDate recency signal is verified at the unit level in TestComputeFinalScore
+		s.AddObjects(t, []TestObject{fresh, stale})
+
+		sameScore := 2.77
+		results := []database.FulltextResult{
+			{Path: domain.ObjectPath{ObjectId: "fresh", RelationKey: "description"}, Score: sameScore},
+			{Path: domain.ObjectPath{ObjectId: "stale", RelationKey: "description"}, Score: sameScore},
+		}
+
+		// when
+		records, err := s.QueryFromFulltext(results, emptyFilters(t, s), 10, 0, "query")
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+		byId := map[string]float64{}
+		for _, r := range records {
+			id := r.Details.GetString(bundle.RelationKeyId)
+			byId[id] = r.Details.GetFloat64(database.RecordFinalScoreField)
+		}
+		assert.Greater(t, byId["fresh"], byId["stale"], "fresh object should outscore stale one with same BM25")
 	})
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_test.go
@@ -24,7 +24,8 @@ import (
 
 func removeScoreFromRecords(records []database.Record) []database.Record {
 	for i := range records {
-		records[i].Details.Delete("_score")
+		records[i].Details.Delete(database.RecordScoreField)
+		records[i].Details.Delete(database.RecordFinalScoreField)
 	}
 	return records
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_test.go
@@ -24,8 +24,8 @@ import (
 
 func removeScoreFromRecords(records []database.Record) []database.Record {
 	for i := range records {
-		records[i].Details.Delete(database.RecordScoreField)
-		records[i].Details.Delete(database.RecordFinalScoreField)
+		records[i].Details.Delete(bundle.RelationKey_score)
+		records[i].Details.Delete(bundle.RelationKey_final_score)
 	}
 	return records
 }

--- a/space/clientspace/mock_clientspace/mock_Space.go
+++ b/space/clientspace/mock_clientspace/mock_Space.go
@@ -27,6 +27,8 @@ import (
 
 	smartblock "github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 
+	spacedomain "github.com/anyproto/anytype-heart/space/spacedomain"
+
 	threads "github.com/anyproto/anytype-heart/pkg/lib/threads"
 
 	treestorage "github.com/anyproto/any-sync/commonspace/object/tree/treestorage"
@@ -1695,6 +1697,51 @@ func (_c *MockSpace_Remove_Call) Return(_a0 error) *MockSpace_Remove_Call {
 }
 
 func (_c *MockSpace_Remove_Call) RunAndReturn(run func(context.Context, string) error) *MockSpace_Remove_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// SpaceType provides a mock function with no fields
+func (_m *MockSpace) SpaceType() spacedomain.SpaceType {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for SpaceType")
+	}
+
+	var r0 spacedomain.SpaceType
+	if rf, ok := ret.Get(0).(func() spacedomain.SpaceType); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(spacedomain.SpaceType)
+	}
+
+	return r0
+}
+
+// MockSpace_SpaceType_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SpaceType'
+type MockSpace_SpaceType_Call struct {
+	*mock.Call
+}
+
+// SpaceType is a helper method to define mock.On call
+func (_e *MockSpace_Expecter) SpaceType() *MockSpace_SpaceType_Call {
+	return &MockSpace_SpaceType_Call{Call: _e.mock.On("SpaceType")}
+}
+
+func (_c *MockSpace_SpaceType_Call) Run(run func()) *MockSpace_SpaceType_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSpace_SpaceType_Call) Return(_a0 spacedomain.SpaceType) *MockSpace_SpaceType_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSpace_SpaceType_Call) RunAndReturn(run func() spacedomain.SpaceType) *MockSpace_SpaceType_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
## Summary

- Adds `_final_score` to `ObjectSearchWithMeta` fulltext results, computed as `ln(1+bm25) + recency + name_boost`
- Recency uses a 30-day exponential half-life on the more-recent of `lastOpenedDate`/`lastModifiedDate` (clamped to [0,1]); name_boost is 1.0 when the match landed in the `name` relation field
- `_score` (raw BM25) is unchanged — clients opt into recency-aware ranking by sorting on `_final_score`

## Formula

```
recency    = max(decay(lastOpenedDate), decay(lastModifiedDate))
decay(ts)  = min(1, exp(-ln(2) / 30 × age_in_days))
name_boost = 1.0 if match.relationKey == "name" else 0.0

_final_score = ln(1 + bm25) + recency + name_boost
```

Log-compressing BM25 keeps recency and name_boost as equal-weight additive signals — each contributes at most +1.0 regardless of corpus size or index growth.

## Test Plan

- [x] Unit tests for `recencyDecay` and `ComputeFinalScore` in `pkg/lib/database/database_test.go` (11 sub-tests covering zero sentinel, half-life, future clamp, nil-guard, all signal combinations)
- [x] Integration tests for `_final_score` in `pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go` (baseline, name-boost delta, recency ordering)
- [x] Verify `ObjectSearchWithMeta` response includes `_final_score` when `"_final_score"` is in `keys`
- [x] Confirm exact-match outlier still ranks #1 and flat-plateau results are sorted by recency

Closes GO-7133