### PR TITLE
GO-7217 Add missing bundled relation links in ResetToVersion

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -920,7 +920,7 @@ func (sb *smartBlock) ResetToVersion(s *state.State) (err error) {
 	// Without this, imported states may lack relation links for details like setOf,
 	// producing a RelationRemove change that wipes the detail on replay (GO-7217).
 	var relKeys []domain.RelationKey
-	for k, _ := range s.Details().Iterate() {
+	for k := range s.Details().Iterate() {
 		if bundle.HasRelation(k) {
 			relKeys = append(relKeys, k)
 		}

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -916,6 +916,16 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 
 func (sb *smartBlock) ResetToVersion(s *state.State) (err error) {
 	source.NewSubObjectsAndProfileLinksMigration(sb.Type(), sb.space, sb.currentParticipantId, sb.spaceIndex, sb.formatFetcher).Migrate(s)
+	// Ensure bundled relation links are present for all bundled detail keys.
+	// Without this, imported states may lack relation links for details like setOf,
+	// producing a RelationRemove change that wipes the detail on replay (GO-7217).
+	var relKeys []domain.RelationKey
+	for k, _ := range s.Details().Iterate() {
+		if bundle.HasRelation(k) {
+			relKeys = append(relKeys, k)
+		}
+	}
+	s.AddBundledRelationLinks(relKeys...)
 	s.SetParent(sb.Doc.(*state.State))
 	sb.storeFileKeys(s)
 	sb.injectLocalDetails(s)


### PR DESCRIPTION
## Summary
- During import, `ResetToVersion` receives a state built from the imported snapshot that may lack relation links for bundled details (e.g. `setOf`)
- This produces a spurious `RelationRemove` change in the tree. When replayed from an earlier snapshot, `changeRelationRemove` → `RemoveRelation` wipes both the relation link **and** its detail value, breaking object types with empty `setOf`
- Add the same bundled-relation-link injection that `Init` already performs (smartblock.go:362-369): iterate all detail keys and ensure corresponding bundled relation links exist before computing the diff

## Linear
GO-7217

## Test plan
- [x] `go build ./core/block/editor/smartblock/` compiles
- [x] Existing objectcreator tests pass
- [x] Manual: import a Protobuf archive containing an object type into a space that already has that type → verify `setOf` detail is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)