### PR TITLE
GO-7264 Scope object GC to files with non-empty CreatedInContextRef

### DIFF
--- a/core/block/objectgc/objectgc.go
+++ b/core/block/objectgc/objectgc.go
@@ -118,6 +118,10 @@ func (gc *objectGC) ArchiveOrphansOnLinksRemoval(spaceId, contextId string, remo
 			Value:       domain.String(contextId),
 		},
 		{
+			RelationKey: bundle.RelationKeyCreatedInContextRef,
+			Condition:   model.BlockContentDataviewFilter_NotEmpty, // collections have empty ref
+		},
+		{
 			RelationKey: bundle.RelationKeyResolvedLayout,
 			Condition:   model.BlockContentDataviewFilter_In,
 			Value:       domain.Int64List(gcLayouts),
@@ -144,7 +148,11 @@ func (gc *objectGC) ArchiveOrphansOnLinksRemoval(spaceId, contextId string, remo
 	var toArchive []string
 	for _, record := range records {
 		id := record.Details.GetString(bundle.RelationKeyId)
-
+		// temporarily disable non-file objects
+		if !slices.Contains(domain.FileLayouts, model.ObjectTypeLayout(record.Details.GetInt64(bundle.RelationKeyResolvedLayout))) {
+			// todo: remove when we move to orphan events
+			continue
+		}
 		// Filter out the current context and self-references from backlinks.
 		backlinks := record.Details.GetStringList(bundle.RelationKeyBacklinks)
 		activeBacklinks := lo.Filter(backlinks, func(link string, _ int) bool {
@@ -266,6 +274,10 @@ func (gc *objectGC) collectOrphanedObjects(idx spaceindex.Store, objectId string
 					Value:       domain.String(current),
 				},
 				{
+					RelationKey: bundle.RelationKeyCreatedInContextRef,
+					Condition:   model.BlockContentDataviewFilter_NotEmpty, // collections have empty ref
+				},
+				{
 					RelationKey: bundle.RelationKeyResolvedLayout,
 					Condition:   model.BlockContentDataviewFilter_In,
 					Value:       domain.Int64List(gcLayouts),
@@ -355,8 +367,13 @@ func (gc *objectGC) collectOrphanedObjects(idx spaceindex.Store, objectId string
 			}
 		}
 
-		for id := range candidates {
+		for id, details := range candidates {
 			visited[id] = struct{}{}
+			// temporarily disable non-file objects
+			if !slices.Contains(domain.FileLayouts, model.ObjectTypeLayout(details.GetInt64(bundle.RelationKeyResolvedLayout))) {
+				// todo: remove when we move to orphan events
+				continue
+			}
 			result = append(result, id)
 			queue = append(queue, id)
 		}
@@ -379,6 +396,10 @@ func (gc *objectGC) collectOrphanedObjects(idx spaceindex.Store, objectId string
 				RelationKey: bundle.RelationKeyCreatedInContext,
 				Condition:   model.BlockContentDataviewFilter_NotEqual,
 				Value:       domain.String(objectId),
+			},
+			{
+				RelationKey: bundle.RelationKeyCreatedInContextRef,
+				Condition:   model.BlockContentDataviewFilter_NotEmpty,
 			},
 			{
 				RelationKey: bundle.RelationKeyResolvedLayout,
@@ -447,6 +468,11 @@ func (gc *objectGC) collectOrphanedObjects(idx spaceindex.Store, objectId string
 				continue
 			}
 			visited[id] = struct{}{}
+			// temporarily disable non-file objects
+			if !slices.Contains(domain.FileLayouts, model.ObjectTypeLayout(record.Details.GetInt64(bundle.RelationKeyResolvedLayout))) {
+				// todo: remove when we move to orphan events
+				continue
+			}
 			result = append(result, id)
 		}
 	}

--- a/core/block/objectgc/objectgc_test.go
+++ b/core/block/objectgc/objectgc_test.go
@@ -134,9 +134,9 @@ func TestCheckObjectsOnObjectArchived_ParentArchived_NoOtherBacklinks(t *testing
 	// when
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then
+	// then: hotfix — file has empty CreatedInContextRef (collections-created), so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_ParentArchived_WithActiveBacklink(t *testing.T) {
@@ -164,9 +164,9 @@ func TestCheckObjectsOnObjectArchived_ParentArchived_OtherBacklinksAllArchived(t
 	// when
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_ParentArchived_OtherBacklinksAllDeleted(t *testing.T) {
@@ -179,9 +179,9 @@ func TestCheckObjectsOnObjectArchived_ParentArchived_OtherBacklinksAllDeleted(t 
 	// when
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentStillActive(t *testing.T) {
@@ -209,9 +209,9 @@ func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentArchived_NoOtherB
 	// when: backlinker is archived
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "backlinker", true)
 
-	// then: file should be archived
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentArchived_OtherActiveBacklink(t *testing.T) {
@@ -241,9 +241,9 @@ func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentArchived_OtherBac
 	// when: backlinker is archived
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "backlinker", true)
 
-	// then: file should be archived
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentMissingFromStore(t *testing.T) {
@@ -271,9 +271,9 @@ func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentArchivedInStore(t
 	// when: backlinker is archived
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "backlinker", true)
 
-	// then: file archived — parent confirmed inactive
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentDeletedInStore(t *testing.T) {
@@ -286,9 +286,9 @@ func TestCheckObjectsOnObjectArchived_BacklinkerArchived_ParentDeletedInStore(t 
 	// when: backlinker is archived
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "backlinker", true)
 
-	// then: file archived — parent confirmed inactive (deleted)
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_BacklinkerArchived_NoCreatedInContext_NotArchived(t *testing.T) {
@@ -443,9 +443,9 @@ func TestCheckObjectsOnObjectArchived_NonFileObject_ParentArchived_NoOtherBackli
 	// when: parent is archived
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then: child is archived too
+	// then: hotfix — non-file objects are NOT archived (file-only scope)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"child"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_NonFileObject_ParentArchived_WithActiveBacklink(t *testing.T) {
@@ -502,9 +502,9 @@ func TestArchiveOrphansOnLinksRemoval_NonFileObject_SkipBinForcedFalse(t *testin
 	// when: caller requests skipBin=true (as chat service does for files)
 	_, err := fx.ArchiveOrphansOnLinksRemoval(testSpaceId, "parent", []string{"child"}, true, nil)
 
-	// then: child is archived, NOT permanently deleted — skipBin overridden to false for non-files
+	// then: hotfix — non-file objects are NOT archived (file-only scope)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"child"}, fx.archiver.archivedIds)
+	assert.Empty(t, fx.archiver.archivedIds)
 }
 
 func TestCheckObjectsOnObjectArchived_SystemLayoutObject_NotGCd(t *testing.T) {
@@ -553,10 +553,10 @@ func TestArchiveOrphansOnLinksRemoval_ReturnsArchivedIds(t *testing.T) {
 	// when
 	archivedIds, err := fx.ArchiveOrphansOnLinksRemoval(testSpaceId, "page", []string{"file1"}, false, nil)
 
-	// then: file archived and returned
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
-	assert.ElementsMatch(t, []string{"file1"}, archivedIds)
+	assert.Empty(t, fx.archiver.archivedIds)
+	assert.Empty(t, archivedIds)
 }
 
 func TestArchiveOrphansOnLinksRemoval_ActiveBacklink_ReturnsEmpty(t *testing.T) {
@@ -574,6 +574,47 @@ func TestArchiveOrphansOnLinksRemoval_ActiveBacklink_ReturnsEmpty(t *testing.T) 
 	assert.Empty(t, archivedIds)
 }
 
+// fileObjectWithRef builds a file with a non-empty CreatedInContextRef — i.e. a file added
+// via a block (not via a collection). Under the file-only hotfix this is the only scenario
+// where archive GC currently fires.
+func fileObjectWithRef(id, createdInContext, createdInContextRef string, backlinks []string) objectstore.TestObject {
+	return objectstore.TestObject{
+		bundle.RelationKeyId:                  domain.String(id),
+		bundle.RelationKeyResolvedLayout:      domain.Int64(int64(model.ObjectType_image)),
+		bundle.RelationKeyCreatedInContext:    domain.String(createdInContext),
+		bundle.RelationKeyCreatedInContextRef: domain.String(createdInContextRef),
+		bundle.RelationKeyBacklinks:           domain.StringList(backlinks),
+	}
+}
+
+func TestArchiveOrphansOnLinksRemoval_FileWithRef_Archived(t *testing.T) {
+	// given: a file with non-empty CreatedInContextRef (block-attached file)
+	fx := newFixture(t)
+	fx.addObject(t, fileObjectWithRef("file1", "page", "block1", []string{"page"}))
+
+	// when
+	archivedIds, err := fx.ArchiveOrphansOnLinksRemoval(testSpaceId, "page", []string{"file1"}, false, nil)
+
+	// then: file is archived — non-empty ref means it is NOT a collection-created file
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, fx.archiver.archivedIds)
+	assert.ElementsMatch(t, []string{"file1"}, archivedIds)
+}
+
+func TestCheckObjectsOnObjectArchived_FileWithRef_ParentArchived_Archived(t *testing.T) {
+	// given: parent archived, file has a non-empty CreatedInContextRef and no other backlinks
+	fx := newFixture(t)
+	fx.addObject(t, regularObject("parent"))
+	fx.addObject(t, fileObjectWithRef("file1", "parent", "block1", []string{"parent"}))
+
+	// when
+	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
+
+	// then: file is archived — file layout + non-empty ref pass the hotfix gates
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"file1"}, ids)
+}
+
 // -- returned-IDs tests for CheckObjectsOnObjectArchived --
 
 func TestCheckObjectsOnObjectArchived_ReturnsArchivedIds(t *testing.T) {
@@ -585,9 +626,9 @@ func TestCheckObjectsOnObjectArchived_ReturnsArchivedIds(t *testing.T) {
 	// when
 	archivedIds, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then: file archived and returned
+	// then: hotfix — file has empty CreatedInContextRef, so it is NOT archived
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"file1"}, archivedIds)
+	assert.Empty(t, archivedIds)
 }
 
 func TestCheckObjectsOnObjectArchived_Unarchive_ReturnsRestoredIds(t *testing.T) {
@@ -699,16 +740,16 @@ func TestCheckObjectsOnObjectArchived_TwoLevelTree_BothLevelsArchived(t *testing
 	// when
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then
+	// then: hotfix — non-file objects are NOT archived (file-only scope)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"child", "grandchild"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_CycleAB_TerminatesAndArchivesB(t *testing.T) {
 	// given: A.createdInContext=B, B.createdInContext=A — cycle
 	// Archiving A: BFS visits A (seed), finds B (child of A), visited={A,B}.
 	// When processing B, finds A as its child — but A is already in visited → skip.
-	// Result: B is archived, no infinite loop.
+	// (BFS termination must still hold under the file-only hotfix.)
 	fx := newFixture(t)
 	fx.addObject(t, basicObject("A", "B", []string{"B"}))
 	fx.addObject(t, basicObject("B", "A", []string{"A"}))
@@ -716,9 +757,9 @@ func TestCheckObjectsOnObjectArchived_CycleAB_TerminatesAndArchivesB(t *testing.
 	// when — must complete without hanging
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "A", true)
 
-	// then
+	// then: hotfix — non-file objects are NOT archived (file-only scope)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"B"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_GrandchildWithExternalBacklink_SubtreeExcluded(t *testing.T) {
@@ -737,10 +778,9 @@ func TestCheckObjectsOnObjectArchived_GrandchildWithExternalBacklink_SubtreeExcl
 	// when
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then
+	// then: hotfix — non-file objects are NOT archived (file-only scope)
 	require.NoError(t, err)
-	// child is archived; grandchild and greatgrandchild are kept (external backlink on grandchild)
-	assert.ElementsMatch(t, []string{"child"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_SiblingCrossReference_BothArchived(t *testing.T) {
@@ -758,9 +798,9 @@ func TestCheckObjectsOnObjectArchived_SiblingCrossReference_BothArchived(t *test
 	// when
 	ids, err := fx.CheckObjectsOnObjectArchived(testSpaceId, "parent", true)
 
-	// then: both siblings are archived because their only backlinks are each other (in pending set)
+	// then: hotfix — non-file objects are NOT archived (file-only scope)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"child1", "child2"}, ids)
+	assert.Empty(t, ids)
 }
 
 func TestCheckObjectsOnObjectArchived_Unarchive_MultiLevelRestored(t *testing.T) {

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "e197bc55a42d31ee93e99229200a1eba2e17a73782ee719ac69579634e676051"
+const RelationChecksum = "61f183bee6d86cc5298efbf46cb83c9ce4a01a41699d3affcee2975aa301fd78"
 const (
 	RelationKeyTag                                  domain.RelationKey = "tag"
 	RelationKeyCamera                               domain.RelationKey = "camera"
@@ -539,7 +539,6 @@ var (
 			DataSource:       model.Relation_details,
 			Description:      "Object ID where the object was initially created",
 			Format:           model.RelationFormat_object,
-			Hidden:           true,
 			Id:               "_brcreatedInContext",
 			Key:              "createdInContext",
 			MaxCount:         1,

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1346,7 +1346,7 @@
   {
     "description": "Object ID where the object was initially created",
     "format": "object",
-    "hidden": true,
+    "hidden": false,
     "key": "createdInContext",
     "maxCount": 1,
     "name": "Created in context",


### PR DESCRIPTION
Hotfix in response to user feedback: limit auto-archive on link removal and on parent archive to file-layout objects, and skip files with empty CreatedInContextRef so files created via collections are left alone.
