### PR TITLE
GO-7145 Index Object text marks as outgoing links

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1482,9 +1482,11 @@ func (sb *smartBlock) collectOutgoingLinks(st *state.State) []OutgoingLink {
 		}
 
 		if text := blockModel.GetText(); text != nil && text.Marks != nil {
-			// Extract mentions from text marks
 			for _, mark := range text.Marks.Marks {
-				if mark.Type == model.BlockContentTextMark_Mention && mark.Param != "" && mark.Param != objectId && !linkSet[mark.Param] {
+				if mark.Type != model.BlockContentTextMark_Mention && mark.Type != model.BlockContentTextMark_Object {
+					continue
+				}
+				if mark.Param != "" && mark.Param != objectId && !linkSet[mark.Param] {
 					linkSet[mark.Param] = true
 					outgoingLinks = append(outgoingLinks, OutgoingLink{
 						TargetID:      mark.Param,

--- a/core/block/editor/smartblock/smartblock_test.go
+++ b/core/block/editor/smartblock/smartblock_test.go
@@ -348,6 +348,33 @@ func TestSmartBlock_CollectOutgoingLinks(t *testing.T) {
 		assert.Equal(t, "text1", links[0].SourceBlockID)
 	})
 
+	t.Run("collect link from text object mark", func(t *testing.T) {
+		// given
+		objectId := "root"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{
+			{Id: objectId, ChildrenIds: []string{"text1"}},
+			{Id: "text1", Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Text: "Hello inline-object",
+					Marks: &model.BlockContentTextMarks{
+						Marks: []*model.BlockContentTextMark{
+							{Type: model.BlockContentTextMark_Object, Param: "objectTarget1"},
+						},
+					},
+				},
+			}},
+		})
+
+		// when
+		links := fx.collectOutgoingLinks(fx.NewState())
+
+		// then
+		require.Len(t, links, 1)
+		assert.Equal(t, "objectTarget1", links[0].TargetID)
+		assert.Equal(t, "text1", links[0].SourceBlockID)
+	})
+
 	t.Run("skip self-reference in link block", func(t *testing.T) {
 		// given
 		objectId := "root"


### PR DESCRIPTION
## Summary
- Backlinks were updating correctly for `BlockContentTextMark_Mention` marks but not for `BlockContentTextMark_Object` marks. Inline-object text marks reference other objects the same way mentions do, but `collectOutgoingLinks` skipped them, so the target object's `backlinks` relation never picked them up.
- Fix in `core/block/editor/smartblock/smartblock.go` — treat `BlockContentTextMark_Object` the same as `BlockContentTextMark_Mention` when collecting outgoing links from text blocks. This matches the existing handling in `core/block/simple/text/text.go` (`FillSmartIds`, `HasSmartIds`, `ReplaceLinkIds`), which already covers both mark types.
- Added a `collect link from text object mark` subtest to `TestSmartBlock_CollectOutgoingLinks` mirroring the existing mention case.

## Test plan
- [x] `go test ./core/block/editor/smartblock/ -run TestSmartBlock_CollectOutgoingLinks -count=1`
- [ ] Manual: create object A with an inline-object mark pointing to object B; confirm B's backlinks relation now includes A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)