### PR TITLE
GO-7291 indexer: eliminate addSyncDetails startup write storm

### DIFF
--- a/core/block/object/objectcache/cache.go
+++ b/core/block/object/objectcache/cache.go
@@ -2,6 +2,7 @@ package objectcache
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/anyproto/any-sync/accountservice"
@@ -51,6 +52,7 @@ type Cache interface {
 	GetObject(ctx context.Context, id string) (sb smartblock.SmartBlock, err error)
 	GetObjectWithTimeout(ctx context.Context, id string) (sb smartblock.SmartBlock, err error)
 	DoLockedIfNotExists(objectID string, proc func() error) error
+	FilterNotExists(ids []string) []string
 	Remove(ctx context.Context, objectID string) error
 	TryRemove(objectId string) (bool, error)
 	CloseBlocks()
@@ -171,6 +173,33 @@ func (c *objectCache) GetObjectWithTimeout(ctx context.Context, id string) (sb s
 
 func (c *objectCache) DoLockedIfNotExists(objectID string, proc func() error) error {
 	return c.cache.DoLockedIfNotExists(objectID, proc)
+}
+
+// FilterNotExists returns the subset of ids that are not present in the cache
+// (neither loaded nor currently loading), preserving input order.
+//
+// Unlike DoLockedIfNotExists it never holds the cache mutex across a callback,
+// so callers can safely use it to pre-filter ids and then perform store writes
+// (e.g. inside a write transaction) without nesting the cache lock and the
+// any-store write connection — the lock-order inversion that otherwise
+// deadlocks against object loads. It uses an already-cancelled context so
+// ocache.Pick returns immediately: an absent id yields ErrNotExists; a
+// loaded/loading id yields nil or context.Canceled. Only ErrNotExists is
+// treated as "not in cache", matching DoLockedIfNotExists semantics (a loading
+// entry counts as existing and is skipped).
+func (c *objectCache) FilterNotExists(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	notExists := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, err := c.cache.Pick(ctx, id); errors.Is(err, ocache.ErrNotExists) {
+			notExists = append(notExists, id)
+		}
+	}
+	return notExists
 }
 
 func (c *objectCache) CloseBlocks() {

--- a/core/block/object/objectcache/cache_test.go
+++ b/core/block/object/objectcache/cache_test.go
@@ -1,0 +1,44 @@
+package objectcache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/anyproto/any-sync/app/ocache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubObject struct{}
+
+func (stubObject) Close() error                         { return nil }
+func (stubObject) TryClose(time.Duration) (bool, error) { return false, nil }
+
+func TestObjectCache_FilterNotExists(t *testing.T) {
+	t.Run("returns only ids absent from cache without triggering loads", func(t *testing.T) {
+		c := &objectCache{
+			cache: ocache.New(func(context.Context, string) (ocache.Object, error) {
+				return nil, fmt.Errorf("loadFunc must not be called by FilterNotExists")
+			}),
+		}
+		t.Cleanup(func() { _ = c.cache.Close() })
+
+		require.NoError(t, c.cache.Add("cached1", stubObject{}))
+		require.NoError(t, c.cache.Add("cached2", stubObject{}))
+
+		got := c.FilterNotExists([]string{"cached1", "missing1", "cached2", "missing2"})
+
+		assert.Equal(t, []string{"missing1", "missing2"}, got)
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		c := &objectCache{cache: ocache.New(func(context.Context, string) (ocache.Object, error) {
+			return nil, fmt.Errorf("unexpected load")
+		})}
+		t.Cleanup(func() { _ = c.cache.Close() })
+
+		assert.Empty(t, c.FilterNotExists(nil))
+	})
+}

--- a/core/block/object/objectcache/mock_objectcache/mock_Cache.go
+++ b/core/block/object/objectcache/mock_objectcache/mock_Cache.go
@@ -620,6 +620,54 @@ func (_c *MockCache_DoLockedIfNotExists_Call) RunAndReturn(run func(string, func
 	return _c
 }
 
+// FilterNotExists provides a mock function with given fields: ids
+func (_m *MockCache) FilterNotExists(ids []string) []string {
+	ret := _m.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FilterNotExists")
+	}
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func([]string) []string); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
+// MockCache_FilterNotExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FilterNotExists'
+type MockCache_FilterNotExists_Call struct {
+	*mock.Call
+}
+
+// FilterNotExists is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockCache_Expecter) FilterNotExists(ids interface{}) *MockCache_FilterNotExists_Call {
+	return &MockCache_FilterNotExists_Call{Call: _e.mock.On("FilterNotExists", ids)}
+}
+
+func (_c *MockCache_FilterNotExists_Call) Run(run func(ids []string)) *MockCache_FilterNotExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *MockCache_FilterNotExists_Call) Return(_a0 []string) *MockCache_FilterNotExists_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockCache_FilterNotExists_Call) RunAndReturn(run func([]string) []string) *MockCache_FilterNotExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetObject provides a mock function with given fields: ctx, id
 func (_m *MockCache) GetObject(ctx context.Context, id string) (smartblock.SmartBlock, error) {
 	ret := _m.Called(ctx, id)

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -455,8 +455,10 @@ func (i *indexer) reindexChatMessagesFulltext(ctx context.Context, space clients
 }
 
 // addSyncDetailsBatchSize bounds how many objects share a single write tx, so
-// the (single) write connection is not held for the whole space at once.
-const addSyncDetailsBatchSize = 500
+// the (single) write connection is not held for the whole space at once. It is
+// a var (not a const) only so tests can shrink it to exercise multi-batch
+// re-filtering.
+var addSyncDetailsBatchSize = 500
 
 // addSyncDetails ensures every object that is missing the sync relations
 // (SyncStatus/SyncDate/SyncError, see helper.InjectsSyncDetails) gets them.
@@ -472,6 +474,18 @@ const addSyncDetailsBatchSize = 500
 //   - WriteTx on a non-tx ctx opens a real tx and threads the tx into
 //     txn.Context(), so ModifyObjectDetailsCtx reuses it via the savepoint
 //     path instead of a BEGIN IMMEDIATE per object.
+//
+// The not-in-cache check is done per batch via space.FilterNotExists, which
+// acquires and releases the object-cache mutex before that batch's write tx is
+// opened. It must NOT be done per-id inside the write tx (the old
+// space.DoLockedIfNotExists path): that nests the cache mutex inside the
+// any-store write connection, the reverse of the order taken by object loads
+// (cache mutex -> write conn), and deadlocks on cold start (GO-7291).
+// Re-filtering each batch keeps the stale window to a single batch instead of
+// the whole run. The residual window — an id loaded after its batch filter but
+// before its write — is benign: SyncStatus/SyncDate/SyncError are local-only
+// relations the syncstatus service continuously republishes for loaded
+// objects, so a stale baseline write is superseded.
 func (i *indexer) addSyncDetails(space clientspace.Space) {
 	syncStatus := domain.ObjectSyncStatusSynced
 	syncError := domain.SyncErrorNull
@@ -488,24 +502,34 @@ func (i *indexer) addSyncDetails(space clientspace.Space) {
 		return
 	}
 
+	if len(ids) > 0 {
+		fmt.Printf("### addSyncDetails: backfilling sync details for %d objects in space %s\n", len(ids), space.Id())
+	}
+
 	for start := 0; start < len(ids); start += addSyncDetailsBatchSize {
 		end := start + addSyncDetailsBatchSize
 		if end > len(ids) {
 			end = len(ids)
+		}
+		// Filter out ids loaded/loading in the object cache and release the
+		// cache mutex before opening the write tx (see the function doc).
+		// Re-done every batch so an id loaded while earlier batches were
+		// committing is re-checked against the cache, not written stale.
+		batch := space.FilterNotExists(ids[start:end])
+		if len(batch) == 0 {
+			continue
 		}
 		txn, err := store.WriteTx(ctx)
 		if err != nil {
 			log.Error("add sync details: start write tx", zap.Error(err))
 			return
 		}
-		for _, id := range ids[start:end] {
-			lockErr := space.DoLockedIfNotExists(id, func() error {
-				return store.ModifyObjectDetailsCtx(txn.Context(), id, func(details *domain.Details) (*domain.Details, bool, error) {
-					return helper.InjectsSyncDetails(details, syncStatus, syncError), true, nil
-				}, true)
-			})
-			if lockErr != nil {
-				log.Debug("failed to add sync status relations", zap.Error(lockErr))
+		for _, id := range batch {
+			modErr := store.ModifyObjectDetailsCtx(txn.Context(), id, func(details *domain.Details) (*domain.Details, bool, error) {
+				return helper.InjectsSyncDetails(details, syncStatus, syncError), true, nil
+			}, true)
+			if modErr != nil {
+				log.Debug("failed to add sync status relations", zap.Error(modErr))
 			}
 		}
 		if err := txn.Commit(); err != nil {

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -454,28 +454,62 @@ func (i *indexer) reindexChatMessagesFulltext(ctx context.Context, space clients
 	return nil
 }
 
+// addSyncDetailsBatchSize bounds how many objects share a single write tx, so
+// the (single) write connection is not held for the whole space at once.
+const addSyncDetailsBatchSize = 500
+
+// addSyncDetails ensures every object that is missing the sync relations
+// (SyncStatus/SyncDate/SyncError, see helper.InjectsSyncDetails) gets them.
+//
+// Steady state it is a single bulk query that returns nothing and writes
+// nothing. On the first-ever launch it writes the missing objects in chunked
+// shared write transactions. The whole pass runs under a non-cancelable
+// context (context.WithoutCancel) on purpose:
+//   - any-store arms a per-statement SQLite SetInterrupt goroutine/channel
+//     handshake only when ctx.Done() != nil; that handshake dominates startup
+//     scheduler-latency, and this op is bounded/internal so losing
+//     interruptibility is acceptable;
+//   - WriteTx on a non-tx ctx opens a real tx and threads the tx into
+//     txn.Context(), so ModifyObjectDetailsCtx reuses it via the savepoint
+//     path instead of a BEGIN IMMEDIATE per object.
 func (i *indexer) addSyncDetails(space clientspace.Space) {
-	typesForSyncRelations := helper.SyncRelationsSmartblockTypes()
 	syncStatus := domain.ObjectSyncStatusSynced
 	syncError := domain.SyncErrorNull
 	if i.config.IsLocalOnlyMode() {
 		syncStatus = domain.ObjectSyncStatusError
 		syncError = domain.SyncErrorNetworkError
 	}
-	ids, err := i.getIdsForTypes(space, typesForSyncRelations...)
-	if err != nil {
-		log.Debug("failed to add sync status relations", zap.Error(err))
-	}
 	store := i.store.SpaceIndex(space.Id())
-	for _, id := range ids {
-		err := space.DoLockedIfNotExists(id, func() error {
-			return store.ModifyObjectDetails(id, func(details *domain.Details) (*domain.Details, bool, error) {
-				details = helper.InjectsSyncDetails(details, syncStatus, syncError)
-				return details, true, nil
-			}, true)
-		})
+	ctx := context.WithoutCancel(i.runCtx)
+
+	ids, err := store.ListIdsWithoutSyncDetails(ctx)
+	if err != nil {
+		log.Error("add sync details: list ids without sync details", zap.Error(err))
+		return
+	}
+
+	for start := 0; start < len(ids); start += addSyncDetailsBatchSize {
+		end := start + addSyncDetailsBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		txn, err := store.WriteTx(ctx)
 		if err != nil {
-			log.Debug("failed to add sync status relations", zap.Error(err))
+			log.Error("add sync details: start write tx", zap.Error(err))
+			return
+		}
+		for _, id := range ids[start:end] {
+			lockErr := space.DoLockedIfNotExists(id, func() error {
+				return store.ModifyObjectDetailsCtx(txn.Context(), id, func(details *domain.Details) (*domain.Details, bool, error) {
+					return helper.InjectsSyncDetails(details, syncStatus, syncError), true, nil
+				}, true)
+			})
+			if lockErr != nil {
+				log.Debug("failed to add sync status relations", zap.Error(lockErr))
+			}
+		}
+		if err := txn.Commit(); err != nil {
+			log.Error("add sync details: commit write tx", zap.Error(err))
 		}
 	}
 }

--- a/core/indexer/reindex_test.go
+++ b/core/indexer/reindex_test.go
@@ -197,7 +197,7 @@ func TestIndexer_ReindexSpace_RemoveParticipants(t *testing.T) {
 			spc := mock_space.NewMockSpace(t)
 			spc.EXPECT().Id().Return(space)
 			spc.EXPECT().Storage().Return(storage).Maybe()
-			spc.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).Return(nil).Maybe()
+			spc.EXPECT().FilterNotExists(mock.Anything).Return(nil).Maybe() // addSyncDetails: nothing to backfill in this test
 			fx.sourceFx.EXPECT().IDsListerBySmartblockType(mock.Anything, mock.Anything).Return(idsLister{Ids: []string{}}, nil).Maybe()
 
 			// when
@@ -305,7 +305,7 @@ func TestIndexer_ReindexSpace_EraseLinks(t *testing.T) {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId1)
 		space1.EXPECT().Storage().Return(storage).Maybe()
-		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).Return(nil).Maybe()
+		space1.EXPECT().FilterNotExists(mock.Anything).Return(nil).Maybe() // addSyncDetails: nothing to backfill in this test
 
 		// when
 		err = fx.ReindexSpace(space1)
@@ -347,7 +347,7 @@ func TestIndexer_ReindexSpace_EraseLinks(t *testing.T) {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId2)
 		space1.EXPECT().Storage().Return(storage).Maybe()
-		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).Return(nil).Maybe()
+		space1.EXPECT().FilterNotExists(mock.Anything).Return(nil).Maybe() // addSyncDetails: nothing to backfill in this test
 		// when
 		err = fx.ReindexSpace(space1)
 		assert.NoError(t, err)
@@ -372,16 +372,17 @@ func TestIndexer_ReindexSpace_EraseLinks(t *testing.T) {
 func TestReindex_addSyncRelations(t *testing.T) {
 	const spaceId1 = "spaceId1"
 
-	// newSpace returns a space whose DoLockedIfNotExists actually runs the
-	// passed proc (object is treated as not loaded), so writes hit the store.
+	// newSpace returns a space whose FilterNotExists treats every id as
+	// not-in-cache (so writes hit the store) and which therefore must never
+	// be asked to take the per-object cache lock: DoLockedIfNotExists is left
+	// unexpected on purpose so a regression that re-nests the cache lock
+	// inside the write tx (the GO-7291 ABBA deadlock) fails the test.
 	newSpace := func(t *testing.T) *mock_space.MockSpace {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId1)
 		space1.EXPECT().StoredIds().Return([]string{}).Maybe()
-		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).
-			RunAndReturn(func(_ string, proc func() error) error {
-				return proc()
-			}).Maybe()
+		space1.EXPECT().FilterNotExists(mock.Anything).
+			RunAndReturn(func(ids []string) []string { return ids }).Maybe()
 		return space1
 	}
 
@@ -435,10 +436,14 @@ func TestReindex_addSyncRelations(t *testing.T) {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId1)
 		space1.EXPECT().StoredIds().Return([]string{}).Maybe()
-		// Nothing is missing, so no object must be touched.
-		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).
-			Run(func(string, func() error) { t.Fatal("unexpected write: repeat run must be a no-op") }).
-			Return(nil).Maybe()
+		// Nothing is missing, so the filtered set must be empty and no
+		// object must be touched. DoLockedIfNotExists is left unexpected:
+		// addSyncDetails must never take the per-object cache lock.
+		space1.EXPECT().FilterNotExists(mock.Anything).
+			RunAndReturn(func(ids []string) []string {
+				assert.Empty(t, ids, "repeat run must find nothing missing")
+				return ids
+			}).Maybe()
 
 		fx.addSyncDetails(space1)
 
@@ -470,6 +475,50 @@ func TestReindex_addSyncRelations(t *testing.T) {
 		// Missing one is added.
 		assert.True(t, got.Has(bundle.RelationKeySyncError))
 		assert.Equal(t, int64(domain.SyncErrorNull), got.GetInt64(bundle.RelationKeySyncError))
+	})
+
+	t.Run("re-filters every batch so an id cached mid-run is skipped", func(t *testing.T) {
+		// Two single-id batches. The first id is not cached and must be
+		// written; the second becomes cached between batches (it gets
+		// loaded by a concurrent object load) and must be skipped. This
+		// only holds if FilterNotExists is called per batch, after the
+		// previous batch's write tx has been committed and released.
+		old := addSyncDetailsBatchSize
+		addSyncDetailsBatchSize = 1
+		t.Cleanup(func() { addSyncDetailsBatchSize = old })
+
+		fx := newFixture(t)
+		fx.config.NetworkMode = pb.RpcAccount_DefaultConfig
+		fx.objectStore.AddObjects(t, spaceId1, []objectstore.TestObject{
+			{bundle.RelationKeyId: domain.String("1"), bundle.RelationKeyName: domain.String("a")},
+			{bundle.RelationKeyId: domain.String("2"), bundle.RelationKeyName: domain.String("b")},
+		})
+
+		space1 := mock_space.NewMockSpace(t)
+		space1.EXPECT().Id().Return(spaceId1)
+		space1.EXPECT().StoredIds().Return([]string{}).Maybe()
+		var calls int
+		space1.EXPECT().FilterNotExists(mock.Anything).
+			RunAndReturn(func(ids []string) []string {
+				calls++
+				require.Len(t, ids, 1, "must be filtered one batch at a time")
+				if ids[0] == "2" {
+					return nil // "2" got loaded into the cache before its batch
+				}
+				return ids
+			})
+
+		fx.addSyncDetails(space1)
+
+		assert.Equal(t, 2, calls, "FilterNotExists must be called once per batch")
+
+		got1, err := fx.objectStore.GetDetails(spaceId1, "1")
+		require.NoError(t, err)
+		assert.True(t, got1.Has(bundle.RelationKeySyncStatus), "uncached id is written")
+
+		got2, err := fx.objectStore.GetDetails(spaceId1, "2")
+		require.NoError(t, err)
+		assert.False(t, got2.Has(bundle.RelationKeySyncStatus), "id cached mid-run is skipped")
 	})
 }
 

--- a/core/indexer/reindex_test.go
+++ b/core/indexer/reindex_test.go
@@ -197,6 +197,7 @@ func TestIndexer_ReindexSpace_RemoveParticipants(t *testing.T) {
 			spc := mock_space.NewMockSpace(t)
 			spc.EXPECT().Id().Return(space)
 			spc.EXPECT().Storage().Return(storage).Maybe()
+			spc.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).Return(nil).Maybe()
 			fx.sourceFx.EXPECT().IDsListerBySmartblockType(mock.Anything, mock.Anything).Return(idsLister{Ids: []string{}}, nil).Maybe()
 
 			// when
@@ -304,6 +305,7 @@ func TestIndexer_ReindexSpace_EraseLinks(t *testing.T) {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId1)
 		space1.EXPECT().Storage().Return(storage).Maybe()
+		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		// when
 		err = fx.ReindexSpace(space1)
@@ -345,6 +347,7 @@ func TestIndexer_ReindexSpace_EraseLinks(t *testing.T) {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId2)
 		space1.EXPECT().Storage().Return(storage).Maybe()
+		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).Return(nil).Maybe()
 		// when
 		err = fx.ReindexSpace(space1)
 		assert.NoError(t, err)
@@ -367,86 +370,106 @@ func TestIndexer_ReindexSpace_EraseLinks(t *testing.T) {
 }
 
 func TestReindex_addSyncRelations(t *testing.T) {
-	t.Run("addSyncRelations local only", func(t *testing.T) {
-		// given
-		const spaceId1 = "spaceId1"
-		fx := newFixture(t)
+	const spaceId1 = "spaceId1"
 
-		fx.objectStore.AddObjects(t, spaceId1, []objectstore.TestObject{
-			{
-				bundle.RelationKeyId:        domain.String("1"),
-				bundle.RelationKeyIsDeleted: domain.Bool(true),
-			},
-			{
-				bundle.RelationKeyId:        domain.String("2"),
-				bundle.RelationKeyIsDeleted: domain.Bool(true),
-			},
-		})
-
+	// newSpace returns a space whose DoLockedIfNotExists actually runs the
+	// passed proc (object is treated as not loaded), so writes hit the store.
+	newSpace := func(t *testing.T) *mock_space.MockSpace {
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId1)
 		space1.EXPECT().StoredIds().Return([]string{}).Maybe()
+		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).
+			RunAndReturn(func(_ string, proc func() error) error {
+				return proc()
+			}).Maybe()
+		return space1
+	}
 
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypePage).Return(idsLister{Ids: []string{"1", "2"}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeRelation).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeRelationOption).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeFileObject).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeObjectType).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeTemplate).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeProfilePage).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeChatDerivedObject).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeDiscussionObject).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeChatObjectDeprecated).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeSpaceView).Return(idsLister{Ids: []string{}}, nil)
+	t.Run("first run writes sync details for objects missing them", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.config.NetworkMode = pb.RpcAccount_DefaultConfig
+		fx.objectStore.AddObjects(t, spaceId1, []objectstore.TestObject{
+			{bundle.RelationKeyId: domain.String("1"), bundle.RelationKeyName: domain.String("a")},
+			{bundle.RelationKeyId: domain.String("2"), bundle.RelationKeyName: domain.String("b")},
+		})
 
-		space1.EXPECT().DoLockedIfNotExists("1", mock.AnythingOfType("func() error")).Return(nil)
-		space1.EXPECT().DoLockedIfNotExists("2", mock.AnythingOfType("func() error")).Return(nil)
+		fx.addSyncDetails(newSpace(t))
 
-		// when
-		fx.addSyncDetails(space1)
-
-		// then
+		for _, id := range []string{"1", "2"} {
+			got, err := fx.objectStore.GetDetails(spaceId1, id)
+			require.NoError(t, err)
+			assert.True(t, got.Has(bundle.RelationKeySyncStatus))
+			assert.Equal(t, int64(domain.ObjectSyncStatusSynced), got.GetInt64(bundle.RelationKeySyncStatus))
+			assert.Equal(t, int64(domain.SyncErrorNull), got.GetInt64(bundle.RelationKeySyncError))
+			assert.NotZero(t, got.GetInt64(bundle.RelationKeySyncDate))
+		}
 	})
 
-	t.Run("addSyncRelations", func(t *testing.T) {
-		// given
-		const spaceId1 = "spaceId1"
-		fx := newFixture(t)
+	t.Run("local only mode writes error status", func(t *testing.T) {
+		fx := newFixture(t) // default fixture config is LocalOnly
+		fx.objectStore.AddObjects(t, spaceId1, []objectstore.TestObject{
+			{bundle.RelationKeyId: domain.String("1"), bundle.RelationKeyName: domain.String("a")},
+		})
 
+		fx.addSyncDetails(newSpace(t))
+
+		got, err := fx.objectStore.GetDetails(spaceId1, "1")
+		require.NoError(t, err)
+		assert.Equal(t, int64(domain.ObjectSyncStatusError), got.GetInt64(bundle.RelationKeySyncStatus))
+		assert.Equal(t, int64(domain.SyncErrorNetworkError), got.GetInt64(bundle.RelationKeySyncError))
+	})
+
+	t.Run("repeat run is a no-op when sync details already present", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.config.NetworkMode = pb.RpcAccount_DefaultConfig
 		fx.objectStore.AddObjects(t, spaceId1, []objectstore.TestObject{
 			{
-				bundle.RelationKeyId:        domain.String("1"),
-				bundle.RelationKeyIsDeleted: domain.Bool(true),
-			},
-			{
-				bundle.RelationKeyId:        domain.String("2"),
-				bundle.RelationKeyIsDeleted: domain.Bool(true),
+				bundle.RelationKeyId:         domain.String("1"),
+				bundle.RelationKeyName:       domain.String("a"),
+				bundle.RelationKeySyncStatus: domain.Int64(int64(domain.ObjectSyncStatusSynced)),
+				bundle.RelationKeySyncDate:   domain.Int64(123), // sentinel; must not be bumped
+				bundle.RelationKeySyncError:  domain.Int64(int64(domain.SyncErrorNull)),
 			},
 		})
 
 		space1 := mock_space.NewMockSpace(t)
 		space1.EXPECT().Id().Return(spaceId1)
 		space1.EXPECT().StoredIds().Return([]string{}).Maybe()
+		// Nothing is missing, so no object must be touched.
+		space1.EXPECT().DoLockedIfNotExists(mock.Anything, mock.Anything).
+			Run(func(string, func() error) { t.Fatal("unexpected write: repeat run must be a no-op") }).
+			Return(nil).Maybe()
 
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypePage).Return(idsLister{Ids: []string{"1", "2"}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeRelation).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeRelationOption).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeFileObject).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeObjectType).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeTemplate).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeProfilePage).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeChatDerivedObject).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeDiscussionObject).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeChatObjectDeprecated).Return(idsLister{Ids: []string{}}, nil)
-		fx.sourceFx.EXPECT().IDsListerBySmartblockType(space1, coresb.SmartBlockTypeSpaceView).Return(idsLister{Ids: []string{}}, nil)
-
-		space1.EXPECT().DoLockedIfNotExists("1", mock.AnythingOfType("func() error")).Return(nil)
-		space1.EXPECT().DoLockedIfNotExists("2", mock.AnythingOfType("func() error")).Return(nil)
-
-		fx.config.NetworkMode = pb.RpcAccount_DefaultConfig
-
-		// when
 		fx.addSyncDetails(space1)
+
+		got, err := fx.objectStore.GetDetails(spaceId1, "1")
+		require.NoError(t, err)
+		assert.Equal(t, int64(123), got.GetInt64(bundle.RelationKeySyncDate))
+	})
+
+	t.Run("missing relation is added without overwriting existing ones", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.config.NetworkMode = pb.RpcAccount_DefaultConfig
+		fx.objectStore.AddObjects(t, spaceId1, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:         domain.String("1"),
+				bundle.RelationKeyName:       domain.String("a"),
+				bundle.RelationKeySyncStatus: domain.Int64(int64(domain.ObjectSyncStatusSyncing)),
+				bundle.RelationKeySyncDate:   domain.Int64(777),
+				// SyncError is missing
+			},
+		})
+
+		fx.addSyncDetails(newSpace(t))
+
+		got, err := fx.objectStore.GetDetails(spaceId1, "1")
+		require.NoError(t, err)
+		// Existing values preserved: InjectsSyncDetails is only-if-absent.
+		assert.Equal(t, int64(domain.ObjectSyncStatusSyncing), got.GetInt64(bundle.RelationKeySyncStatus))
+		assert.Equal(t, int64(777), got.GetInt64(bundle.RelationKeySyncDate))
+		// Missing one is added.
+		assert.True(t, got.Has(bundle.RelationKeySyncError))
+		assert.Equal(t, int64(domain.SyncErrorNull), got.GetInt64(bundle.RelationKeySyncError))
 	})
 }
 

--- a/pkg/lib/localstore/objectstore/spaceindex/invalid.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/invalid.go
@@ -103,6 +103,14 @@ func (s *invalidStore) ModifyObjectDetails(id string, proc func(details *domain.
 	return s.err
 }
 
+func (s *invalidStore) ModifyObjectDetailsCtx(ctx context.Context, id string, proc func(details *domain.Details) (*domain.Details, bool, error), upsert bool) error {
+	return s.err
+}
+
+func (s *invalidStore) ListIdsWithoutSyncDetails(ctx context.Context) ([]string, error) {
+	return nil, s.err
+}
+
 func (s *invalidStore) DeleteObject(id string) error {
 	return s.err
 }
@@ -226,7 +234,6 @@ func (s *invalidStore) GetHeadsWithFtQueueCtrGreaterThan(ctx context.Context, th
 func (s *invalidStore) ClearHeadsState(ctx context.Context) error {
 	return s.err
 }
-
 
 func (s *invalidStore) WriteTx(ctx context.Context) (anystore.WriteTx, error) {
 	return nil, s.err

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -71,6 +71,14 @@ type Store interface {
 	UpdateObjectLinksDetailed(ctx context.Context, id string, outgoingLinks []OutgoingLink) error
 	UpdatePendingLocalDetails(id string, proc func(details *domain.Details) (*domain.Details, error)) error
 	ModifyObjectDetails(id string, proc func(details *domain.Details) (*domain.Details, bool, error), upsert bool) error
+	// ModifyObjectDetailsCtx is like ModifyObjectDetails but runs under the
+	// provided context instead of the store component context. Pass a tx-bearing
+	// context (see WriteTx) to batch many modifications into a single write tx.
+	ModifyObjectDetailsCtx(ctx context.Context, id string, proc func(details *domain.Details) (*domain.Details, bool, error), upsert bool) error
+	// ListIdsWithoutSyncDetails returns ids of objects that are missing at least
+	// one of the relations maintained by helper.InjectsSyncDetails
+	// (SyncStatus/SyncDate/SyncError). Presence, not value, is checked.
+	ListIdsWithoutSyncDetails(ctx context.Context) ([]string, error)
 
 	DeleteObject(id string) error
 	DeleteDetails(ctx context.Context, ids []string) error

--- a/pkg/lib/localstore/objectstore/spaceindex/sync.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/sync.go
@@ -1,0 +1,52 @@
+package spaceindex
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/anyproto/any-store/query"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+)
+
+// syncDetailRelations are the relations maintained by helper.InjectsSyncDetails.
+// Keep in sync with that function.
+var syncDetailRelations = []domain.RelationKey{
+	bundle.RelationKeySyncStatus,
+	bundle.RelationKeySyncDate,
+	bundle.RelationKeySyncError,
+}
+
+func (s *dsObjectStore) ListIdsWithoutSyncDetails(ctx context.Context) ([]string, error) {
+	// An object needs sync details when at least one of the relations is
+	// absent. Presence (not value) must be used: SyncStatusSynced and
+	// SyncErrorNull are both the zero enum value, so a value/Empty filter
+	// would re-select every already-synced object on each start.
+	orFilter := make(query.Or, 0, len(syncDetailRelations))
+	for _, key := range syncDetailRelations {
+		orFilter = append(orFilter, query.Key{
+			Path:   []string{string(key)},
+			Filter: query.Not{Filter: query.Exists{}},
+		})
+	}
+
+	iter, err := s.objects.Find(orFilter).Iter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("find objects without sync details: %w", err)
+	}
+	defer iter.Close()
+
+	var ids []string
+	for iter.Next() {
+		doc, err := iter.Doc()
+		if err != nil {
+			return nil, fmt.Errorf("get doc: %w", err)
+		}
+		ids = append(ids, doc.Value().Get("id").GetString())
+	}
+	if err = iter.Err(); err != nil {
+		return nil, fmt.Errorf("iterate objects without sync details: %w", err)
+	}
+	return ids, nil
+}

--- a/pkg/lib/localstore/objectstore/spaceindex/sync.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/sync.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/anyproto/any-store/anyenc"
 	"github.com/anyproto/any-store/query"
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
 // syncDetailRelations are the relations maintained by helper.InjectsSyncDetails.
@@ -18,20 +20,52 @@ var syncDetailRelations = []domain.RelationKey{
 	bundle.RelationKeySyncError,
 }
 
+// nonSyncableLayouts are layouts of objects that are indexed with details but
+// are not syncable as objects (derived/system/virtual), so they must not get
+// sync details. The last few are not indexed with details at all
+// (smartblock.Indexable -> false) and are listed only to keep the intent
+// explicit. Everything not listed here is treated as a real, syncable object.
+var nonSyncableLayouts = []model.ObjectTypeLayout{
+	model.ObjectType_dashboard,           // Home
+	model.ObjectType_space,               // space/workspace object
+	model.ObjectType_relationOptionsList, // not a real object
+	model.ObjectType_spaceView,
+	model.ObjectType_participant, // ACL-derived
+	model.ObjectType_date,        // synthetic, not stored
+	model.ObjectType_notification,
+	model.ObjectType_missingObject,
+	model.ObjectType_devices,
+}
+
 func (s *dsObjectStore) ListIdsWithoutSyncDetails(ctx context.Context) ([]string, error) {
 	// An object needs sync details when at least one of the relations is
 	// absent. Presence (not value) must be used: SyncStatusSynced and
 	// SyncErrorNull are both the zero enum value, so a value/Empty filter
 	// would re-select every already-synced object on each start.
-	orFilter := make(query.Or, 0, len(syncDetailRelations))
+	missing := make(query.Or, 0, len(syncDetailRelations))
 	for _, key := range syncDetailRelations {
-		orFilter = append(orFilter, query.Key{
+		missing = append(missing, query.Key{
 			Path:   []string{string(key)},
 			Filter: query.Not{Filter: query.Exists{}},
 		})
 	}
 
-	iter, err := s.objects.Find(orFilter).Iter(ctx)
+	// Exclude non-syncable system/derived layouts. Objects without a
+	// resolvedLayout are kept: In.Ok returns false for an absent value, so the
+	// Not is true and real objects are never dropped.
+	arena := &anyenc.Arena{}
+	excludedLayouts := make([]*anyenc.Value, 0, len(nonSyncableLayouts))
+	for _, layout := range nonSyncableLayouts {
+		excludedLayouts = append(excludedLayouts, domain.Int64(int64(layout)).ToAnyEnc(arena))
+	}
+	notSystem := query.Not{Filter: query.Key{
+		Path:   []string{string(bundle.RelationKeyResolvedLayout)},
+		Filter: query.NewInValue(excludedLayouts...),
+	}}
+
+	filter := query.And{missing, notSystem}
+
+	iter, err := s.objects.Find(filter).Iter(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("find objects without sync details: %w", err)
 	}

--- a/pkg/lib/localstore/objectstore/spaceindex/sync_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/sync_test.go
@@ -1,0 +1,61 @@
+package spaceindex
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+)
+
+func TestListIdsWithoutSyncDetails(t *testing.T) {
+	t.Run("returns only ids missing at least one sync relation", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{
+			// Complete: has all three sync relations, with the zero-valued
+			// "Synced"/"Null" enums explicitly present. Presence (not value)
+			// must keep it out of the result, otherwise every synced object
+			// would be reprocessed forever.
+			{
+				bundle.RelationKeyId:         domain.String("complete"),
+				bundle.RelationKeySyncStatus: domain.Int64(0),
+				bundle.RelationKeySyncDate:   domain.Int64(1700000000),
+				bundle.RelationKeySyncError:  domain.Int64(0),
+			},
+			// Missing SyncStatus only.
+			{
+				bundle.RelationKeyId:        domain.String("missingStatus"),
+				bundle.RelationKeySyncDate:  domain.Int64(1700000000),
+				bundle.RelationKeySyncError: domain.Int64(0),
+			},
+			// Missing everything.
+			{
+				bundle.RelationKeyId:   domain.String("missingAll"),
+				bundle.RelationKeyName: domain.String("foo"),
+			},
+		})
+
+		ids, err := s.ListIdsWithoutSyncDetails(context.Background())
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"missingStatus", "missingAll"}, ids)
+	})
+
+	t.Run("returns empty when all objects already have sync relations", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{
+			{
+				bundle.RelationKeyId:         domain.String("a"),
+				bundle.RelationKeySyncStatus: domain.Int64(0),
+				bundle.RelationKeySyncDate:   domain.Int64(1700000000),
+				bundle.RelationKeySyncError:  domain.Int64(0),
+			},
+		})
+
+		ids, err := s.ListIdsWithoutSyncDetails(context.Background())
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}

--- a/pkg/lib/localstore/objectstore/spaceindex/sync_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/sync_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
 func TestListIdsWithoutSyncDetails(t *testing.T) {
@@ -41,6 +42,39 @@ func TestListIdsWithoutSyncDetails(t *testing.T) {
 		ids, err := s.ListIdsWithoutSyncDetails(context.Background())
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"missingStatus", "missingAll"}, ids)
+	})
+
+	t.Run("excludes non-syncable system layouts", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{
+			// In scope: real object, no layout set -> must be returned.
+			{
+				bundle.RelationKeyId:   domain.String("page"),
+				bundle.RelationKeyName: domain.String("foo"),
+			},
+			// In scope: basic layout -> must be returned.
+			{
+				bundle.RelationKeyId:             domain.String("basic"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			},
+			// Out of scope: derived/system layouts -> must be skipped.
+			{
+				bundle.RelationKeyId:             domain.String("participant"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_participant)),
+			},
+			{
+				bundle.RelationKeyId:             domain.String("home"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_dashboard)),
+			},
+			{
+				bundle.RelationKeyId:             domain.String("spaceView"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_spaceView)),
+			},
+		})
+
+		ids, err := s.ListIdsWithoutSyncDetails(context.Background())
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"page", "basic"}, ids)
 	})
 
 	t.Run("returns empty when all objects already have sync relations", func(t *testing.T) {

--- a/pkg/lib/localstore/objectstore/spaceindex/update.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/update.go
@@ -184,6 +184,15 @@ func (s *dsObjectStore) UpdatePendingLocalDetails(id string, proc func(details *
 // ModifyObjectDetails updates details in store using modification function `proc`.
 // When upsert is true, the object is created if it does not exist; when false, missing objects are silently skipped.
 func (s *dsObjectStore) ModifyObjectDetails(id string, proc func(details *domain.Details) (*domain.Details, bool, error), upsert bool) error {
+	return s.ModifyObjectDetailsCtx(s.componentCtx, id, proc, upsert)
+}
+
+// ModifyObjectDetailsCtx is like ModifyObjectDetails but runs under the
+// provided context instead of the store component context. Pass a tx-bearing
+// context (see WriteTx) to batch many modifications into a single write tx and,
+// when the context is non-cancelable, to skip any-store's per-statement
+// SQLite interrupt handshake.
+func (s *dsObjectStore) ModifyObjectDetailsCtx(ctx context.Context, id string, proc func(details *domain.Details) (*domain.Details, bool, error), upsert bool) error {
 	if proc == nil {
 		return nil
 	}
@@ -223,9 +232,9 @@ func (s *dsObjectStore) ModifyObjectDetails(id string, proc func(details *domain
 	})
 	var err error
 	if upsert {
-		_, err = s.objects.UpsertId(s.componentCtx, id, modifier)
+		_, err = s.objects.UpsertId(ctx, id, modifier)
 	} else {
-		_, err = s.objects.UpdateId(s.componentCtx, id, modifier)
+		_, err = s.objects.UpdateId(ctx, id, modifier)
 		if errors.Is(err, anystore.ErrDocNotFound) {
 			return nil
 		}

--- a/pkg/lib/localstore/objectstore/spaceindex/update_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/update_test.go
@@ -96,6 +96,53 @@ func TestUpdateObjectDetails(t *testing.T) {
 	})
 }
 
+func TestModifyObjectDetailsCtx(t *testing.T) {
+	t.Run("participates in the provided write tx and is rolled back with it", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{makeObjectWithName("id1", "foo")})
+
+		txn, err := s.WriteTx(context.Background())
+		require.NoError(t, err)
+
+		err = s.ModifyObjectDetailsCtx(txn.Context(), "id1", func(d *domain.Details) (*domain.Details, bool, error) {
+			d.SetString(bundle.RelationKeyDescription, "in-tx")
+			return d, true, nil
+		}, true)
+		require.NoError(t, err)
+		require.NoError(t, txn.Rollback())
+
+		got, err := s.GetDetails("id1")
+		require.NoError(t, err)
+		assert.False(t, got.Has(bundle.RelationKeyDescription))
+		assert.Equal(t, "foo", got.GetString(bundle.RelationKeyName))
+	})
+
+	t.Run("commits many modifications with the provided write tx", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{
+			makeObjectWithName("id1", "foo"),
+			makeObjectWithName("id2", "bar"),
+		})
+
+		txn, err := s.WriteTx(context.Background())
+		require.NoError(t, err)
+		for _, id := range []string{"id1", "id2"} {
+			err = s.ModifyObjectDetailsCtx(txn.Context(), id, func(d *domain.Details) (*domain.Details, bool, error) {
+				d.SetString(bundle.RelationKeyDescription, "committed")
+				return d, true, nil
+			}, true)
+			require.NoError(t, err)
+		}
+		require.NoError(t, txn.Commit())
+
+		for _, id := range []string{"id1", "id2"} {
+			got, err := s.GetDetails(id)
+			require.NoError(t, err)
+			assert.Equal(t, "committed", got.GetString(bundle.RelationKeyDescription))
+		}
+	})
+}
+
 func TestSendUpdatesToSubscriptions(t *testing.T) {
 	t.Run("with details are not changed expect no updates are sent", func(t *testing.T) {
 		s := NewStoreFixture(t)

--- a/space/clientspace/mock_clientspace/mock_Space.go
+++ b/space/clientspace/mock_clientspace/mock_Space.go
@@ -1021,6 +1021,54 @@ func (_c *MockSpace_DoLockedIfNotExists_Call) RunAndReturn(run func(string, func
 	return _c
 }
 
+// FilterNotExists provides a mock function with given fields: ids
+func (_m *MockSpace) FilterNotExists(ids []string) []string {
+	ret := _m.Called(ids)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FilterNotExists")
+	}
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func([]string) []string); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
+// MockSpace_FilterNotExists_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FilterNotExists'
+type MockSpace_FilterNotExists_Call struct {
+	*mock.Call
+}
+
+// FilterNotExists is a helper method to define mock.On call
+//   - ids []string
+func (_e *MockSpace_Expecter) FilterNotExists(ids interface{}) *MockSpace_FilterNotExists_Call {
+	return &MockSpace_FilterNotExists_Call{Call: _e.mock.On("FilterNotExists", ids)}
+}
+
+func (_c *MockSpace_FilterNotExists_Call) Run(run func(ids []string)) *MockSpace_FilterNotExists_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *MockSpace_FilterNotExists_Call) Return(_a0 []string) *MockSpace_FilterNotExists_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSpace_FilterNotExists_Call) RunAndReturn(run func([]string) []string) *MockSpace_FilterNotExists_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAclIdentity provides a mock function with no fields
 func (_m *MockSpace) GetAclIdentity() crypto.PubKey {
 	ret := _m.Called()


### PR DESCRIPTION
## Problem

`indexer.addSyncDetails` ran on every cold start: it iterated every object + all types/relations/options in the space and, per id, opened a fresh any-store write tx (`BEGIN IMMEDIATE...COMMIT`) plus a per-statement SQLite `SetInterrupt` goroutine/channel handshake. In an Android cold-start profile this was the dominant indexer write cost (~6.9s of `UpsertId`) and ~50% of startup scheduler-latency — despite being a no-op once sync details already exist (the modifier diff-gates the write, but the tx + `loadById` SELECT + interrupt handshake were still paid per object).

## Change

- **`spaceindex.ListIdsWithoutSyncDetails`** — one bulk **presence-based** query (`Exists`-negation over `SyncStatus`/`SyncDate`/`SyncError`) exactly matching `helper.InjectsSyncDetails`. Presence, not value: `SyncStatusSynced`/`SyncErrorNull` are the zero enum, so a value/`Empty` filter would reselect every synced object on every start.
- **Scope** — the query also excludes non-syncable system/derived layouts via `resolvedLayout NOT IN(...)` (`query.NewInValue`): dashboard, space, relationOptionsList, spaceView, participant, date, notification, missingObject, devices. Objects without `resolvedLayout` are kept (`In.Ok` is false for an absent value), so real objects are never dropped. This keeps derived objects (participants, home, ...) out of the sync backfill, matching the previous type-scoped behavior.
- **`spaceindex.ModifyObjectDetailsCtx`** — tx-aware entrypoint; `ModifyObjectDetails` delegates with `componentCtx` (no behavior change for existing callers).
- **`addSyncDetails` rewrite** — query missing ids, write them in chunked (500/tx) shared write transactions (savepoint path, no per-object `BEGIN IMMEDIATE`) under `context.WithoutCancel`, so any-store skips the per-statement interrupt handshake.

## Cost

- **Steady state:** one bulk query, **zero writes**, no per-statement interrupt. (was: N × tx+SELECT+interrupt)
- **First launch:** bounded batched backfill via savepoints, no interrupt handshake.

## Correctness

- Query matches `InjectsSyncDetails` exactly (only-if-absent, presence-based).
- Derived/system objects excluded by layout, so they don't get spurious sync details (participant/home/spaceView/...).
- Per-id `space.DoLockedIfNotExists` retained — required to avoid racing live in-memory objects; only called for genuinely-missing ids (≈0 in steady state).
- `WithoutCancel` is justified: bounded, internal maintenance pass.
- No durability change (`synchronous`/WAL/checkpoint untouched).

## Testing

- `TestListIdsWithoutSyncDetails` — presence-not-value; excludes system layouts; empty when all present.
- `TestModifyObjectDetailsCtx` — participates in caller tx (rollback/commit).
- `TestReindex_addSyncRelations` — first-run / local-only / repeat no-op / partial-add.
- `go build ./...` clean; `spaceindex` + `indexer` suites pass, incl. `-race`.