### PR TITLE
GO-6749 Enable pin messages in chats

### DIFF
--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -49,9 +49,9 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/detailservice"
 	"github.com/anyproto/anytype-heart/core/block/editor/chatobject"
 	"github.com/anyproto/anytype-heart/core/block/object/idresolver"
+	"github.com/anyproto/anytype-heart/core/block/objectgc"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/event"
-	"github.com/anyproto/anytype-heart/core/block/objectgc"
 	"github.com/anyproto/anytype-heart/core/session"
 	subscriptionservice "github.com/anyproto/anytype-heart/core/subscription"
 	"github.com/anyproto/anytype-heart/core/subscription/crossspacesub"
@@ -961,16 +961,14 @@ func (s *service) ReadAll(ctx context.Context) error {
 }
 
 func (s *service) PinMessages(ctx context.Context, chatObjectId string, messageIds []string, pinned bool) error {
-	return fmt.Errorf("not implemented")
-	// TODO: GO-6749 uncomment when old clients will be able to unmarshal messages with pinned=true
-	// return s.chatObjectDo(ctx, chatObjectId, func(sb chatobject.StoreObject) error {
-	// 	for _, msgId := range messageIds {
-	// 		if err := sb.SetMessagePinned(ctx, msgId, pinned); err != nil {
-	// 			return fmt.Errorf("failed to set pinned status %v to message: %w", pinned, err)
-	// 		}
-	// 	}
-	// 	return nil
-	// })
+	return s.chatObjectDo(ctx, chatObjectId, func(sb chatobject.StoreObject) error {
+		for _, msgId := range messageIds {
+			if err := sb.SetMessagePinned(ctx, msgId, pinned); err != nil {
+				return fmt.Errorf("failed to set pinned status %v to message: %w", pinned, err)
+			}
+		}
+		return nil
+	})
 }
 
 func (s *service) GetPinnedMessages(ctx context.Context, chatObjectId string) (msgs []*chatmodel.Message, err error) {

--- a/core/block/chats/service_test.go
+++ b/core/block/chats/service_test.go
@@ -67,10 +67,10 @@ func (s *accountServiceDummy) Init(a *app.App) error {
 
 type chatRepoServiceDummy struct{}
 
-func (s *chatRepoServiceDummy) Name() string                                                    { return "chatRepoServiceDummy" }
-func (s *chatRepoServiceDummy) Init(a *app.App) error                                           { return nil }
-func (s *chatRepoServiceDummy) Run(ctx context.Context) error                                   { return nil }
-func (s *chatRepoServiceDummy) Close(ctx context.Context) error                                 { return nil }
+func (s *chatRepoServiceDummy) Name() string                    { return "chatRepoServiceDummy" }
+func (s *chatRepoServiceDummy) Init(a *app.App) error           { return nil }
+func (s *chatRepoServiceDummy) Run(ctx context.Context) error   { return nil }
+func (s *chatRepoServiceDummy) Close(ctx context.Context) error { return nil }
 func (s *chatRepoServiceDummy) Repository(spaceId, chatObjectId string) (chatrepository.Repository, error) {
 	return nil, nil
 }
@@ -1559,121 +1559,119 @@ func TestService_Search(t *testing.T) {
 	})
 }
 
-// TODO: GO-6749 uncomment when old clients will be able to unmarshal messages with pinned=true
-// func TestService_PinMessages(t *testing.T) {
-// 	t.Run("pin single message successfully", func(t *testing.T) {
-// 		// given
-// 		fx := newFixture(t)
-// 		ctx := context.Background()
-// 		chatObjectId := "chatId1"
-// 		messageIds := []string{"msg1"}
-//
-// 		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
-// 			Records: []*domain.Details{},
-// 		}, nil).Maybe()
-//
-// 		mockChat := mock_chatobject.NewMockStoreObject(t)
-// 		mockChat.EXPECT().Lock().Return()
-// 		mockChat.EXPECT().Unlock().Return()
-// 		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg1", true).Return(nil)
-//
-// 		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
-//
-// 		fx.start(t)
-//
-// 		// when
-// 		err := fx.PinMessages(ctx, chatObjectId, messageIds, true)
-//
-// 		// then
-// 		require.NoError(t, err)
-// 	})
-//
-// 	t.Run("pin multiple messages", func(t *testing.T) {
-// 		// given
-// 		fx := newFixture(t)
-// 		ctx := context.Background()
-// 		chatObjectId := "chatId1"
-// 		messageIds := []string{"msg1", "msg2", "msg3"}
-//
-// 		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
-// 			Records: []*domain.Details{},
-// 		}, nil).Maybe()
-//
-// 		mockChat := mock_chatobject.NewMockStoreObject(t)
-// 		mockChat.EXPECT().Lock().Return()
-// 		mockChat.EXPECT().Unlock().Return()
-// 		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg1", true).Return(nil)
-// 		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg2", true).Return(nil)
-// 		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg3", true).Return(nil)
-//
-// 		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
-//
-// 		fx.start(t)
-//
-// 		// when
-// 		err := fx.PinMessages(ctx, chatObjectId, messageIds, true)
-//
-// 		// then
-// 		require.NoError(t, err)
-// 	})
-//
-// 	t.Run("pin message returns error on failure", func(t *testing.T) {
-// 		// given
-// 		fx := newFixture(t)
-// 		ctx := context.Background()
-// 		chatObjectId := "chatId1"
-// 		messageIds := []string{"msg1"}
-//
-// 		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
-// 			Records: []*domain.Details{},
-// 		}, nil).Maybe()
-//
-// 		mockChat := mock_chatobject.NewMockStoreObject(t)
-// 		mockChat.EXPECT().Lock().Return()
-// 		mockChat.EXPECT().Unlock().Return()
-// 		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg1", true).Return(fmt.Errorf("message not found"))
-//
-// 		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
-//
-// 		fx.start(t)
-//
-// 		// when
-// 		err := fx.PinMessages(ctx, chatObjectId, messageIds, true)
-//
-// 		// then
-// 		require.Error(t, err)
-// 	})
-// }
+func TestService_PinMessages(t *testing.T) {
+	t.Run("pin single message successfully", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ctx := context.Background()
+		chatObjectId := "chatId1"
+		messageIds := []string{"msg1"}
 
-// TODO: GO-6749 uncomment when old clients will be able to unmarshal messages with pinned=true
-// func TestService_UnpinMessages(t *testing.T) {
-// 	t.Run("unpin single message successfully", func(t *testing.T) {
-// 		// given
-// 		fx := newFixture(t)
-// 		ctx := context.Background()
-// 		chatObjectId := "chatId1"
-// 		messageIds := []string{"msg2"}
-//
-// 		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
-// 			Records: []*domain.Details{},
-// 		}, nil).Maybe()
-//
-// 		mockChat := mock_chatobject.NewMockStoreObject(t)
-// 		mockChat.EXPECT().Lock().Return()
-// 		mockChat.EXPECT().Unlock().Return()
-// 		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg2", false).Return(nil)
-//
-// 		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
-//
-// 		fx.start(t)
-//
-// 		// when
-// 		err := fx.PinMessages(ctx, chatObjectId, messageIds, false)
-//
-// 		// then
-// 		require.NoError(t, err)
-// 	})
-// }
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		mockChat := mock_chatobject.NewMockStoreObject(t)
+		mockChat.EXPECT().Lock().Return()
+		mockChat.EXPECT().Unlock().Return()
+		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg1", true).Return(nil)
+
+		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
+
+		fx.start(t)
+
+		// when
+		err := fx.PinMessages(ctx, chatObjectId, messageIds, true)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("pin multiple messages", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ctx := context.Background()
+		chatObjectId := "chatId1"
+		messageIds := []string{"msg1", "msg2", "msg3"}
+
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		mockChat := mock_chatobject.NewMockStoreObject(t)
+		mockChat.EXPECT().Lock().Return()
+		mockChat.EXPECT().Unlock().Return()
+		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg1", true).Return(nil)
+		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg2", true).Return(nil)
+		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg3", true).Return(nil)
+
+		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
+
+		fx.start(t)
+
+		// when
+		err := fx.PinMessages(ctx, chatObjectId, messageIds, true)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("pin message returns error on failure", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ctx := context.Background()
+		chatObjectId := "chatId1"
+		messageIds := []string{"msg1"}
+
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		mockChat := mock_chatobject.NewMockStoreObject(t)
+		mockChat.EXPECT().Lock().Return()
+		mockChat.EXPECT().Unlock().Return()
+		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg1", true).Return(fmt.Errorf("message not found"))
+
+		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
+
+		fx.start(t)
+
+		// when
+		err := fx.PinMessages(ctx, chatObjectId, messageIds, true)
+
+		// then
+		require.Error(t, err)
+	})
+}
+
+func TestService_UnpinMessages(t *testing.T) {
+	t.Run("unpin single message successfully", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ctx := context.Background()
+		chatObjectId := "chatId1"
+		messageIds := []string{"msg2"}
+
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		mockChat := mock_chatobject.NewMockStoreObject(t)
+		mockChat.EXPECT().Lock().Return()
+		mockChat.EXPECT().Unlock().Return()
+		mockChat.EXPECT().SetMessagePinned(mock.Anything, "msg2", false).Return(nil)
+
+		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
+
+		fx.start(t)
+
+		// when
+		err := fx.PinMessages(ctx, chatObjectId, messageIds, false)
+
+		// then
+		require.NoError(t, err)
+	})
+}
 
 func TestService_GetPinnedMessages(t *testing.T) {
 	t.Run("get pinned messages successfully", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Enable `PinMessages` implementation that was previously stubbed out with `not implemented` error
- Uncomment `TestService_PinMessages` and `TestService_UnpinMessages` tests

## Linear
GO-6749

## Test plan
- [x] Unit tests pass (`TestService_PinMessages`, `TestService_UnpinMessages`)
- [x] Existing `TestService_GetPinnedMessages` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)