### PR TITLE
GO-7176 Fix markdown import: scope YAML property resolution by object type

### DIFF
--- a/core/block/import/markdown/import.go
+++ b/core/block/import/markdown/import.go
@@ -574,21 +574,35 @@ func (m *Markdown) createSnapshots(
 				}
 				props = append(props, yamlRelations[prop.Name].Key)
 
-				// Collect option values for non-schema imports
-				if !hasSchemas && (prop.Format == model.RelationFormat_status || prop.Format == model.RelationFormat_tag) {
-					if yamlRelationOptions[prop.Key] == nil {
-						yamlRelationOptions[prop.Key] = make(map[string]string)
-					}
-
-					// Collect values
-					switch prop.Format {
-					case model.RelationFormat_status:
-						if val := prop.Value.String(); val != "" {
-							yamlRelationOptions[prop.Key][val] = ""
+				// Collect option values so we can create snapshots for any
+				// options the schema did not pre-declare (examples/enum).
+				// Non-schema imports still rely on the yamlRelationOptions
+				// map which is materialised below.
+				if prop.Format == model.RelationFormat_status || prop.Format == model.RelationFormat_tag {
+					if hasSchemas {
+						switch prop.Format {
+						case model.RelationFormat_status:
+							if val := prop.Value.String(); val != "" {
+								m.blockConverter.schemaImporter.RegisterOptionValue(prop.Key, val)
+							}
+						case model.RelationFormat_tag:
+							for _, val := range prop.Value.StringList() {
+								m.blockConverter.schemaImporter.RegisterOptionValue(prop.Key, val)
+							}
 						}
-					case model.RelationFormat_tag:
-						for _, val := range prop.Value.StringList() {
-							yamlRelationOptions[prop.Key][val] = ""
+					} else {
+						if yamlRelationOptions[prop.Key] == nil {
+							yamlRelationOptions[prop.Key] = make(map[string]string)
+						}
+						switch prop.Format {
+						case model.RelationFormat_status:
+							if val := prop.Value.String(); val != "" {
+								yamlRelationOptions[prop.Key][val] = ""
+							}
+						case model.RelationFormat_tag:
+							for _, val := range prop.Value.StringList() {
+								yamlRelationOptions[prop.Key][val] = ""
+							}
 						}
 					}
 				}

--- a/core/block/import/markdown/import.go
+++ b/core/block/import/markdown/import.go
@@ -1275,7 +1275,9 @@ func (m *Markdown) processObjectProperties(files *fileContainer, progress proces
 					targetFile := m.findFileByPath(path, files)
 					if targetFile != nil && targetFile.PageID != "" {
 						ids = append(ids, targetFile.PageID)
+						continue
 					}
+					log.Warnf("markdown import: object property %q in %q references missing file %q", prop.Name, fileName, path)
 				}
 				file.YAMLDetails.Set(domain.RelationKey(prop.Key), domain.StringList(ids))
 			}

--- a/core/block/import/markdown/schema.go
+++ b/core/block/import/markdown/schema.go
@@ -139,58 +139,90 @@ func (si *SchemaImporter) optionId(relationKey, optionName string) string {
 	return si.propIdPrefix + "option_" + relationKey + "_" + optionName
 }
 
-// CreateRelationOptionSnapshots creates snapshots for relation options (for select/multi-select relations)
+// RegisterOptionValue records that a relation option value was encountered
+// in YAML. It returns the option ID that will be used in details and
+// ensures CreateRelationOptionSnapshots will emit a matching snapshot.
+// Safe to call multiple times for the same (relationKey, optionName).
+func (si *SchemaImporter) RegisterOptionValue(relationKey, optionName string) string {
+	if si.relationOptions[relationKey] == nil {
+		si.relationOptions[relationKey] = make(map[string]string)
+	}
+	if id, ok := si.relationOptions[relationKey][optionName]; ok && id != "" {
+		return id
+	}
+	id := si.optionId(relationKey, optionName)
+	si.relationOptions[relationKey][optionName] = id
+	return id
+}
+
+// CreateRelationOptionSnapshots creates snapshots for relation options
+// registered either from schema enum/examples or from YAML values
+// encountered during import via RegisterOptionValue. Options from
+// rel.Options (status) and rel.Examples (tag) are emitted, plus any
+// option that showed up in YAML but was not pre-declared — this covers
+// the common case where a schema lists a tag relation without seeding
+// examples.
 func (si *SchemaImporter) CreateRelationOptionSnapshots() []*common.Snapshot {
 	var snapshots []*common.Snapshot
+	emitted := make(map[string]bool)
+
+	emit := func(rel *schema.Relation, optionName, optionId string) {
+		if emitted[optionId] {
+			return
+		}
+		emitted[optionId] = true
+		snapshots = append(snapshots, &common.Snapshot{
+			Id: optionId,
+			Snapshot: &common.SnapshotModel{
+				SbType: smartblock.SmartBlockTypeRelationOption,
+				Data: &common.StateSnapshot{
+					Blocks: []*model.Block{{
+						Id: optionId,
+						Content: &model.BlockContentOfSmartblock{
+							Smartblock: &model.BlockContentSmartblock{},
+						},
+					}},
+					Details: rel.CreateOptionDetails(optionName, ""),
+					ObjectTypes: []string{
+						bundle.TypeKeyRelationOption.String(),
+					},
+				},
+			},
+		})
+	}
 
 	for _, s := range si.schemas {
 		for _, rel := range s.Relations {
-			var optionsToCreate []string
+			if rel.Format != model.RelationFormat_status && rel.Format != model.RelationFormat_tag {
+				continue
+			}
 
-			// Collect options based on relation format
+			// Options declared by the schema.
+			var schemaDeclared []string
 			switch rel.Format {
 			case model.RelationFormat_status:
-				optionsToCreate = rel.Options
+				schemaDeclared = rel.Options
 			case model.RelationFormat_tag:
-				optionsToCreate = rel.Examples
-			default:
-				continue
+				schemaDeclared = rel.Examples
 			}
 
-			if len(optionsToCreate) == 0 {
-				continue
-			}
-
-			// Initialize option map for this relation
-			if si.relationOptions[rel.Key] == nil {
-				si.relationOptions[rel.Key] = make(map[string]string)
-			}
-
-			for _, opt := range optionsToCreate {
-				optionId := si.optionId(rel.Key, opt)
-
-				// Track option ID
-				si.relationOptions[rel.Key][opt] = optionId
-
-				snapshot := &common.Snapshot{
-					Id: optionId,
-					Snapshot: &common.SnapshotModel{
-						SbType: smartblock.SmartBlockTypeRelationOption,
-						Data: &common.StateSnapshot{
-							Blocks: []*model.Block{{
-								Id: optionId,
-								Content: &model.BlockContentOfSmartblock{
-									Smartblock: &model.BlockContentSmartblock{},
-								},
-							}},
-							Details: rel.CreateOptionDetails(opt, ""),
-							ObjectTypes: []string{
-								bundle.TypeKeyRelationOption.String(),
-							},
-						},
-					},
+			if len(schemaDeclared) > 0 {
+				if si.relationOptions[rel.Key] == nil {
+					si.relationOptions[rel.Key] = make(map[string]string)
 				}
-				snapshots = append(snapshots, snapshot)
+				for _, opt := range schemaDeclared {
+					optionId := si.optionId(rel.Key, opt)
+					si.relationOptions[rel.Key][opt] = optionId
+					emit(rel, opt, optionId)
+				}
+			}
+
+			// Options registered from YAML values encountered during import.
+			for opt, id := range si.relationOptions[rel.Key] {
+				if id == "" {
+					continue
+				}
+				emit(rel, opt, id)
 			}
 		}
 	}

--- a/core/block/import/markdown/schema.go
+++ b/core/block/import/markdown/schema.go
@@ -296,9 +296,26 @@ func (si *SchemaImporter) HasSchemas() bool {
 	return len(si.schemas) > 0
 }
 
-// ResolvePropertyKey returns the property key for a given name from schemas
-// This implements the yaml.PropertyResolver interface
-func (si *SchemaImporter) ResolvePropertyKey(name string) string {
+// ResolvePropertyKey returns the property key for a given name from schemas.
+// When objectTypeName is non-empty the resolver first looks for a relation
+// declared by the schema whose Type.Name matches, so two schemas declaring
+// properties with the same display name but different x-keys do not
+// collide. It falls back to a global scan so cross-type or bundled
+// relations still work.
+// This implements the yaml.PropertyResolver interface.
+func (si *SchemaImporter) ResolvePropertyKey(objectTypeName, name string) string {
+	if objectTypeName != "" {
+		for _, s := range si.schemas {
+			if s.Type == nil || s.Type.Name != objectTypeName {
+				continue
+			}
+			for _, rel := range s.Relations {
+				if rel.Name == name {
+					return rel.Key
+				}
+			}
+		}
+	}
 	for _, s := range si.schemas {
 		for _, rel := range s.Relations {
 			// Check if the relation name matches (case-sensitive)
@@ -310,8 +327,22 @@ func (si *SchemaImporter) ResolvePropertyKey(name string) string {
 	return ""
 }
 
-// GetRelationFormat returns the format for a given relation key
-func (si *SchemaImporter) GetRelationFormat(key string) model.RelationFormat {
+// GetRelationFormat returns the format for a given relation key.
+// When objectTypeName is non-empty the resolver prefers a relation from
+// the matching schema before scanning globally.
+func (si *SchemaImporter) GetRelationFormat(objectTypeName, key string) model.RelationFormat {
+	if objectTypeName != "" {
+		for _, s := range si.schemas {
+			if s.Type == nil || s.Type.Name != objectTypeName {
+				continue
+			}
+			for _, rel := range s.Relations {
+				if rel.Key == key {
+					return rel.Format
+				}
+			}
+		}
+	}
 	for _, s := range si.schemas {
 		for _, rel := range s.Relations {
 			if rel.Key == key {

--- a/core/block/import/markdown/schema_options_test.go
+++ b/core/block/import/markdown/schema_options_test.go
@@ -1,0 +1,43 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/pkg/lib/schema"
+)
+
+// TestSchemaImporter_CollectsOptionsFromYAML verifies that when a tag
+// relation is declared in schema without an examples list, the importer
+// still creates option snapshots for option values encountered in YAML
+// files via RegisterOptionValue.
+func TestSchemaImporter_CollectsOptionsFromYAML(t *testing.T) {
+	si := NewSchemaImporter()
+	s := schema.NewSchema()
+	if err := s.AddRelation(&schema.Relation{
+		Key:    "mood_board_mood_words",
+		Name:   "Mood Words",
+		Format: model.RelationFormat_tag,
+	}); err != nil {
+		t.Fatalf("AddRelation: %v", err)
+	}
+	si.schemas["mood_board.json"] = s
+
+	// Register an option value the way createSnapshots will once the fix
+	// is wired up.
+	id := si.RegisterOptionValue("mood_board_mood_words", "tactile")
+	assert.NotEmpty(t, id, "expected RegisterOptionValue to return a non-empty option ID")
+
+	snapshots := si.CreateRelationOptionSnapshots()
+
+	var found bool
+	for _, snap := range snapshots {
+		if snap.Id == id {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a snapshot for the YAML-registered option")
+}

--- a/core/block/import/markdown/schema_scoped_test.go
+++ b/core/block/import/markdown/schema_scoped_test.go
@@ -1,0 +1,71 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/import/common"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// TestSchemaImporter_ResolvePropertyKey_ScopedByObjectType verifies that when
+// multiple schemas declare properties with the same display name but different
+// x-keys, the resolver returns the key from the schema matching the file's
+// object type. An empty object type name must fall back to a global scan so
+// cross-type lookups still work.
+func TestSchemaImporter_ResolvePropertyKey_ScopedByObjectType(t *testing.T) {
+	moodBoardSchema := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"title": "Mood Board",
+		"x-app": "Anytype",
+		"x-type-key": "mood_board",
+		"properties": {
+			"References": {
+				"type": "array",
+				"x-key": "mood_board_references",
+				"x-format": "object",
+				"items": {"type": "object"}
+			}
+		}
+	}`
+	pieceSchema := `{
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"type": "object",
+		"title": "Piece",
+		"x-app": "Anytype",
+		"x-type-key": "piece",
+		"properties": {
+			"References": {
+				"type": "array",
+				"x-key": "piece_references",
+				"x-format": "object",
+				"items": {"type": "object"}
+			}
+		}
+	}`
+
+	si := NewSchemaImporter()
+	src := &mockSource{files: map[string]string{
+		"mood_board.json": moodBoardSchema,
+		"piece.json":      pieceSchema,
+	}}
+	allErrors := common.NewError(pb.RpcObjectImportRequest_ALL_OR_NOTHING)
+	require.NoError(t, si.LoadSchemas(src, allErrors))
+
+	// Mood Board file must get mood_board_references, not piece_references.
+	assert.Equal(t, "mood_board_references", si.ResolvePropertyKey("Mood Board", "References"))
+
+	// Piece file must get piece_references, not mood_board_references.
+	assert.Equal(t, "piece_references", si.ResolvePropertyKey("Piece", "References"))
+
+	// Empty object type falls back to any matching relation.
+	assert.NotEmpty(t, si.ResolvePropertyKey("", "References"))
+
+	// Format is returned for both scopes.
+	assert.Equal(t, model.RelationFormat_object, si.GetRelationFormat("Mood Board", "mood_board_references"))
+	assert.Equal(t, model.RelationFormat_object, si.GetRelationFormat("Piece", "piece_references"))
+}

--- a/core/block/import/markdown/yamlresolver.go
+++ b/core/block/import/markdown/yamlresolver.go
@@ -18,8 +18,10 @@ func NewYAMLPropertyResolver() *YAMLPropertyResolver {
 	}
 }
 
-// ResolvePropertyKey returns the key for a property name, creating one if it doesn't exist
-func (r *YAMLPropertyResolver) ResolvePropertyKey(name string) string {
+// ResolvePropertyKey returns the key for a property name, creating one if it doesn't exist.
+// objectTypeName is accepted for interface compatibility and is ignored —
+// the non-schema import path has no per-type scope.
+func (r *YAMLPropertyResolver) ResolvePropertyKey(_ string, name string) string {
 	if key, exists := r.nameToKey[name]; exists {
 		return key
 	}
@@ -31,7 +33,7 @@ func (r *YAMLPropertyResolver) ResolvePropertyKey(name string) string {
 }
 
 // GetRelationFormat returns the format for a relation - not used for non-schema imports
-func (r *YAMLPropertyResolver) GetRelationFormat(key string) model.RelationFormat {
+func (r *YAMLPropertyResolver) GetRelationFormat(_ string, _ string) model.RelationFormat {
 	// Return longtext as default - the actual format will be determined by the YAML value type
 	return model.RelationFormat_longtext
 }

--- a/pkg/lib/schema/integration_test.go
+++ b/pkg/lib/schema/integration_test.go
@@ -101,7 +101,7 @@ func (r *SimpleSchemaRegistry) ListSchemas() []*schema.Schema {
 }
 
 // ResolvePropertyKey returns the property key for a given name
-func (r *SimpleSchemaRegistry) ResolvePropertyKey(name string) string {
+func (r *SimpleSchemaRegistry) ResolvePropertyKey(_ string, name string) string {
 	if rel, ok := r.GetRelationByName(name); ok {
 		return rel.Key
 	}
@@ -109,7 +109,7 @@ func (r *SimpleSchemaRegistry) ResolvePropertyKey(name string) string {
 }
 
 // GetRelationFormat returns the format for a given relation key
-func (r *SimpleSchemaRegistry) GetRelationFormat(key string) model.RelationFormat {
+func (r *SimpleSchemaRegistry) GetRelationFormat(_ string, key string) model.RelationFormat {
 	if rel, ok := r.GetRelation(key); ok {
 		return rel.Format
 	}
@@ -524,14 +524,14 @@ func TestSchemaRegistryIntegration(t *testing.T) {
 		registry.RegisterSchema(s)
 
 		// Test ResolvePropertyKey
-		assert.Equal(t, "test_name", registry.ResolvePropertyKey("Name"))
-		assert.Equal(t, "test_status", registry.ResolvePropertyKey("Status"))
-		assert.Equal(t, "", registry.ResolvePropertyKey("Unknown"))
+		assert.Equal(t, "test_name", registry.ResolvePropertyKey("", "Name"))
+		assert.Equal(t, "test_status", registry.ResolvePropertyKey("", "Status"))
+		assert.Equal(t, "", registry.ResolvePropertyKey("", "Unknown"))
 
 		// Test GetRelationFormat
-		assert.Equal(t, model.RelationFormat_shorttext, registry.GetRelationFormat("test_name"))
-		assert.Equal(t, model.RelationFormat_status, registry.GetRelationFormat("test_status"))
-		assert.Equal(t, model.RelationFormat_tag, registry.GetRelationFormat("test_tags"))
+		assert.Equal(t, model.RelationFormat_shorttext, registry.GetRelationFormat("", "test_name"))
+		assert.Equal(t, model.RelationFormat_status, registry.GetRelationFormat("", "test_status"))
+		assert.Equal(t, model.RelationFormat_tag, registry.GetRelationFormat("", "test_tags"))
 
 		// Test option resolution
 		optionId := registry.ResolveOptionValue("test_status", "Done")

--- a/pkg/lib/schema/interfaces.go
+++ b/pkg/lib/schema/interfaces.go
@@ -4,14 +4,23 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-// PropertyResolver resolves property keys and formats from names
+// PropertyResolver resolves property keys and formats from names.
+// objectTypeName is the display Name of the type declared by the current
+// file (e.g. via `Object type:` in YAML frontmatter). Implementations
+// should prefer a relation defined by the matching schema before falling
+// back to other schemas, so two schemas declaring properties with the
+// same display name but different keys do not collide. An empty
+// objectTypeName means "no scope" and implementations must behave as a
+// global search.
 type PropertyResolver interface {
-	// ResolvePropertyKey returns the property key for a given name
-	// Returns empty string if not found in schema
-	ResolvePropertyKey(name string) string
+	// ResolvePropertyKey returns the property key for a given name, scoped
+	// to the schema of objectTypeName when possible. Returns empty string
+	// if not found in any schema.
+	ResolvePropertyKey(objectTypeName, name string) string
 
-	// GetRelationFormat returns the format for a given relation key
-	GetRelationFormat(key string) model.RelationFormat
+	// GetRelationFormat returns the format for a given relation key, scoped
+	// to the schema of objectTypeName when possible.
+	GetRelationFormat(objectTypeName, key string) model.RelationFormat
 
 	// ResolveOptionValue converts option name to option ID
 	ResolveOptionValue(relationKey string, optionName string) string

--- a/pkg/lib/schema/yaml/integration_workflow_test.go
+++ b/pkg/lib/schema/yaml/integration_workflow_test.go
@@ -270,7 +270,7 @@ type mockResolver struct {
 	schema *schema.Schema
 }
 
-func (m *mockResolver) ResolvePropertyKey(name string) string {
+func (m *mockResolver) ResolvePropertyKey(_ string, name string) string {
 	// Check exact match first
 	for key, rel := range m.schema.Relations {
 		if rel.Name == name {
@@ -289,7 +289,7 @@ func (m *mockResolver) ResolvePropertyKey(name string) string {
 	return ""
 }
 
-func (m *mockResolver) GetRelationFormat(key string) model.RelationFormat {
+func (m *mockResolver) GetRelationFormat(_ string, key string) model.RelationFormat {
 	if rel, exists := m.schema.Relations[key]; exists {
 		return rel.Format
 	}

--- a/pkg/lib/schema/yaml/parser.go
+++ b/pkg/lib/schema/yaml/parser.go
@@ -200,10 +200,10 @@ func ParseYAMLFrontMatterWithResolverAndPath(frontMatter []byte, resolver schema
 		if prop.Key == "" {
 			// Try to resolve property key from schema if resolver is available
 			if resolver != nil {
-				if schemaKey := resolver.ResolvePropertyKey(prop.Name); schemaKey != "" {
+				if schemaKey := resolver.ResolvePropertyKey(result.ObjectType, prop.Name); schemaKey != "" {
 					prop.Key = schemaKey
 					// Get the actual format from schema
-					schemaFormat := resolver.GetRelationFormat(schemaKey)
+					schemaFormat := resolver.GetRelationFormat(result.ObjectType, schemaKey)
 					if schemaFormat != model.RelationFormat_longtext {
 						prop.Format = schemaFormat
 					}

--- a/pkg/lib/schema/yaml/parser_test.go
+++ b/pkg/lib/schema/yaml/parser_test.go
@@ -18,11 +18,11 @@ type MockResolver struct {
 // Ensure MockResolver implements schema.PropertyResolver
 var _ schema.PropertyResolver = (*MockResolver)(nil)
 
-func (m *MockResolver) ResolvePropertyKey(name string) string {
+func (m *MockResolver) ResolvePropertyKey(_ string, name string) string {
 	return m.properties[name]
 }
 
-func (m *MockResolver) GetRelationFormat(key string) model.RelationFormat {
+func (m *MockResolver) GetRelationFormat(_ string, key string) model.RelationFormat {
 	return model.RelationFormat_shorttext
 }
 


### PR DESCRIPTION
## Summary

Fixes three issues that surfaced while importing a folder of markdown files with a bundled `types/` directory of JSON schemas.

### 1. Ambiguous property-name resolution across schemas (main bug)

`SchemaImporter.ResolvePropertyKey` iterated `si.schemas` (a Go map, non-deterministic order) and returned the first relation whose `Name` matched — ignoring which schema/type the current file actually belonged to. When several schemas declare properties with the same display name but different `x-key` (e.g. `References`, `Ideas`, `Pieces`, `Commissions` defined by `mood_board`, `piece`, `idea`, `commission`, `concept`, `reference` types), the resolver could return `piece_references` for a Mood Board file. The value ended up in details under a key that is not in the Mood Board type's RecommendedRelations, so the property never surfaced on the imported object. Which property happened to resolve correctly changed between runs.

Extend `schema.PropertyResolver` with an `objectTypeName` parameter and scope `SchemaImporter.ResolvePropertyKey` / `GetRelationFormat` to the schema whose `Type.Name` matches the file's frontmatter `Object type:`. Falls back to a global scan so cross-type / bundled-relation lookups still work. The parser threads `result.ObjectType` through.

### 2. Tag/status options dropped when schemas have no examples

`createSnapshots` only collected tag/status option values from YAML when `!hasSchemas`, and `CreateRelationOptionSnapshots` only emitted snapshots for `rel.Options` (status) / `rel.Examples` (tag). A schema that declares a tag relation without pre-seeding examples (e.g. `Mood Words` in `mood_board.json`) produced details with option IDs pointing at snapshots that were never created.

Add `SchemaImporter.RegisterOptionValue` and extend `CreateRelationOptionSnapshots` to also emit YAML-registered options, de-duped against the schema-declared set. In `createSnapshots`, route tag/status values through `RegisterOptionValue` when schemas are loaded; the non-schema path is unchanged.

### 3. Silent drop of unresolved object refs

`processObjectProperties` silently discarded object-format property values whose file path could not be resolved. Emit a `log.Warnf` so broken links in imported folders show up in logs.

## Test plan

- [x] `go test ./core/block/import/markdown/ -run TestSchemaImporter_ResolvePropertyKey_ScopedByObjectType`
- [x] `go test ./core/block/import/markdown/ -run TestSchemaImporter_CollectsOptionsFromYAML`
- [x] `go test ./core/block/import/markdown/... ./pkg/lib/schema/...`
- [x] `go test ./core/block/import/...`
- [ ] Manual: re-import the repro fixture folder and confirm the Mood Board object shows `Mood Words` (tactile/raw/intimate), `References` (2), `Ideas` (2), `Pieces` (2), and `Commissions` (1).