### PR TITLE
Fix: Set homepage to space description

### DIFF
--- a/space/spaceinfo/spaceinfo.go
+++ b/space/spaceinfo/spaceinfo.go
@@ -138,6 +138,7 @@ type SpaceDescription struct {
 	IconOption                 int
 	SpaceUxType                model.SpaceUxType // TODO: GO-7102 remove
 	SpaceType                  model.SpaceType
+	Homepage                   string
 	OneToOneIdentity           string
 	OneToOneRequestMetadataKey string
 	OneToOneInboxSentStatus    OneToOneInboxSentStatus
@@ -150,6 +151,7 @@ func NewSpaceDescriptionFromDetails(details *domain.Details) SpaceDescription {
 		IconOption:                 int(details.GetInt64(bundle.RelationKeyIconOption)),
 		SpaceUxType:                model.SpaceUxType(details.GetInt64(bundle.RelationKeySpaceUxType)), // #nosec G115
 		SpaceType:                  model.SpaceType(details.GetInt64(bundle.RelationKeySpaceType)),     // #nosec G115
+		Homepage:                   details.GetString(bundle.RelationKeyHomepage),
 		OneToOneIdentity:           details.GetString(bundle.RelationKeyOneToOneIdentity),
 		OneToOneRequestMetadataKey: details.GetString(bundle.RelationKeyOneToOneRequestMetadataKey),
 	}
@@ -164,6 +166,7 @@ func (s *SpaceDescription) UpdateDetails(st *state.State) {
 	st.SetDetailAndBundledRelation(bundle.RelationKeySpaceType, domain.Int64(s.SpaceType))
 	st.SetDetailAndBundledRelation(bundle.RelationKeyIconImage, domain.String(s.IconImage))
 	st.SetDetailAndBundledRelation(bundle.RelationKeyIconOption, domain.Int64(s.IconOption))
+	st.SetDetailAndBundledRelation(bundle.RelationKeyHomepage, domain.String(s.Homepage))
 	st.SetDetailAndBundledRelation(bundle.RelationKeyOneToOneInboxSentStatus, domain.Int64(s.OneToOneInboxSentStatus))
 	// OneToOneIdentity is set only once
 }


### PR DESCRIPTION
**Root Cause**                                                                                                         
                                                                                                                     
The homepage flickers on iOS client on Group Channel creation because of a race between synchronous SpaceView creation and async workspace detail propagation. Here's the exact sequence:                                                           
                                                                                                                     
  **What happens step by step:**

  1. CreateWorkspace (core/block/create.go:154) receives request with all details including homepage
  2. spaceDescription := NewSpaceDescriptionFromDetails(spaceDetails) (line 160) — SpaceDescription struct
  (space/spaceinfo/spaceinfo.go:135-144) does NOT have a Homepage field, so homepage is lost here
  3. spaceService.Create(ctx, &spaceDescription) (line 171) creates the space and SpaceView. Since
  SpaceDescription.UpdateDetails() (line 158-169) doesn't set homepage, SpaceView is created with homepage = ""
  → Client gets event: homepage = ""
  4. SetDetails on Workspace object (line 177-197) sets ALL details including homepage on the Workspace smartblock
  5. This triggers onApply hook (workspaces.go:242) → onWorkspaceChanged → spaceService.OnWorkspaceChanged
  (service.go:434) which runs in a goroutine (go func()) that calls SpaceViewSetData asynchronously
  → Client eventually gets event: homepage = "selected_chat_id"

  So the client sees: homepage="" → homepage="chat_id" — the flicker.

  **The fix**

  Add Homepage to SpaceDescription so it's set synchronously during SpaceView creation