### PR TITLE
GO-7130 Improve file GC edge cases: archived backlinks, backlinker-triggered GC, undo restore

### DIFF
--- a/core/block/chats/service_test.go
+++ b/core/block/chats/service_test.go
@@ -87,6 +87,9 @@ func (s *fileGCDummy) CheckFilesOnLinksRemoval(spaceId, contextId string, remove
 func (s *fileGCDummy) CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error {
 	return nil
 }
+func (s *fileGCDummy) CheckFilesOnLinksRestored(spaceId, contextId string, addedLinks []string) error {
+	return nil
+}
 
 type actionType int
 

--- a/core/block/chats/service_test.go
+++ b/core/block/chats/service_test.go
@@ -84,7 +84,7 @@ func (s *fileGCDummy) Close(ctx context.Context) error { return nil }
 func (s *fileGCDummy) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLinks []string, skipBin bool, onlyBlockIds []string) error {
 	return nil
 }
-func (s *fileGCDummy) CheckFilesOnContextArchived(spaceId, contextId string, isArchived bool) error {
+func (s *fileGCDummy) CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error {
 	return nil
 }
 

--- a/core/block/delete.go
+++ b/core/block/delete.go
@@ -46,7 +46,7 @@ func (s *Service) DeleteObjectByFullID(id domain.FullID) error {
 
 	if sbType != coresb.SmartBlockTypeFileObject {
 		// in case client skips archiving, lets still call fileGC
-		if err := s.fileGC.CheckFilesOnContextArchived(id.SpaceID, id.ObjectID, true); err != nil {
+		if err := s.fileGC.CheckFilesOnObjectArchived(id.SpaceID, id.ObjectID, true); err != nil {
 			log.With("objectId", id.ObjectID).Warnf("failed to check files on context deletion: %v", err)
 		}
 	}

--- a/core/block/detailservice/service_test.go
+++ b/core/block/detailservice/service_test.go
@@ -44,6 +44,9 @@ func (f *fileGCStub) CheckFilesOnLinksRemoval(spaceId, contextId string, removed
 func (f *fileGCStub) CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error {
 	return nil
 }
+func (f *fileGCStub) CheckFilesOnLinksRestored(spaceId, contextId string, addedLinks []string) error {
+	return nil
+}
 
 type fixture struct {
 	Service

--- a/core/block/detailservice/service_test.go
+++ b/core/block/detailservice/service_test.go
@@ -41,7 +41,7 @@ func (f *fileGCStub) Close(ctx context.Context) error { return nil }
 func (f *fileGCStub) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLinks []string, skipBin bool, onlyBlockIds []string) error {
 	return nil
 }
-func (f *fileGCStub) CheckFilesOnContextArchived(spaceId, contextId string, isArchived bool) error {
+func (f *fileGCStub) CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error {
 	return nil
 }
 

--- a/core/block/detailservice/set_details.go
+++ b/core/block/detailservice/set_details.go
@@ -252,7 +252,7 @@ func (s *service) triggerFileGCOnArchive(spaceId string, objectIds []string, isA
 
 	for _, objId := range objectIds {
 		go func(objId string) {
-			if err := s.fileGC.CheckFilesOnContextArchived(spaceId, objId, isArchived); err != nil {
+			if err := s.fileGC.CheckFilesOnObjectArchived(spaceId, objId, isArchived); err != nil {
 				log.Error("file GC failed for archived object", zap.String("objectId", objId), zap.Error(err))
 			}
 		}(objId)

--- a/core/block/editor/smartblock/filegclinks_test.go
+++ b/core/block/editor/smartblock/filegclinks_test.go
@@ -1,0 +1,141 @@
+package smartblock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/anyproto/any-sync/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// fileGCCallRecorder records calls to CheckFilesOnLinksRemoval and CheckFilesOnLinksRestored
+// via buffered channels so goroutine timing works in tests.
+type fileGCCallRecorder struct {
+	removedCh  chan linksRemovalCall
+	restoredCh chan linksRestoredCall
+}
+
+type linksRemovalCall struct {
+	spaceId   string
+	contextId string
+	links     []string
+	skipBin   bool
+}
+
+type linksRestoredCall struct {
+	spaceId   string
+	contextId string
+	links     []string
+}
+
+func newFileGCCallRecorder() *fileGCCallRecorder {
+	return &fileGCCallRecorder{
+		removedCh:  make(chan linksRemovalCall, 4),
+		restoredCh: make(chan linksRestoredCall, 4),
+	}
+}
+
+func (r *fileGCCallRecorder) Init(_ *app.App) error                                  { return nil }
+func (r *fileGCCallRecorder) Name() string                                            { return "test-filegc" }
+func (r *fileGCCallRecorder) Run(_ context.Context) error                             { return nil }
+func (r *fileGCCallRecorder) Close(_ context.Context) error                           { return nil }
+func (r *fileGCCallRecorder) CheckFilesOnObjectArchived(_, _ string, _ bool) error    { return nil }
+func (r *fileGCCallRecorder) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLinks []string, skipBin bool, _ []string) error {
+	r.removedCh <- linksRemovalCall{spaceId: spaceId, contextId: contextId, links: removedLinks, skipBin: skipBin}
+	return nil
+}
+func (r *fileGCCallRecorder) CheckFilesOnLinksRestored(spaceId, contextId string, addedLinks []string) error {
+	r.restoredCh <- linksRestoredCall{spaceId: spaceId, contextId: contextId, links: addedLinks}
+	return nil
+}
+
+// TestSmartBlock_FileGC_LinksAdded_TriggersRestore verifies that Apply calls
+// CheckFilesOnLinksRestored when links are added from an empty state (the undo case).
+// This exercises the fix for the len(linksBefore) > 0 guard that used to skip the diff.
+func TestSmartBlock_FileGC_LinksAdded_TriggersRestore(t *testing.T) {
+	// given – object with no link blocks initially
+	objectId := "root"
+	fx := newFixture(objectId, t)
+	fx.init(t, []*model.Block{{Id: objectId}})
+
+	recorder := newFileGCCallRecorder()
+	fx.fileGC = recorder
+
+	fx.indexer.EXPECT().Index(mock.Anything, mock.Anything).Return(nil).Maybe()
+	fx.eventSender.EXPECT().SendToSession(mock.Anything, mock.Anything).Maybe()
+
+	// when – add a link block pointing to "file1" (simulates undo that re-adds a file block)
+	s := fx.NewState()
+	s.Add(simple.New(&model.Block{
+		Id: "link1",
+		Content: &model.BlockContentOfLink{
+			Link: &model.BlockContentLink{TargetBlockId: "file1"},
+		},
+	}))
+	require.NoError(t, s.InsertTo(objectId, model.Block_Inner, "link1"))
+	require.NoError(t, fx.Apply(s))
+
+	// then – CheckFilesOnLinksRestored must be called with "file1"
+	select {
+	case call := <-recorder.restoredCh:
+		assert.Equal(t, testSpaceId, call.spaceId)
+		assert.Equal(t, objectId, call.contextId)
+		assert.Equal(t, []string{"file1"}, call.links)
+	case <-time.After(time.Second):
+		t.Fatal("timeout: CheckFilesOnLinksRestored was not called")
+	}
+}
+
+// TestSmartBlock_FileGC_LinksRemoved_TriggersGC verifies that Apply calls
+// CheckFilesOnLinksRemoval when a link block is removed.
+func TestSmartBlock_FileGC_LinksRemoved_TriggersGC(t *testing.T) {
+	// given – object starts empty
+	objectId := "root"
+	fx := newFixture(objectId, t)
+	fx.init(t, []*model.Block{{Id: objectId}})
+
+	recorder := newFileGCCallRecorder()
+	fx.fileGC = recorder
+
+	fx.indexer.EXPECT().Index(mock.Anything, mock.Anything).Return(nil).Maybe()
+	fx.eventSender.EXPECT().SendToSession(mock.Anything, mock.Anything).Maybe()
+
+	// First Apply: add link block to establish links in the doc state
+	s1 := fx.NewState()
+	s1.Add(simple.New(&model.Block{
+		Id: "link1",
+		Content: &model.BlockContentOfLink{
+			Link: &model.BlockContentLink{TargetBlockId: "file1"},
+		},
+	}))
+	require.NoError(t, s1.InsertTo(objectId, model.Block_Inner, "link1"))
+	require.NoError(t, fx.Apply(s1))
+
+	// Drain the restore call triggered by the first Apply
+	select {
+	case <-recorder.restoredCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for restore call from first apply")
+	}
+
+	// when – remove the link block (simulates user deleting a file block)
+	s2 := fx.NewState()
+	s2.Unlink("link1")
+	require.NoError(t, fx.Apply(s2))
+
+	// then – CheckFilesOnLinksRemoval must be called with "file1"
+	select {
+	case call := <-recorder.removedCh:
+		assert.Equal(t, testSpaceId, call.spaceId)
+		assert.Equal(t, objectId, call.contextId)
+		assert.Contains(t, call.links, "file1")
+	case <-time.After(time.Second):
+		t.Fatal("timeout: CheckFilesOnLinksRemoval was not called")
+	}
+}

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -861,12 +861,19 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 	if parent := s.ParentState(); parent != nil && len(linksBefore) > 0 {
 		linksAfter := st.LocalDetails().GetStringList(bundle.RelationKeyLinks)
 
+		// Compute added links unconditionally — needed for both session tracking and file restore.
+		addedLinks := getAddedLinks(linksBefore, linksAfter)
+
 		// Track newly added links as session-created (if object was explicitly opened)
 		if sb.sessionCreatedLinks != nil {
-			addedLinks := getAddedLinks(linksBefore, linksAfter)
 			for _, link := range addedLinks {
 				sb.sessionCreatedLinks[link] = struct{}{}
 			}
+		}
+
+		// Restore archived files whose links were re-added (e.g. via undo).
+		if len(addedLinks) > 0 {
+			go sb.restoreArchivedFilesOnLinksAdded(sb.SpaceID(), sb.Id(), addedLinks)
 		}
 
 		removedLinks := getRemovedLinks(linksBefore, linksAfter)
@@ -1556,6 +1563,17 @@ func guessRelationFormatFromValue(val domain.Value) model.RelationFormat {
 		return model.RelationFormat_file
 	default:
 		return 0
+	}
+}
+
+// restoreArchivedFilesOnLinksAdded unarchives file objects that were GC'd when their link is re-added
+// to the context (e.g. via undo).
+func (sb *smartBlock) restoreArchivedFilesOnLinksAdded(spaceId, contextId string, addedLinks []string) {
+	if sb.fileGC == nil {
+		return
+	}
+	if err := sb.fileGC.CheckFilesOnLinksRestored(spaceId, contextId, addedLinks); err != nil {
+		log.With("objectId", contextId).Errorf("file restore on links added failed: %v", err)
 	}
 }
 

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -857,8 +857,10 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 		sb.CheckSubscriptions()
 	}
 
-	// Check for file GC after successful apply
-	if parent := s.ParentState(); parent != nil && len(linksBefore) > 0 {
+	// Check for file GC after successful apply.
+	// Note: do NOT guard on len(linksBefore) > 0 — undo can add links from an empty state
+	// (linksBefore == []) and we must still detect those additions to restore archived files.
+	if parent := s.ParentState(); parent != nil {
 		linksAfter := st.LocalDetails().GetStringList(bundle.RelationKeyLinks)
 
 		// Compute added links unconditionally — needed for both session tracking and file restore.

--- a/core/files/filegc/filegc.go
+++ b/core/files/filegc/filegc.go
@@ -25,6 +25,7 @@ type FileGC interface {
 	app.ComponentRunnable
 	CheckFilesOnLinksRemoval(spaceId, contextId string, removedLinks []string, skipBin bool, onlyBlockIds []string) error
 	CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error
+	CheckFilesOnLinksRestored(spaceId, contextId string, addedLinks []string) error
 }
 
 // ObjectDeleter is an interface to delete objects by their full ID
@@ -434,6 +435,61 @@ func hasActiveBacklinks(details *domain.Details, fileId, currentlyArchivingId st
 		}
 	}
 	return false
+}
+
+// CheckFilesOnLinksRestored unarchives file objects that were previously GC'd when links are re-added
+// to a context object (e.g. via undo). For each added link that is an archived file whose
+// CreatedInContext matches the context, the file is restored unconditionally — the active link
+// in the page is sufficient justification to unarchive it.
+func (gc *fileGC) CheckFilesOnLinksRestored(spaceId, contextId string, addedLinks []string) error {
+	if len(addedLinks) == 0 {
+		return nil
+	}
+
+	log.Debugf("checking %d restored links in context %s", len(addedLinks), contextId)
+
+	gc.backlinksWatcher.FlushUpdates()
+	idx := gc.objectStore.SpaceIndex(spaceId)
+
+	fileLayouts := makeFileLayouts()
+
+	// Find archived files among the added links that belong to this context.
+	// Explicit IsArchived == true suppresses the implicit IsArchived != true default filter.
+	records, err := idx.Query(database.Query{
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyId,
+				Condition:   model.BlockContentDataviewFilter_In,
+				Value:       domain.StringList(addedLinks),
+			},
+			{
+				RelationKey: bundle.RelationKeyCreatedInContext,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.String(contextId),
+			},
+			{
+				RelationKey: bundle.RelationKeyResolvedLayout,
+				Condition:   model.BlockContentDataviewFilter_In,
+				Value:       domain.Int64List(fileLayouts),
+			},
+			{
+				RelationKey: bundle.RelationKeyIsArchived,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.Bool(true),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("query archived files for restore: %w", err)
+	}
+
+	var toRestore []string
+	for _, record := range records {
+		fileId := record.Details.GetString(bundle.RelationKeyId)
+		log.Debugf("restoring archived file %s after link re-added to context %s", fileId, contextId)
+		toRestore = append(toRestore, fileId)
+	}
+	return gc.objectArchiver.SetListIsArchived(gc.componentCtx, toRestore, false)
 }
 
 func makeFileLayouts() []int64 {

--- a/core/files/filegc/filegc.go
+++ b/core/files/filegc/filegc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
@@ -23,7 +24,7 @@ const CName = "core.files.filegc"
 type FileGC interface {
 	app.ComponentRunnable
 	CheckFilesOnLinksRemoval(spaceId, contextId string, removedLinks []string, skipBin bool, onlyBlockIds []string) error
-	CheckFilesOnContextArchived(spaceId, contextId string, isArchived bool) error
+	CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error
 }
 
 // ObjectDeleter is an interface to delete objects by their full ID
@@ -81,8 +82,8 @@ func (gc *fileGC) Close(ctx context.Context) error {
 	return nil
 }
 
-// CheckFilesOnLinksRemoval checks if any of the removed links are file objects that should be garbage collected
-// If onlyBlockIds is provided, it will only process files created in those specific block IDs
+// CheckFilesOnLinksRemoval checks if any of the removed links are file objects that should be garbage collected.
+// If onlyBlockIds is provided, it will only process files created in those specific block IDs.
 func (gc *fileGC) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLinks []string, skipBin bool, onlyBlockIds []string) error {
 	if len(removedLinks) == 0 {
 		return nil
@@ -92,13 +93,9 @@ func (gc *fileGC) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLin
 
 	// make sure we have all backlinks updates flushed to the store
 	gc.backlinksWatcher.FlushUpdates()
-	// Get space index
-	spaceIndex := gc.objectStore.SpaceIndex(spaceId)
+	idx := gc.objectStore.SpaceIndex(spaceId)
 
-	fileLayouts := make([]int64, 0, len(domain.FileLayouts))
-	for _, layout := range domain.FileLayouts {
-		fileLayouts = append(fileLayouts, int64(layout))
-	}
+	fileLayouts := makeFileLayouts()
 
 	// Build query filters
 	filters := []database.FilterRequest{
@@ -129,22 +126,19 @@ func (gc *fileGC) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLin
 	}
 
 	// Query file objects from removed links
-	fileRecords, err := spaceIndex.Query(database.Query{
+	fileRecords, err := idx.Query(database.Query{
 		Filters: filters,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to query file objects: %w", err)
+		return fmt.Errorf("query file objects: %w", err)
 	}
 
 	var toArchive []string
 	for _, record := range fileRecords {
 		fileId := record.Details.GetString(bundle.RelationKeyId)
 
-		// Check if file has any backlinks (references from other objects)
+		// Filter out the current context and self-references from backlinks.
 		backlinks := record.Details.GetStringList(bundle.RelationKeyBacklinks)
-
-		// Filter out the current context from backlinks
-		// Also filter out self-references (link != fileId) to prevent files from keeping themselves alive
 		activeBacklinks := lo.Filter(backlinks, func(link string, _ int) bool {
 			return link != contextId && link != fileId
 		})
@@ -154,10 +148,10 @@ func (gc *fileGC) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLin
 			continue
 		}
 
-		// File has no active backlinks and was created in this context - can be deleted or archived
+		// File has no active backlinks and was created in this context - can be deleted or archived.
 		shouldSkipBin := skipBin
 		if shouldSkipBin {
-			// Additional safety: only permanently delete if the file was created by the current user
+			// Additional safety: only permanently delete if the file was created by the current user.
 			fileCreator := record.Details.GetString(bundle.RelationKeyCreator)
 			myParticipantId := gc.participantProvider.MyParticipantId(spaceId)
 			if fileCreator != myParticipantId {
@@ -168,10 +162,8 @@ func (gc *fileGC) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLin
 
 		if shouldSkipBin {
 			log.With("fileId", fileId).Debugf("deleting orphaned file created in context %s", contextId)
-			// Delete the file object
 			if err := gc.deleteFileObject(spaceId, fileId); err != nil {
 				log.With("fileId", fileId).Errorf("failed to delete file object: %v", err)
-				// Continue with other files even if one fails
 			}
 		} else {
 			log.With("fileId", fileId).Debugf("archiving orphaned file created in context %s", contextId)
@@ -182,43 +174,183 @@ func (gc *fileGC) CheckFilesOnLinksRemoval(spaceId, contextId string, removedLin
 }
 
 func (gc *fileGC) deleteFileObject(spaceId, fileId string) error {
-	// Delete the file object using the full ID
 	return gc.objectDeleter.DeleteObjectByFullID(domain.FullID{
 		SpaceID:  spaceId,
 		ObjectID: fileId,
 	})
 }
 
-// CheckFilesOnContextArchived finds all files created in the given context and archives/unarchived them
-// This should be called when the context object itself is being archived/unarchived
-func (gc *fileGC) CheckFilesOnContextArchived(spaceId, contextId string, isArchived bool) error {
-	log.Debugf("checking files on context deletion: %s", contextId)
-	spaceIndex := gc.objectStore.SpaceIndex(spaceId)
-	d, err := spaceIndex.GetDetails(contextId)
-	if err != nil {
-		return fmt.Errorf("failed to get details of context object: %w", err)
-	}
+// CheckFilesOnObjectArchived finds file objects that should be garbage collected when objectId is archived or unarchived.
+//
+// Archive direction (isArchived=true): two disjoint queries are run.
+//   - Query 1 (parent case): files whose CreatedInContext == objectId. Since objectId is being archived
+//     right now, no safety gate is needed — we just check that all other backlinks are archived or deleted.
+//   - Query 2 (backlinker case): files where objectId appears in their backlinks but is NOT their parent.
+//     A safety gate checks that the file's actual parent (CreatedInContext) is already archived or deleted
+//     before proceeding, preventing over-eager GC when the parent is still active.
+//
+// In both queries, a single batch Id IN [...] query resolves the active-status of all relevant IDs at once,
+// rather than querying each backlink individually. objectId itself is always excluded from the active-backlinks
+// check because it is currently being processed and may not yet be reflected as archived in the store.
+//
+// Unarchive direction (isArchived=false): only Query 1 runs, restoring files whose parent is being unarchived,
+// provided they have no other backlinks besides the parent itself.
+func (gc *fileGC) CheckFilesOnObjectArchived(spaceId, objectId string, isArchived bool) error {
+	log.Debugf("checking files on object archived: %s isArchived=%v", objectId, isArchived)
+	idx := gc.objectStore.SpaceIndex(spaceId)
 
+	d, err := idx.GetDetails(objectId)
+	if err != nil {
+		return fmt.Errorf("get details of object: %w", err)
+	}
 	if slices.Contains(domain.FileLayouts, model.ObjectTypeLayout(int32(d.GetInt64(bundle.RelationKeyResolvedLayout)))) {
 		// files can't have files as children, so there's no need to check them
 		return nil
 	}
 
-	fileLayouts := make([]int64, 0, len(domain.FileLayouts))
-	for _, layout := range domain.FileLayouts {
-		fileLayouts = append(fileLayouts, int64(layout))
-	}
-
 	// make sure we have all backlinks updates flushed to the store
 	gc.backlinksWatcher.FlushUpdates()
 
-	// Query all files created in this context
-	fileRecords, err := spaceIndex.Query(database.Query{
+	fileLayouts := makeFileLayouts()
+
+	if !isArchived {
+		return gc.restoreFilesOnUnarchive(idx, objectId, fileLayouts)
+	}
+	return gc.archiveOrphanedFiles(idx, objectId, fileLayouts)
+}
+
+// archiveOrphanedFiles runs both queries and archives files that have no active backlinks.
+// Active-status of all referenced objects is resolved via at most two batch Id IN [...] queries —
+// one per query set — rather than per-item detail lookups.
+func (gc *fileGC) archiveOrphanedFiles(idx spaceindex.Store, objectId string, fileLayouts []int64) error {
+	var toArchive []string
+
+	// Query 1: files whose parent context is the object being archived.
+	// No safety gate needed — objectId IS the parent and is being archived right now.
+	parentFiles, err := idx.Query(database.Query{
 		Filters: []database.FilterRequest{
 			{
 				RelationKey: bundle.RelationKeyCreatedInContext,
 				Condition:   model.BlockContentDataviewFilter_Equal,
-				Value:       domain.String(contextId),
+				Value:       domain.String(objectId),
+			},
+			{
+				RelationKey: bundle.RelationKeyResolvedLayout,
+				Condition:   model.BlockContentDataviewFilter_In,
+				Value:       domain.Int64List(fileLayouts),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("query parent files: %w", err)
+	}
+
+	if len(parentFiles) > 0 {
+		// Collect all unique backlink IDs to check across all parent files.
+		linksToCheck := make(map[string]struct{})
+		for _, record := range parentFiles {
+			fileId := record.Details.GetString(bundle.RelationKeyId)
+			for _, link := range record.Details.GetStringList(bundle.RelationKeyBacklinks) {
+				if link != fileId && link != objectId {
+					linksToCheck[link] = struct{}{}
+				}
+			}
+		}
+
+		// Single batch query: which of these backlinks are still active (not archived/deleted)?
+		// The implicit IsArchived/IsDeleted filter from Query() excludes archived and deleted objects.
+		activeIds, err := gc.queryActiveIds(idx, linksToCheck)
+		if err != nil {
+			return fmt.Errorf("query active backlinks for parent files: %w", err)
+		}
+
+		for _, record := range parentFiles {
+			fileId := record.Details.GetString(bundle.RelationKeyId)
+			if hasActiveBacklinks(record.Details, fileId, objectId, activeIds) {
+				log.Debugf("file %s has active backlinks, keeping", fileId)
+				continue
+			}
+			log.Debugf("archiving orphaned file %s (parent %s archived)", fileId, objectId)
+			toArchive = append(toArchive, fileId)
+		}
+	}
+
+	// Query 2: files where objectId is a backlinker but NOT the parent.
+	// Safety gate per file: the file's own parent must already be archived or deleted.
+	backlinkFiles, err := idx.Query(database.Query{
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyBacklinks,
+				Condition:   model.BlockContentDataviewFilter_AllIn,
+				Value:       domain.StringList([]string{objectId}),
+			},
+			{
+				RelationKey: bundle.RelationKeyCreatedInContext,
+				Condition:   model.BlockContentDataviewFilter_NotEqual,
+				Value:       domain.String(objectId),
+			},
+			{
+				RelationKey: bundle.RelationKeyResolvedLayout,
+				Condition:   model.BlockContentDataviewFilter_In,
+				Value:       domain.Int64List(fileLayouts),
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("query backlinker files: %w", err)
+	}
+
+	if len(backlinkFiles) > 0 {
+		// Collect all unique IDs to check: parent IDs (for safety gate) + backlink IDs.
+		idsToCheck := make(map[string]struct{})
+		for _, record := range backlinkFiles {
+			fileId := record.Details.GetString(bundle.RelationKeyId)
+			if parentId := record.Details.GetString(bundle.RelationKeyCreatedInContext); parentId != "" {
+				idsToCheck[parentId] = struct{}{}
+			}
+			for _, link := range record.Details.GetStringList(bundle.RelationKeyBacklinks) {
+				if link != fileId && link != objectId {
+					idsToCheck[link] = struct{}{}
+				}
+			}
+		}
+
+		// Single batch query: which of these IDs are still active?
+		activeIds, err := gc.queryActiveIds(idx, idsToCheck)
+		if err != nil {
+			return fmt.Errorf("query active ids for backlinker files: %w", err)
+		}
+
+		for _, record := range backlinkFiles {
+			fileId := record.Details.GetString(bundle.RelationKeyId)
+			parentId := record.Details.GetString(bundle.RelationKeyCreatedInContext)
+
+			// Safety gate: only GC if the file's own parent is already in the bin or fully deleted.
+			if _, parentActive := activeIds[parentId]; parentActive {
+				log.Debugf("file %s parent %s is still active, keeping", fileId, parentId)
+				continue
+			}
+			if hasActiveBacklinks(record.Details, fileId, objectId, activeIds) {
+				log.Debugf("file %s has active backlinks, keeping", fileId)
+				continue
+			}
+			log.Debugf("archiving orphaned file %s (backlinker %s archived, parent %s already in bin)", fileId, objectId, parentId)
+			toArchive = append(toArchive, fileId)
+		}
+	}
+
+	return gc.objectArchiver.SetListIsArchived(gc.componentCtx, toArchive, true)
+}
+
+// restoreFilesOnUnarchive restores files whose parent is being unarchived, provided they have
+// no other backlinks besides the parent itself.
+func (gc *fileGC) restoreFilesOnUnarchive(idx spaceindex.Store, objectId string, fileLayouts []int64) error {
+	fileRecords, err := idx.Query(database.Query{
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyCreatedInContext,
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.String(objectId),
 			},
 			{
 				RelationKey: bundle.RelationKeyResolvedLayout,
@@ -226,39 +358,88 @@ func (gc *fileGC) CheckFilesOnContextArchived(spaceId, contextId string, isArchi
 				Value:       domain.Int64List(fileLayouts),
 			},
 			{
+				// Explicit IsArchived filter suppresses the implicit IsArchived != true default,
+				// allowing archived files to appear in results.
 				RelationKey: bundle.RelationKeyIsArchived,
-				Condition:   model.BlockContentDataviewFilter_NotEqual,
-				Value:       domain.Bool(isArchived),
+				Condition:   model.BlockContentDataviewFilter_Equal,
+				Value:       domain.Bool(true),
 			},
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to query file objects: %w", err)
+		return fmt.Errorf("query archived files for restore: %w", err)
 	}
 
 	if len(fileRecords) == 0 {
 		return nil
 	}
 
-	log.Debugf("found %d files created in context %s", len(fileRecords), contextId)
+	log.Debugf("found %d archived files created in context %s to consider restoring", len(fileRecords), objectId)
 
-	var toProcess []string
+	var toRestore []string
 	for _, record := range fileRecords {
 		fileId := record.Details.GetString(bundle.RelationKeyId)
-
-		// Check if file has any backlinks from other objects (not the context being deleted)
 		backlinks := record.Details.GetStringList(bundle.RelationKeyBacklinks)
-		activeBacklinks := lo.Filter(backlinks, func(link string, _ int) bool {
-			return link != contextId && link != fileId
+		otherBacklinks := lo.Filter(backlinks, func(link string, _ int) bool {
+			return link != objectId && link != fileId
 		})
-
-		if len(activeBacklinks) > 0 {
-			log.Debugf("file %s has %d active backlinks, keeping", fileId, len(activeBacklinks))
+		if len(otherBacklinks) > 0 {
+			log.Debugf("file %s has %d other backlinks, keeping archived", fileId, len(otherBacklinks))
 			continue
 		}
-
-		// File has no active backlinks - archive it since the context is being deleted
-		toProcess = append(toProcess, fileId)
+		toRestore = append(toRestore, fileId)
 	}
-	return gc.objectArchiver.SetListIsArchived(gc.componentCtx, toProcess, isArchived)
+	return gc.objectArchiver.SetListIsArchived(gc.componentCtx, toRestore, false)
+}
+
+// queryActiveIds returns the subset of the given IDs that are active (not archived, not deleted).
+// It issues a single Id IN [...] query and relies on the implicit IsArchived/IsDeleted filter from
+// database.Query to exclude non-active objects.
+func (gc *fileGC) queryActiveIds(idx spaceindex.Store, ids map[string]struct{}) (map[string]struct{}, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	idList := make([]string, 0, len(ids))
+	for id := range ids {
+		idList = append(idList, id)
+	}
+	records, err := idx.Query(database.Query{
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyId,
+				Condition:   model.BlockContentDataviewFilter_In,
+				Value:       domain.StringList(idList),
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query active ids: %w", err)
+	}
+	active := make(map[string]struct{}, len(records))
+	for _, r := range records {
+		active[r.Details.GetString(bundle.RelationKeyId)] = struct{}{}
+	}
+	return active, nil
+}
+
+// hasActiveBacklinks reports whether any backlink of the file (excluding fileId and currentlyArchivingId)
+// appears in activeIds, meaning it is still an active (non-archived, non-deleted) object.
+func hasActiveBacklinks(details *domain.Details, fileId, currentlyArchivingId string, activeIds map[string]struct{}) bool {
+	for _, link := range details.GetStringList(bundle.RelationKeyBacklinks) {
+		if link == fileId || link == currentlyArchivingId {
+			continue
+		}
+		if _, active := activeIds[link]; active {
+			return true
+		}
+	}
+	return false
+}
+
+func makeFileLayouts() []int64 {
+	layouts := make([]int64, 0, len(domain.FileLayouts))
+	for _, layout := range domain.FileLayouts {
+		layouts = append(layouts, int64(layout))
+	}
+	return layouts
 }

--- a/core/files/filegc/filegc_test.go
+++ b/core/files/filegc/filegc_test.go
@@ -254,6 +254,61 @@ func TestCheckFilesOnObjectArchived_ObjectIsFile_EarlyReturn(t *testing.T) {
 	assert.Empty(t, fx.archiver.archivedIds)
 }
 
+// -- links restored (undo) tests --
+
+func TestCheckFilesOnLinksRestored_RestoresArchivedFile(t *testing.T) {
+	// given: file was GC'd (archived) when its link was deleted; undo re-adds the link
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:               domain.String("file1"),
+			bundle.RelationKeyResolvedLayout:   domain.Int64(int64(model.ObjectType_image)),
+			bundle.RelationKeyCreatedInContext: domain.String("page"),
+			bundle.RelationKeyIsArchived:       domain.Bool(true),
+		},
+	})
+
+	// when: undo re-adds the file link
+	err := fx.CheckFilesOnLinksRestored(testSpaceId, "page", []string{"file1"})
+
+	// then: file is unarchived
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.unarchivedIds)
+}
+
+func TestCheckFilesOnLinksRestored_IgnoresFileFromDifferentContext(t *testing.T) {
+	// given: file belongs to a different context
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:               domain.String("file1"),
+			bundle.RelationKeyResolvedLayout:   domain.Int64(int64(model.ObjectType_image)),
+			bundle.RelationKeyCreatedInContext: domain.String("other-page"),
+			bundle.RelationKeyIsArchived:       domain.Bool(true),
+		},
+	})
+
+	// when: link restored to a different page
+	err := fx.CheckFilesOnLinksRestored(testSpaceId, "page", []string{"file1"})
+
+	// then: file is not touched — wrong context
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.unarchivedIds)
+}
+
+func TestCheckFilesOnLinksRestored_IgnoresAlreadyActiveFile(t *testing.T) {
+	// given: file is not archived (was never GC'd or was already restored)
+	fx := newFixture(t)
+	fx.addObject(t, fileObject("file1", "page", []string{"page"}))
+
+	// when
+	err := fx.CheckFilesOnLinksRestored(testSpaceId, "page", []string{"file1"})
+
+	// then: nothing to do
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.unarchivedIds)
+}
+
 // -- unarchive direction tests --
 
 func TestCheckFilesOnObjectArchived_Unarchive_NoOtherBacklinks(t *testing.T) {

--- a/core/files/filegc/filegc_test.go
+++ b/core/files/filegc/filegc_test.go
@@ -1,0 +1,301 @@
+package filegc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anyproto/any-sync/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+const testSpaceId = "test-space"
+
+// -- fixture --
+
+type fixture struct {
+	*fileGC
+	store    *objectstore.StoreFixture
+	archiver *mockArchiver
+}
+
+func newFixture(t *testing.T) *fixture {
+	store := objectstore.NewStoreFixture(t)
+	archiver := &mockArchiver{}
+	gc := &fileGC{
+		objectStore:      store,
+		objectArchiver:   archiver,
+		backlinksWatcher: &noopFlusher{},
+		componentCtx:     context.Background(),
+	}
+	return &fixture{
+		fileGC:   gc,
+		store:    store,
+		archiver: archiver,
+	}
+}
+
+func (f *fixture) addObject(t *testing.T, obj objectstore.TestObject) {
+	f.store.AddObjects(t, testSpaceId, []objectstore.TestObject{obj})
+}
+
+func fileObject(id, createdInContext string, backlinks []string) objectstore.TestObject {
+	return objectstore.TestObject{
+		bundle.RelationKeyId:               domain.String(id),
+		bundle.RelationKeyResolvedLayout:   domain.Int64(int64(model.ObjectType_image)),
+		bundle.RelationKeyCreatedInContext: domain.String(createdInContext),
+		bundle.RelationKeyBacklinks:        domain.StringList(backlinks),
+	}
+}
+
+func regularObject(id string) objectstore.TestObject {
+	return objectstore.TestObject{
+		bundle.RelationKeyId:             domain.String(id),
+		bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+	}
+}
+
+func archivedObject(id string) objectstore.TestObject {
+	return objectstore.TestObject{
+		bundle.RelationKeyId:             domain.String(id),
+		bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+		bundle.RelationKeyIsArchived:     domain.Bool(true),
+	}
+}
+
+func deletedObject(id string) objectstore.TestObject {
+	return objectstore.TestObject{
+		bundle.RelationKeyId:             domain.String(id),
+		bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+		bundle.RelationKeyIsDeleted:      domain.Bool(true),
+	}
+}
+
+// -- mocks --
+
+type mockArchiver struct {
+	archivedIds   []string
+	unarchivedIds []string
+}
+
+func (m *mockArchiver) SetListIsArchived(_ context.Context, objectIds []string, isArchived bool) error {
+	if isArchived {
+		m.archivedIds = append(m.archivedIds, objectIds...)
+	} else {
+		m.unarchivedIds = append(m.unarchivedIds, objectIds...)
+	}
+	return nil
+}
+
+type noopFlusher struct{}
+
+func (n *noopFlusher) Name() string              { return "noopFlusher" }
+func (n *noopFlusher) Init(_ *app.App) error     { return nil }
+func (n *noopFlusher) FlushUpdates()             {}
+
+// -- archive direction tests --
+
+func TestCheckFilesOnObjectArchived_ParentArchived_NoOtherBacklinks(t *testing.T) {
+	// given
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent"}))
+
+	// when
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "parent", true)
+
+	// then
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_ParentArchived_WithActiveBacklink(t *testing.T) {
+	// given
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.addObject(t, regularObject("other"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "other"}))
+
+	// when
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "parent", true)
+
+	// then
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_ParentArchived_OtherBacklinksAllArchived(t *testing.T) {
+	// given
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.addObject(t, archivedObject("other"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "other"}))
+
+	// when
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "parent", true)
+
+	// then
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_ParentArchived_OtherBacklinksAllDeleted(t *testing.T) {
+	// given
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.addObject(t, deletedObject("other"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "other"}))
+
+	// when
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "parent", true)
+
+	// then
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_BacklinkerArchived_ParentStillActive(t *testing.T) {
+	// given: file's parent is active, objectId is just a backlinker
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.addObject(t, regularObject("backlinker"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "backlinker"}))
+
+	// when: backlinker is archived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "backlinker", true)
+
+	// then: file must not be touched — parent is still active (safety gate)
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_BacklinkerArchived_ParentArchived_NoOtherBacklinks(t *testing.T) {
+	// given: file's parent is already archived, backlinker is the last reference
+	fx := newFixture(t)
+	fx.addObject(t, archivedObject("parent"))
+	fx.addObject(t, regularObject("backlinker"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "backlinker"}))
+
+	// when: backlinker is archived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "backlinker", true)
+
+	// then: file should be archived
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_BacklinkerArchived_ParentArchived_OtherActiveBacklink(t *testing.T) {
+	// given: file's parent is archived, but another object still actively links to the file
+	fx := newFixture(t)
+	fx.addObject(t, archivedObject("parent"))
+	fx.addObject(t, regularObject("backlinker"))
+	fx.addObject(t, regularObject("activeRef"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "backlinker", "activeRef"}))
+
+	// when: backlinker is archived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "backlinker", true)
+
+	// then: file kept because activeRef is still active
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_BacklinkerArchived_ParentArchived_OtherBacklinksAllArchived(t *testing.T) {
+	// given: file's parent and all other backlinks are archived
+	fx := newFixture(t)
+	fx.addObject(t, archivedObject("parent"))
+	fx.addObject(t, regularObject("backlinker"))
+	fx.addObject(t, archivedObject("archivedRef"))
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "backlinker", "archivedRef"}))
+
+	// when: backlinker is archived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "backlinker", true)
+
+	// then: file should be archived
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_BacklinkerArchived_ParentMissingFromStore(t *testing.T) {
+	// given: file's parent is not in the store at all (fully deleted), backlinker is the last reference
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("backlinker"))
+	// "parent" is intentionally not added to the store
+	fx.addObject(t, fileObject("file1", "parent", []string{"parent", "backlinker"}))
+
+	// when: backlinker is archived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "backlinker", true)
+
+	// then: file archived — missing parent treated as deleted (safety gate passes)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_ObjectIsFile_EarlyReturn(t *testing.T) {
+	// given: the archived object is itself a file
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:             domain.String("fileContext"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_image)),
+		},
+	})
+
+	// when
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "fileContext", true)
+
+	// then: returns immediately, no GC triggered
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.archivedIds)
+}
+
+// -- unarchive direction tests --
+
+func TestCheckFilesOnObjectArchived_Unarchive_NoOtherBacklinks(t *testing.T) {
+	// given: file was archived alongside its parent, now parent is being restored
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:               domain.String("file1"),
+			bundle.RelationKeyResolvedLayout:   domain.Int64(int64(model.ObjectType_image)),
+			bundle.RelationKeyCreatedInContext: domain.String("parent"),
+			bundle.RelationKeyBacklinks:        domain.StringList([]string{"parent"}),
+			bundle.RelationKeyIsArchived:       domain.Bool(true),
+		},
+	})
+
+	// when: parent unarchived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "parent", false)
+
+	// then: file restored
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.unarchivedIds)
+}
+
+func TestCheckFilesOnObjectArchived_Unarchive_HasOtherBacklinks(t *testing.T) {
+	// given: file has another backlink besides the parent
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:               domain.String("file1"),
+			bundle.RelationKeyResolvedLayout:   domain.Int64(int64(model.ObjectType_image)),
+			bundle.RelationKeyCreatedInContext: domain.String("parent"),
+			bundle.RelationKeyBacklinks:        domain.StringList([]string{"parent", "otherRef"}),
+			bundle.RelationKeyIsArchived:       domain.Bool(true),
+		},
+	})
+
+	// when: parent unarchived
+	err := fx.CheckFilesOnObjectArchived(testSpaceId, "parent", false)
+
+	// then: file kept archived because it has other backlinks
+	require.NoError(t, err)
+	assert.Empty(t, fx.archiver.unarchivedIds)
+}


### PR DESCRIPTION
## What

Fixes two gaps in file GC (introduced in #2889 / GO-6052) and one undo regression.

**Gap 1 — archived backlinks counted as active**
When deciding whether to GC a file, the old code counted every backlink as "active" regardless of its archive/deleted status. A file shared between two objects would stay alive even after both objects were moved to the bin.

**Gap 2 — GC not triggered when a non-parent backlinker is archived last**
GC was only triggered when the file's `CreatedInContext` parent was archived. If the parent was already in the bin and a second backlinker got archived later, no GC fired and the file was never cleaned up.

**Undo regression — file not restored after undo**
After GC archived a file (link removed), undoing the removal didn't restore it. Root cause: the link-diff block in `Apply` was guarded by `len(linksBefore) > 0`, which evaluated to false when undoing from an empty state (linksBefore = []), silently skipping the added-links detection.

## How

- Replaced `CheckFilesOnContextArchived` with `CheckFilesOnObjectArchived` (unified entry point called for every archived object, not just file parents).
  - **Query 1** (parent case): files whose `CreatedInContext == objectId` — no safety gate, check that all remaining backlinks are archived/deleted.
  - **Query 2** (backlinker case): files where `objectId` is in `backlinks` but is not the parent — safety gate: only proceed if the file's actual parent is already archived or deleted, preventing over-eager GC.
  - Both queries use a single batch `Id IN [...]` query to resolve active-status of all referenced objects at once (no per-item `GetDetails` calls).
- Added `CheckFilesOnLinksRestored`: called from `Apply` when links are re-added (undo). Queries archived files matching the added link IDs + `CreatedInContext == contextId` and unarchives them.
- Removed the `len(linksBefore) > 0` guard so undo from an empty state is handled correctly.

## Tests

**Unit tests — `core/files/filegc/filegc_test.go` (new, 15 cases)**
- Parent archived, file has no other backlinks → archived
- Parent archived, file has active non-archived backlink → kept
- Parent archived, all other backlinks also archived → archived ← new
- Backlinker archived, file's parent still active → kept ← new
- Backlinker archived, parent archived, no other active backlinks → archived ← new
- Backlinker archived, parent archived, other active backlink exists → kept ← new
- Backlinker archived, parent archived, all other backlinks archived → archived ← new
- Backlinker archived, parent missing from store (deleted) → archived ← new
- objectId is itself a file layout → returns nil immediately
- Unarchive parent, file has no other backlinks → restored
- Unarchive parent, file has another backlink → stays archived
- Links restored (undo): archived file matching context → unarchived ← new
- Links restored (undo): non-archived file → ignored ← new
- Links restored (undo): archived file with different context → ignored ← new

**Unit tests — `core/block/editor/smartblock/filegclinks_test.go` (new, 2 cases)**
- Links added from empty state (`linksBefore = []`) → `CheckFilesOnLinksRestored` called (exercises the guard fix)
- Links removed → `CheckFilesOnLinksRemoval` called

**E2E tests — anyproto/anytype-suite#36**

`file-context-gc-undo.test.ts`:
- Upload file into page → delete block → file archived → undo → file must be unarchived

`file-context-gc-multi-context.test.ts` (2 cases):
- Archive backlinker (obj2) first, then parent (obj1) → file stays alive until obj1 archived, then archived
- Archive parent (obj1) first, then backlinker (obj2) → file stays alive until obj2 archived, then archived

## Manual verification needed
- Archive an object that contains a file also referenced by a second object → file should stay in the bin only after *both* objects are archived
- Archive the second referencing object when the file's parent is already in the bin → file should move to bin
- Restore (unarchive) the parent object → file should be restored from bin along with it