### PR TITLE
Fix: Restrict featuredRelations block paste

### DIFF
--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -106,6 +106,12 @@ func (cb *clipboard) Copy(ctx session.Context, req pb.RpcBlockCopyRequest) (text
 		return textSlot, htmlSlot, anySlot, fmt.Errorf("copy: no blocks")
 	}
 
+	for _, b := range req.Blocks {
+		if b.Id == template.FeaturedRelationsId {
+			return textSlot, htmlSlot, anySlot, fmt.Errorf("copy: block %q is a system block and cannot be copied", b.Id)
+		}
+	}
+
 	s := cb.blocksToState(req.Blocks)
 
 	textSlot = renderText(s, len(req.Blocks) == 1)

--- a/core/block/editor/clipboard/clipboard.go
+++ b/core/block/editor/clipboard/clipboard.go
@@ -75,6 +75,12 @@ func (cb *clipboard) Paste(ctx session.Context, req *pb.RpcBlockPasteRequest, gr
 		return nil, nil, caretPosition, false, err
 	}
 
+	for _, b := range req.AnySlot {
+		if b.Id == template.FeaturedRelationsId {
+			return nil, nil, caretPosition, false, fmt.Errorf("paste: block %q is a system block and cannot be pasted", b.Id)
+		}
+	}
+
 	if len(req.FileSlot) > 0 {
 		blockIds, err = cb.pasteFiles(ctx, req)
 		return
@@ -104,12 +110,6 @@ func (cb *clipboard) Copy(ctx session.Context, req pb.RpcBlockCopyRequest) (text
 
 	if len(req.Blocks) == 0 {
 		return textSlot, htmlSlot, anySlot, fmt.Errorf("copy: no blocks")
-	}
-
-	for _, b := range req.Blocks {
-		if b.Id == template.FeaturedRelationsId {
-			return textSlot, htmlSlot, anySlot, fmt.Errorf("copy: block %q is a system block and cannot be copied", b.Id)
-		}
 	}
 
 	s := cb.blocksToState(req.Blocks)

--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -838,6 +838,33 @@ func TestClipboard_TitleOps(t *testing.T) {
 			require.True(t, hasBlockId)
 		})
 	}
+	t.Run("paste - when pasted blocks contain featuredRelations system block", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithTitle))
+		cb := newFixture(t, sb)
+
+		// when
+		_, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			AnySlot: []*model.Block{
+				{
+					Id: "paste1",
+					Content: &model.BlockContentOfText{
+						Text: &model.BlockContentText{Text: "some text"},
+					},
+				},
+				{
+					Id:      template.FeaturedRelationsId,
+					Content: &model.BlockContentOfFeaturedRelations{FeaturedRelations: &model.BlockContentFeaturedRelations{}},
+				},
+			},
+		}, "")
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system block")
+		assert.Contains(t, err.Error(), template.FeaturedRelationsId)
+	})
 	t.Run("paste - when insert partially", func(t *testing.T) {
 		// given
 		sb := smarttest.New("text")
@@ -1648,27 +1675,6 @@ func Test_CopyAndCutText(t *testing.T) {
 		assert.Len(t, anySlotCut, 1)
 	})
 
-	t.Run("copy - featuredRelations system block is rejected", func(t *testing.T) {
-		// given
-		sb := smarttest.New("text")
-		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithEmpty))
-		cb := newFixture(t, sb)
-
-		// when
-		_, _, _, err := cb.Copy(nil, pb.RpcBlockCopyRequest{
-			Blocks: []*model.Block{
-				{
-					Id:      template.FeaturedRelationsId,
-					Content: &model.BlockContentOfFeaturedRelations{FeaturedRelations: &model.BlockContentFeaturedRelations{}},
-				},
-			},
-		})
-
-		// then
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "system block")
-		assert.Contains(t, err.Error(), template.FeaturedRelationsId)
-	})
 }
 
 func givenRow3Level1NumberedBlock(s *state.State) *model.Block {

--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -1647,6 +1647,28 @@ func Test_CopyAndCutText(t *testing.T) {
 		assert.Len(t, anySlotCopy, 1)
 		assert.Len(t, anySlotCut, 1)
 	})
+
+	t.Run("copy - featuredRelations system block is rejected", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		require.NoError(t, smartblock.ObjectApplyTemplate(sb, nil, template.WithEmpty))
+		cb := newFixture(t, sb)
+
+		// when
+		_, _, _, err := cb.Copy(nil, pb.RpcBlockCopyRequest{
+			Blocks: []*model.Block{
+				{
+					Id:      template.FeaturedRelationsId,
+					Content: &model.BlockContentOfFeaturedRelations{FeaturedRelations: &model.BlockContentFeaturedRelations{}},
+				},
+			},
+		})
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "system block")
+		assert.Contains(t, err.Error(), template.FeaturedRelationsId)
+	})
 }
 
 func givenRow3Level1NumberedBlock(s *state.State) *model.Block {


### PR DESCRIPTION
We should not allow clients to paste featuredRelations block in Anytype editor