### PR TITLE
sync tag, property, type to cache

### DIFF
--- a/core/api/service/property.go
+++ b/core/api/service/property.go
@@ -225,7 +225,16 @@ func (s *Service) CreateProperty(ctx context.Context, spaceId string, request ap
 		}
 	}
 
-	return s.GetProperty(ctx, spaceId, resp.ObjectId)
+	prop, err := s.GetProperty(ctx, spaceId, resp.ObjectId)
+	if err != nil {
+		return nil, fmt.Errorf("get created property: %w", err)
+	}
+
+	// Synchronously cache the property so it's immediately available for subsequent
+	// requests without waiting for async subscription events.
+	s.cache.cacheProperty(spaceId, prop)
+
+	return prop, nil
 }
 
 // UpdateProperty updates an existing property in a specific space.

--- a/core/api/service/tag.go
+++ b/core/api/service/tag.go
@@ -132,7 +132,16 @@ func (s *Service) CreateTag(ctx context.Context, spaceId string, propertyId stri
 		return nil, ErrFailedCreateTag
 	}
 
-	return s.GetTag(ctx, spaceId, propertyId, resp.ObjectId)
+	tag, err := s.GetTag(ctx, spaceId, propertyId, resp.ObjectId)
+	if err != nil {
+		return nil, fmt.Errorf("get created tag: %w", err)
+	}
+
+	// Synchronously cache the tag so it's immediately available for subsequent
+	// requests (e.g. object creation) without waiting for async subscription events.
+	s.cache.cacheTag(spaceId, tag)
+
+	return tag, nil
 }
 
 // UpdateTag updates an existing tag option for a given property ID in a space.

--- a/core/api/service/type.go
+++ b/core/api/service/type.go
@@ -130,7 +130,16 @@ func (s *Service) CreateType(ctx context.Context, spaceId string, request apimod
 		return nil, ErrFailedCreateType
 	}
 
-	return s.GetType(ctx, spaceId, resp.ObjectId)
+	t, err := s.GetType(ctx, spaceId, resp.ObjectId)
+	if err != nil {
+		return nil, fmt.Errorf("get created type: %w", err)
+	}
+
+	// Synchronously cache the type so it's immediately available for subsequent
+	// requests without waiting for async subscription events.
+	s.cache.cacheType(spaceId, t)
+
+	return t, nil
 }
 
 // UpdateType updates an existing type in a specific space.


### PR DESCRIPTION
to avoid immediate api call fail on querying them
