### PR TITLE
GO-7177 Restrict homepage changes in 1-on-1 spaces

### DIFF
--- a/core/block/create.go
+++ b/core/block/create.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/block/cache"
+	"github.com/anyproto/anytype-heart/core/block/detailservice"
 	"github.com/anyproto/anytype-heart/core/block/editor/basic"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
@@ -159,7 +160,7 @@ func (s *Service) CreateWorkspace(ctx context.Context, req *pb.RpcWorkspaceCreat
 
 	spaceDescription := spaceinfo.NewSpaceDescriptionFromDetails(spaceDetails)
 
-	if err = validateSpaceType(spaceDescription.SpaceType); err != nil {
+	if err = validateSpaceDescription(spaceDescription); err != nil {
 		return "", "", err
 	}
 
@@ -242,9 +243,14 @@ func deriveSpaceTypeIfNeeded(details *domain.Details) {
 	}
 }
 
-func validateSpaceType(spaceType model.SpaceType) error {
-	switch spaceType {
-	case model.SpaceType_SpaceTypeRegular, model.SpaceType_SpaceTypeOneToOne:
+func validateSpaceDescription(desc spaceinfo.SpaceDescription) error {
+	switch desc.SpaceType {
+	case model.SpaceType_SpaceTypeRegular:
+		return nil
+	case model.SpaceType_SpaceTypeOneToOne:
+		if desc.Homepage != "" && desc.Homepage != domain.HomepageChat {
+			return detailservice.ErrHomepageChangeRestricted
+		}
 		return nil
 	case model.SpaceType_SpaceTypeTech:
 		return errors.New("creation of technical space via command is restricted")

--- a/core/block/detailservice/service_test.go
+++ b/core/block/detailservice/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/threads"
 	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
 	"github.com/anyproto/anytype-heart/space/mock_space"
+	"github.com/anyproto/anytype-heart/space/spacedomain"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
@@ -290,6 +291,74 @@ func TestService_SetSpaceInfo(t *testing.T) {
 
 		// then
 		assert.Error(t, err)
+	})
+
+	t.Run("reject homepage change for 1-on-1 space", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.space.EXPECT().DerivedIDs().Return(threads.DerivedSmartblockIds{Workspace: wsObjectId})
+		fx.space.EXPECT().SpaceType().Return(spacedomain.SpaceTypeOneToOne)
+		homepageDetails := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyHomepage: domain.String("someObjectId"),
+		})
+
+		// when
+		err := fx.SetSpaceInfo(spaceId, homepageDetails)
+
+		// then
+		require.ErrorIs(t, err, ErrHomepageChangeRestricted)
+	})
+
+	t.Run("allow homepage change for regular space", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ws := smarttest.New(wsObjectId)
+		fx.space.EXPECT().DerivedIDs().Return(threads.DerivedSmartblockIds{Workspace: wsObjectId})
+		fx.space.EXPECT().SpaceType().Return(spacedomain.SpaceTypeRegular)
+		fx.space.EXPECT().Id().Return(spaceId)
+		fx.store.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("someObjectId"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			},
+		})
+		fx.getter.EXPECT().GetObject(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, objectId string) (smartblock.SmartBlock, error) {
+			assert.Equal(t, wsObjectId, objectId)
+			return ws, nil
+		})
+		homepageDetails := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyHomepage: domain.String("someObjectId"),
+		})
+
+		// when
+		err := fx.SetSpaceInfo(spaceId, homepageDetails)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "someObjectId", ws.NewState().Details().GetString(bundle.RelationKeyHomepage))
+	})
+
+	t.Run("allow non-homepage changes for 1-on-1 space", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ws := smarttest.New(wsObjectId)
+		fx.space.EXPECT().DerivedIDs().Return(threads.DerivedSmartblockIds{Workspace: wsObjectId})
+		fx.getter.EXPECT().GetObject(mock.Anything, mock.Anything).RunAndReturn(func(_ context.Context, objectId string) (smartblock.SmartBlock, error) {
+			assert.Equal(t, wsObjectId, objectId)
+			return ws, nil
+		})
+		nameDetails := domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyName:       domain.String("Renamed space"),
+			bundle.RelationKeyIconOption: domain.Int64(3),
+		})
+
+		// when
+		err := fx.SetSpaceInfo(spaceId, nameDetails)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, "Renamed space", ws.NewState().Details().GetString(bundle.RelationKeyName))
+		assert.Equal(t, int64(3), ws.NewState().Details().GetInt64(bundle.RelationKeyIconOption))
 	})
 }
 

--- a/core/block/detailservice/set_details.go
+++ b/core/block/detailservice/set_details.go
@@ -18,8 +18,12 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/space/clientspace"
+	"github.com/anyproto/anytype-heart/space/spacedomain"
 	"github.com/anyproto/anytype-heart/util/slice"
 )
+
+var ErrHomepageChangeRestricted = errors.New("homepage change is restricted for 1-on-1 spaces")
 
 func (s *service) SetSpaceInfo(spaceId string, details *domain.Details) error {
 	spc, err := s.spaceService.Get(s.componentCtx, spaceId)
@@ -31,7 +35,7 @@ func (s *service) SetSpaceInfo(spaceId string, details *domain.Details) error {
 	setDetails := make([]domain.Detail, 0, details.Len())
 	for k, v := range details.Iterate() {
 		if k == bundle.RelationKeyHomepage {
-			if err = s.validateHomepage(spaceId, v); err != nil {
+			if err = s.validateHomepage(spc, v); err != nil {
 				return fmt.Errorf("validate homepage: %w", err)
 			}
 		}
@@ -352,20 +356,25 @@ func (s *service) appendGCEvent(sctx session.Context, gcIds []string, explicitId
 	objectgc.FilterExplicitIds(sctx, explicitIds)
 }
 
-func (s *service) validateHomepage(spaceId string, homepageValue domain.Value) error {
+func (s *service) validateHomepage(spc clientspace.Space, homepageValue domain.Value) error {
 	if !homepageValue.IsString() {
 		return fmt.Errorf("invalid homepage value type: %s", homepageValue.Type().String())
 	}
 	homepage := homepageValue.String()
+
+	if spc.SpaceType() == spacedomain.SpaceTypeOneToOne {
+		return ErrHomepageChangeRestricted
+	}
+
 	if domain.IsHomepageConstant(homepage) {
 		return nil
 	}
-	exists, err := s.store.SpaceIndex(spaceId).HasIds([]string{homepage})
+	exists, err := s.store.SpaceIndex(spc.Id()).HasIds([]string{homepage})
 	if err != nil {
 		return fmt.Errorf("check homepage object existence: %w", err)
 	}
 	if len(exists) == 0 {
-		return fmt.Errorf("homepage object %s not found in space %s", homepage, spaceId)
+		return fmt.Errorf("homepage object %s not found in space %s", homepage, spc.Id())
 	}
 	return nil
 }

--- a/core/util.go
+++ b/core/util.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/anyproto/anytype-heart/core/block/detailservice"
 	"github.com/anyproto/anytype-heart/core/block/object/idresolver"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/session"
@@ -19,6 +20,7 @@ const universalBadInputCode int32 = 2
 
 var universalBadInputErrors = []error{
 	idresolver.ErrEmptyObjectId,
+	detailservice.ErrHomepageChangeRestricted,
 }
 
 func (mw *Middleware) getResponseEvent(ctx session.Context) *pb.ResponseEvent {

--- a/core/workspace.go
+++ b/core/workspace.go
@@ -41,6 +41,9 @@ func (mw *Middleware) WorkspaceCreate(cctx context.Context, req *pb.RpcWorkspace
 		return err
 	})
 	if err != nil {
+		if errors.Is(err, detailservice.ErrHomepageChangeRestricted) {
+			return response("", "", pb.RpcWorkspaceCreateResponseError_BAD_INPUT, err)
+		}
 		return response("", "", pb.RpcWorkspaceCreateResponseError_UNKNOWN_ERROR, err)
 	}
 
@@ -120,42 +123,28 @@ func (mw *Middleware) WorkspaceOpen(cctx context.Context, req *pb.RpcWorkspaceOp
 	return response(info, pb.RpcWorkspaceOpenResponseError_NULL, nil)
 }
 
-func (mw *Middleware) WorkspaceSetInfo(cctx context.Context, req *pb.RpcWorkspaceSetInfoRequest) *pb.RpcWorkspaceSetInfoResponse {
-	response := func(code pb.RpcWorkspaceSetInfoResponseErrorCode, err error) *pb.RpcWorkspaceSetInfoResponse {
-		m := &pb.RpcWorkspaceSetInfoResponse{Error: &pb.RpcWorkspaceSetInfoResponseError{Code: code}}
-		if err != nil {
-			m.Error.Description = getErrorDescription(err)
-		}
-
-		return m
-	}
-
+func (mw *Middleware) WorkspaceSetInfo(_ context.Context, req *pb.RpcWorkspaceSetInfoRequest) *pb.RpcWorkspaceSetInfoResponse {
 	err := mustService[detailservice.Service](mw).SetSpaceInfo(req.SpaceId, domain.NewDetailsFromProto(req.Details))
-	if err != nil {
-		return response(pb.RpcWorkspaceSetInfoResponseError_UNKNOWN_ERROR, err)
+	code := mapErrorCode[pb.RpcWorkspaceSetInfoResponseErrorCode](err)
+	return &pb.RpcWorkspaceSetInfoResponse{
+		Error: &pb.RpcWorkspaceSetInfoResponseError{
+			Description: getErrorDescription(err),
+			Code:        code,
+		},
 	}
-
-	return response(pb.RpcWorkspaceSetInfoResponseError_NULL, nil)
 }
 
-func (mw *Middleware) WorkspaceSetHomepage(cctx context.Context, req *pb.RpcWorkspaceSetHomepageRequest) *pb.RpcWorkspaceSetHomepageResponse {
-	response := func(code pb.RpcWorkspaceSetHomepageResponseErrorCode, err error) *pb.RpcWorkspaceSetHomepageResponse {
-		m := &pb.RpcWorkspaceSetHomepageResponse{Error: &pb.RpcWorkspaceSetHomepageResponseError{Code: code}}
-		if err != nil {
-			m.Error.Description = getErrorDescription(err)
-		}
-
-		return m
-	}
-
+func (mw *Middleware) WorkspaceSetHomepage(_ context.Context, req *pb.RpcWorkspaceSetHomepageRequest) *pb.RpcWorkspaceSetHomepageResponse {
 	err := mustService[detailservice.Service](mw).SetSpaceInfo(req.SpaceId, domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
 		bundle.RelationKeyHomepage: domain.String(req.Homepage),
 	}))
-	if err != nil {
-		return response(pb.RpcWorkspaceSetHomepageResponseError_UNKNOWN_ERROR, err)
+	code := mapErrorCode[pb.RpcWorkspaceSetHomepageResponseErrorCode](err)
+	return &pb.RpcWorkspaceSetHomepageResponse{
+		Error: &pb.RpcWorkspaceSetHomepageResponseError{
+			Description: getErrorDescription(err),
+			Code:        code,
+		},
 	}
-
-	return response(pb.RpcWorkspaceSetHomepageResponseError_NULL, nil)
 }
 
 func (mw *Middleware) WorkspaceSelect(cctx context.Context, req *pb.RpcWorkspaceSelectRequest) *pb.RpcWorkspaceSelectResponse {


### PR DESCRIPTION
## Summary
- Add `ErrHomepageChangeRestricted` sentinel error in `detailservice`
- Reject homepage changes for 1-on-1 spaces in `SetSpaceInfo` (via `validateHomepage` checking `spc.SpaceType()`)
- Reject non-empty homepage in `CreateWorkspace` for 1-on-1 spaces (unified `validateSpaceDescription` function)
- Map error to `BAD_INPUT` in `WorkspaceCreate`, `WorkspaceSetInfo`, and `WorkspaceSetHomepage` middleware handlers

## Linear
GO-7177

## Test plan
- [x] Unit tests: reject homepage change for 1-on-1 space
- [x] Unit tests: allow homepage change for regular space
- [x] Unit tests: allow non-homepage changes (name, icon) for 1-on-1 space
- [x] `go test ./core/block/detailservice/...` passes
- [x] `go build ./core/...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)