### PR TITLE
GO-7312 Optimize per-space load happy path: skip redundant maintenance work

### DIFF
--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -738,20 +738,15 @@ func (i *indexer) reindexOutdatedObjects(ctx context.Context, space clientspace.
 	if err != nil {
 		return
 	}
+	indexedHashes, err := store.ListLastIndexedHeadsHashes(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("list last indexed heads hashes: %w", err)
+	}
 	var idsToReindex []string
 	for _, entry := range entries {
-		// todo: make it more effective
-		id := entry.Id
-		logErr := func(err error) {
-			log.With("tree", entry.Id).Errorf("reindexOutdatedObjects failed to get tree to reindex: %s", err)
-		}
-		lastHash, err := store.GetLastIndexedHeadsHash(ctx, id)
-		if err != nil {
-			logErr(err)
-			continue
-		}
-		if lastHash == "" || lastHash != headsHash(entry.Heads) {
-			idsToReindex = append(idsToReindex, id)
+		// an id missing from indexedHashes yields "", which never matches a real hash
+		if indexedHashes[entry.Id] != headsHash(entry.Heads) {
+			idsToReindex = append(idsToReindex, entry.Id)
 		}
 	}
 	if len(idsToReindex) == 0 {
@@ -854,6 +849,14 @@ func (i *indexer) getLatestChecksums(isMarketplace bool) (checksums model.Object
 
 func (i *indexer) saveLatestChecksums(spaceID string) error {
 	checksums := i.getLatestChecksums(spaceID == addr.AnytypeMarketplaceWorkspace)
+	stored, err := i.store.GetChecksums(spaceID)
+	if err != nil && !errors.Is(err, anystore.ErrDocNotFound) {
+		return fmt.Errorf("get stored checksums: %w", err)
+	}
+	// this runs on every space load; skip the write tx when nothing changed
+	if stored != nil && *stored == checksums {
+		return nil
+	}
 	return i.store.SaveChecksums(spaceID, &checksums)
 }
 

--- a/core/indexer/reindex_test.go
+++ b/core/indexer/reindex_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/anyproto/any-sync/commonspace/headsync/headstorage"
 	"github.com/anyproto/any-sync/commonspace/headsync/headstorage/mock_headstorage"
+	"github.com/anyproto/any-sync/commonspace/headsync/statestorage/mock_statestorage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/anyproto/anytype-heart/core/block/editor"
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
 	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
 	"github.com/anyproto/anytype-heart/core/block/object/objectcache/mock_objectcache"
 	"github.com/anyproto/anytype-heart/core/block/source"
@@ -547,4 +549,146 @@ type idsLister struct {
 
 func (l idsLister) ListIds() ([]string, error) {
 	return l.Ids, nil
+}
+
+func TestReindexOutdatedObjects(t *testing.T) {
+	const spaceId = "space1"
+
+	t.Run("only objects with stale or missing indexed hash are reindexed", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		store := fx.store.SpaceIndex(spaceId)
+
+		require.NoError(t, store.SaveLastIndexedHeadsHash(ctx, "objUpToDate", headsHash([]string{"head1"})))
+		require.NoError(t, store.SaveLastIndexedHeadsHash(ctx, "objStale", "staleHash"))
+
+		entries := []headstorage.HeadsEntry{
+			{Id: "objUpToDate", Heads: []string{"head1"}, CommonSnapshot: "cs"},
+			{Id: "objStale", Heads: []string{"head2"}, CommonSnapshot: "cs"},
+			{Id: "objNeverIndexed", Heads: []string{"head3"}, CommonSnapshot: "cs"},
+			{Id: "settingsId", Heads: []string{"head4"}, CommonSnapshot: "cs"},
+			{Id: "aclId", Heads: []string{"head5"}},
+		}
+
+		ctrl := gomock.NewController(t)
+		headStorage := mock_headstorage.NewMockHeadStorage(ctrl)
+		headStorage.EXPECT().IterateEntries(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ headstorage.IterOpts, iter headstorage.EntryIterator) error {
+				for _, entry := range entries {
+					if cont, err := iter(entry); !cont || err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		stateStorage := mock_statestorage.NewMockStateStorage(ctrl)
+		stateStorage.EXPECT().SettingsId().AnyTimes().Return("settingsId")
+		storage := mock_anystorage.NewMockClientSpaceStorage(t)
+		storage.EXPECT().HeadStorage().Return(headStorage).Maybe()
+		storage.EXPECT().StateStorage().Return(stateStorage).Maybe()
+
+		var reindexed []string
+		spc := mock_space.NewMockSpace(t)
+		spc.EXPECT().Id().Return(spaceId).Maybe()
+		spc.EXPECT().Storage().Return(storage).Maybe()
+		spc.EXPECT().Do(mock.Anything, mock.Anything).RunAndReturn(func(id string, _ func(smartblock.SmartBlock) error) error {
+			reindexed = append(reindexed, id)
+			return nil
+		})
+
+		// when
+		total, success, err := fx.reindexOutdatedObjects(ctx, spc)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 2, total)
+		assert.Equal(t, 2, success)
+		assert.ElementsMatch(t, []string{"objStale", "objNeverIndexed"}, reindexed)
+	})
+
+	t.Run("nothing to reindex when all hashes match", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		store := fx.store.SpaceIndex(spaceId)
+
+		require.NoError(t, store.SaveLastIndexedHeadsHash(ctx, "obj1", headsHash([]string{"head1"})))
+
+		ctrl := gomock.NewController(t)
+		headStorage := mock_headstorage.NewMockHeadStorage(ctrl)
+		headStorage.EXPECT().IterateEntries(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ headstorage.IterOpts, iter headstorage.EntryIterator) error {
+				_, err := iter(headstorage.HeadsEntry{Id: "obj1", Heads: []string{"head1"}, CommonSnapshot: "cs"})
+				return err
+			})
+		stateStorage := mock_statestorage.NewMockStateStorage(ctrl)
+		stateStorage.EXPECT().SettingsId().AnyTimes().Return("settingsId")
+		storage := mock_anystorage.NewMockClientSpaceStorage(t)
+		storage.EXPECT().HeadStorage().Return(headStorage).Maybe()
+		storage.EXPECT().StateStorage().Return(stateStorage).Maybe()
+
+		spc := mock_space.NewMockSpace(t)
+		spc.EXPECT().Id().Return(spaceId).Maybe()
+		spc.EXPECT().Storage().Return(storage).Maybe()
+
+		// when
+		total, success, err := fx.reindexOutdatedObjects(ctx, spc)
+
+		// then
+		require.NoError(t, err)
+		assert.Zero(t, total)
+		assert.Zero(t, success)
+	})
+}
+
+func TestSaveLatestChecksums(t *testing.T) {
+	const spaceId = "space1"
+
+	t.Run("writes checksums when none are stored", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		want := fx.getLatestChecksums(false)
+
+		// when
+		err := fx.saveLatestChecksums(spaceId)
+
+		// then
+		require.NoError(t, err)
+		got, err := fx.store.GetChecksums(spaceId)
+		require.NoError(t, err)
+		assert.Equal(t, &want, got)
+	})
+
+	t.Run("idempotent when stored checksums are up to date", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		want := fx.getLatestChecksums(false)
+		require.NoError(t, fx.saveLatestChecksums(spaceId))
+
+		// when
+		err := fx.saveLatestChecksums(spaceId)
+
+		// then
+		require.NoError(t, err)
+		got, err := fx.store.GetChecksums(spaceId)
+		require.NoError(t, err)
+		assert.Equal(t, &want, got)
+	})
+
+	t.Run("overwrites stale checksums", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		stale := fx.getLatestChecksums(false)
+		stale.ObjectsForceReindexCounter--
+		require.NoError(t, fx.store.SaveChecksums(spaceId, &stale))
+		want := fx.getLatestChecksums(false)
+
+		// when
+		err := fx.saveLatestChecksums(spaceId)
+
+		// then
+		require.NoError(t, err)
+		got, err := fx.store.GetChecksums(spaceId)
+		require.NoError(t, err)
+		assert.Equal(t, &want, got)
+	})
 }

--- a/core/migration/objectcontext.go
+++ b/core/migration/objectcontext.go
@@ -16,7 +16,6 @@ import (
 	time2 "github.com/anyproto/anytype-heart/util/time"
 )
 
-
 // contextTimeTolerance is the maximum allowed time difference (in seconds) between a file's
 // creation and a potential context (block link or chat message). This accounts for the fact
 // that file objects are created before the containing block/message is finalized.
@@ -93,6 +92,11 @@ func (s *service) runObjectContextMigration(ctx context.Context, spaceId string,
 	l.With(zap.Int("count", len(fileRecords))).Debug("found files without context")
 
 	if len(fileRecords) == 0 {
+		// persist the marker even with nothing to migrate, otherwise file-less spaces
+		// re-enter the RunMigrationsWhenIdle polling loop on every load
+		if err := s.markFileContextMigrationDone(workspaceId); err != nil {
+			l.Warn("failed to mark migration done", zap.Error(err))
+		}
 		return nil
 	}
 

--- a/core/migration/objectcontext_test.go
+++ b/core/migration/objectcontext_test.go
@@ -1,14 +1,20 @@
 package migration
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anyproto/anytype-heart/core/block/detailservice/mock_detailservice"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
+	"github.com/anyproto/anytype-heart/pkg/lib/threads"
 )
 
 func TestService_findBestContext(t *testing.T) {
@@ -294,4 +300,93 @@ func TestNew(t *testing.T) {
 
 	assert.NotNil(t, service)
 	assert.Equal(t, CName, service.Name())
+}
+
+func TestRunMigrationsWhenIdleGate(t *testing.T) {
+	const (
+		spaceId     = "space1"
+		workspaceId = "workspace1"
+	)
+
+	t.Run("returns without polling when migration version is current", func(t *testing.T) {
+		// given
+		store := objectstore.NewStoreFixture(t)
+		store.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:                     domain.String(workspaceId),
+				bundle.RelationKeySpaceId:                domain.String(spaceId),
+				bundle.RelationKeyMigrationObjectContext: domain.Int64(domain.MigrationObjectContextVersion),
+			},
+		})
+		// only objectStore is set: entering the polling loop would panic on the nil deps
+		s := &service{objectStore: store}
+
+		// when
+		done := make(chan struct{})
+		go func() {
+			s.RunMigrationsWhenIdle(spaceId, threads.DerivedSmartblockIds{Workspace: workspaceId})
+			close(done)
+		}()
+
+		// then
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("RunMigrationsWhenIdle did not return for an already-migrated space")
+		}
+	})
+
+	t.Run("gate is open when migration version is older", func(t *testing.T) {
+		// given
+		store := objectstore.NewStoreFixture(t)
+		store.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:                     domain.String(workspaceId),
+				bundle.RelationKeySpaceId:                domain.String(spaceId),
+				bundle.RelationKeyMigrationObjectContext: domain.Int64(domain.MigrationObjectContextVersion - 1),
+			},
+		})
+		s := &service{objectStore: store}
+
+		// then
+		assert.False(t, s.isObjectContextMigrationDone(store.SpaceIndex(spaceId), workspaceId))
+	})
+
+	t.Run("gate is open when workspace is not indexed", func(t *testing.T) {
+		// given
+		store := objectstore.NewStoreFixture(t)
+		s := &service{objectStore: store}
+
+		// then
+		assert.False(t, s.isObjectContextMigrationDone(store.SpaceIndex(spaceId), workspaceId))
+	})
+}
+
+func TestRunObjectContextMigrationWithoutFiles(t *testing.T) {
+	const (
+		spaceId     = "space1"
+		workspaceId = "workspace1"
+	)
+
+	t.Run("marks migration done when no files need migration", func(t *testing.T) {
+		// given
+		store := objectstore.NewStoreFixture(t)
+		store.AddObjects(t, spaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:      domain.String(workspaceId),
+				bundle.RelationKeySpaceId: domain.String(spaceId),
+			},
+		})
+		detailsService := mock_detailservice.NewMockService(t)
+		detailsService.EXPECT().SetDetails(mock.Anything, workspaceId, []domain.Detail{
+			{Key: bundle.RelationKeyMigrationObjectContext, Value: domain.Int64(domain.MigrationObjectContextVersion)},
+		}).Return(nil)
+		s := &service{objectStore: store, detailsService: detailsService}
+
+		// when
+		err := s.runObjectContextMigration(context.Background(), spaceId, workspaceId)
+
+		// then
+		require.NoError(t, err)
+	})
 }

--- a/core/migration/service.go
+++ b/core/migration/service.go
@@ -91,6 +91,14 @@ func (s *service) Close() error {
 // In network mode (not local-only), it also waits for the node to be connected to the network
 // to ensure remote changes have been received before running migrations.
 func (s *service) RunMigrationsWhenIdle(spaceId string, derivedIDs threads.DerivedSmartblockIds) {
+	// Fast path: every migration run by runAllMigrations is gated by a persisted marker.
+	// When all markers are already set there is nothing to wait for, so exit before the
+	// polling loop instead of keeping a per-space goroutine ticking for the whole session.
+	// A new migration added to runAllMigrations must extend this check with its own gate.
+	if s.isObjectContextMigrationDone(s.objectStore.SpaceIndex(spaceId), derivedIDs.Workspace) {
+		return
+	}
+
 	isLocalOnly := s.networkConfig.GetNetworkMode() == pb.RpcAccount_LocalOnly
 	onlineSince := time.Time{}
 	for {

--- a/pkg/lib/localstore/objectstore/spaceindex/indexer.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/indexer.go
@@ -36,6 +36,30 @@ func (s *dsObjectStore) SaveLastIndexedHeadsHash(ctx context.Context, id string,
 	return err
 }
 
+// ListLastIndexedHeadsHashes returns the last indexed heads hash for every object in a single
+// collection scan. Callers that need the whole space (reindexOutdatedObjects) must use this
+// instead of per-id GetLastIndexedHeadsHash lookups, which cost one statement per object.
+func (s *dsObjectStore) ListLastIndexedHeadsHashes(ctx context.Context) (map[string]string, error) {
+	iter, err := s.headsState.Find(nil).Iter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("find heads state entries: %w", err)
+	}
+	defer iter.Close()
+
+	hashes := make(map[string]string)
+	for iter.Next() {
+		doc, err := iter.Doc()
+		if err != nil {
+			return nil, fmt.Errorf("get doc: %w", err)
+		}
+		hashes[doc.Value().GetString("id")] = doc.Value().GetString(headsStateField)
+	}
+	if err = iter.Err(); err != nil {
+		return nil, fmt.Errorf("iterate heads state entries: %w", err)
+	}
+	return hashes, nil
+}
+
 // SaveLastIndexedHeadsHashWithFtQueueCtr saves the heads hash along with the FT queue counter.
 // The ftQueueCtr is used for crash recovery: if the common DB (FT queue) doesn't flush before crash,
 // we can detect objects with ftQueueCtr > persisted counter and re-add them to the queue.

--- a/pkg/lib/localstore/objectstore/spaceindex/indexer_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/indexer_test.go
@@ -31,6 +31,31 @@ func TestHeadsHash(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("list all hashes on empty store", func(t *testing.T) {
+		s := NewStoreFixture(t)
+
+		got, err := s.ListLastIndexedHeadsHashes(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("list all hashes", func(t *testing.T) {
+		s := NewStoreFixture(t)
+
+		require.NoError(t, s.SaveLastIndexedHeadsHash(ctx, "id1", "hash1"))
+		require.NoError(t, s.SaveLastIndexedHeadsHash(ctx, "id2", "hash2"))
+		require.NoError(t, s.SaveLastIndexedHeadsHashWithFtQueueCtr(ctx, "id3", "hash3", 42))
+		want := map[string]string{
+			"id1": "hash1",
+			"id2": "hash2",
+			"id3": "hash3",
+		}
+
+		got, err := s.ListLastIndexedHeadsHashes(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("clear heads state removes all hashes", func(t *testing.T) {
 		s := NewStoreFixture(t)
 

--- a/pkg/lib/localstore/objectstore/spaceindex/invalid.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/invalid.go
@@ -223,6 +223,10 @@ func (s *invalidStore) GetLastIndexedHeadsHash(ctx context.Context, id string) (
 	return "", s.err
 }
 
+func (s *invalidStore) ListLastIndexedHeadsHashes(ctx context.Context) (map[string]string, error) {
+	return nil, s.err
+}
+
 func (s *invalidStore) SaveLastIndexedHeadsHash(ctx context.Context, id string, headsHash string) (err error) {
 	return s.err
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -117,6 +117,7 @@ type Store interface {
 	GetObjectType(id string) (*model.ObjectType, error)
 
 	GetLastIndexedHeadsHash(ctx context.Context, id string) (headsHash string, err error)
+	ListLastIndexedHeadsHashes(ctx context.Context) (map[string]string, error)
 	SaveLastIndexedHeadsHash(ctx context.Context, id string, headsHash string) (err error)
 	SaveLastIndexedHeadsHashWithFtQueueCtr(ctx context.Context, id string, headsHash string, ftQueueCtr uint64) (err error)
 	GetHeadsWithFtQueueCtrGreaterThan(ctx context.Context, threshold uint64) ([]HeadsStateEntry, error)

--- a/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
+++ b/space/internal/components/migration/systemobjectreviser/systemobjectreviser.go
@@ -111,12 +111,15 @@ func reviseObject(ctx context.Context, log logger.CtxLogger, space dependencies.
 		return false, fmt.Errorf("failed to unmarshal unique key '%s': %w", uniqueKeyRaw, err)
 	}
 
-	bundleObject, isSystem := getBundleObjectDetails(uk)
-	if bundleObject == nil {
+	// compare raw bundle revision first: constructing full bundled details for every
+	// type/relation on every space load is pure waste when nothing changed
+	bundleRevision, isBundled := getBundleObjectRevision(uk)
+	if !isBundled || bundleRevision <= localObject.GetInt64(revisionKey) {
 		return false, nil
 	}
 
-	if bundleObject.GetInt64(revisionKey) <= localObject.GetInt64(revisionKey) {
+	bundleObject, isSystem := getBundleObjectDetails(uk)
+	if bundleObject == nil {
 		return false, nil
 	}
 	details := buildDiffDetails(bundleObject, localObject, isSystem)
@@ -155,6 +158,27 @@ func reviseObject(ctx context.Context, log logger.CtxLogger, space dependencies.
 		}
 	}
 	return true, nil
+}
+
+// getBundleObjectRevision returns the revision of the bundled counterpart without building
+// its details. Mirrors getBundleObjectDetails: ok is false for non-bundled types and
+// non-system relations, which are not revisable.
+func getBundleObjectRevision(uk domain.UniqueKey) (revision int64, ok bool) {
+	switch uk.SmartblockType() {
+	case coresb.SmartBlockTypeObjectType:
+		objectType, err := bundle.GetType(domain.TypeKey(uk.InternalKey()))
+		if err != nil {
+			return 0, false
+		}
+		return objectType.Revision, true
+	case coresb.SmartBlockTypeRelation:
+		if !isSystemRelation(uk) {
+			return 0, false
+		}
+		return bundle.MustGetRelation(domain.RelationKey(uk.InternalKey())).Revision, true
+	default:
+		return 0, false
+	}
 }
 
 // getBundleObjectDetails returns nil if the object with provided unique key is not either system relation or bundled type


### PR DESCRIPTION
Part of the space-load happy-path optimization (spec: `docs/SpaceLoadOptimization.md`, phase 1). On every space load we pay fixed maintenance costs even when nothing changed; on a 78-space account this is the bulk of the ~98k SQLite statements (each arming a `SetInterrupt` watcher goroutine) during AccountSelect.

## Changes

1. **`reindexOutdatedObjects`: bulk scan instead of per-object queries.** The outdated-heads check issued one `GetLastIndexedHeadsHash` query per object in the space, every load. New `spaceindex.Store.ListLastIndexedHeadsHashes` does a single `headsState` collection scan; the heads-hash compare happens in memory. O(N) statements → 1 per space.
2. **`saveLatestChecksums`: write only on change.** The per-space checksums record was rewritten on every load. Now it's compared with the stored record first and the write tx is skipped when equal — avoiding write-connection acquisition during the startup storm (`SaveChecksums` already deduped the physical disk write, so the win is the connection contention).
3. **`RunMigrationsWhenIdle`: check the gate before polling.** A 10s-tick goroutine was spawned per space before the persisted `MigrationObjectContextVersion` gate was ever read (and ticked forever while offline). The gate is now read first. Also, `runObjectContextMigration` never wrote the done-marker for spaces with zero context-less files, so the gate could never close for new/empty spaces — the marker is now persisted on the 0-files path too.
4. **`systemobjectreviser`: revision-first compare.** The reviser constructed full bundled details (`BundledTypeDetails`/`ToDetails`, ~140 objects per space) before comparing revisions. It now compares the raw bundle `Revision` field (verified identical to what the details would carry) and builds details only for objects actually being revised.

## Behavior notes

- A bulk-read failure in `reindexOutdatedObjects` now aborts that (async, logged, retried-next-load) pass instead of skipping a single id — the old per-id error path.
- A headstorage entry with empty heads and no stored hash is now skipped instead of being fed into a guaranteed-failing reindex; unreachable for live trees.
- Cold/migration paths are unchanged: unclean shutdown still triggers outdated-object reindex via heads-hash mismatch, bundle revision bumps still revise installed system objects, `Force*ReindexCounter` bumps still fire their passes.

## Testing

- New unit tests: bulk hash listing (empty/populated/ftQueueCtr docs); outdated-object selection incl. settings-id and ACL-entry filtering and never-indexed objects; checksum write-when-missing / skip-when-equal / overwrite-when-stale; migration-poller gate (closed, open-on-older-version, open-on-unindexed-workspace); done-marker written for file-less spaces.
- Full test suites of the touched packages pass; `-race` clean on the new indexer tests; whole-repo build OK.
- Reviewed for semantic parity with the old code paths (map-miss ⇒ `""` matches the old `ErrDocNotFound ⇒ ""` contract; revision values verified against `relationutils` detail construction).

Manual verification planned on a large staging account: SQLite statement count + goroutine count during AccountSelect, `reindexOutdatedObjects` duration in logs.