### PR TITLE
GO-7302 Add file layouts to head-sync priority after discussions

### DIFF
--- a/core/block/priority_test.go
+++ b/core/block/priority_test.go
@@ -21,31 +21,28 @@ func TestService_GetPriorityIds(t *testing.T) {
 	const spaceId = "space1"
 	const otherSpaceId = "space2"
 
-	// seed a per-space chat subscription with the given ids and layouts
-	newService := func(chatDerivedIds, discussionIds []string, opened map[string]string) *Service {
-		var records []*domain.Details
-		for _, id := range chatDerivedIds {
-			records = append(records, domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-				bundle.RelationKeyId:             domain.String(id),
-				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_chatDerived)),
-			}))
-		}
-		for _, id := range discussionIds {
-			records = append(records, domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-				bundle.RelationKeyId:             domain.String(id),
-				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_discussion)),
-			}))
-		}
-		sub := objectsubscription.NewFromQueue(mb.New[*pb.EventMessage](0), chatPrioritySubParams, records)
+	record := func(id string, layout model.ObjectTypeLayout) *domain.Details {
+		return domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:             domain.String(id),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(layout)),
+		})
+	}
+
+	// seed a per-space priority subscription with the given records
+	newService := func(records []*domain.Details, opened map[string]string) *Service {
+		sub := objectsubscription.NewFromQueue(mb.New[*pb.EventMessage](0), prioritySubParams, records)
 		return &Service{
-			chatSubs:   map[string]*objectsubscription.ObjectSubscription[int64]{spaceId: sub},
-			openedObjs: &openedObjects{objects: opened, lock: &sync.Mutex{}},
+			prioritySubs: map[string]*objectsubscription.ObjectSubscription[int64]{spaceId: sub},
+			openedObjs:   &openedObjects{objects: opened, lock: &sync.Mutex{}},
 		}
 	}
 
 	t.Run("chat objects come first, then opened objects in the space", func(t *testing.T) {
 		// given: page1 (non-chat) is opened in this space
-		svc := newService([]string{"chatA", "chatB"}, nil, map[string]string{"page1": spaceId})
+		svc := newService([]*domain.Details{
+			record("chatA", model.ObjectType_chatDerived),
+			record("chatB", model.ObjectType_chatDerived),
+		}, map[string]string{"page1": spaceId})
 
 		// when
 		got := svc.GetPriorityIds(spaceId)
@@ -56,23 +53,34 @@ func TestService_GetPriorityIds(t *testing.T) {
 		assert.Equal(t, []string{"page1"}, got[2:])
 	})
 
-	t.Run("chatDerived chats come before discussion objects", func(t *testing.T) {
-		// given: a mix of space-level chats and discussions, plus an opened page
-		svc := newService([]string{"chatA", "chatB"}, []string{"discA", "discB"}, map[string]string{"page1": spaceId})
+	t.Run("chatDerived, then discussions, then files, then opened objects", func(t *testing.T) {
+		// given: a mix of chats, discussions and files, plus an opened page
+		svc := newService([]*domain.Details{
+			record("fileA", model.ObjectType_file),
+			record("discA", model.ObjectType_discussion),
+			record("chatA", model.ObjectType_chatDerived),
+			record("imageA", model.ObjectType_image),
+			record("discB", model.ObjectType_discussion),
+			record("chatB", model.ObjectType_chatDerived),
+		}, map[string]string{"page1": spaceId})
 
 		// when
 		got := svc.GetPriorityIds(spaceId)
 
-		// then: chatDerived first, discussions after, opened page last
-		require.Len(t, got, 5)
+		// then: chatDerived first, discussions next, files after, opened page last
+		require.Len(t, got, 7)
 		assert.ElementsMatch(t, []string{"chatA", "chatB"}, got[:2])
 		assert.ElementsMatch(t, []string{"discA", "discB"}, got[2:4])
-		assert.Equal(t, []string{"page1"}, got[4:])
+		assert.ElementsMatch(t, []string{"fileA", "imageA"}, got[4:6])
+		assert.Equal(t, []string{"page1"}, got[6:])
 	})
 
 	t.Run("a chat that is also open is listed once", func(t *testing.T) {
 		// given: chatA is both a chat and currently open in this space
-		svc := newService([]string{"chatA", "chatB"}, nil, map[string]string{"chatA": spaceId, "page1": spaceId})
+		svc := newService([]*domain.Details{
+			record("chatA", model.ObjectType_chatDerived),
+			record("chatB", model.ObjectType_chatDerived),
+		}, map[string]string{"chatA": spaceId, "page1": spaceId})
 
 		// when
 		got := svc.GetPriorityIds(spaceId)
@@ -85,7 +93,10 @@ func TestService_GetPriorityIds(t *testing.T) {
 
 	t.Run("opened objects from other spaces are excluded", func(t *testing.T) {
 		// given: an object opened in a different space
-		svc := newService([]string{"chatA", "chatB"}, nil, map[string]string{"otherPage": otherSpaceId})
+		svc := newService([]*domain.Details{
+			record("chatA", model.ObjectType_chatDerived),
+			record("chatB", model.ObjectType_chatDerived),
+		}, map[string]string{"otherPage": otherSpaceId})
 
 		// when
 		got := svc.GetPriorityIds(spaceId)
@@ -96,29 +107,29 @@ func TestService_GetPriorityIds(t *testing.T) {
 
 	t.Run("ReleasePriorityIds unsubscribes and drops the space subscription", func(t *testing.T) {
 		// given
-		svc := newService([]string{"chatA"}, nil, map[string]string{})
+		svc := newService([]*domain.Details{record("chatA", model.ObjectType_chatDerived)}, map[string]string{})
 		subService := mock_subscription.NewMockService(t)
-		subService.EXPECT().Unsubscribe("block-chat-priority-" + spaceId).Return(nil)
+		subService.EXPECT().Unsubscribe(prioritySubId(spaceId)).Return(nil)
 		svc.subscriptionService = subService
 
 		// when
 		svc.ReleasePriorityIds(spaceId)
 
 		// then: the subscription is gone; releasing again is a no-op
-		assert.Empty(t, svc.chatSubs)
+		assert.Empty(t, svc.prioritySubs)
 		svc.ReleasePriorityIds(spaceId)
 	})
 
 	t.Run("after Close no subscription is restarted", func(t *testing.T) {
 		// given
-		svc := newService([]string{"chatA"}, nil, map[string]string{"page1": spaceId})
+		svc := newService([]*domain.Details{record("chatA", model.ObjectType_chatDerived)}, map[string]string{"page1": spaceId})
 		require.NoError(t, svc.Close(context.Background()))
 
 		// when: a diffsync cycle racing shutdown asks for priority ids
 		got := svc.GetPriorityIds(spaceId)
 
-		// then: chat subs are closed and not re-created, opened objects still listed
+		// then: priority subs are closed and not re-created, opened objects still listed
 		assert.Equal(t, []string{"page1"}, got)
-		assert.Empty(t, svc.chatSubs)
+		assert.Empty(t, svc.prioritySubs)
 	})
 }

--- a/core/block/service.go
+++ b/core/block/service.go
@@ -13,7 +13,7 @@ Scope: global
 - Coordinates workspace/space creation including one-to-one spaces
 - Exposes ObjectGetter interface for cache.Do pattern used throughout codebase
 - Tracks currently opened objects to prevent premature cache eviction
-- Supplies priority tree ids for per-space diffsync (chats first, then opened objects) via GetPriorityIds, backed by lazily-started per-space chat-id subscriptions
+- Supplies priority tree ids for per-space diffsync (chats, then files, then opened objects) via GetPriorityIds, backed by lazily-started per-space subscriptions
 
 ## Background Tasks
 - ObjectBookmarkFetch: async bookmark content update after initial fetch
@@ -114,7 +114,7 @@ func New() *Service {
 			objects: make(map[string]string),
 			lock:    &sync.Mutex{},
 		},
-		chatSubs: map[string]*objectsubscription.ObjectSubscription[int64]{},
+		prioritySubs: map[string]*objectsubscription.ObjectSubscription[int64]{},
 	}
 	return s
 }
@@ -148,14 +148,14 @@ type Service struct {
 	predefinedObjectWasMissing bool
 	openedObjs                 *openedObjects
 
-	// chatSubs holds a lazily-started, per-space internal subscription tracking
-	// chat object ids and their resolved layout. It feeds GetPriorityIds so
-	// diffsync can head-sync chats first (chatDerived before discussion) without
-	// re-querying the store each cycle (GO-7302).
+	// prioritySubs holds a lazily-started, per-space internal subscription
+	// tracking chat and file object ids with their resolved layout. It feeds
+	// GetPriorityIds so diffsync can head-sync chats first (chatDerived before
+	// discussion), then files, without re-querying the store each cycle (GO-7302).
 	subscriptionService subscription.Service
-	chatSubsMu          sync.Mutex
-	chatSubs            map[string]*objectsubscription.ObjectSubscription[int64]
-	chatSubsClosed      bool
+	prioritySubsMu      sync.Mutex
+	prioritySubs        map[string]*objectsubscription.ObjectSubscription[int64]
+	prioritySubsClosed  bool
 
 	componentCtx       context.Context
 	componentCtxCancel context.CancelFunc
@@ -408,10 +408,10 @@ func (s *Service) GetOpenedObjects() []lo.Entry[string, string] {
 	return mutex.WithLock(s.openedObjs.lock, func() []lo.Entry[string, string] { return lo.Entries[string, string](s.openedObjs.objects) })
 }
 
-// chatPrioritySubParams tracks each chat object's resolved layout so
-// GetPriorityIds can order chatDerived chats (space-level chats) ahead of
-// discussion objects.
-var chatPrioritySubParams = objectsubscription.SubscriptionParams[int64]{
+// prioritySubParams tracks each object's resolved layout so GetPriorityIds can
+// order chatDerived chats (space-level chats) ahead of discussion objects ahead
+// of files.
+var prioritySubParams = objectsubscription.SubscriptionParams[int64]{
 	SetDetails: func(details *domain.Details) (string, int64) {
 		return details.GetString(bundle.RelationKeyId), details.GetInt64(bundle.RelationKeyResolvedLayout)
 	},
@@ -428,30 +428,40 @@ var chatPrioritySubParams = objectsubscription.SubscriptionParams[int64]{
 	},
 }
 
+func prioritySubId(spaceId string) string {
+	return "block-sync-priority-" + spaceId
+}
+
 // GetPriorityIds returns tree ids that diffsync should head-sync first for the
-// space: chatDerived chats, then discussion objects, then objects the user
-// currently has open. The tree syncer (GO-7302) intersects this with its diff
-// set and moves the matches to the front of the single-worker head queue, so the
-// order here is the sync priority order. An object appearing in more than one
-// group is listed once, in the highest-priority group.
+// space: chatDerived chats, then discussion objects, then file objects, then
+// objects the user currently has open. The tree syncer (GO-7302) intersects this
+// with its diff set and moves the matches to the front of the single-worker head
+// queue, so the order here is the sync priority order. An object appearing in
+// more than one group is listed once, in the highest-priority group.
 //
-// Chat ids and layouts are read from a lazily-started, per-space internal
+// Ids and layouts are read from a lazily-started, per-space internal
 // subscription so we don't re-query the store on every diffsync cycle.
 func (s *Service) GetPriorityIds(spaceId string) []string {
-	var chats, discussions []string
+	var chats, discussions, files []string
 	seen := map[string]struct{}{}
-	if sub := s.chatIdsSub(spaceId); sub != nil {
+	if sub := s.prioritySub(spaceId); sub != nil {
 		sub.Iterate(func(id string, layout int64) bool {
 			seen[id] = struct{}{}
-			if layout == int64(model.ObjectType_chatDerived) {
+			switch model.ObjectTypeLayout(layout) {
+			case model.ObjectType_chatDerived:
 				chats = append(chats, id)
-			} else {
+			case model.ObjectType_discussion:
 				discussions = append(discussions, id)
+			default:
+				files = append(files, id)
 			}
 			return true
 		})
 	}
-	ids := append(chats, discussions...)
+	ids := make([]string, 0, len(seen))
+	ids = append(ids, chats...)
+	ids = append(ids, discussions...)
+	ids = append(ids, files...)
 	for _, opened := range s.GetOpenedObjects() {
 		if opened.Value != spaceId {
 			continue
@@ -464,23 +474,24 @@ func (s *Service) GetPriorityIds(spaceId string) []string {
 	return ids
 }
 
-// chatIdsSub returns the per-space chat subscription, starting it on first use.
-// The subscription requests only the id and resolved layout and stays live, so
-// repeated reads are in-memory. Returns nil if the subscription can't be started
-// or the service is closing (so a diffsync racing Close can't re-create a
-// subscription that would never be released).
-func (s *Service) chatIdsSub(spaceId string) *objectsubscription.ObjectSubscription[int64] {
-	s.chatSubsMu.Lock()
-	defer s.chatSubsMu.Unlock()
-	if s.chatSubsClosed {
+// prioritySub returns the per-space priority subscription (chats + files),
+// starting it on first use. The subscription requests only the id and resolved
+// layout and stays live, so repeated reads are in-memory. Returns nil if the
+// subscription can't be started or the service is closing (so a diffsync racing
+// Close can't re-create a subscription that would never be released).
+func (s *Service) prioritySub(spaceId string) *objectsubscription.ObjectSubscription[int64] {
+	s.prioritySubsMu.Lock()
+	defer s.prioritySubsMu.Unlock()
+	if s.prioritySubsClosed {
 		return nil
 	}
-	if sub, ok := s.chatSubs[spaceId]; ok {
+	if sub, ok := s.prioritySubs[spaceId]; ok {
 		return sub
 	}
+	layouts := append([]model.ObjectTypeLayout{model.ObjectType_chatDerived, model.ObjectType_discussion}, domain.FileLayouts...)
 	sub := objectsubscription.New(s.subscriptionService, subscription.SubscribeRequest{
 		SpaceId:           spaceId,
-		SubId:             "block-chat-priority-" + spaceId,
+		SubId:             prioritySubId(spaceId),
 		Internal:          true,
 		NoDepSubscription: true,
 		Keys:              []string{bundle.RelationKeyId.String(), bundle.RelationKeyResolvedLayout.String()},
@@ -488,32 +499,32 @@ func (s *Service) chatIdsSub(spaceId string) *objectsubscription.ObjectSubscript
 			{
 				RelationKey: bundle.RelationKeyResolvedLayout,
 				Condition:   model.BlockContentDataviewFilter_In,
-				Value:       domain.Int64List([]model.ObjectTypeLayout{model.ObjectType_chatDerived, model.ObjectType_discussion}),
+				Value:       domain.Int64List(layouts),
 			},
 		},
-	}, chatPrioritySubParams)
+	}, prioritySubParams)
 	if err := sub.Run(); err != nil {
-		log.With("spaceId", spaceId).Errorf("run chat priority subscription: %v", err)
+		log.With("spaceId", spaceId).Errorf("run sync priority subscription: %v", err)
 		return nil
 	}
-	s.chatSubs[spaceId] = sub
+	s.prioritySubs[spaceId] = sub
 	return sub
 }
 
-// ReleasePriorityIds drops the per-space chat-id subscription backing
-// GetPriorityIds. The space's tree syncer calls it on close so subscriptions
-// don't outlive their space (unload, deletion); a later GetPriorityIds for the
-// same space lazily restarts the subscription.
+// ReleasePriorityIds drops the per-space subscription backing GetPriorityIds.
+// The space's tree syncer calls it on close so subscriptions don't outlive
+// their space (unload, deletion); a later GetPriorityIds for the same space
+// lazily restarts the subscription.
 func (s *Service) ReleasePriorityIds(spaceId string) {
-	s.chatSubsMu.Lock()
-	defer s.chatSubsMu.Unlock()
-	sub, ok := s.chatSubs[spaceId]
+	s.prioritySubsMu.Lock()
+	defer s.prioritySubsMu.Unlock()
+	sub, ok := s.prioritySubs[spaceId]
 	if !ok {
 		return
 	}
-	delete(s.chatSubs, spaceId)
-	if err := s.subscriptionService.Unsubscribe("block-chat-priority-" + spaceId); err != nil {
-		log.With("spaceId", spaceId).Errorf("unsubscribe chat priority subscription: %v", err)
+	delete(s.prioritySubs, spaceId)
+	if err := s.subscriptionService.Unsubscribe(prioritySubId(spaceId)); err != nil {
+		log.With("spaceId", spaceId).Errorf("unsubscribe sync priority subscription: %v", err)
 	}
 	sub.Close()
 }
@@ -788,13 +799,13 @@ func (s *Service) Close(_ context.Context) (err error) {
 	if s.componentCtxCancel != nil {
 		s.componentCtxCancel()
 	}
-	s.chatSubsMu.Lock()
-	s.chatSubsClosed = true
-	for _, sub := range s.chatSubs {
+	s.prioritySubsMu.Lock()
+	s.prioritySubsClosed = true
+	for _, sub := range s.prioritySubs {
 		sub.Close()
 	}
-	s.chatSubs = map[string]*objectsubscription.ObjectSubscription[int64]{}
-	s.chatSubsMu.Unlock()
+	s.prioritySubs = map[string]*objectsubscription.ObjectSubscription[int64]{}
+	s.prioritySubsMu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Follow-up to #3163 (merged while this was in flight).

The per-space diffsync priority subscription now also tracks file objects (file/image/video/audio/pdf via `domain.FileLayouts`). `GetPriorityIds` orders **chatDerived chats → discussions → files → currently opened objects**; previously files weren't prioritized at all.

Since the subscription is no longer chat-only, the chat-specific internals were renamed (`chatSubs` → `prioritySubs`, sub id `block-chat-priority-` → `block-sync-priority-`).

Covered by an ordering subtest in `core/block/priority_test.go`.