### PR TITLE
GO-7224 Fix BlockLinkCreateWithObject response missing parent events

### DIFF
--- a/core/block/create.go
+++ b/core/block/create.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/anyproto/any-sync/util/crypto"
+	"github.com/globalsign/mgo/bson"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/block/cache"
@@ -283,6 +284,23 @@ func (s *Service) CreateLinkToTheNewObject(
 		ObjectTypeKey: objectTypeKey,
 		TemplateId:    req.TemplateId,
 	}
+
+	// When ContextId is set, validate req.Block up front and pre-generate the link block id.
+	// Validating before CreateObject prevents leaving an orphan object in the space if the
+	// block is malformed. Pre-generating the id lets us bake createdInContext /
+	// createdInContextRef into the new object's initial state, avoiding a second Apply on
+	// the new object that would clobber the parent's link-block events held on sctx.
+	// When ContextId is empty, the RPC's link-block half is skipped (legacy "just create
+	// the object" mode); req.Block is intentionally ignored in that path.
+	if req.ContextId != "" {
+		if req.Block != nil && req.Block.GetLink() == nil {
+			return "", "", nil, errors.New("block content is not a link")
+		}
+		linkID = bson.NewObjectId().Hex()
+		createReq.Details.SetString(bundle.RelationKeyCreatedInContext, req.ContextId)
+		createReq.Details.SetString(bundle.RelationKeyCreatedInContextRef, linkID)
+	}
+
 	objectId, objectDetails, err = s.objectCreator.CreateObject(ctx, req.SpaceId, createReq)
 	if err != nil {
 		return
@@ -302,44 +320,21 @@ func (s *Service) CreateLinkToTheNewObject(
 			Fields: req.Fields,
 		}
 	} else {
-		link := req.Block.GetLink()
-		if link == nil {
-			return "", "", nil, errors.New("block content is not a link")
-		} else {
-			link.TargetBlockId = objectId
-		}
+		req.Block.GetLink().TargetBlockId = objectId
 	}
+	req.Block.Id = linkID
 
 	err = cache.DoStateCtx(s, sctx, req.ContextId, func(st *state.State, sb basic.Creatable) error {
-		linkID, err = sb.CreateBlock(st, pb.RpcBlockCreateRequest{
+		if _, err := sb.CreateBlock(st, pb.RpcBlockCreateRequest{
 			TargetId: req.TargetId,
 			Block:    req.Block,
 			Position: req.Position,
-		})
-		if err != nil {
+		}); err != nil {
 			return fmt.Errorf("link create error: %w", err)
 		}
 		return nil
 	})
-	if err == nil {
-		s.setCreatedInContext(sctx, objectId, req.ContextId, linkID)
-	}
 	return
-}
-
-// setCreatedInContext sets createdInContext and createdInContextRef on an object.
-// No-op when contextId or contextRef is empty.
-func (s *Service) setCreatedInContext(sctx session.Context, objectId, contextId, contextRef string) {
-	if contextId == "" || contextRef == "" {
-		return
-	}
-	if err := s.detailsService.ModifyDetails(sctx, objectId, func(current *domain.Details) (*domain.Details, error) {
-		current.SetString(bundle.RelationKeyCreatedInContext, contextId)
-		current.SetString(bundle.RelationKeyCreatedInContextRef, contextRef)
-		return current, nil
-	}); err != nil {
-		log.With("objectId", objectId).Warnf("set createdInContext: %v", err)
-	}
 }
 
 func (s *Service) ObjectToSet(id string, source []string) error {

--- a/core/block/create_test.go
+++ b/core/block/create_test.go
@@ -1,51 +1,126 @@
 package block
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/anyproto/anytype-heart/core/block/detailservice/mock_detailservice"
+	"github.com/anyproto/anytype-heart/core/block/object/objectcreator"
+	"github.com/anyproto/anytype-heart/core/block/object/objectcreator/mock_objectcreator"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/session"
+	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	coresb "github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-func TestService_setCreatedInContext_SetsFields(t *testing.T) {
+// pageTypeUniqueKey is the raw unique key form ("ot-page") accepted by
+// CreateLinkToTheNewObject.
+var pageTypeUniqueKey = domain.MustUniqueKey(coresb.SmartBlockTypeObjectType, "page").Marshal()
+
+func TestService_CreateLinkToTheNewObject_BakesCreatedInContextIntoInitialDetails(t *testing.T) {
 	// given
-	detailsSvc := mock_detailservice.NewMockService(t)
-	svc := &Service{detailsService: detailsSvc}
+	const (
+		spaceId  = "space1"
+		parentId = "parentPage"
+	)
+	creator := mock_objectcreator.NewMockService(t)
+	svc := &Service{objectCreator: creator}
 	sctx := session.NewContext()
 
-	var capturedDetails *domain.Details
-	detailsSvc.EXPECT().
-		ModifyDetails(mock.Anything, "obj1", mock.Anything).
-		RunAndReturn(func(_ session.Context, _ string, modifier func(*domain.Details) (*domain.Details, error)) error {
-			d := domain.NewDetails()
-			result, err := modifier(d)
-			capturedDetails = result
-			return err
+	stop := errors.New("stop before link block creation")
+
+	var captured objectcreator.CreateObjectRequest
+	creator.EXPECT().
+		CreateObject(mock.Anything, spaceId, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, req objectcreator.CreateObjectRequest) (string, *domain.Details, error) {
+			captured = req
+			return "", nil, stop
 		})
 
 	// when
-	svc.setCreatedInContext(sctx, "obj1", "ctx1", "link1")
+	linkID, _, _, err := svc.CreateLinkToTheNewObject(context.Background(), sctx, &pb.RpcBlockLinkCreateWithObjectRequest{
+		SpaceId:             spaceId,
+		ContextId:           parentId,
+		ObjectTypeUniqueKey: pageTypeUniqueKey,
+	})
 
 	// then
-	require.NotNil(t, capturedDetails)
-	assert.Equal(t, "ctx1", capturedDetails.GetString(bundle.RelationKeyCreatedInContext))
-	assert.Equal(t, "link1", capturedDetails.GetString(bundle.RelationKeyCreatedInContextRef))
+	require.ErrorIs(t, err, stop)
+	require.NotEmpty(t, linkID, "linkID must be pre-generated before CreateObject is called")
+	require.NotNil(t, captured.Details)
+	assert.Equal(t, parentId, captured.Details.GetString(bundle.RelationKeyCreatedInContext))
+	assert.Equal(t, linkID, captured.Details.GetString(bundle.RelationKeyCreatedInContextRef),
+		"createdInContextRef must equal the pre-generated link block id")
 }
 
-func TestService_setCreatedInContext_NoOpWhenContextIdEmpty(t *testing.T) {
+func TestService_CreateLinkToTheNewObject_NoContextSkipsCreatedInContext(t *testing.T) {
 	// given
-	detailsSvc := mock_detailservice.NewMockService(t)
-	svc := &Service{detailsService: detailsSvc}
-	// detailsSvc.ModifyDetails must NOT be called
+	const spaceId = "space1"
+	creator := mock_objectcreator.NewMockService(t)
+	svc := &Service{objectCreator: creator}
+
+	var captured objectcreator.CreateObjectRequest
+	creator.EXPECT().
+		CreateObject(mock.Anything, spaceId, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, req objectcreator.CreateObjectRequest) (string, *domain.Details, error) {
+			captured = req
+			return "newObj", domain.NewDetails(), nil
+		})
 
 	// when
-	svc.setCreatedInContext(nil, "obj1", "", "link1")
+	linkID, objectId, _, err := svc.CreateLinkToTheNewObject(context.Background(), nil, &pb.RpcBlockLinkCreateWithObjectRequest{
+		SpaceId:             spaceId,
+		ContextId:           "",
+		ObjectTypeUniqueKey: pageTypeUniqueKey,
+	})
 
-	// then: no mock calls expected — testify will fail the test if ModifyDetails is called unexpectedly
+	// then
+	require.NoError(t, err)
+	assert.Empty(t, linkID, "no link block should be created when ContextId is empty")
+	assert.Equal(t, "newObj", objectId)
+	require.NotNil(t, captured.Details)
+	assert.Empty(t, captured.Details.GetString(bundle.RelationKeyCreatedInContext))
+	assert.Empty(t, captured.Details.GetString(bundle.RelationKeyCreatedInContextRef))
+}
+
+func TestService_CreateLinkToTheNewObject_RejectsNonLinkBlockBeforeObjectCreation(t *testing.T) {
+	// Regression: with ContextId set, validation must happen before objectCreator.CreateObject.
+	// Otherwise a malformed Block leaves an orphan object in the space (the new object is
+	// created, then the link-block insert fails, then the RPC returns an error — but the
+	// object stays).
+	// given
+	creator := mock_objectcreator.NewMockService(t)
+	svc := &Service{objectCreator: creator}
+	// no EXPECT().CreateObject(...) — testify mock auto-fails on any call
+
+	nonLinkBlock := &model.Block{
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{Text: "not a link"},
+		},
+	}
+
+	// when
+	linkID, objectId, details, err := svc.CreateLinkToTheNewObject(
+		context.Background(),
+		session.NewContext(),
+		&pb.RpcBlockLinkCreateWithObjectRequest{
+			SpaceId:             "space1",
+			ContextId:           "parent",
+			ObjectTypeUniqueKey: pageTypeUniqueKey,
+			Block:               nonLinkBlock,
+		},
+	)
+
+	// then
+	require.Error(t, err, "non-link block must be rejected")
+	assert.Empty(t, linkID)
+	assert.Empty(t, objectId, "no objectId returned — proxy for: no orphan object in the space")
+	assert.Nil(t, details)
+	creator.AssertNotCalled(t, "CreateObject", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/core/block/editor/basic/basic.go
+++ b/core/block/editor/basic/basic.go
@@ -144,14 +144,15 @@ func (bs *basic) CreateBlock(s *state.State, req pb.RpcBlockCreateRequest) (id s
 		err = fmt.Errorf("no block content")
 		return
 	}
-	req.Block.Id = ""
 	block := simple.New(req.Block)
 	block.Model().ChildrenIds = nil
 	err = block.Validate()
 	if err != nil {
 		return
 	}
-	s.Add(block)
+	if !s.Add(block) {
+		return "", fmt.Errorf("block id %s already exists", block.Model().Id)
+	}
 	if err = s.InsertTo(req.TargetId, req.Position, block.Model().Id); err != nil {
 		return
 	}

--- a/core/block/editor/basic/extract_objects.go
+++ b/core/block/editor/basic/extract_objects.go
@@ -153,6 +153,7 @@ func buildBlock(b *model.Block, targetID string) (result *model.Block) {
 		return fallback
 	}
 	result = pbtypes.CopyBlock(b)
+	result.Id = ""
 
 	switch v := result.Content.(type) {
 	case *model.BlockContentOfLink:

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -745,6 +745,16 @@ func (sb *smartBlock) Apply(s *state.State, flags ...ApplyFlag) (err error) {
 	if sendEvent {
 		events := msgsToEvents(msgs)
 		if ctx := s.Context(); ctx != nil {
+			// TODO: sessionContext.SetMessages replaces (not appends), so a second Apply
+			// against a different smartblock under the same sctx silently drops the first
+			// smartblock's events. The response slot can only carry events for one smartblock,
+			// but today we let the second writer win. Decide on the right behavior (route the
+			// mismatched writer through sb.sendEvent, or model multi-smartblock responses
+			// explicitly) and remove this warning. See GO-7152.
+			if prevId := ctx.ObjectID(); prevId != "" && prevId != sb.Id() {
+				log.With("prevSmartBlockId", prevId, "smartBlockId", sb.Id()).
+					Warnf("session context already holds events for a different smartblock; previous events will be discarded")
+			}
 			ctx.SetMessages(sb.Id(), events)
 		} else {
 			sb.sendEvent(&pb.Event{


### PR DESCRIPTION
Linear: [GO-7224](https://linear.app/anytype/issue/GO-7224)
Regression from GO-7152 (`68f82b20b`).

## Summary
- Avoid 2 changes: Pre-generate link block id; bake `createdInContext` / `createdInContextRef` into the new object's initial details so a single `Apply` writes them. Drops the follow-up `setCreatedInContext` whose second `Apply` was clobbering the parent's link-block events on `sctx` (`SetMessages` replaces, not appends).
- `basic.CreateBlock` honors caller-set `Block.Id` and surfaces collisions as errors. `extract_objects.buildBlock` clears the template id so each insertion still gets a fresh one.
- Block-content validation moved before `objectCreator.CreateObject` (when `ContextId != ""`) — a malformed `Block` no longer orphans the new object.
- `smartblock.Apply` warn-logs + `TODO` when `sctx` already holds events for a different smartblock; underlying `SetMessages` footgun left for a follow-up.

## Test plan
- [x] `go test ./core/block/...` — all green
- [x] `TestService_CreateLinkToTheNewObject_BakesCreatedInContextIntoInitialDetails`
- [x] `TestService_CreateLinkToTheNewObject_NoContextSkipsCreatedInContext`
- [x] `TestService_CreateLinkToTheNewObject_RejectsNonLinkBlockBeforeObjectCreation`
- [x] `TestExtractObjects/add_custom_link_block_for_multiple_blocks`
- [ ] E2E: send `BlockLinkCreateWithObject` with `contextId = parentId`; assert `ResponseEvent.contextId == parentId` and `messages` contains `BlockAdd` (link → new object) + `BlockSetChildrenIds` for the parent. Verify `ObjectShow(objectId)` shows `createdInContext = parentId`, `createdInContextRef = linkId`.
- [ ] E2E orphan check: send with non-link `Block` + `ContextId` set; assert error returned and the space's object count is unchanged.