### PR TITLE
GO-6946 Fix race in acl service

### DIFF
--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -213,12 +213,6 @@ func (a *aclService) pushGuest(ctx context.Context, privKey crypto.PrivKey) (met
 }
 
 func (a *aclService) AddGuestAccount(ctx context.Context, spaceId string) (privKey crypto.PrivKey, err error) {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
-	return a.addGuestAccount(ctx, spaceId)
-}
-
-func (a *aclService) addGuestAccount(ctx context.Context, spaceId string) (privKey crypto.PrivKey, err error) {
 	pk, pubKey, err := crypto.GenerateRandomEd25519KeyPair()
 	if err != nil {
 		return nil, err
@@ -227,7 +221,7 @@ func (a *aclService) addGuestAccount(ctx context.Context, spaceId string) (privK
 	if err != nil {
 		return nil, err
 	}
-	return pk, a.addAccounts(ctx, spaceId, []list.AccountAdd{{
+	return pk, a.AddAccounts(ctx, spaceId, []list.AccountAdd{{
 		Identity:    pubKey,
 		Metadata:    metadata,
 		Permissions: list.AclPermissionsGuest,
@@ -235,16 +229,12 @@ func (a *aclService) addGuestAccount(ctx context.Context, spaceId string) (privK
 }
 
 func (a *aclService) AddAccounts(ctx context.Context, spaceId string, additions []list.AccountAdd) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
-	return a.addAccounts(ctx, spaceId, additions)
-}
-
-func (a *aclService) addAccounts(ctx context.Context, spaceId string, additions []list.AccountAdd) error {
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
 	}
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	err = sp.CommonSpace().AclClient().AddAccounts(ctx, list.AccountsAddPayload{Additions: additions})
 	if err != nil {
 		return convertedOrAclRequestError(err)
@@ -253,12 +243,6 @@ func (a *aclService) addAccounts(ctx context.Context, spaceId string, additions 
 }
 
 func (a *aclService) Remove(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
-	return a.remove(ctx, spaceId, identities)
-}
-
-func (a *aclService) remove(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
 	removeSpace, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -268,6 +252,8 @@ func (a *aclService) remove(ctx context.Context, spaceId string, identities []cr
 		return convertedOrInternalError("generate random key pair", err)
 	}
 	cl := removeSpace.CommonSpace().AclClient()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	err = cl.RemoveAccounts(ctx, list.AccountRemovePayload{
 		Identities: identities,
 		Change: list.ReadKeyChangePayload{
@@ -294,13 +280,13 @@ func (a *aclService) CancelJoin(ctx context.Context, spaceId string) (err error)
 }
 
 func (a *aclService) Decline(ctx context.Context, spaceId string, identity crypto.PubKey) (err error) {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
 	}
 	cl := sp.CommonSpace().AclClient()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	err = cl.DeclineRequest(ctx, identity)
 	if err != nil {
 		return convertedOrAclRequestError(err)
@@ -309,14 +295,14 @@ func (a *aclService) Decline(ctx context.Context, spaceId string, identity crypt
 }
 
 func (a *aclService) RevokeInvite(ctx context.Context, spaceId string) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
 	}
 	cl := sp.CommonSpace().AclClient()
+	a.aclClientLock.Lock()
 	err = cl.RevokeAllInvites(ctx)
+	a.aclClientLock.Unlock()
 	if err != nil {
 		return convertedOrAclRequestError(err)
 	}
@@ -328,8 +314,6 @@ func (a *aclService) RevokeInvite(ctx context.Context, spaceId string) error {
 }
 
 func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perms []AccountPermissions) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	if len(perms) == 0 {
 		return fmt.Errorf("%w: empty permissions", ErrIncorrectPermissions)
 	}
@@ -366,6 +350,8 @@ func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perm
 	}
 	acl.RUnlock()
 	cl := sp.CommonSpace().AclClient()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	err = cl.ChangePermissions(ctx, list.PermissionChangesPayload{
 		Changes: listPerms,
 	})
@@ -376,8 +362,6 @@ func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perm
 }
 
 func (a *aclService) ApproveLeave(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -405,7 +389,7 @@ func (a *aclService) ApproveLeave(ctx context.Context, spaceId string, identitie
 		return fmt.Errorf("%w with identities: %s", ErrRequestNotExists, strings.Join(identities, ", "))
 	}
 	acl.RUnlock()
-	return a.remove(ctx, spaceId, identities)
+	return a.Remove(ctx, spaceId, identities)
 }
 
 func (a *aclService) Leave(ctx context.Context, spaceId string) (err error) {
@@ -432,8 +416,6 @@ func (a *aclService) Leave(ctx context.Context, spaceId string) (err error) {
 }
 
 func (a *aclService) StopSharing(ctx context.Context, spaceId string) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	removeSpace, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -456,10 +438,12 @@ func (a *aclService) StopSharing(ctx context.Context, spaceId string) error {
 		return convertedOrInternalError("generate random key pair", err)
 	}
 	cl := commonSpace.AclClient()
+	a.aclClientLock.Lock()
 	err = cl.StopSharing(ctx, list.ReadKeyChangePayload{
 		MetadataKey: newPrivKey,
 		ReadKey:     crypto.NewAES(),
 	})
+	a.aclClientLock.Unlock()
 	if err != nil {
 		return convertedOrAclRequestError(err)
 	}
@@ -634,8 +618,6 @@ func (a *aclService) ViewInvite(ctx context.Context, inviteCid cid.Cid, inviteFi
 }
 
 func (a *aclService) Accept(ctx context.Context, spaceId string, identity crypto.PubKey, permissions model.ParticipantPermissions) error {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	validPerms := permissions == model.ParticipantPermissions_Reader || permissions == model.ParticipantPermissions_Writer
 	if !validPerms {
 		return ErrIncorrectPermissions
@@ -662,7 +644,6 @@ func (a *aclService) Accept(ctx context.Context, spaceId string, identity crypto
 	if recId == "" {
 		return fmt.Errorf("%w with identity: %s", ErrRequestNotExists, identity.Account())
 	}
-	cl := acceptSpace.CommonSpace().AclClient()
 	var aclPerms list.AclPermissions
 	switch permissions {
 	case model.ParticipantPermissions_Reader:
@@ -670,6 +651,9 @@ func (a *aclService) Accept(ctx context.Context, spaceId string, identity crypto
 	case model.ParticipantPermissions_Writer:
 		aclPerms = list.AclPermissionsWriter
 	}
+	cl := acceptSpace.CommonSpace().AclClient()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	err = cl.AcceptRequest(ctx, list.RequestAcceptPayload{
 		RequestRecordId: recId,
 		Permissions:     aclPerms,
@@ -685,8 +669,6 @@ func (a *aclService) GetCurrentInvite(ctx context.Context, spaceId string) (doma
 }
 
 func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissions model.ParticipantPermissions) (err error) {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -717,7 +699,9 @@ func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissio
 	if invite.Permissions == invitePermissions {
 		return ErrIncorrectPermissions
 	}
+	a.aclClientLock.Lock()
 	err = aclClient.ChangeInvitePermissions(ctx, invites[0].Id, invitePermissions)
+	a.aclClientLock.Unlock()
 	if err != nil {
 		return convertedOrAclRequestError(err)
 	}
@@ -729,8 +713,6 @@ func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissio
 }
 
 func (a *aclService) GenerateInvite(ctx context.Context, spaceId string, invType model.InviteType, permissions model.ParticipantPermissions) (result domain.InviteInfo, err error) {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -752,6 +734,8 @@ func (a *aclService) GenerateInvite(ctx context.Context, spaceId string, invType
 		Permissions: aclPermissions,
 		InviteType:  domain.ConvertInviteType(inviteType),
 	}
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	res, err := aclClient.ReplaceInvite(ctx, invitePayload)
 	if err != nil {
 		err = convertedOrInternalError("couldn't generate acl invite", err)
@@ -797,11 +781,9 @@ func (a *aclService) GetGuestUserInvite(ctx context.Context, spaceId string) (in
 			return
 		}
 	}
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	// todo: race conds in case guest user already created?
 	// we can iterate users to find the guest key
-	guestKey, err := a.addGuestAccount(ctx, spaceId)
+	guestKey, err := a.AddGuestAccount(ctx, spaceId)
 	if err != nil {
 		return domain.InviteInfo{}, convertedOrInternalError("add guest account", err)
 	}
@@ -817,8 +799,6 @@ func (a *aclService) joinAsGuest(ctx context.Context, spaceId string, guestUserK
 }
 
 func (a *aclService) OwnershipChange(ctx context.Context, spaceId string, newOwner crypto.PubKey, oldOwnerPerm model.ParticipantPermissions) (err error) {
-	a.aclClientLock.Lock()
-	defer a.aclClientLock.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -827,7 +807,8 @@ func (a *aclService) OwnershipChange(ctx context.Context, spaceId string, newOwn
 	if err != nil {
 		return convertedOrSpaceErr(err)
 	}
-
 	aclClient := ownedSpace.CommonSpace().AclClient()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	return aclClient.OwnershipChange(ctx, newOwner, domain.ConvertParticipantPermissions(oldOwnerPerm))
 }

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -121,11 +121,11 @@ type aclService struct {
 	updater          *aclUpdater
 	getter           *aclGetter
 
-	// spaceOpMu provides per-space serialization of ACL modification operations.
+	// aclClientLock serializes all ACL modification operations.
 	// This prevents race conditions where concurrent operations (e.g. GenerateInvite
 	// and AddAccounts) read the same ACL head, build records with the same prevId,
 	// and only one succeeds on the node ("incorrect prev id of a record" error).
-	spaceOpMu sync.Map // spaceId -> *sync.Mutex
+	aclClientLock sync.Mutex
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -186,10 +186,6 @@ func (a *aclService) Name() (name string) {
 	return CName
 }
 
-func (a *aclService) getSpaceOpMu(spaceId string) *sync.Mutex {
-	mu, _ := a.spaceOpMu.LoadOrStore(spaceId, &sync.Mutex{})
-	return mu.(*sync.Mutex)
-}
 
 func (a *aclService) MakeShareable(ctx context.Context, spaceId string) error {
 	err := a.coordClient.SpaceMakeShareable(ctx, spaceId)
@@ -218,9 +214,8 @@ func (a *aclService) pushGuest(ctx context.Context, privKey crypto.PrivKey) (met
 }
 
 func (a *aclService) AddGuestAccount(ctx context.Context, spaceId string) (privKey crypto.PrivKey, err error) {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	return a.addGuestAccount(ctx, spaceId)
 }
 
@@ -241,9 +236,8 @@ func (a *aclService) addGuestAccount(ctx context.Context, spaceId string) (privK
 }
 
 func (a *aclService) AddAccounts(ctx context.Context, spaceId string, additions []list.AccountAdd) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	return a.addAccounts(ctx, spaceId, additions)
 }
 
@@ -260,9 +254,8 @@ func (a *aclService) addAccounts(ctx context.Context, spaceId string, additions 
 }
 
 func (a *aclService) Remove(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	return a.remove(ctx, spaceId, identities)
 }
 
@@ -302,9 +295,8 @@ func (a *aclService) CancelJoin(ctx context.Context, spaceId string) (err error)
 }
 
 func (a *aclService) Decline(ctx context.Context, spaceId string, identity crypto.PubKey) (err error) {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -318,9 +310,8 @@ func (a *aclService) Decline(ctx context.Context, spaceId string, identity crypt
 }
 
 func (a *aclService) RevokeInvite(ctx context.Context, spaceId string) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -338,9 +329,8 @@ func (a *aclService) RevokeInvite(ctx context.Context, spaceId string) error {
 }
 
 func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perms []AccountPermissions) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	if len(perms) == 0 {
 		return fmt.Errorf("%w: empty permissions", ErrIncorrectPermissions)
 	}
@@ -387,9 +377,8 @@ func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perm
 }
 
 func (a *aclService) ApproveLeave(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -444,9 +433,8 @@ func (a *aclService) Leave(ctx context.Context, spaceId string) (err error) {
 }
 
 func (a *aclService) StopSharing(ctx context.Context, spaceId string) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	removeSpace, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -647,9 +635,8 @@ func (a *aclService) ViewInvite(ctx context.Context, inviteCid cid.Cid, inviteFi
 }
 
 func (a *aclService) Accept(ctx context.Context, spaceId string, identity crypto.PubKey, permissions model.ParticipantPermissions) error {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	validPerms := permissions == model.ParticipantPermissions_Reader || permissions == model.ParticipantPermissions_Writer
 	if !validPerms {
 		return ErrIncorrectPermissions
@@ -699,9 +686,8 @@ func (a *aclService) GetCurrentInvite(ctx context.Context, spaceId string) (doma
 }
 
 func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissions model.ParticipantPermissions) (err error) {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -744,9 +730,8 @@ func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissio
 }
 
 func (a *aclService) GenerateInvite(ctx context.Context, spaceId string, invType model.InviteType, permissions model.ParticipantPermissions) (result domain.InviteInfo, err error) {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -813,9 +798,8 @@ func (a *aclService) GetGuestUserInvite(ctx context.Context, spaceId string) (in
 			return
 		}
 	}
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	// todo: race conds in case guest user already created?
 	// we can iterate users to find the guest key
 	guestKey, err := a.addGuestAccount(ctx, spaceId)
@@ -834,9 +818,8 @@ func (a *aclService) joinAsGuest(ctx context.Context, spaceId string, guestUserK
 }
 
 func (a *aclService) OwnershipChange(ctx context.Context, spaceId string, newOwner crypto.PubKey, oldOwnerPerm model.ParticipantPermissions) (err error) {
-	mu := a.getSpaceOpMu(spaceId)
-	mu.Lock()
-	defer mu.Unlock()
+	a.aclClientLock.Lock()
+	defer a.aclClientLock.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
@@ -120,6 +121,12 @@ type aclService struct {
 	updater          *aclUpdater
 	getter           *aclGetter
 
+	// spaceOpMu provides per-space serialization of ACL modification operations.
+	// This prevents race conditions where concurrent operations (e.g. GenerateInvite
+	// and AddAccounts) read the same ACL head, build records with the same prevId,
+	// and only one succeeds on the node ("incorrect prev id of a record" error).
+	spaceOpMu sync.Map // spaceId -> *sync.Mutex
+
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 }
@@ -179,6 +186,11 @@ func (a *aclService) Name() (name string) {
 	return CName
 }
 
+func (a *aclService) getSpaceOpMu(spaceId string) *sync.Mutex {
+	mu, _ := a.spaceOpMu.LoadOrStore(spaceId, &sync.Mutex{})
+	return mu.(*sync.Mutex)
+}
+
 func (a *aclService) MakeShareable(ctx context.Context, spaceId string) error {
 	err := a.coordClient.SpaceMakeShareable(ctx, spaceId)
 	if err != nil {
@@ -206,6 +218,13 @@ func (a *aclService) pushGuest(ctx context.Context, privKey crypto.PrivKey) (met
 }
 
 func (a *aclService) AddGuestAccount(ctx context.Context, spaceId string) (privKey crypto.PrivKey, err error) {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
+	return a.addGuestAccount(ctx, spaceId)
+}
+
+func (a *aclService) addGuestAccount(ctx context.Context, spaceId string) (privKey crypto.PrivKey, err error) {
 	pk, pubKey, err := crypto.GenerateRandomEd25519KeyPair()
 	if err != nil {
 		return nil, err
@@ -214,7 +233,7 @@ func (a *aclService) AddGuestAccount(ctx context.Context, spaceId string) (privK
 	if err != nil {
 		return nil, err
 	}
-	return pk, a.AddAccounts(ctx, spaceId, []list.AccountAdd{{
+	return pk, a.addAccounts(ctx, spaceId, []list.AccountAdd{{
 		Identity:    pubKey,
 		Metadata:    metadata,
 		Permissions: list.AclPermissionsGuest,
@@ -222,6 +241,13 @@ func (a *aclService) AddGuestAccount(ctx context.Context, spaceId string) (privK
 }
 
 func (a *aclService) AddAccounts(ctx context.Context, spaceId string, additions []list.AccountAdd) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
+	return a.addAccounts(ctx, spaceId, additions)
+}
+
+func (a *aclService) addAccounts(ctx context.Context, spaceId string, additions []list.AccountAdd) error {
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -234,6 +260,13 @@ func (a *aclService) AddAccounts(ctx context.Context, spaceId string, additions 
 }
 
 func (a *aclService) Remove(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
+	return a.remove(ctx, spaceId, identities)
+}
+
+func (a *aclService) remove(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
 	removeSpace, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -269,6 +302,9 @@ func (a *aclService) CancelJoin(ctx context.Context, spaceId string) (err error)
 }
 
 func (a *aclService) Decline(ctx context.Context, spaceId string, identity crypto.PubKey) (err error) {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -282,6 +318,9 @@ func (a *aclService) Decline(ctx context.Context, spaceId string, identity crypt
 }
 
 func (a *aclService) RevokeInvite(ctx context.Context, spaceId string) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -299,6 +338,9 @@ func (a *aclService) RevokeInvite(ctx context.Context, spaceId string) error {
 }
 
 func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perms []AccountPermissions) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	if len(perms) == 0 {
 		return fmt.Errorf("%w: empty permissions", ErrIncorrectPermissions)
 	}
@@ -345,6 +387,9 @@ func (a *aclService) ChangePermissions(ctx context.Context, spaceId string, perm
 }
 
 func (a *aclService) ApproveLeave(ctx context.Context, spaceId string, identities []crypto.PubKey) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	sp, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -372,7 +417,7 @@ func (a *aclService) ApproveLeave(ctx context.Context, spaceId string, identitie
 		return fmt.Errorf("%w with identities: %s", ErrRequestNotExists, strings.Join(identities, ", "))
 	}
 	acl.RUnlock()
-	return a.Remove(ctx, spaceId, identities)
+	return a.remove(ctx, spaceId, identities)
 }
 
 func (a *aclService) Leave(ctx context.Context, spaceId string) (err error) {
@@ -399,6 +444,9 @@ func (a *aclService) Leave(ctx context.Context, spaceId string) (err error) {
 }
 
 func (a *aclService) StopSharing(ctx context.Context, spaceId string) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	removeSpace, err := a.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return convertedOrSpaceErr(err)
@@ -599,6 +647,9 @@ func (a *aclService) ViewInvite(ctx context.Context, inviteCid cid.Cid, inviteFi
 }
 
 func (a *aclService) Accept(ctx context.Context, spaceId string, identity crypto.PubKey, permissions model.ParticipantPermissions) error {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	validPerms := permissions == model.ParticipantPermissions_Reader || permissions == model.ParticipantPermissions_Writer
 	if !validPerms {
 		return ErrIncorrectPermissions
@@ -648,6 +699,9 @@ func (a *aclService) GetCurrentInvite(ctx context.Context, spaceId string) (doma
 }
 
 func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissions model.ParticipantPermissions) (err error) {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -690,6 +744,9 @@ func (a *aclService) ChangeInvite(ctx context.Context, spaceId string, permissio
 }
 
 func (a *aclService) GenerateInvite(ctx context.Context, spaceId string, invType model.InviteType, permissions model.ParticipantPermissions) (result domain.InviteInfo, err error) {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return
@@ -756,9 +813,12 @@ func (a *aclService) GetGuestUserInvite(ctx context.Context, spaceId string) (in
 			return
 		}
 	}
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	// todo: race conds in case guest user already created?
 	// we can iterate users to find the guest key
-	guestKey, err := a.AddGuestAccount(ctx, spaceId)
+	guestKey, err := a.addGuestAccount(ctx, spaceId)
 	if err != nil {
 		return domain.InviteInfo{}, convertedOrInternalError("add guest account", err)
 	}
@@ -774,6 +834,9 @@ func (a *aclService) joinAsGuest(ctx context.Context, spaceId string, guestUserK
 }
 
 func (a *aclService) OwnershipChange(ctx context.Context, spaceId string, newOwner crypto.PubKey, oldOwnerPerm model.ParticipantPermissions) (err error) {
+	mu := a.getSpaceOpMu(spaceId)
+	mu.Lock()
+	defer mu.Unlock()
 	if spaceId == a.accountService.PersonalSpaceID() {
 		err = ErrPersonalSpace
 		return

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -186,7 +186,6 @@ func (a *aclService) Name() (name string) {
 	return CName
 }
 
-
 func (a *aclService) MakeShareable(ctx context.Context, spaceId string) error {
 	err := a.coordClient.SpaceMakeShareable(ctx, spaceId)
 	if err != nil {

--- a/core/acl/aclservice_test.go
+++ b/core/acl/aclservice_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/commonspace/acl/aclclient"
 	"github.com/anyproto/any-sync/commonspace/acl/aclclient/mock_aclclient"
 	"github.com/anyproto/any-sync/commonspace/mock_commonspace"
 	"github.com/anyproto/any-sync/commonspace/object/accountdata"
@@ -857,4 +860,176 @@ func TestService_Leave(t *testing.T) {
 		// ErrNoSuchAccount should be wrapped as ErrNoSuchAccount (converted in convertedOrAclRequestError)
 		require.True(t, errors.Is(err, ErrNoSuchAccount))
 	})
+}
+
+func TestService_ConcurrentInviteGeneration(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish(t)
+	spaceId := "spaceId"
+	goroutines := 5
+
+	keys, err := accountdata.NewRandom()
+	require.NoError(t, err)
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	fx.mockAccountService.EXPECT().PersonalSpaceID().Return("personal").Maybe()
+
+	// First call has no existing invite; subsequent ones find the invite already exists
+	fx.mockInviteService.EXPECT().GetCurrent(ctx, spaceId).
+		Return(domain.InviteInfo{}, inviteservice.ErrInviteNotExists).Once()
+	fx.mockInviteService.EXPECT().GetCurrent(ctx, spaceId).
+		Return(domain.InviteInfo{
+			InviteType:    domain.InviteTypeDefault,
+			InviteFileCid: "testCid",
+		}, nil).Maybe()
+
+	mockSpace := mock_clientspace.NewMockSpace(t)
+	mockCommonSpace := mock_commonspace.NewMockSpace(fx.ctrl)
+	mockAclClient := mock_aclclient.NewMockAclSpaceClient(fx.ctrl)
+
+	mockSpace.EXPECT().CommonSpace().Return(mockCommonSpace).Maybe()
+	mockCommonSpace.EXPECT().AclClient().Return(mockAclClient).AnyTimes()
+	fx.mockSpaceService.EXPECT().Get(ctx, spaceId).Return(mockSpace, nil).Maybe()
+
+	rec := &consensusproto.RawRecord{Payload: []byte("test")}
+	mockAclClient.EXPECT().ReplaceInvite(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, payload aclclient.InvitePayload) (list.InviteResult, error) {
+			cur := concurrent.Add(1)
+			for {
+				old := maxConcurrent.Load()
+				if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			concurrent.Add(-1)
+			return list.InviteResult{
+				InviteRec: rec,
+				InviteKey: keys.SignKey,
+			}, nil
+		}).AnyTimes()
+
+	mockAclClient.EXPECT().AddRecord(ctx, rec).
+		DoAndReturn(func(ctx context.Context, rec *consensusproto.RawRecord) error {
+			cur := concurrent.Add(1)
+			for {
+				old := maxConcurrent.Load()
+				if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			concurrent.Add(-1)
+			return nil
+		}).AnyTimes()
+
+	fx.mockInviteService.EXPECT().Generate(ctx, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx2 context.Context, params inviteservice.GenerateInviteParams, f func() error) (domain.InviteInfo, error) {
+			return domain.InviteInfo{InviteFileCid: "testCid"}, f()
+		}).Maybe()
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, genErr := fx.GenerateInvite(ctx, spaceId, model.InviteType_Member, model.ParticipantPermissions_Reader)
+			require.NoError(t, genErr)
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), maxConcurrent.Load(), "expected operations to be serialized, but observed concurrent execution")
+}
+
+func TestService_ConcurrentInviteAndAddAccounts(t *testing.T) {
+	fx := newFixture(t)
+	defer fx.finish(t)
+	spaceId := "spaceId"
+
+	keys, err := accountdata.NewRandom()
+	require.NoError(t, err)
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	trackConcurrency := func(duration time.Duration) {
+		cur := concurrent.Add(1)
+		for {
+			old := maxConcurrent.Load()
+			if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		time.Sleep(duration)
+		concurrent.Add(-1)
+	}
+
+	fx.mockAccountService.EXPECT().PersonalSpaceID().Return("personal").Maybe()
+	fx.mockInviteService.EXPECT().GetCurrent(ctx, spaceId).
+		Return(domain.InviteInfo{}, inviteservice.ErrInviteNotExists).Maybe()
+
+	mockSpace := mock_clientspace.NewMockSpace(t)
+	mockCommonSpace := mock_commonspace.NewMockSpace(fx.ctrl)
+	mockAclClient := mock_aclclient.NewMockAclSpaceClient(fx.ctrl)
+
+	mockSpace.EXPECT().CommonSpace().Return(mockCommonSpace).Maybe()
+	mockCommonSpace.EXPECT().AclClient().Return(mockAclClient).AnyTimes()
+	fx.mockSpaceService.EXPECT().Get(ctx, spaceId).Return(mockSpace, nil).Maybe()
+
+	rec := &consensusproto.RawRecord{Payload: []byte("test")}
+	mockAclClient.EXPECT().ReplaceInvite(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, payload aclclient.InvitePayload) (list.InviteResult, error) {
+			trackConcurrency(50 * time.Millisecond)
+			return list.InviteResult{
+				InviteRec: rec,
+				InviteKey: keys.SignKey,
+			}, nil
+		}).AnyTimes()
+
+	mockAclClient.EXPECT().AddRecord(ctx, rec).
+		DoAndReturn(func(ctx context.Context, rec *consensusproto.RawRecord) error {
+			trackConcurrency(50 * time.Millisecond)
+			return nil
+		}).AnyTimes()
+
+	mockAclClient.EXPECT().AddAccounts(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, payload list.AccountsAddPayload) error {
+			trackConcurrency(50 * time.Millisecond)
+			return nil
+		}).AnyTimes()
+
+	fx.mockInviteService.EXPECT().Generate(ctx, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx2 context.Context, params inviteservice.GenerateInviteParams, f func() error) (domain.InviteInfo, error) {
+			return domain.InviteInfo{InviteFileCid: "testCid"}, f()
+		}).Maybe()
+
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	// 2 concurrent invite generations
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			_, genErr := fx.GenerateInvite(ctx, spaceId, model.InviteType_Member, model.ParticipantPermissions_Reader)
+			require.NoError(t, genErr)
+		}()
+	}
+
+	// 2 concurrent AddAccounts
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			addErr := fx.AddAccounts(ctx, spaceId, []list.AccountAdd{
+				{Identity: keys.SignKey.GetPublic(), Permissions: list.AclPermissionsReader, Metadata: []byte("meta")},
+			})
+			require.NoError(t, addErr)
+		}()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, int32(1), maxConcurrent.Load(), "expected operations to be serialized, but observed concurrent execution")
 }


### PR DESCRIPTION
https://linear.app/anytype/issue/GO-6946/contacts-list-and-space-creation-with-members

When client performs two consequent calls - SpaceInviteGenerate and SpaceParticipantsListAdd - it causes data race. Both operations first read last ACL record and then modify ACL state. ACL state changes and one of operations fail, because saved previous record id has already changed.

Per-space mutex helps to fix this problem.