### PR TITLE
GO-7178 ResolveSpaceId: fail fast for empty ids

### DIFF
--- a/core/block/object/idresolver/resolver.go
+++ b/core/block/object/idresolver/resolver.go
@@ -25,6 +25,8 @@ import (
 
 const CName = "block.object.resolver"
 
+var ErrEmptyObjectId = errors.New("empty object id")
+
 type Resolver interface {
 	app.ComponentRunnable
 	ResolveSpaceID(objectID string) (string, error)
@@ -74,6 +76,9 @@ func (r *resolver) Name() (name string) {
 }
 
 func (r *resolver) ResolveSpaceID(objectID string) (string, error) {
+	if objectID == "" {
+		return "", ErrEmptyObjectId
+	}
 	select {
 	case <-r.componentCtx.Done():
 		return "", r.componentCtx.Err()
@@ -83,6 +88,9 @@ func (r *resolver) ResolveSpaceID(objectID string) (string, error) {
 }
 
 func (r *resolver) ResolveSpaceIdWithRetry(ctx context.Context, objectId string) (string, error) {
+	if objectId == "" {
+		return "", ErrEmptyObjectId
+	}
 	return retry.DoWithData(func() (string, error) {
 		spaceId, err := r.ResolveSpaceID(objectId)
 		if errors.Is(err, context.Canceled) {

--- a/core/util.go
+++ b/core/util.go
@@ -5,12 +5,21 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/anyproto/anytype-heart/core/block/object/idresolver"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/session"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/anyerror"
 )
+
+// universalBadInputErrors are errors that map to BAD_INPUT across any RPC response error enum.
+// All generated Rpc*ResponseError_BAD_INPUT constants share the value 2, so we can safely type-assert.
+const universalBadInputCode int32 = 2
+
+var universalBadInputErrors = []error{
+	idresolver.ErrEmptyObjectId,
+}
 
 func (mw *Middleware) getResponseEvent(ctx session.Context) *pb.ResponseEvent {
 	ev := ctx.GetResponseEvent()
@@ -50,6 +59,11 @@ func mapErrorCode[T ~int32](err error, mappings ...errToCodeTuple[T]) T {
 			if errors.As(err, m.checkErrorType) {
 				return m.code
 			}
+		}
+	}
+	for _, badInputErr := range universalBadInputErrors {
+		if errors.Is(err, badInputErr) {
+			return T(universalBadInputCode)
 		}
 	}
 	// Unknown error

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/object/idresolver"
 )
 
 type testErrorType struct {
@@ -42,6 +44,15 @@ func TestErrorCodeMapping(t *testing.T) {
 	assert.Equal(t, testCode(3), mapper(wrapped2))
 	assert.Equal(t, testCode(4), mapper(err3))
 	assert.Equal(t, testCode(5), mapper(err4))
+}
+
+func TestErrorCodeMappingUniversalBadInput(t *testing.T) {
+	mapper := func(err error) testCode {
+		return mapErrorCode[testCode](err)
+	}
+
+	assert.Equal(t, testCode(universalBadInputCode), mapper(idresolver.ErrEmptyObjectId))
+	assert.Equal(t, testCode(universalBadInputCode), mapper(fmt.Errorf("wrap: %w", idresolver.ErrEmptyObjectId)))
 }
 
 func TestErrorCodeMappingWithPayload(t *testing.T) {


### PR DESCRIPTION
## Summary

Empty objectId in ResolveSpaceIdWithRetry caused infinite retry loop — the retry-go wrapper uses Attempts(0) (unlimited) and only treats context.Canceled as unrecoverable, so the ErrObjectNotFound returned by the underlying store lookup kept the goroutine spinning until context deadline.

## Changes

- `core/block/object/idresolver/resolver.go`: new `ErrEmptyObjectId` sentinel; early-return in both `ResolveSpaceID` and `ResolveSpaceIdWithRetry` before entering the retry loop.
- `core/util.go`: added `universalBadInputErrors` fallback in `mapErrorCode`. All generated `Rpc*ResponseError_BAD_INPUT` constants equal 2, so a single `T(2)` return covers every RPC without per-handler registration. Future BAD_INPUT-class sentinels plug into the same slice.
- `core/util_test.go`: coverage for direct and wrapped (`errors.Is`) matching against the global fallback.

## Test plan

- [x] `go build ./...`
- [x] `go test ./core/ -run TestErrorCodeMapping`
- [ ] Manual: client sends empty objectId to an RPC hitting `WaitAndGetObject` → response returns immediately with BAD_INPUT instead of hanging.