### PR TITLE
GO-7284 Fix DebugRunProfiler crash on iOS (IOKit null-deref)

### DIFF
--- a/core/debug/debugsnapshot/debugsnapshot.go
+++ b/core/debug/debugsnapshot/debugsnapshot.go
@@ -254,6 +254,16 @@ func ReadInfoFromZip(zipPath string) (Info, bool) {
 // --- host helpers ---
 
 func getCPUModel() string {
+	// On iOS, gopsutil's cpu.Info() reaches into IOKit
+	// (AppleARMIODevice / IORegistryEntryCreateCFProperty) to read CPU
+	// frequency. Those properties are restricted by the iOS sandbox, the
+	// IOKit call returns NULL, and the subsequent CFDataGetLength(NULL)
+	// crashes the process with EXC_BAD_ACCESS. The CPU model is cosmetic
+	// metadata for the snapshot — skip it on iOS rather than risk the
+	// crash.
+	if runtime.GOOS == "ios" {
+		return ""
+	}
 	infos, err := cpu.Info()
 	if err != nil || len(infos) == 0 {
 		return ""


### PR DESCRIPTION
## Summary

- `DebugRunProfiler` RPC crashes the iOS app (both `durationInSeconds = 0` and `> 0`) with `EXC_BAD_ACCESS code=1 address=0x0`.
- Root cause: `gopsutil/v4@v4.26.2` `cpu.Info()` on darwin/arm64 calls `getFrequency()` (`cpu_darwin_arm64.go:51`), which uses IOKit's `IORegistryEntryCreateCFProperty(..., "voltage-states5-sram", ...)` against `AppleARMIODevice`. On iOS those properties are sandbox-restricted — the IOKit call returns NULL and the subsequent `CFDataGetLength(NULL)` null-derefs. Stack matches: `__CF_IS_OBJC` → `CFDataGetLength` → `syscall15X` → `runtime.asmcgocall`.
- Introduced in `08211d407` (GO-7143, 2026-04-24) when `gopsutil/v4/cpu` was pulled into the snapshot path via `BuildInfo` → `getCPUModel`.
- Fix: short-circuit `getCPUModel()` to `""` on `runtime.GOOS == "ios"`. CPU model is cosmetic metadata for the snapshot. Desktop and Android paths are unchanged — Android's `cpu.Info` runs the Linux backend (reads `/proc/cpuinfo`, no IOKit).
- Other gopsutil calls in `BuildInfo` (`mem.VirtualMemory`, `disk.Usage`, `process.MemoryInfo`) use sysctl / `statfs` / `proc_pidinfo` on Darwin — no IOKit, safe on iOS.

## Test plan

- [ ] iOS build: `DebugRunProfiler` with `durationInSeconds = 0` no longer crashes; snapshot zip is produced.
- [ ] iOS build: `DebugRunProfiler` with `durationInSeconds = 30` no longer crashes; full profile zip is produced.
- [ ] Resulting `info.json` on iOS has empty `cpuModel` (other fields populated).
- [ ] macOS desktop: `info.json` still contains a populated `cpuModel`.
- [ ] Android: `info.json` still contains a populated `cpuModel`.