### PR TITLE
GO-6681 Merge multi-value relations from template with incoming details

### DIFF
--- a/core/block/template/templateimpl/impl.go
+++ b/core/block/template/templateimpl/impl.go
@@ -531,7 +531,7 @@ func (s *service) addDetailsToTemplateState(st *state.State, details *domain.Det
 	}
 
 	// Merge multi-value relations (tag, object, file) from template and incoming details
-	if s.formatFetcher != nil && st.Details() != nil {
+	if st.Details() != nil {
 		for key, incomingVal := range toAdd.Iterate() {
 			templateVal := st.Details().GetStringList(key)
 			if len(templateVal) == 0 {

--- a/core/block/template/templateimpl/impl.go
+++ b/core/block/template/templateimpl/impl.go
@@ -112,7 +112,7 @@ func (s *service) CreateTemplateStateWithDetails(req templateSvc.CreateTemplateR
 	}
 
 	s.resolveTemplatePlaceholders(targetState, req.SpaceId)
-	addDetailsToTemplateState(targetState, req.Details)
+	s.addDetailsToTemplateState(targetState, req.Details, req.SpaceId)
 	return targetState, nil
 }
 
@@ -183,7 +183,7 @@ func (s *service) CreateTemplateStateFromSmartBlock(sb smartblock.SmartBlock, re
 		st = s.createBlankTemplateState(domain.FullID{SpaceID: req.SpaceId, ObjectID: req.TypeId}, req.Layout)
 	}
 	s.resolveTemplatePlaceholders(st, req.SpaceId)
-	addDetailsToTemplateState(st, req.Details)
+	s.addDetailsToTemplateState(st, req.Details, req.SpaceId)
 	return st
 }
 
@@ -509,7 +509,7 @@ func (s *service) buildTemplateStateFromObject(sb smartblock.SmartBlock) (*state
 	return st, nil
 }
 
-func addDetailsToTemplateState(st *state.State, details *domain.Details) {
+func (s *service) addDetailsToTemplateState(st *state.State, details *domain.Details, spaceId string) {
 	var keysToExclude []domain.RelationKey
 	if st.Details() != nil {
 		for key := range templatePreferableRelationKeys {
@@ -530,6 +530,32 @@ func addDetailsToTemplateState(st *state.State, details *domain.Details) {
 		st.AddBundledRelationLinks(bundle.RelationKeyName)
 	}
 
+	// Merge multi-value relations (tag, object, file) from template and incoming details
+	if s.formatFetcher != nil && st.Details() != nil {
+		for key, incomingVal := range toAdd.Iterate() {
+			templateVal := st.Details().GetStringList(key)
+			if len(templateVal) == 0 {
+				continue
+			}
+			format, err := s.formatFetcher.GetRelationFormatByKey(spaceId, key)
+			if err != nil {
+				continue
+			}
+			if isMultiValueRelationFormat(format) {
+				merged := lo.Uniq(append(templateVal, incomingVal.StringList()...))
+				toAdd.Set(key, domain.StringList(merged))
+			}
+		}
+	}
+
 	st.AddDetails(toAdd)
 	st.BlocksInit(st)
+}
+
+func isMultiValueRelationFormat(format model.RelationFormat) bool {
+	switch format {
+	case model.RelationFormat_tag, model.RelationFormat_object, model.RelationFormat_file:
+		return true
+	}
+	return false
 }

--- a/core/block/template/templateimpl/impl.go
+++ b/core/block/template/templateimpl/impl.go
@@ -531,20 +531,18 @@ func (s *service) addDetailsToTemplateState(st *state.State, details *domain.Det
 	}
 
 	// Merge multi-value relations (tag, object, file) from template and incoming details
-	if st.Details() != nil {
-		for key, incomingVal := range toAdd.Iterate() {
-			templateVal := st.Details().GetStringList(key)
-			if len(templateVal) == 0 {
-				continue
-			}
-			format, err := s.formatFetcher.GetRelationFormatByKey(spaceId, key)
-			if err != nil {
-				continue
-			}
-			if isMultiValueRelationFormat(format) {
-				merged := lo.Uniq(append(templateVal, incomingVal.StringList()...))
-				toAdd.Set(key, domain.StringList(merged))
-			}
+	for key, incomingVal := range toAdd.Iterate() {
+		templateVal := st.Details().GetStringList(key)
+		if len(templateVal) == 0 {
+			continue
+		}
+		format, err := s.formatFetcher.GetRelationFormatByKey(spaceId, key)
+		if err != nil {
+			continue
+		}
+		if isMultiValueRelationFormat(format) {
+			merged := lo.Uniq(append(templateVal, incomingVal.StringList()...))
+			toAdd.Set(key, domain.StringList(merged))
 		}
 	}
 

--- a/core/block/template/templateimpl/impl_test.go
+++ b/core/block/template/templateimpl/impl_test.go
@@ -1215,3 +1215,191 @@ func TestService_collectOriginalDetails(t *testing.T) {
 		assert.False(t, result.Has(bundle.RelationKeyName), "Empty name should be removed when previous template also had empty name")
 	})
 }
+
+func newTemplateTestWithTags(templateName, typeKey string, tags []string) smartblock.SmartBlock {
+	sb := newTemplateTest(templateName, typeKey).(*smarttest.SmartTest)
+	_ = sb.SetDetails(nil, []domain.Detail{
+		{Key: bundle.RelationKeyTag, Value: domain.StringList(tags)},
+	}, false)
+	return sb
+}
+
+func TestService_MultiValueRelationMerging(t *testing.T) {
+	const (
+		testSpaceId  = "space1"
+		templateName = "template"
+	)
+
+	t.Run("template tags are preserved when incoming details has empty tag list", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTestWithTags(templateName, bundle.TypeKeyTask.String(), []string{"tag1", "tag2"})
+		details := domain.NewDetails()
+		details.Set(bundle.RelationKeyTag, domain.StringList(nil))
+
+		s := service{
+			picker:        &testPicker{sb: tmpl},
+			formatFetcher: newFormatFetcher(t, map[string]model.RelationFormat{bundle.RelationKeyTag.String(): model.RelationFormat_tag}),
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tag1", "tag2"}, st.Details().GetStringList(bundle.RelationKeyTag))
+	})
+
+	t.Run("template tags are merged with incoming tag values", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTestWithTags(templateName, bundle.TypeKeyTask.String(), []string{"tag1", "tag2"})
+		details := domain.NewDetails()
+		details.Set(bundle.RelationKeyTag, domain.StringList([]string{"tag2", "tag3"}))
+
+		s := service{
+			picker:        &testPicker{sb: tmpl},
+			formatFetcher: newFormatFetcher(t, map[string]model.RelationFormat{bundle.RelationKeyTag.String(): model.RelationFormat_tag}),
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, []string{"tag1", "tag2", "tag3"}, st.Details().GetStringList(bundle.RelationKeyTag))
+	})
+
+	t.Run("single-value relations still overwrite correctly", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTest(templateName, bundle.TypeKeyTask.String())
+		details := domain.NewDetails()
+		details.Set(bundle.RelationKeyDescription, domain.String("new description"))
+
+		s := service{
+			picker:        &testPicker{sb: tmpl},
+			formatFetcher: newFormatFetcher(t, map[string]model.RelationFormat{bundle.RelationKeyDescription.String(): model.RelationFormat_longtext}),
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "new description", st.Details().GetString(bundle.RelationKeyDescription))
+	})
+
+	t.Run("object relations are merged", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTest(templateName, bundle.TypeKeyTask.String()).(*smarttest.SmartTest)
+		_ = tmpl.SetDetails(nil, []domain.Detail{
+			{Key: domain.RelationKey("assignee"), Value: domain.StringList([]string{"user1", "user2"})},
+		}, false)
+
+		details := domain.NewDetails()
+		details.Set(domain.RelationKey("assignee"), domain.StringList([]string{"user2", "user3"}))
+
+		s := service{
+			picker:        &testPicker{sb: tmpl},
+			formatFetcher: newFormatFetcher(t, map[string]model.RelationFormat{"assignee": model.RelationFormat_object}),
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, []string{"user1", "user2", "user3"}, st.Details().GetStringList(domain.RelationKey("assignee")))
+	})
+
+	t.Run("file relations are merged", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTest(templateName, bundle.TypeKeyTask.String()).(*smarttest.SmartTest)
+		_ = tmpl.SetDetails(nil, []domain.Detail{
+			{Key: domain.RelationKey("attachments"), Value: domain.StringList([]string{"file1"})},
+		}, false)
+
+		details := domain.NewDetails()
+		details.Set(domain.RelationKey("attachments"), domain.StringList([]string{"file2"}))
+
+		s := service{
+			picker:        &testPicker{sb: tmpl},
+			formatFetcher: newFormatFetcher(t, map[string]model.RelationFormat{"attachments": model.RelationFormat_file}),
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, []string{"file1", "file2"}, st.Details().GetStringList(domain.RelationKey("attachments")))
+	})
+
+	t.Run("status relations are not merged - incoming overwrites", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTest(templateName, bundle.TypeKeyTask.String()).(*smarttest.SmartTest)
+		_ = tmpl.SetDetails(nil, []domain.Detail{
+			{Key: domain.RelationKey("status"), Value: domain.StringList([]string{"status1"})},
+		}, false)
+
+		details := domain.NewDetails()
+		details.Set(domain.RelationKey("status"), domain.StringList([]string{"status2"}))
+
+		s := service{
+			picker:        &testPicker{sb: tmpl},
+			formatFetcher: newFormatFetcher(t, map[string]model.RelationFormat{"status": model.RelationFormat_status}),
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, []string{"status2"}, st.Details().GetStringList(domain.RelationKey("status")))
+	})
+
+	t.Run("no formatFetcher does not break backward compatibility", func(t *testing.T) {
+		// given
+		tmpl := newTemplateTestWithTags(templateName, bundle.TypeKeyTask.String(), []string{"tag1"})
+		details := domain.NewDetails()
+		details.Set(bundle.RelationKeyTag, domain.StringList([]string{"tag2"}))
+
+		s := service{
+			picker: &testPicker{sb: tmpl},
+		}
+
+		// when
+		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
+			SpaceId:    testSpaceId,
+			TemplateId: templateName,
+			Details:    details,
+		})
+
+		// then
+		require.NoError(t, err)
+		// Without formatFetcher, incoming overwrites (old behavior)
+		assert.Equal(t, []string{"tag2"}, st.Details().GetStringList(bundle.RelationKeyTag))
+	})
+}

--- a/core/block/template/templateimpl/impl_test.go
+++ b/core/block/template/templateimpl/impl_test.go
@@ -1379,27 +1379,4 @@ func TestService_MultiValueRelationMerging(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"status2"}, st.Details().GetStringList(domain.RelationKey("status")))
 	})
-
-	t.Run("no formatFetcher does not break backward compatibility", func(t *testing.T) {
-		// given
-		tmpl := newTemplateTestWithTags(templateName, bundle.TypeKeyTask.String(), []string{"tag1"})
-		details := domain.NewDetails()
-		details.Set(bundle.RelationKeyTag, domain.StringList([]string{"tag2"}))
-
-		s := service{
-			picker: &testPicker{sb: tmpl},
-		}
-
-		// when
-		st, err := s.CreateTemplateStateWithDetails(templateSvc.CreateTemplateRequest{
-			SpaceId:    testSpaceId,
-			TemplateId: templateName,
-			Details:    details,
-		})
-
-		// then
-		require.NoError(t, err)
-		// Without formatFetcher, incoming overwrites (old behavior)
-		assert.Equal(t, []string{"tag2"}, st.Details().GetStringList(bundle.RelationKeyTag))
-	})
 }


### PR DESCRIPTION
## Summary
- Fix template tags (and other multi-value relations) not being inherited by new objects
- Multi-value relations (tag, object, file) are now merged as a union of template values and incoming details
- Single-value relations and status keep the existing overwrite behavior

## Linear
GO-6681

## Test plan
- [x] Unit tests for tag preservation when incoming is empty
- [x] Unit tests for tag merging (union with deduplication)
- [x] Unit tests for single-value relation overwrite
- [x] Unit tests for object and file relation merging
- [x] Unit tests for status relation NOT being merged
- [x] All existing template tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)