### PR TITLE
GO-7275 Distinguish transient errors from quota in allocateFile

### DIFF
--- a/core/files/filestorage/rpcstore/inmemory.go
+++ b/core/files/filestorage/rpcstore/inmemory.go
@@ -57,6 +57,11 @@ type InMemoryStore struct {
 	spaceCids map[string]map[cid.Cid]struct{}
 	mu        sync.Mutex
 
+	// spaceInfoErr, when non-nil, is returned from SpaceInfo. Used in tests to
+	// simulate transient backend failures (e.g. cross-DC redsync lock contention).
+	errMu        sync.Mutex
+	spaceInfoErr error
+
 	stats *InMemoryStoreStats
 }
 
@@ -255,6 +260,13 @@ func (t *InMemoryStore) DeleteFiles(ctx context.Context, spaceId string, fileIds
 }
 
 func (t *InMemoryStore) SpaceInfo(ctx context.Context, spaceId string) (*fileproto.SpaceInfoResponse, error) {
+	t.errMu.Lock()
+	if injected := t.spaceInfoErr; injected != nil {
+		t.errMu.Unlock()
+		return nil, injected
+	}
+	t.errMu.Unlock()
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -279,6 +291,14 @@ func (t *InMemoryStore) SetLimit(limit int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.limit = limit
+}
+
+// SetSpaceInfoError sets an error that subsequent SpaceInfo calls will return.
+// Pass nil to clear. Used in tests to simulate transient backend failures.
+func (t *InMemoryStore) SetSpaceInfoError(err error) {
+	t.errMu.Lock()
+	defer t.errMu.Unlock()
+	t.spaceInfoErr = err
 }
 
 func (t *InMemoryStore) AccountInfo(ctx context.Context) (*fileproto.AccountInfoResponse, error) {

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -184,6 +184,14 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 
 	allocateErr := spaceLimits.allocateFile(ctx, it.Key(), blocksAvailability.bytesToUploadOrBind)
 	if allocateErr != nil {
+		var limitErr *errLimitReached
+		if !errors.As(allocateErr, &limitErr) {
+			// Transient infra failure (e.g. SpaceInfo failed). Reschedule for
+			// retry instead of marking the file as Limited.
+			it = it.Reschedule()
+			return it, fmt.Errorf("allocate file: %w", allocateErr)
+		}
+
 		it.State = FileStateLimited
 		it = it.Reschedule()
 

--- a/core/files/filesync/upload_test.go
+++ b/core/files/filesync/upload_test.go
@@ -333,6 +333,18 @@ func TestFileSync_TransientAllocateErrorReschedules(t *testing.T) {
 		// Update fails and its cache stays empty — subsequent allocateFile
 		// calls will retry SpaceInfo and hit the same error.
 		fx.rpcStore.SetSpaceInfoError(transientErr)
+
+		// Capture filesyncstatus updates: the user-visible regression in GO-7275
+		// was a stray filesyncstatus.Limited emitted via OnStatusUpdated.
+		var statusMu sync.Mutex
+		statuses := map[string][]filesyncstatus.Status{}
+		fx.OnStatusUpdated(func(objectId string, _ domain.FullFileId, status filesyncstatus.Status) error {
+			statusMu.Lock()
+			defer statusMu.Unlock()
+			statuses[objectId] = append(statuses[objectId], status)
+			return nil
+		})
+
 		require.NoError(t, fx.a.Start(ctx))
 		defer fx.Finish(t)
 
@@ -349,10 +361,11 @@ func TestFileSync_TransientAllocateErrorReschedules(t *testing.T) {
 		dummyCid, err := cid.Parse("bafybeihqbmekus5fwgtlybi7qdjmwo7d2o2aksjth4fqabzcduswc7o6re")
 		require.NoError(t, err)
 
+		objectId := "objectId1"
 		it := FileInfo{
 			FileId:              domain.FileId("bafybeihqbmekus5fwgtlybi7qdjmwo7d2o2aksjth4fqabzcduswc7o6re"),
 			SpaceId:             spaceId,
-			ObjectId:            "objectId1",
+			ObjectId:            objectId,
 			State:               FileStatePendingUpload,
 			ScheduledAt:         time.Now(),
 			AddedByUser:         true,
@@ -369,11 +382,17 @@ func TestFileSync_TransientAllocateErrorReschedules(t *testing.T) {
 		assert.Equal(t, FileStatePendingUpload, result.State, "file should stay PendingUpload for retry")
 
 		fx.eventsLock.Lock()
-		defer fx.eventsLock.Unlock()
 		for _, e := range fx.events {
 			for _, msg := range e.Messages {
 				assert.Nil(t, msg.GetFileLimitReached(), "FileLimitReached event must not be broadcast for transient errors")
 			}
+		}
+		fx.eventsLock.Unlock()
+
+		statusMu.Lock()
+		defer statusMu.Unlock()
+		for _, s := range statuses[objectId] {
+			assert.NotEqual(t, filesyncstatus.Limited, s, "filesyncstatus.Limited must not be emitted for transient errors")
 		}
 	})
 }

--- a/core/files/filesync/upload_test.go
+++ b/core/files/filesync/upload_test.go
@@ -324,6 +324,60 @@ func TestFileSync_UploadTransitionsToMissingBlocks(t *testing.T) {
 	assert.Equal(t, fileId, result.FileId)
 }
 
+func TestFileSync_TransientAllocateErrorReschedules(t *testing.T) {
+	t.Run("transient SpaceInfo error must not flip file to Limited", func(t *testing.T) {
+		transientErr := errors.New("lock already taken, locked nodes: [0]")
+
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		// Inject the transient error before start so spaceUsage's initial
+		// Update fails and its cache stays empty — subsequent allocateFile
+		// calls will retry SpaceInfo and hit the same error.
+		fx.rpcStore.SetSpaceInfoError(transientErr)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		// Wait until the space view subscription has registered spaceUsage
+		// for "space1" so getSpace returns a valid usage tracker.
+		spaceId := "space1"
+		fx.waitCondition(t, 2*time.Second, func() bool {
+			_, err := fx.limitManager.getSpace(spaceId)
+			return err == nil
+		})
+
+		// Pre-populate CidsToUpload so checkBlocksAvailability short-circuits
+		// without walking the local DAG.
+		dummyCid, err := cid.Parse("bafybeihqbmekus5fwgtlybi7qdjmwo7d2o2aksjth4fqabzcduswc7o6re")
+		require.NoError(t, err)
+
+		it := FileInfo{
+			FileId:              domain.FileId("bafybeihqbmekus5fwgtlybi7qdjmwo7d2o2aksjth4fqabzcduswc7o6re"),
+			SpaceId:             spaceId,
+			ObjectId:            "objectId1",
+			State:               FileStatePendingUpload,
+			ScheduledAt:         time.Now(),
+			AddedByUser:         true,
+			BytesToUploadOrBind: 1024,
+			CidsToUpload:        map[cid.Cid]struct{}{dummyCid: {}},
+			CidsToBind:          map[cid.Cid]struct{}{},
+		}
+
+		result, processErr := fx.processFilePendingUpload(ctx, it)
+
+		require.Error(t, processErr, "transient allocateFile error must propagate to caller")
+		assert.ErrorIs(t, processErr, transientErr, "error chain should preserve underlying transient error")
+		assert.NotEqual(t, FileStateLimited, result.State, "transient error must not flip file to Limited")
+		assert.Equal(t, FileStatePendingUpload, result.State, "file should stay PendingUpload for retry")
+
+		fx.eventsLock.Lock()
+		defer fx.eventsLock.Unlock()
+		for _, e := range fx.events {
+			for _, msg := range e.Messages {
+				assert.Nil(t, msg.GetFileLimitReached(), "FileLimitReached event must not be broadcast for transient errors")
+			}
+		}
+	})
+}
+
 func TestFileSync_NoSyncingStatusWhenLimitReached(t *testing.T) {
 	fx := newFixtureNotStarted(t, 1024)
 	spaceId := "space1"


### PR DESCRIPTION
## Summary

`fileSync.processFilePendingUpload` (`core/files/filesync/upload.go:185`) treated **any** error returned by `spaceUsage.allocateFile` as "space limit reached", regardless of cause. When `SpaceInfo` to the file node failed transiently (e.g. cross-DC redsync `lock already taken`), the file's user-visible status was flipped to `filesyncstatus.Limited`, the file was removed from active retry, and an extra failing `DeleteFiles` call was fired — the user saw an error/limit-reached state even though they were not over quota.

## Root cause

`allocateFile` (`core/files/filesync/nodeusage.go:91`) returns errors for two distinct reasons:

1. **Real over-quota** — typed `*errLimitReached`.
2. **Transient infra failure** — anything wrong inside `getFreeSpace → update → SpaceInfo`, returned wrapped as `"get free space: %w"`.

The caller could not distinguish them.

## Fix

Use `errors.As` against `*errLimitReached` to gate the limit-reached branch. Other errors reschedule the item for retry without:
- flipping `it.State` to `FileStateLimited`
- calling `handleLimitReached` (which broadcasts `FileLimitReached` UI events and fires an unbind `DeleteFiles` RPC)

```go
allocateErr := spaceLimits.allocateFile(ctx, it.Key(), blocksAvailability.bytesToUploadOrBind)
if allocateErr != nil {
    var limitErr *errLimitReached
    if !errors.As(allocateErr, &limitErr) {
        // Transient infra failure — reschedule for retry.
        it = it.Reschedule()
        return it, fmt.Errorf("allocate file: %w", allocateErr)
    }
    // ...existing limit-reached path unchanged
}
```

## Test

`TestFileSync_TransientAllocateErrorReschedules` — injects a `lock already taken` error into `SpaceInfo` via the in-memory rpcstore, calls `processFilePendingUpload` directly, and asserts:

- the transient error is propagated (`errors.Is(err, transientErr)`)
- `result.State` stays `FileStatePendingUpload` (not `FileStateLimited`)
- no `FileLimitReached` event is broadcast

To enable that injection, `rpcstore.InMemoryStore` gains a `SetSpaceInfoError(err error)` test helper.

Verified the test fails on the unfixed code (and the bug-evidence log line `"calculate limits: unbind off-limit file"` appears in that run) and passes on the fixed code.

## Why this didn't surface earlier

In normal operation `SpaceInfo` succeeds in <500ms, so `allocateFile` errors out only on real quota exhaustion. The bug only triggers when `SpaceInfo` itself fails — currently happening due to cross-DC Redis lock contention, tracked separately in GO-7267.

## Test plan

- [x] `go test ./core/files/filesync/ -count=1`
- [x] `go test ./core/files/filestorage/rpcstore/ -count=1`
- [x] `go build ./...`
- [x] New test fails before fix, passes after fix