### PR TITLE
GO-7175 Reset homepage to widgets on object deletion

### DIFF
--- a/core/block/delete.go
+++ b/core/block/delete.go
@@ -213,9 +213,9 @@ func (s *Service) unsetHomepageIfNeeded(id domain.FullID, spc clientspace.Space)
 	homepage := details.GetString(bundle.RelationKeyHomepage)
 	if homepage == id.ObjectID {
 		if err = s.detailsService.SetSpaceInfo(spc.Id(), domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-			bundle.RelationKeyHomepage: domain.String(""),
+			bundle.RelationKeyHomepage: domain.String(domain.HomepageWidgets),
 		})); err != nil {
-			log.With("objectId", id.ObjectID).Warnf("failed to unset homepage: %v", err)
+			log.With("objectId", id.ObjectID).Warnf("failed to reset homepage to widgets: %v", err)
 		}
 	}
 }

--- a/core/block/delete_test.go
+++ b/core/block/delete_test.go
@@ -22,7 +22,7 @@ func TestService_unsetDashboardIdIfNeeded(t *testing.T) {
 		objectId    = "deletedObj"
 	)
 
-	t.Run("deleting object that is current dashboard resets homepage", func(t *testing.T) {
+	t.Run("deleting homepage object resets homepage to widgets", func(t *testing.T) {
 		// given
 		store := objectstore.NewStoreFixture(t)
 		detailsSvc := mock_detailservice.NewMockService(t)
@@ -49,7 +49,7 @@ func TestService_unsetDashboardIdIfNeeded(t *testing.T) {
 			assert.Equal(t, spaceId, spcId)
 			require.NotNil(t, details)
 			require.NotEmpty(t, details)
-			assert.Empty(t, details.GetString(bundle.RelationKeyHomepage))
+			assert.Equal(t, domain.HomepageWidgets, details.GetString(bundle.RelationKeyHomepage))
 			return nil
 		})
 


### PR DESCRIPTION
## Summary
- When the homepage object is deleted, reset homepage to `"widgets"` instead of `""` so clients always have a valid homepage value
- Updates test assertions and naming to match the new behavior

## Linear
GO-7175

## Test plan
- [x] `go test ./core/block/ -run TestService_unsetDashboardIdIfNeeded -v` — all 3 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)