### PR TITLE
GO-7267 Bound doNodeReserved RPCs by per-call deadline

### DIFF
--- a/core/files/filestorage/rpcstore/store.go
+++ b/core/files/filestorage/rpcstore/store.go
@@ -71,6 +71,16 @@ const (
 	localPeerBanTTL  = 5 * time.Minute
 )
 
+// reservedCallTimeout bounds a single doNodeReserved RPC. The reserved
+// sub-connection is shared and serialized by s.mu, so a stuck call would
+// block every other metadata RPC (SpaceInfo, AccountInfo, BlocksCheck,
+// FilesInfo). All RPCs routed through doNodeReserved are metadata-only
+// and complete in well under a second on healthy infra; 15s is generous
+// headroom that still bounds queue growth when the server is degraded.
+//
+// var (not const) so tests can shorten it.
+var reservedCallTimeout = 15 * time.Second
+
 type store struct {
 	pool      pool.Pool
 	peerStore peerstore.PeerStore
@@ -137,16 +147,28 @@ func (s *store) doNodeDrpc(ctx context.Context, do func(cl fileproto.DRPCFileCli
 
 // doNodeReserved uses a lazily-acquired reserved sub-connection for small-payload operations.
 // A mutex serializes access since DRPC connections support only one concurrent stream.
-func (s *store) doNodeReserved(ctx context.Context, do func(cl fileproto.DRPCFileClient) error) error {
+//
+// The do callback receives a context bounded by reservedCallTimeout so that a single
+// stuck RPC cannot wedge every other caller queued on s.mu. On timeout we reset the
+// reserved connection so the next caller starts with a fresh sub-conn.
+func (s *store) doNodeReserved(ctx context.Context, do func(ctx context.Context, cl fileproto.DRPCFileClient) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if err := s.ensureReservedConn(ctx); err != nil {
 		return err
 	}
-	err := do(fileproto.NewDRPCFileClient(s.reservedConn))
+	callCtx, cancel := context.WithTimeout(ctx, reservedCallTimeout)
+	defer cancel()
+	err := do(callCtx, fileproto.NewDRPCFileClient(s.reservedConn))
 	if err != nil {
-		// Connection may be broken; reset for reconnect on next call
+		// Connection may be broken (or stuck past the deadline); reset for reconnect on next call.
+		// Distinguish a deadline-induced reset from a real RPC error so we can spot it in logs:
+		// the deadline only fires when callCtx expired but the parent ctx did not.
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			log.Warn("doNodeReserved: reserved call exceeded deadline, resetting conn",
+				zap.Duration("timeout", reservedCallTimeout))
+		}
 		s.resetReservedConnLocked()
 		return err
 	}
@@ -342,7 +364,7 @@ func (s *store) CheckAvailability(ctx context.Context, spaceID string, cids []ci
 		cidsB[i] = c.Bytes()
 	}
 	var result []*fileproto.BlockAvailability
-	err := s.doNodeReserved(ctx, func(cl fileproto.DRPCFileClient) error {
+	err := s.doNodeReserved(ctx, func(ctx context.Context, cl fileproto.DRPCFileClient) error {
 		resp, err := cl.BlocksCheck(ctx, &fileproto.BlocksCheckRequest{
 			SpaceId: spaceID,
 			Cids:    cidsB,
@@ -396,7 +418,7 @@ func (s *store) DeleteFiles(ctx context.Context, spaceId string, fileIds ...doma
 // AccountInfo retrieves account-level file storage info.
 func (s *store) AccountInfo(ctx context.Context) (*fileproto.AccountInfoResponse, error) {
 	var result *fileproto.AccountInfoResponse
-	err := s.doNodeReserved(ctx, func(cl fileproto.DRPCFileClient) error {
+	err := s.doNodeReserved(ctx, func(ctx context.Context, cl fileproto.DRPCFileClient) error {
 		resp, err := cl.AccountInfo(ctx, &fileproto.AccountInfoRequest{})
 		if err != nil {
 			return rpcerr.Unwrap(err)
@@ -410,7 +432,7 @@ func (s *store) AccountInfo(ctx context.Context) (*fileproto.AccountInfoResponse
 // SpaceInfo retrieves space-level file storage info.
 func (s *store) SpaceInfo(ctx context.Context, spaceId string) (*fileproto.SpaceInfoResponse, error) {
 	var result *fileproto.SpaceInfoResponse
-	err := s.doNodeReserved(ctx, func(cl fileproto.DRPCFileClient) error {
+	err := s.doNodeReserved(ctx, func(ctx context.Context, cl fileproto.DRPCFileClient) error {
 		resp, err := cl.SpaceInfo(ctx, &fileproto.SpaceInfoRequest{
 			SpaceId: spaceId,
 		})
@@ -430,7 +452,7 @@ func (s *store) FilesInfo(ctx context.Context, spaceId string, fileIds ...domain
 		rawFileIds = append(rawFileIds, id.String())
 	}
 	var result []*fileproto.FileInfo
-	err := s.doNodeReserved(ctx, func(cl fileproto.DRPCFileClient) error {
+	err := s.doNodeReserved(ctx, func(ctx context.Context, cl fileproto.DRPCFileClient) error {
 		resp, err := cl.FilesInfo(ctx, &fileproto.FilesInfoRequest{
 			SpaceId: spaceId,
 			FileIds: rawFileIds,

--- a/core/files/filestorage/rpcstore/store_test.go
+++ b/core/files/filestorage/rpcstore/store_test.go
@@ -2,10 +2,12 @@ package rpcstore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/anyproto/any-sync/accountservice/mock_accountservice"
 	"github.com/anyproto/any-sync/app"
@@ -109,6 +111,66 @@ func TestStore_GetMany(t *testing.T) {
 	assert.Equal(t, bs, resBlocks)
 }
 
+func TestStore_doNodeReserved_TimeoutUnblocksMutex(t *testing.T) {
+	// Regression test for GO-7267: a stuck reserved RPC would hold s.mu
+	// indefinitely, wedging every other metadata caller. doNodeReserved must
+	// bound the inner call by reservedCallTimeout, return a deadline error,
+	// and reset the reserved conn so subsequent callers can proceed.
+	prev := reservedCallTimeout
+	reservedCallTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { reservedCallTimeout = prev })
+
+	fx := newFixture(t)
+	defer fx.Finish(t)
+
+	// Make every SpaceInfo handler block until release is signalled
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	fx.serv.setSpaceInfoHook(func(ctx context.Context) error {
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	// 1) The first call must return within ~timeout with a deadline error, not hang.
+	start := time.Now()
+	_, err := fx.SpaceInfo(ctx, "spaceA")
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded),
+		"expected context.DeadlineExceeded, got %v", err)
+	assert.Less(t, elapsed, 2*time.Second, "first call must respect reservedCallTimeout")
+
+	// 2) reservedConn must be reset after a deadline-induced failure so the next caller
+	// starts from a fresh sub-conn rather than reusing one whose stream we abandoned.
+	fx.store.mu.Lock()
+	resetOk := fx.store.reservedConn == nil
+	fx.store.mu.Unlock()
+	assert.True(t, resetOk, "reservedConn must be reset after deadline timeout")
+
+	// 3) The mutex must be released so other callers aren't wedged.
+	// Fire two concurrent SpaceInfo calls and verify both unblock within ~2 windows.
+	results := make(chan time.Duration, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			t0 := time.Now()
+			_, _ = fx.SpaceInfo(ctx, "spaceB")
+			results <- time.Since(t0)
+		}()
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case d := <-results:
+			assert.Less(t, d, 2*time.Second, "follow-up calls must not wedge")
+		case <-time.After(3 * time.Second):
+			t.Fatal("doNodeReserved still wedged after timeout fix")
+		}
+	}
+}
+
 func TestStore_AddAsync(t *testing.T) {
 	fx := newFixture(t)
 	defer fx.Finish(t)
@@ -179,6 +241,16 @@ type testServer struct {
 	mu    sync.Mutex
 	data  map[string][]byte
 	files map[string][][]byte
+	// spaceInfoHook, if set, runs at the start of SpaceInfo. Tests use it
+	// to simulate a hung server (block until ctx is canceled).
+	// Always read/write under mu — races trip -race otherwise.
+	spaceInfoHook func(ctx context.Context) error
+}
+
+func (t *testServer) setSpaceInfoHook(f func(ctx context.Context) error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.spaceInfoHook = f
 }
 
 func (t *testServer) BlockPushMany(ctx2 context.Context, request *fileproto.BlockPushManyRequest) (*fileproto.Ok, error) {
@@ -267,6 +339,14 @@ func (t *testServer) FilesInfo(ctx context.Context, req *fileproto.FilesInfoRequ
 }
 
 func (t *testServer) SpaceInfo(ctx context.Context, req *fileproto.SpaceInfoRequest) (*fileproto.SpaceInfoResponse, error) {
+	t.mu.Lock()
+	hook := t.spaceInfoHook
+	t.mu.Unlock()
+	if hook != nil {
+		if err := hook(ctx); err != nil {
+			return nil, err
+		}
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	resp := &fileproto.SpaceInfoResponse{


### PR DESCRIPTION
## Summary

`rpcstore.doNodeReserved` holds `s.mu` for the entire DRPC round-trip with no per-call deadline. A single slow metadata RPC therefore wedges every other caller (`SpaceInfo`, `AccountInfo`, `BlocksCheck`, `FilesInfo`) on the same `*store`. With many spaces firing periodic `SpaceInfo`, the queue grows faster than it drains as soon as the server tail latency exceeds ~1.3s — even though the connection itself is healthy.

Fix: wrap the inner `do(...)` call in `context.WithTimeout(ctx, 15s)` and reset the reserved conn on error.

The big-payload path (`doNodeDrpc`) is intentionally untouched — those calls don't share the mutex and need to support legitimately long uploads/downloads.

## Sequencing

Should land **with or after** [GO-7275](https://github.com/anyproto/anytype-heart/tree/go-7275-filesync-allocatefile-transient-errors-mis-classified-as) — without it, the new `context.DeadlineExceeded` from `SpaceInfo` would trip the `allocateFile` misclassification and flip files to `Limited` more often. No textual conflict.

## Test plan

- [x] `go test -race ./core/files/filestorage/rpcstore/` — passes
- [x] New regression test verifies: deadline error returned, `reservedConn` reset, follow-up callers unblocked
- [x] QA: take filenode3 down, confirm 47-space user's file subsystem stays responsive (no 3-min wedge)