### PR TITLE
GO-6962 personalfavorites: persist widget layout/limit/viewId via Apply override

### DIFF
--- a/core/block/editor/personalfavorites/virtualwidget.go
+++ b/core/block/editor/personalfavorites/virtualwidget.go
@@ -332,3 +332,27 @@ func (v *VirtualWidgetObject) Unlink(ctx session.Context, ids ...string) (err er
 	widget.UnlinkWithWrapper(st, ids...)
 	return v.Apply(st)
 }
+
+// Update overrides basic.Updatable so block mutations (e.g. BlockWidgetSetLayout,
+// SetLimit, SetViewId) are applied through v.Apply — the override that diffs the
+// pre/post state and pushes the per-entry delta to the CRDT store.
+//
+// basic.Update calls its embedded SmartBlock.Apply directly, which bypasses
+// VirtualWidgetObject.Apply. Without this override a layout/limit/viewId change
+// would mutate only the in-memory block state and never reach the store; the
+// next store-triggered rebuildAll (e.g. after a reorder) would then overwrite
+// the in-memory value with the stale store value, and the change would not
+// survive a restart.
+func (v *VirtualWidgetObject) Update(ctx session.Context, apply func(b simple.Block) error, blockIds ...string) (err error) {
+	st := v.NewStateCtx(ctx)
+	for _, id := range blockIds {
+		b := st.Get(id)
+		if b == nil {
+			return smartblock.ErrSimpleBlockNotFound
+		}
+		if err = apply(b); err != nil {
+			return err
+		}
+	}
+	return v.Apply(st)
+}

--- a/core/block/editor/personalfavorites/virtualwidget_test.go
+++ b/core/block/editor/personalfavorites/virtualwidget_test.go
@@ -429,6 +429,69 @@ func TestApply_doesNotClobberConcurrentRemoteEntry(t *testing.T) {
 	assert.Empty(t, stub.creates)
 }
 
+// TestUpdate_pushesDeltaToStore locks the regression behind the
+// "personal-favorites widget layout reset on reorder" bug: BlockWidgetSetLayout
+// (and SetLimit/SetViewId) flow through basic.Updatable.Update. The base
+// basic.Update calls its embedded SmartBlock.Apply directly, which bypasses
+// VirtualWidgetObject.Apply and never pushes the change to the CRDT store. As a
+// result the layout lived only in memory and a later store-triggered rebuild
+// (e.g. after a reorder) would overwrite it with the stale store value.
+//
+// VirtualWidgetObject.Update overrides Update so it applies through v.Apply,
+// which diffs the state and pushes the per-entry op. This test asserts the
+// store actually receives the layout update.
+func TestUpdate_pushesDeltaToStore(t *testing.T) {
+	const (
+		spaceId = "spaceA"
+		linkId  = "l1"
+	)
+	existing := personalfavorites.WidgetEntry{
+		Id: linkId, SpaceId: spaceId, TargetId: "targetA",
+		Layout: model.BlockContentWidget_Link, Limit: 5, ViewId: "vA",
+	}
+
+	stub := &stubService{
+		getWidgetsFn: func(context.Context, string) ([]personalfavorites.WidgetEntry, error) {
+			return []personalfavorites.WidgetEntry{existing}, nil
+		},
+	}
+
+	sb := smarttest.New("root")
+	sb.SetSpaceId(spaceId)
+	sb.Doc = buildDoc(widgetBlock{
+		wrapperId: linkId + widgetWrapperSuffix,
+		linkId:    linkId,
+		target:    existing.TargetId,
+		layout:    existing.Layout,
+		limit:     existing.Limit,
+		view:      existing.ViewId,
+	})
+
+	v := NewVirtualWidget(sb, nil, stub, nil)
+
+	// Simulate SetWidgetBlockLayout: mutate the wrapper's widget layout via the
+	// Updatable.Update path on the wrapper block id.
+	err := v.Update(nil, func(b simple.Block) error {
+		wc, ok := b.Model().Content.(*model.BlockContentOfWidget)
+		require.True(t, ok, "block is not a widget wrapper (%T)", b.Model().Content)
+		wc.Widget.Layout = model.BlockContentWidget_Tree
+		return nil
+	}, linkId+widgetWrapperSuffix)
+	require.NoError(t, err)
+
+	// The layout change must have reached the store as a single layout update.
+	require.Len(t, stub.updates, 1, "layout change was not pushed to the store")
+	assert.Equal(t, linkId, stub.updates[0].id)
+	require.NotNil(t, stub.updates[0].update.Layout)
+	assert.Equal(t, model.BlockContentWidget_Tree, *stub.updates[0].update.Layout)
+	assert.Empty(t, stub.creates)
+	assert.Empty(t, stub.deletes)
+
+	// And the in-memory wrapper reflects the new layout.
+	got := pickWidget(t, v.NewState(), linkId+widgetWrapperSuffix)
+	assert.Equal(t, model.BlockContentWidget_Tree, got.Layout)
+}
+
 func TestPushDelta(t *testing.T) {
 	const spaceId = "spaceA"
 


### PR DESCRIPTION
## Problem
On the personal-favorites virtual widget, changing a widget's layout via `BlockWidgetSetLayout` (or `SetLimit`/`SetViewId`) did not persist. `ObjectShow` right after the call reported the new layout, but any subsequent store-triggered rebuild (e.g. reordering a sibling widget with `BlockListMoveToExistingObject`) silently reverted it, and the change did not survive an account restart.

## Root cause
`VirtualWidgetObject.Apply` is the only path that diffs pre/post block state and pushes per-entry ops to the CRDT store (`pushDelta`). But `BlockWidgetSetLayout/SetLimit/SetViewId` reach the object through `basic.Updatable.Update` (`core/block/editor/basic/basic.go`), which ends with the embedded `SmartBlock.Apply` and **bypasses** `VirtualWidgetObject.Apply`. So the mutation only touched in-memory state and never reached the store. The next store-triggered `rebuildAll` then overwrote the in-memory value with the stale store value — layout reverted on reorder and did not survive restart. Every other VW mutation (`Move`, `Unlink`, `SetTargetId`) already routes through `v.Apply`; `Update` was the outlier.

## Fix
Add an `Update` override on `*VirtualWidgetObject` that mirrors `basic.Update` but finishes with `v.Apply(st)` instead of the embedded `SmartBlock.Apply`, so widget mutations route through `pushDelta` to the store. 24 lines, plus a regression unit test (`TestUpdate_pushesDeltaToStore`).

## Verification
- `go test ./core/block/editor/personalfavorites/` — pass (new regression test fails on old code path).
- anytype-suite integration test `blocks/widget-personal-favorites.test.ts` ("create, reorder, reconfigure, delete and persist personal widgets") — **was failing, now passes** against a server built from this branch.