### PR TITLE
GO-7237 Hotfix: include collection/dataview/Object-marks in collectOutgoingLinks

### DIFF
--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1492,9 +1492,14 @@ func (sb *smartBlock) collectOutgoingLinks(st *state.State) []OutgoingLink {
 		}
 
 		if text := blockModel.GetText(); text != nil && text.Marks != nil {
-			// Extract mentions from text marks
+			// Extract mentions and inline-object marks from text marks. Object marks
+			// (e.g. @page references) are semantically equivalent to mentions for the
+			// purpose of outgoing links.
 			for _, mark := range text.Marks.Marks {
-				if mark.Type == model.BlockContentTextMark_Mention && mark.Param != "" && mark.Param != objectId && !linkSet[mark.Param] {
+				if mark.Type != model.BlockContentTextMark_Mention && mark.Type != model.BlockContentTextMark_Object {
+					continue
+				}
+				if mark.Param != "" && mark.Param != objectId && !linkSet[mark.Param] {
 					linkSet[mark.Param] = true
 					outgoingLinks = append(outgoingLinks, OutgoingLink{
 						TargetID:      mark.Param,
@@ -1504,9 +1509,31 @@ func (sb *smartBlock) collectOutgoingLinks(st *state.State) []OutgoingLink {
 			}
 		}
 
+		// Inline dataview embed (e.g. a Set/Collection embedded on a Page) — its
+		// TargetObjectId is the embedded object. A standalone Set/Collection's own
+		// dataview block has TargetObjectId == "" and is unaffected.
+		if dv := blockModel.GetDataview(); dv != nil && dv.TargetObjectId != "" && dv.TargetObjectId != objectId && !linkSet[dv.TargetObjectId] {
+			linkSet[dv.TargetObjectId] = true
+			outgoingLinks = append(outgoingLinks, OutgoingLink{
+				TargetID:      dv.TargetObjectId,
+				SourceBlockID: blockModel.Id,
+			})
+		}
+
 		return true
 	}); err != nil {
 		log.Warnf("failed to iterate state blocks: %v", err)
+	}
+
+	// Collect collection members (StoreSlice). A Collection points at its members via
+	// a store slice, not via blocks or relations, so they need an explicit emission.
+	if !internalflag.NewFromState(st).Has(model.InternalFlag_collectionDontIndexLinks) {
+		for _, id := range st.GetStoreSlice(template.CollectionStoreKey) {
+			if id != "" && id != objectId && !linkSet[id] {
+				linkSet[id] = true
+				outgoingLinks = append(outgoingLinks, OutgoingLink{TargetID: id})
+			}
+		}
 	}
 
 	// Collect links from object relations

--- a/core/block/editor/smartblock/smartblock_test.go
+++ b/core/block/editor/smartblock/smartblock_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/editor/template"
 	"github.com/anyproto/anytype-heart/core/block/object/idresolver/mock_idresolver"
 	"github.com/anyproto/anytype-heart/core/block/simple"
 	_ "github.com/anyproto/anytype-heart/core/block/simple/base"
@@ -546,5 +547,112 @@ func TestSmartBlock_CollectOutgoingLinks(t *testing.T) {
 		assert.Equal(t, OutgoingLink{TargetID: "user1", RelationKey: bundle.RelationKeyAssignee.String()}, first[2])
 		assert.Equal(t, OutgoingLink{TargetID: "author1", RelationKey: bundle.RelationKeyAuthor.String()}, first[3])
 		assert.Equal(t, OutgoingLink{TargetID: "company1", RelationKey: bundle.RelationKeyCompany.String()}, first[4])
+	})
+
+	t.Run("collect link from text Object mark (inline link mark)", func(t *testing.T) {
+		// given
+		objectId := "root"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{
+			{Id: objectId, ChildrenIds: []string{"text1"}},
+			{Id: "text1", Content: &model.BlockContentOfText{
+				Text: &model.BlockContentText{
+					Text: "see [[page]]",
+					Marks: &model.BlockContentTextMarks{
+						Marks: []*model.BlockContentTextMark{
+							{Type: model.BlockContentTextMark_Object, Param: "linkedPage"},
+						},
+					},
+				},
+			}},
+		})
+
+		// when
+		links := fx.collectOutgoingLinks(fx.NewState())
+
+		// then
+		require.Len(t, links, 1)
+		assert.Equal(t, "linkedPage", links[0].TargetID)
+		assert.Equal(t, "text1", links[0].SourceBlockID)
+	})
+
+	t.Run("collect link from inline dataview embed", func(t *testing.T) {
+		// given a page with a dataview block embedding an existing Set/Collection
+		objectId := "root"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{
+			{Id: objectId, ChildrenIds: []string{"dv"}},
+			{Id: "dv", Content: &model.BlockContentOfDataview{
+				Dataview: &model.BlockContentDataview{
+					TargetObjectId: "embeddedSet",
+				},
+			}},
+		})
+
+		// when
+		links := fx.collectOutgoingLinks(fx.NewState())
+
+		// then
+		require.Len(t, links, 1)
+		assert.Equal(t, "embeddedSet", links[0].TargetID)
+		assert.Equal(t, "dv", links[0].SourceBlockID)
+	})
+
+	t.Run("dataview embed pointing at self is skipped", func(t *testing.T) {
+		// given
+		objectId := "root"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{
+			{Id: objectId, ChildrenIds: []string{"dv"}},
+			{Id: "dv", Content: &model.BlockContentOfDataview{
+				Dataview: &model.BlockContentDataview{TargetObjectId: objectId},
+			}},
+		})
+
+		// when
+		links := fx.collectOutgoingLinks(fx.NewState())
+
+		// then
+		assert.Empty(t, links)
+	})
+
+	t.Run("collect collection store members", func(t *testing.T) {
+		// given a Collection-shaped state with two members in its store slice
+		objectId := "coll1"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{{Id: objectId}})
+		st := fx.NewState()
+		st.UpdateStoreSlice(template.CollectionStoreKey, []string{"member1", "member2"})
+
+		// when
+		links := fx.collectOutgoingLinks(st)
+
+		// then
+		targets := map[string]bool{}
+		for _, l := range links {
+			targets[l.TargetID] = true
+		}
+		assert.True(t, targets["member1"])
+		assert.True(t, targets["member2"])
+	})
+
+	t.Run("collection store skipped when InternalFlag_collectionDontIndexLinks is set", func(t *testing.T) {
+		// given
+		objectId := "coll1"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{{Id: objectId}})
+		st := fx.NewState()
+		st.UpdateStoreSlice(template.CollectionStoreKey, []string{"member1"})
+		flags := internalflag.NewFromState(st)
+		flags.Add(model.InternalFlag_collectionDontIndexLinks)
+		flags.AddToState(st)
+
+		// when
+		links := fx.collectOutgoingLinks(st)
+
+		// then
+		for _, l := range links {
+			assert.NotEqual(t, "member1", l.TargetID, "store-slice members must be skipped while flag is set")
+		}
 	})
 }

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -64,7 +64,9 @@ const (
 	// ForceInvalidateObjectsIndexCounter clears all indexed heads hashes, causing reindexOutdatedObjects
 	// to reindex all objects. This is more efficient than ForceObjectsReindexCounter because it
 	// reindexes objects asynchronously and continue reindex after app F
-	ForceInvalidateObjectsIndexCounter int32 = 3
+	// Bumped to 4 for GO-7237: collection members, inline dataview embeds, and Object-marks
+	// are now indexed as outgoing links — existing objects need a one-shot reindex pass.
+	ForceInvalidateObjectsIndexCounter int32 = 4
 )
 
 type allDeletedIdsProvider interface {


### PR DESCRIPTION
## Summary

Minimal surgical hotfix for GO-7237 — adds the three missing emission sources to the existing `collectOutgoingLinks` walker without any refactor or structural changes. Restores:

- Collection-member backlinks (StoreSlice members)
- Inline dataview embed backlinks (when a Page embeds a Set/Collection via `Dataview.TargetObjectId`)
- Inline Object-mark backlinks in text (`Mark_Object`, alongside existing `Mark_Mention`)

Self-reference guard (`!= objectId`) is applied to all three new paths, matching existing Link/File/Mention behavior. Honors `InternalFlag_collectionDontIndexLinks` for the collection store, matching `injectLinksDetails`.

## Why a hotfix

The full refactor unifying the two walkers is in PR #3129 (branch `go-7237-…`). This hotfix targets the same regression with the smallest possible diff, keeping the existing parallel walker in place. Use whichever ships faster.

## Test plan

New subtests in `TestSmartBlock_CollectOutgoingLinks`:

- [x] `collect link from text Object mark (inline link mark)`
- [x] `collect link from inline dataview embed`
- [x] `dataview embed pointing at self is skipped`
- [x] `collect collection store members`
- [x] `collection store skipped when InternalFlag_collectionDontIndexLinks is set`

Plus all 12 pre-existing subtests still pass unchanged.

- [x] `go test ./core/block/editor/smartblock/...`
- [x] `go test ./core/indexer/...`
- [x] `go test ./core/block/collection/...`
- [ ] **Manual smoke test**:
  - [ ] Add an existing Object to a Collection — Object's Backlinks shows the Collection.
  - [ ] Embed a Set inline on a Page — Set's Backlinks shows the Page.
  - [ ] Use `[[link]]`-style inline Object mark — target's Backlinks shows the source page.