### PR TITLE
GO-6052 bookmark: set CreatedInContextRef on bookmark images so GC cascade-archives them

### DIFF
--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -244,27 +244,30 @@ func (s *service) updateFilesCreatedInContext(bookmarkObjectId string, content *
 		return
 	}
 
-	fileIds := []string{}
-	if content.BookmarkContent.ImageHash != "" {
-		fileIds = append(fileIds, content.BookmarkContent.ImageHash)
-	}
-	if content.BookmarkContent.FaviconHash != "" {
-		fileIds = append(fileIds, content.BookmarkContent.FaviconHash)
+	// The bookmark references these files via object relations (iconImage/picture)
+	// rather than via a block, so the in-context reference is the relation key the
+	// file is linked through. A non-empty CreatedInContextRef is required for object
+	// GC to cascade-archive these files when the bookmark is archived or deleted
+	// (see core/block/objectgc: the GC query gates on a non-empty CreatedInContextRef
+	// to leave collection-linked files untouched).
+	files := []struct {
+		fileId      string
+		relationKey domain.RelationKey
+	}{
+		{content.BookmarkContent.ImageHash, bundle.RelationKeyPicture},
+		{content.BookmarkContent.FaviconHash, bundle.RelationKeyIconImage},
 	}
 
-	for _, fileId := range fileIds {
-		err := s.detailsSetter.SetDetails(nil, fileId, []domain.Detail{
+	for _, f := range files {
+		if f.fileId == "" {
+			continue
+		}
+		err := s.detailsSetter.SetDetails(nil, f.fileId, []domain.Detail{
 			{Key: bundle.RelationKeyCreatedInContext, Value: domain.String(bookmarkObjectId)},
-			// The bookmark references these files via the iconImage/picture object
-			// relations rather than via a block, so the in-context reference is the
-			// bookmark object itself. A non-empty CreatedInContextRef is required for
-			// object GC to cascade-archive these files when the bookmark is archived or
-			// deleted (see core/block/objectgc: the GC query gates on a non-empty
-			// CreatedInContextRef to leave collection-linked files untouched).
-			{Key: bundle.RelationKeyCreatedInContextRef, Value: domain.String(bookmarkObjectId)},
+			{Key: bundle.RelationKeyCreatedInContextRef, Value: domain.String(f.relationKey.String())},
 		})
 		if err != nil {
-			log.Errorf("update CreatedInContext for file %s: %s", fileId, err)
+			log.Errorf("update CreatedInContext for file %s: %s", f.fileId, err)
 		}
 	}
 }

--- a/core/block/bookmark/bookmark_service.go
+++ b/core/block/bookmark/bookmark_service.go
@@ -255,6 +255,13 @@ func (s *service) updateFilesCreatedInContext(bookmarkObjectId string, content *
 	for _, fileId := range fileIds {
 		err := s.detailsSetter.SetDetails(nil, fileId, []domain.Detail{
 			{Key: bundle.RelationKeyCreatedInContext, Value: domain.String(bookmarkObjectId)},
+			// The bookmark references these files via the iconImage/picture object
+			// relations rather than via a block, so the in-context reference is the
+			// bookmark object itself. A non-empty CreatedInContextRef is required for
+			// object GC to cascade-archive these files when the bookmark is archived or
+			// deleted (see core/block/objectgc: the GC query gates on a non-empty
+			// CreatedInContextRef to leave collection-linked files untouched).
+			{Key: bundle.RelationKeyCreatedInContextRef, Value: domain.String(bookmarkObjectId)},
 		})
 		if err != nil {
 			log.Errorf("update CreatedInContext for file %s: %s", fileId, err)

--- a/core/block/bookmark/bookmark_service_test.go
+++ b/core/block/bookmark/bookmark_service_test.go
@@ -149,6 +149,8 @@ func TestService_updateFilesCreatedInContext(t *testing.T) {
 	// AND a non-empty CreatedInContextRef set so that object GC cascade-archives them
 	// when the bookmark is archived/deleted. The GC query (core/block/objectgc) gates
 	// on a non-empty CreatedInContextRef, so setting only CreatedInContext is not enough.
+	// CreatedInContextRef holds the relation key the bookmark links the file through
+	// (picture/iconImage), not the bookmark object id.
 	t.Run("sets CreatedInContext and CreatedInContextRef on icon and picture files", func(t *testing.T) {
 		// given
 		ds := &recordingDetailsSetter{}
@@ -158,19 +160,23 @@ func TestService_updateFilesCreatedInContext(t *testing.T) {
 			ImageHash:   "picture-file-id",
 			FaviconHash: "icon-file-id",
 		}}
+		wantRef := map[string]domain.RelationKey{
+			"picture-file-id": bundle.RelationKeyPicture,
+			"icon-file-id":    bundle.RelationKeyIconImage,
+		}
 
 		// when
 		s.updateFilesCreatedInContext(bk, content)
 
 		// then
-		for _, fileId := range []string{"picture-file-id", "icon-file-id"} {
+		for fileId, relationKey := range wantRef {
 			ctx, ok := ds.valueFor(fileId, bundle.RelationKeyCreatedInContext)
 			assert.True(t, ok, "CreatedInContext must be set for %s", fileId)
 			assert.Equal(t, bk, ctx.String())
 
 			ref, ok := ds.valueFor(fileId, bundle.RelationKeyCreatedInContextRef)
 			assert.True(t, ok, "CreatedInContextRef must be set for %s", fileId)
-			assert.Equal(t, bk, ref.String(), "CreatedInContextRef must be non-empty for GC to cascade-archive")
+			assert.Equal(t, relationKey.String(), ref.String(), "CreatedInContextRef must be the relation key the file is linked through, for GC to cascade-archive")
 		}
 	})
 

--- a/core/block/bookmark/bookmark_service_test.go
+++ b/core/block/bookmark/bookmark_service_test.go
@@ -33,6 +33,29 @@ func (ds *detailsSetter) SetDetails(session.Context, string, []domain.Detail) er
 	return nil
 }
 
+// recordingDetailsSetter captures the per-object detail updates so tests can
+// assert exactly which relations were written.
+type recordingDetailsSetter struct {
+	calls map[string][]domain.Detail
+}
+
+func (ds *recordingDetailsSetter) SetDetails(_ session.Context, objectId string, details []domain.Detail) error {
+	if ds.calls == nil {
+		ds.calls = map[string][]domain.Detail{}
+	}
+	ds.calls[objectId] = append(ds.calls[objectId], details...)
+	return nil
+}
+
+func (ds *recordingDetailsSetter) valueFor(objectId string, key domain.RelationKey) (domain.Value, bool) {
+	for _, d := range ds.calls[objectId] {
+		if d.Key == key {
+			return d.Value, true
+		}
+	}
+	return domain.Value{}, false
+}
+
 type fixture struct {
 	s *service
 
@@ -118,6 +141,50 @@ func TestService_CreateBookmarkObject(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, "bk", id)
+	})
+}
+
+func TestService_updateFilesCreatedInContext(t *testing.T) {
+	// Regression for GO-6052: bookmark image files must get both CreatedInContext
+	// AND a non-empty CreatedInContextRef set so that object GC cascade-archives them
+	// when the bookmark is archived/deleted. The GC query (core/block/objectgc) gates
+	// on a non-empty CreatedInContextRef, so setting only CreatedInContext is not enough.
+	t.Run("sets CreatedInContext and CreatedInContextRef on icon and picture files", func(t *testing.T) {
+		// given
+		ds := &recordingDetailsSetter{}
+		s := &service{detailsSetter: ds}
+		const bk = "bookmark-object-id"
+		content := &bookmark.ObjectContent{BookmarkContent: &model.BlockContentBookmark{
+			ImageHash:   "picture-file-id",
+			FaviconHash: "icon-file-id",
+		}}
+
+		// when
+		s.updateFilesCreatedInContext(bk, content)
+
+		// then
+		for _, fileId := range []string{"picture-file-id", "icon-file-id"} {
+			ctx, ok := ds.valueFor(fileId, bundle.RelationKeyCreatedInContext)
+			assert.True(t, ok, "CreatedInContext must be set for %s", fileId)
+			assert.Equal(t, bk, ctx.String())
+
+			ref, ok := ds.valueFor(fileId, bundle.RelationKeyCreatedInContextRef)
+			assert.True(t, ok, "CreatedInContextRef must be set for %s", fileId)
+			assert.Equal(t, bk, ref.String(), "CreatedInContextRef must be non-empty for GC to cascade-archive")
+		}
+	})
+
+	t.Run("no files - nothing is written", func(t *testing.T) {
+		// given
+		ds := &recordingDetailsSetter{}
+		s := &service{detailsSetter: ds}
+		content := &bookmark.ObjectContent{BookmarkContent: &model.BlockContentBookmark{}}
+
+		// when
+		s.updateFilesCreatedInContext("bookmark-object-id", content)
+
+		// then
+		assert.Empty(t, ds.calls)
 	})
 }
 


### PR DESCRIPTION
## Problem
Deleting/archiving a bookmark object did not archive its `iconImage`/`picture` file objects. They lingered un-archived (the anytype-suite test polls 20s for `isArchived` and times out).

## Root cause
Two interacting pieces:
1. The bookmark service sets only `CreatedInContext` on its image files, never `CreatedInContextRef` (`core/block/bookmark/bookmark_service.go` `updateFilesCreatedInContext`).
2. Object GC was scoped (commit b03a1b272, GO-7264 "Scope object GC to files with non-empty CreatedInContextRef") to require a **non-empty** `CreatedInContextRef` (`core/block/objectgc/objectgc.go` collect query + `ArchiveOrphansOnLinksRemoval`).

Because bookmark images had an empty `CreatedInContextRef`, they were filtered out of the GC query and never collected for archival when the bookmark was deleted. The GO-7264 hotfix (meant to leave collection-linked files alone) inadvertently regressed the GO-6052 bookmark cascade-archive.

## Fix
In `updateFilesCreatedInContext`, set `CreatedInContextRef = bookmarkObjectId` alongside `CreatedInContext` for bookmark image files. A bookmark references these files via the `iconImage`/`picture` object relations (not a block), so the in-context reference is the bookmark object itself. This is scoped strictly to bookmark images (collection-linked files still get an empty ref via a different path, preserving the GO-7264 protection); the ref value is used only as the GC NotEmpty gate, so it cannot cause over-eager archival.

## Verification
- `go test ./core/block/bookmark/ -run TestService_updateFilesCreatedInContext` — pass (asserts both `CreatedInContext` and `CreatedInContextRef` are set).
- anytype-suite integration test `bookmarks/bookmark-context.test.ts` ("should archive iconImage and picture when bookmark is deleted") — **was failing, now passes** against a server built from this branch.