### PR TITLE
GO-3794 Add file extension to Unsplash downloaded images

### DIFF
--- a/util/unsplash/unsplash.go
+++ b/util/unsplash/unsplash.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -241,7 +241,8 @@ func (l *unsplashService) Download(ctx context.Context, id string) (imgPath stri
 		return "", fmt.Errorf("failed to download file from unsplash: %w", err)
 	}
 	defer resp.Body.Close()
-	tmpfile, err := ioutil.TempFile(l.tempDirProvider.TempDir(), picture.ID)
+	ext := extensionFromContentType(resp.Header.Get("Content-Type"))
+	tmpfile, err := os.CreateTemp(l.tempDirProvider.TempDir(), picture.ID+"*"+ext)
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %w", err)
 	}
@@ -302,6 +303,22 @@ func injectIntoExif(filePath, artistName, artistUrl, description string) error {
 		return fmt.Errorf("failed to write exif: %w", err)
 	}
 	return nil
+}
+
+func extensionFromContentType(contentType string) string {
+	if contentType == "" {
+		return ".jpg"
+	}
+	// mime.ExtensionsByType returns extensions alphabetically,
+	// so image/jpeg gives ".jpe" instead of ".jpeg"
+	if contentType == "image/jpeg" {
+		return ".jpg"
+	}
+	exts, err := mime.ExtensionsByType(contentType)
+	if err == nil && len(exts) > 0 {
+		return exts[0]
+	}
+	return ".jpg"
 }
 
 func init() {

--- a/util/unsplash/unsplash_test.go
+++ b/util/unsplash/unsplash_test.go
@@ -6,8 +6,27 @@ import (
 	"testing"
 
 	"github.com/rwcarlsen/goexif/exif"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_extensionFromContentType(t *testing.T) {
+	t.Run("jpeg content type", func(t *testing.T) {
+		assert.Equal(t, ".jpg", extensionFromContentType("image/jpeg"))
+	})
+	t.Run("png content type", func(t *testing.T) {
+		assert.Equal(t, ".png", extensionFromContentType("image/png"))
+	})
+	t.Run("webp content type", func(t *testing.T) {
+		assert.Equal(t, ".webp", extensionFromContentType("image/webp"))
+	})
+	t.Run("empty content type falls back to jpg", func(t *testing.T) {
+		assert.Equal(t, ".jpg", extensionFromContentType(""))
+	})
+	t.Run("unknown content type falls back to jpg", func(t *testing.T) {
+		assert.Equal(t, ".jpg", extensionFromContentType("application/x-unknown-type"))
+	})
+}
 
 func Test_injectArtistIntoExif(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
## Summary
- Derive file extension from HTTP `Content-Type` header when creating temp files for Unsplash downloads
- Previously `os.CreateTemp` produced extensionless files (e.g. `/tmp/abc123`), which propagated through the upload pipeline as the object name
- Special-case `image/jpeg` to return `.jpg` (Go's `mime.ExtensionsByType` returns `.jpe` alphabetically)
- Fall back to `.jpg` when Content-Type is empty or unrecognized

## Linear
GO-3794

## Test plan
- [x] Unit tests for `extensionFromContentType` covering jpeg, png, webp, empty, and unknown content types
- [x] Existing `Test_injectArtistIntoExif` still passes
- [x] Manual: download an Unsplash image and verify the file object has a `.jpg` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)