### PR TITLE
GO-6869 Exclude nightly tags from git describe in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
           INHOUSE_KEY: ${{ secrets.INHOUSE_KEY }}
         run: |
-          GIT_SUMMARY=$(git describe --tags --always)
+          GIT_SUMMARY=$(git describe --tags --exclude='*-nightly.*' --always)
           echo "FLAGS=-X github.com/anyproto/anytype-heart/util/vcs.GitSummary=${GIT_SUMMARY} -X github.com/anyproto/anytype-heart/metrics.DefaultInHouseKey=${INHOUSE_KEY} -X github.com/anyproto/anytype-heart/util/unsplash.DefaultToken=${UNSPLASH_KEY}" >> $GITHUB_ENV
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION=${{ github.event.inputs.alpha_version }}

--- a/.github/workflows/perftests-grafana.yml
+++ b/.github/workflows/perftests-grafana.yml
@@ -54,7 +54,7 @@ jobs:
           UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
           INHOUSE_KEY: ${{ secrets.INHOUSE_KEY }}
         run: |
-          GIT_SUMMARY=$(git describe --tags --always)
+          GIT_SUMMARY=$(git describe --tags --exclude='*-nightly.*' --always)
           echo "FLAGS=-X github.com/anyproto/anytype-heart/util/vcs.GitSummary=${GIT_SUMMARY} -X github.com/anyproto/anytype-heart/metrics.DefaultInHouseKey=${INHOUSE_KEY} -X github.com/anyproto/anytype-heart/util/unsplash.DefaultToken=${UNSPLASH_KEY}" >> $GITHUB_ENV
           VERSION=$(git rev-parse --short HEAD)
           if [ -z "$VERSION" ]; then

--- a/.github/workflows/perftests.yml
+++ b/.github/workflows/perftests.yml
@@ -137,7 +137,7 @@ jobs:
   #         UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
   #         INHOUSE_KEY: ${{ secrets.INHOUSE_KEY }}
   #       run: |
-  #         $GIT_SUMMARY = git describe --tags --always
+  #         $GIT_SUMMARY = git describe --tags --exclude='*-nightly.*' --always
   #         echo "FLAGS=-X github.com/anyproto/anytype-heart/util/vcs.GitSummary=$GIT_SUMMARY -X github.com/anyproto/anytype-heart/metrics.DefaultInHouseKey=$env:INHOUSE_KEY -X github.com/anyproto/anytype-heart/util/unsplash.DefaultToken=$env:UNSPLASH_KEY" >> $env:GITHUB_ENV
   #         if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
   #           $VERSION = ${{ github.event.inputs.alpha_version }}


### PR DESCRIPTION
## Summary

- Add `--exclude='*-nightly.*'` to `git describe` in `build.yml`, `perftests-grafana.yml`, and `perftests.yml`
- Fixes non-deterministic tag selection when a nightly tag and a release tag coexist on the same commit
- `nightly.yml` already computes its version explicitly and is unaffected

## Problem

`git describe --tags --always` picks tags non-deterministically when multiple tags point to the same commit. A nightly tag like `v0.44.0-nightly.20260307.1` can be selected over the actual release tag `v0.49.0`, causing the built binary to report an incorrect version.

## Fix

```bash
# Before
GIT_SUMMARY=$(git describe --tags --always)

# After
GIT_SUMMARY=$(git describe --tags --exclude='*-nightly.*' --always)
```

## Test plan

- [ ] Trigger a release build on a commit that has both a nightly tag and a release tag — verify the binary reports the release version