### PR TITLE
GO-0000 Add type query parameter filter to GET /objects

### DIFF
--- a/core/api/filter/expression.go
+++ b/core/api/filter/expression.go
@@ -6,6 +6,7 @@ import (
 
 	apimodel "github.com/anyproto/anytype-heart/core/api/model"
 	"github.com/anyproto/anytype-heart/core/api/util"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
@@ -87,7 +88,15 @@ func buildConditionFilter(cond apimodel.FilterItem, validator *Validator, spaceI
 		return nil, fmt.Errorf("failed to resolve property %q: %w", wrapped.GetPropertyKey(), err)
 	}
 
-	if !isValidConditionForType(property.Format, dbCondition) {
+	// Type filter supports equality and array conditions
+	isTypeFilter := property.RelationKey == bundle.RelationKeyType.String()
+	if isTypeFilter {
+		if !isValidConditionForType(property.Format, dbCondition) &&
+			dbCondition != model.BlockContentDataviewFilter_Equal &&
+			dbCondition != model.BlockContentDataviewFilter_NotEqual {
+			return nil, util.ErrBadInput(fmt.Sprintf("condition %q is not valid for type filter", wrapped.GetCondition()))
+		}
+	} else if !isValidConditionForType(property.Format, dbCondition) {
 		return nil, util.ErrBadInput(fmt.Sprintf("condition %q is not valid for property type %q", wrapped.GetCondition(), property.Format))
 	}
 
@@ -102,6 +111,11 @@ func buildConditionFilter(cond apimodel.FilterItem, validator *Validator, spaceI
 	value := wrapped.GetValue()
 	if value == nil {
 		return nil, util.ErrBadInput(fmt.Sprintf("value is required for condition %q on property %q", wrapped.GetCondition(), wrapped.GetPropertyKey()))
+	}
+
+	// Resolve type filter values
+	if isTypeFilter {
+		return validator.buildTypeFilter(spaceId, rk, dbCondition, value)
 	}
 
 	validatedValue, err := validator.apiService.SanitizeAndValidatePropertyValue(spaceId, wrapped.GetPropertyKey(), value, property, propertyMap)

--- a/core/api/filter/expression_test.go
+++ b/core/api/filter/expression_test.go
@@ -145,22 +145,21 @@ func TestBuildExpressionFilters(t *testing.T) {
 				},
 			},
 			setupMock: func(m *mock_filter.MockApiService) {
-				propertyMap := map[string]*apimodel.Property{
-					"type": {
-						Key:         "type",
-						RelationKey: bundle.RelationKeyType.String(),
-						Format:      apimodel.PropertyFormatText,
-					},
+				propertyMap := map[string]*apimodel.Property{}
+				typeMap := map[string]*apimodel.Type{
+					"page": {Id: "type-page-id", Key: "page", UniqueKey: "ot-page"},
+					"task": {Id: "type-task-id", Key: "task", UniqueKey: "ot-task"},
 				}
 				m.On("GetCachedProperties", spaceId).Return(propertyMap)
-				m.On("ResolvePropertyApiKey", propertyMap, "type").Return("type", true)
-				m.On("SanitizeAndValidatePropertyValue", spaceId, "type", "page", propertyMap["type"], propertyMap).Return("page", nil)
-				m.On("SanitizeAndValidatePropertyValue", spaceId, "type", "task", propertyMap["type"], propertyMap).Return("task", nil)
+				m.On("GetCachedTypes", spaceId).Return(typeMap)
 			},
 			checkResult: func(t *testing.T, result *model.BlockContentDataviewFilter) {
 				require.NotNil(t, result)
 				assert.Equal(t, model.BlockContentDataviewFilter_Or, result.Operator)
 				assert.Len(t, result.NestedFilters, 2)
+				assert.Equal(t, bundle.RelationKeyType.String(), result.NestedFilters[0].RelationKey)
+				assert.Equal(t, "type-page-id", result.NestedFilters[0].Value.GetStringValue())
+				assert.Equal(t, "type-task-id", result.NestedFilters[1].Value.GetStringValue())
 			},
 		},
 		{

--- a/core/api/filter/mock_filter/mock_ApiService.go
+++ b/core/api/filter/mock_filter/mock_ApiService.go
@@ -69,6 +69,54 @@ func (_c *MockApiService_GetCachedProperties_Call) RunAndReturn(run func(string)
 	return _c
 }
 
+// GetCachedTypes provides a mock function with given fields: spaceId
+func (_m *MockApiService) GetCachedTypes(spaceId string) map[string]*apimodel.Type {
+	ret := _m.Called(spaceId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCachedTypes")
+	}
+
+	var r0 map[string]*apimodel.Type
+	if rf, ok := ret.Get(0).(func(string) map[string]*apimodel.Type); ok {
+		r0 = rf(spaceId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]*apimodel.Type)
+		}
+	}
+
+	return r0
+}
+
+// MockApiService_GetCachedTypes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCachedTypes'
+type MockApiService_GetCachedTypes_Call struct {
+	*mock.Call
+}
+
+// GetCachedTypes is a helper method to define mock.On call
+//   - spaceId string
+func (_e *MockApiService_Expecter) GetCachedTypes(spaceId interface{}) *MockApiService_GetCachedTypes_Call {
+	return &MockApiService_GetCachedTypes_Call{Call: _e.mock.On("GetCachedTypes", spaceId)}
+}
+
+func (_c *MockApiService_GetCachedTypes_Call) Run(run func(spaceId string)) *MockApiService_GetCachedTypes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockApiService_GetCachedTypes_Call) Return(_a0 map[string]*apimodel.Type) *MockApiService_GetCachedTypes_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockApiService_GetCachedTypes_Call) RunAndReturn(run func(string) map[string]*apimodel.Type) *MockApiService_GetCachedTypes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ResolvePropertyApiKey provides a mock function with given fields: properties, key
 func (_m *MockApiService) ResolvePropertyApiKey(properties map[string]*apimodel.Property, key string) (string, bool) {
 	ret := _m.Called(properties, key)

--- a/core/api/filter/parser.go
+++ b/core/api/filter/parser.go
@@ -20,6 +20,7 @@ const (
 	TopLevelAttrName       = "name"
 	TopLevelAttrGlobalName = "global_name"
 	TopLevelAttrSnippet    = "snippet"
+	TopLevelAttrType       = "type"
 )
 
 // topLevelAttributes maps JSON field names to internal relation keys
@@ -28,6 +29,7 @@ var topLevelAttributes = map[string]string{
 	TopLevelAttrName:       bundle.RelationKeyName.String(),
 	TopLevelAttrGlobalName: bundle.RelationKeyGlobalName.String(),
 	TopLevelAttrSnippet:    bundle.RelationKeySnippet.String(),
+	TopLevelAttrType:       bundle.RelationKeyType.String(),
 }
 
 type Parser struct {
@@ -113,7 +115,10 @@ func (p *Parser) parseFilterKey(key string, spaceId string) (relationKey string,
 
 // getDefaultCondition returns the default condition for a property
 func (p *Parser) getDefaultCondition(propertyKey string, spaceId string) model.BlockContentDataviewFilterCondition {
-	// Top-level attributes default to Contains
+	// Top-level attributes default to Contains, except type which defaults to Equal
+	if propertyKey == TopLevelAttrType {
+		return model.BlockContentDataviewFilter_Equal
+	}
 	if _, isTopLevel := topLevelAttributes[propertyKey]; isTopLevel {
 		return model.BlockContentDataviewFilter_Like // Contains
 	}

--- a/core/api/filter/parser_test.go
+++ b/core/api/filter/parser_test.go
@@ -120,6 +120,7 @@ func CreateTestParser(t *testing.T) *Parser {
 	propertyMap := GetTestPropertyMap()
 
 	mockService.On("GetCachedProperties", mock.Anything).Return(propertyMap).Maybe()
+	mockService.On("GetCachedTypes", mock.Anything).Return(map[string]*apimodel.Type{}).Maybe()
 	mockService.On("ResolvePropertyApiKey", mock.Anything, mock.Anything).Return(
 		func(properties map[string]*apimodel.Property, key string) string {
 			if prop, exists := properties[key]; exists {
@@ -578,6 +579,39 @@ func TestParser_ParseQueryParams(t *testing.T) {
 					PropertyKey: "due_date",
 					Condition:   model.BlockContentDataviewFilter_LessOrEqual,
 					Value:       "2024-12-31",
+				},
+			},
+		},
+		{
+			name:        "type filter without explicit condition defaults to equal",
+			queryString: "type=page",
+			expectedFilters: []Filter{
+				{
+					PropertyKey: "type",
+					Condition:   model.BlockContentDataviewFilter_Equal,
+					Value:       "page",
+				},
+			},
+		},
+		{
+			name:        "type filter with explicit equal condition",
+			queryString: "type[eq]=note",
+			expectedFilters: []Filter{
+				{
+					PropertyKey: "type",
+					Condition:   model.BlockContentDataviewFilter_Equal,
+					Value:       "note",
+				},
+			},
+		},
+		{
+			name:        "type filter with in condition",
+			queryString: "type[in]=page,note",
+			expectedFilters: []Filter{
+				{
+					PropertyKey: "type",
+					Condition:   model.BlockContentDataviewFilter_In,
+					Value:       []string{"page", "note"},
 				},
 			},
 		},

--- a/core/api/filter/validator.go
+++ b/core/api/filter/validator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/api/util"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
 // getTopLevelAttributeAsProperty returns a synthetic property for top-level attributes
@@ -18,6 +19,12 @@ func getTopLevelAttributeAsProperty(key string) *apimodel.Property {
 			RelationKey: key,
 			Format:      apimodel.PropertyFormatText,
 		}
+	case bundle.RelationKeyType.String():
+		return &apimodel.Property{
+			Key:         key,
+			RelationKey: key,
+			Format:      apimodel.PropertyFormatObjects,
+		}
 	default:
 		return nil
 	}
@@ -25,6 +32,7 @@ func getTopLevelAttributeAsProperty(key string) *apimodel.Property {
 
 type ApiService interface {
 	GetCachedProperties(spaceId string) map[string]*apimodel.Property
+	GetCachedTypes(spaceId string) map[string]*apimodel.Type
 	ResolvePropertyApiKey(properties map[string]*apimodel.Property, key string) (string, bool)
 	SanitizeAndValidatePropertyValue(spaceId string, key string, value interface{}, property *apimodel.Property, propertyMap map[string]*apimodel.Property) (interface{}, error)
 }
@@ -65,7 +73,16 @@ func (v *Validator) validateFilter(spaceId string, filter *Filter, propertyMap m
 	}
 
 	// Check if condition is valid for property type
-	if !isValidConditionForType(property.Format, filter.Condition) {
+	// Type filter supports equality and array conditions
+	isTypeFilter := property.RelationKey == bundle.RelationKeyType.String()
+	if isTypeFilter {
+		if !isValidConditionForType(property.Format, filter.Condition) &&
+			filter.Condition != model.BlockContentDataviewFilter_Equal &&
+			filter.Condition != model.BlockContentDataviewFilter_NotEqual {
+			apiCondition, _ := ToApiCondition(filter.Condition)
+			return util.ErrBadInput(fmt.Sprintf("condition %q is not valid for type filter", apiCondition))
+		}
+	} else if !isValidConditionForType(property.Format, filter.Condition) {
 		apiCondition, _ := ToApiCondition(filter.Condition)
 		return util.ErrBadInput(fmt.Sprintf("condition %q is not valid for property type %q", apiCondition, property.Format))
 	}
@@ -100,6 +117,47 @@ func (v *Validator) resolveProperty(spaceId string, propertyKey string, property
 	return prop, nil
 }
 
+// resolveTypeValue resolves a type API key or ID to the type's object ID
+func (v *Validator) resolveTypeValue(spaceId string, value string) (string, error) {
+	typeMap := v.apiService.GetCachedTypes(spaceId)
+	if t, exists := typeMap[value]; exists {
+		return t.Id, nil
+	}
+	return "", util.ErrBadInput(fmt.Sprintf("type %q not found", value))
+}
+
+// buildTypeFilter builds a dataview filter for type filtering, resolving the value through the type cache
+func (v *Validator) buildTypeFilter(spaceId string, relationKey string, condition model.BlockContentDataviewFilterCondition, value interface{}) (*model.BlockContentDataviewFilter, error) {
+	switch val := value.(type) {
+	case string:
+		resolved, err := v.resolveTypeValue(spaceId, val)
+		if err != nil {
+			return nil, err
+		}
+		return &model.BlockContentDataviewFilter{
+			RelationKey: relationKey,
+			Condition:   condition,
+			Value:       pbtypes.ToValue(resolved),
+		}, nil
+	case []string:
+		resolved := make([]string, 0, len(val))
+		for _, item := range val {
+			id, err := v.resolveTypeValue(spaceId, item)
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, id)
+		}
+		return &model.BlockContentDataviewFilter{
+			RelationKey: relationKey,
+			Condition:   condition,
+			Value:       pbtypes.ToValue(resolved),
+		}, nil
+	default:
+		return nil, util.ErrBadInput(fmt.Sprintf("invalid type filter value: expected string, got %T", value))
+	}
+}
+
 // convertAndValidateValue converts and validates the filter value based on property type
 func (v *Validator) convertAndValidateValue(spaceId string, filter *Filter, property *apimodel.Property, propertyMap map[string]*apimodel.Property) (interface{}, error) {
 	switch filter.Condition {
@@ -108,6 +166,26 @@ func (v *Validator) convertAndValidateValue(spaceId string, filter *Filter, prop
 			return boolVal, nil
 		}
 		return true, nil
+	}
+
+	// Special handling for type filter: resolve type API key to type object ID
+	if property.RelationKey == bundle.RelationKeyType.String() {
+		switch val := filter.Value.(type) {
+		case string:
+			return v.resolveTypeValue(spaceId, val)
+		case []string:
+			resolved := make([]string, 0, len(val))
+			for _, item := range val {
+				id, err := v.resolveTypeValue(spaceId, item)
+				if err != nil {
+					return nil, err
+				}
+				resolved = append(resolved, id)
+			}
+			return resolved, nil
+		default:
+			return nil, util.ErrBadInput(fmt.Sprintf("invalid type filter value: expected string, got %T", filter.Value))
+		}
 	}
 
 	value := filter.Value

--- a/core/api/filter/validator_test.go
+++ b/core/api/filter/validator_test.go
@@ -398,6 +398,74 @@ func TestValidator_ValidateFilters(t *testing.T) {
 			},
 		},
 		{
+			name: "type filter resolves type key to object ID",
+			filters: &filter.ParsedFilters{
+				Filters: []filter.Filter{
+					{
+						PropertyKey: "type",
+						Condition:   model.BlockContentDataviewFilter_Equal,
+						Value:       "page",
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				m.On("GetCachedProperties", testSpaceId).Return(mockProperties)
+				m.On("GetCachedTypes", testSpaceId).Return(map[string]*apimodel.Type{
+					"page": {Id: "type-page-id", Key: "page", UniqueKey: "ot-page"},
+				})
+			},
+			checkResult: func(t *testing.T, filters *filter.ParsedFilters) {
+				require.Len(t, filters.Filters, 1)
+				assert.Equal(t, "type", filters.Filters[0].PropertyKey)
+				assert.Equal(t, model.BlockContentDataviewFilter_Equal, filters.Filters[0].Condition)
+				assert.Equal(t, "type-page-id", filters.Filters[0].Value)
+			},
+		},
+		{
+			name: "type filter with in condition resolves multiple type keys",
+			filters: &filter.ParsedFilters{
+				Filters: []filter.Filter{
+					{
+						PropertyKey: "type",
+						Condition:   model.BlockContentDataviewFilter_In,
+						Value:       []string{"page", "note"},
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				m.On("GetCachedProperties", testSpaceId).Return(mockProperties)
+				m.On("GetCachedTypes", testSpaceId).Return(map[string]*apimodel.Type{
+					"page": {Id: "type-page-id", Key: "page", UniqueKey: "ot-page"},
+					"note": {Id: "type-note-id", Key: "note", UniqueKey: "ot-note"},
+				})
+			},
+			checkResult: func(t *testing.T, filters *filter.ParsedFilters) {
+				require.Len(t, filters.Filters, 1)
+				assert.Equal(t, "type", filters.Filters[0].PropertyKey)
+				assert.Equal(t, model.BlockContentDataviewFilter_In, filters.Filters[0].Condition)
+				assert.Equal(t, []string{"type-page-id", "type-note-id"}, filters.Filters[0].Value)
+			},
+		},
+		{
+			name: "type filter with unknown type key returns error",
+			filters: &filter.ParsedFilters{
+				Filters: []filter.Filter{
+					{
+						PropertyKey: "type",
+						Condition:   model.BlockContentDataviewFilter_Equal,
+						Value:       "nonexistent",
+					},
+				},
+			},
+			setupMock: func(m *mock_filter.MockApiService) {
+				m.On("GetCachedProperties", testSpaceId).Return(mockProperties)
+				m.On("GetCachedTypes", testSpaceId).Return(map[string]*apimodel.Type{
+					"page": {Id: "type-page-id", Key: "page", UniqueKey: "ot-page"},
+				})
+			},
+			expectedError: "invalid filter at index 0: invalid value for property \"type\": bad input: type \"nonexistent\" not found",
+		},
+		{
 			name: "multiple filters with one invalid",
 			filters: &filter.ParsedFilters{
 				Filters: []filter.Filter{

--- a/core/api/handler/object.go
+++ b/core/api/handler/object.go
@@ -16,7 +16,7 @@ import (
 //
 //	@Summary		List objects
 //	@Description	Retrieves a paginated list of objects in the given space. The endpoint takes query parameters for pagination (offset and limit) and returns detailed data about each object including its ID, name, icon, type information, a snippet of the content (if applicable), layout, space ID, blocks and details. It is intended for building views where users can see all objects in a space at a glance.
-//	@Description	Supports dynamic filtering via query parameters (e.g., ?done=false, ?created_date[gte]=2024-01-01, ?tags[in]=urgent,important). For select/multi_select properties you can use either tag keys or tag IDs, for object properties use object IDs. See FilterCondition enum for available conditions.
+//	@Description	Supports dynamic filtering via query parameters (e.g., ?type=page, ?done=false, ?created_date[gte]=2024-01-01, ?tags[in]=urgent,important). For type filtering use the type's API key (e.g., ?type=note, ?type=page). For select/multi_select properties you can use either tag keys or tag IDs, for object properties use object IDs. See FilterCondition enum for available conditions.
 //	@Id				list_objects
 //	@Tags			Objects
 //	@Produce		json

--- a/core/api/service/type.go
+++ b/core/api/service/type.go
@@ -366,6 +366,11 @@ func (s *Service) buildRelationIds(ctx context.Context, spaceId string, props []
 	return relationIds, nil
 }
 
+// GetCachedTypes returns the cached types for a space
+func (s *Service) GetCachedTypes(spaceId string) map[string]*apimodel.Type {
+	return s.cache.getTypes(spaceId)
+}
+
 // ResolveTypeApiKey resolves an API type key to its internal unique key
 // by looking it up in the type cache. This is necessary because users can
 // define custom API keys via the apiObjectKey field.


### PR DESCRIPTION
Add support for filtering objects by type via query parameters (e.g., ?type=page, ?type[in]=page,note). The type value is resolved through the type cache, accepting API keys, unique keys, or object IDs.

Treat "type" as a top-level attribute in the filter parser with Equal as default condition. The validator resolves type keys to internal object IDs before building the dataview filter. Both query param filters and expression filters support type filtering with eq, ne, in, nin, empty, and nempty conditions.
