### PR TITLE
GO-7315 Reduce subscription memory allocations and heap usage

### DIFF
--- a/core/domain/details.go
+++ b/core/domain/details.go
@@ -62,6 +62,34 @@ func NewDetailsFromAnyEnc(v *anyenc.Value) (*Details, error) {
 	return res, visitErr
 }
 
+// NewDetailsFromAnyEncWithKeys decodes only the listed keys of the document.
+// A nil keys map decodes everything, same as NewDetailsFromAnyEnc
+func NewDetailsFromAnyEncWithKeys(v *anyenc.Value, keys map[string]struct{}) (*Details, error) {
+	if keys == nil {
+		return NewDetailsFromAnyEnc(v)
+	}
+	obj, err := v.Object()
+	if err != nil {
+		return nil, fmt.Errorf("is object: %w", err)
+	}
+	res := NewDetailsWithSize(len(keys))
+	var visitErr error
+	obj.Visit(func(k []byte, v *anyenc.Value) {
+		if visitErr != nil {
+			return
+		}
+		if _, ok := keys[string(k)]; !ok {
+			return
+		}
+		// key is copied
+		err := setValueFromAnyEnc(res, RelationKey(k), v)
+		if err != nil {
+			visitErr = fmt.Errorf("key %s: %w", k, err)
+		}
+	})
+	return res, visitErr
+}
+
 func setValueFromAnyEnc[T ~string](d *GenericMap[T], key T, val *anyenc.Value) error {
 	switch val.Type() {
 	case anyenc.TypeNumber:

--- a/core/domain/genericmap.go
+++ b/core/domain/genericmap.go
@@ -264,8 +264,8 @@ func (d *GenericMap[K]) CopyOnlyKeys(keys ...K) *GenericMap[K] {
 		return NewGenericMap[K]()
 	}
 	newData := make(map[K]Value, len(keys))
-	for k, v := range d.data {
-		if slices.Contains(keys, k) {
+	for _, k := range keys {
+		if v, ok := d.data[k]; ok {
 			newData[k] = v
 		}
 	}

--- a/core/domain/genericmap.go
+++ b/core/domain/genericmap.go
@@ -319,6 +319,23 @@ func (d *GenericMap[K]) ToProto() *types.Struct {
 	return res
 }
 
+// ToProtoOnlyKeys is equivalent to CopyOnlyKeys(keys...).ToProto() without the
+// intermediate map copy
+func (d *GenericMap[K]) ToProtoOnlyKeys(keys ...K) *types.Struct {
+	res := &types.Struct{
+		Fields: make(map[string]*types.Value, len(keys)),
+	}
+	if d == nil {
+		return res
+	}
+	for _, k := range keys {
+		if v, ok := d.data[k]; ok {
+			res.Fields[string(k)] = v.ToProto()
+		}
+	}
+	return res
+}
+
 func (d *GenericMap[K]) ToAnyEnc(arena *anyenc.Arena) *anyenc.Value {
 	obj := arena.NewObject()
 	for k, v := range d.Iterate() {

--- a/core/subscription/bench_test.go
+++ b/core/subscription/bench_test.go
@@ -1,0 +1,252 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/anyproto/any-sync/app"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/event"
+	"github.com/anyproto/anytype-heart/core/event/mock_event"
+	"github.com/anyproto/anytype-heart/core/kanban"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/database"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+const (
+	benchParticipants = 10
+	benchTags         = 5
+	benchSubId        = "bench-sub"
+)
+
+type benchFixture struct {
+	*service
+	store *objectstore.StoreFixture
+}
+
+func newBenchFixture(b *testing.B) *benchFixture {
+	b.Helper()
+	a := &app.App{}
+	store := objectstore.NewStoreFixture(b)
+	a.Register(store)
+	a.Register(kanban.New())
+	a.Register(&collectionServiceMock{MockCollectionService: NewMockCollectionService(b)})
+	sender := mock_event.NewMockSender(b)
+	sender.EXPECT().Init(mock.Anything).Return(nil)
+	sender.EXPECT().Name().Return(event.CName)
+	sender.EXPECT().Broadcast(mock.Anything).Maybe()
+	a.Register(sender)
+	s := New().(*service)
+	a.Register(s)
+	require.NoError(b, a.Start(context.Background()))
+	b.Cleanup(func() {
+		_ = a.Close(context.Background())
+	})
+	return &benchFixture{service: s, store: store}
+}
+
+func benchObjectId(i int) string {
+	return fmt.Sprintf("obj-%06d", i)
+}
+
+// genBenchObjects generates objects with a realistic number of details (~25 keys),
+// referencing a small set of participant, tag and type objects via object-format relations.
+func genBenchObjects(n int) []spaceindex.TestObject {
+	objs := make([]spaceindex.TestObject, 0, n+benchParticipants+benchTags+1)
+	for i := 0; i < n; i++ {
+		creator := fmt.Sprintf("participant-%d", i%benchParticipants)
+		objs = append(objs, spaceindex.TestObject{
+			bundle.RelationKeyId:               domain.String(benchObjectId(i)),
+			bundle.RelationKeySpaceId:          domain.String(testSpaceId),
+			bundle.RelationKeyName:             domain.String(fmt.Sprintf("Object %06d", i)),
+			bundle.RelationKeyDescription:      domain.String("description of the object, long enough to look like a real one"),
+			bundle.RelationKeySnippet:          domain.String("snippet of the object body, long enough to look like a real one"),
+			bundle.RelationKeyIconEmoji:        domain.String("📄"),
+			bundle.RelationKeyResolvedLayout:   domain.Int64(int64(model.ObjectType_basic)),
+			bundle.RelationKeyLayout:           domain.Int64(int64(model.ObjectType_basic)),
+			bundle.RelationKeyType:             domain.String("type-page"),
+			bundle.RelationKeyCreator:          domain.StringList([]string{creator}),
+			bundle.RelationKeyLastModifiedBy:   domain.StringList([]string{creator}),
+			bundle.RelationKeyCreatedDate:      domain.Int64(int64(1700000000 + i)),
+			bundle.RelationKeyLastModifiedDate: domain.Int64(int64(1700000000 + i*2)),
+			bundle.RelationKeyLastOpenedDate:   domain.Int64(int64(1700000000 + i*3)),
+			bundle.RelationKeyAddedDate:        domain.Int64(int64(1700000000 + i)),
+			bundle.RelationKeyIsFavorite:       domain.Bool(i%10 == 0),
+			bundle.RelationKeyIsArchived:       domain.Bool(false),
+			bundle.RelationKeyIsDeleted:        domain.Bool(false),
+			bundle.RelationKeyIsHidden:         domain.Bool(false),
+			bundle.RelationKeyDone:             domain.Bool(i%2 == 0),
+			bundle.RelationKeyDueDate:          domain.Int64(int64(1800000000 + i)),
+			bundle.RelationKeyTag:              domain.StringList([]string{fmt.Sprintf("tag-%d", i%benchTags), fmt.Sprintf("tag-%d", (i+1)%benchTags)}),
+			bundle.RelationKeyBacklinks:        domain.StringList([]string{benchObjectId((i + 1) % n)}),
+			bundle.RelationKeyLinks:            domain.StringList([]string{benchObjectId((i + 2) % n)}),
+			bundle.RelationKeySyncStatus:       domain.Int64(0),
+			bundle.RelationKeySyncDate:         domain.Int64(int64(1700000000 + i)),
+		})
+	}
+	for i := 0; i < benchParticipants; i++ {
+		objs = append(objs, spaceindex.TestObject{
+			bundle.RelationKeyId:             domain.String(fmt.Sprintf("participant-%d", i)),
+			bundle.RelationKeyName:           domain.String(fmt.Sprintf("Participant %d", i)),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_participant)),
+		})
+	}
+	for i := 0; i < benchTags; i++ {
+		objs = append(objs, spaceindex.TestObject{
+			bundle.RelationKeyId:             domain.String(fmt.Sprintf("tag-%d", i)),
+			bundle.RelationKeyName:           domain.String(fmt.Sprintf("Tag %d", i)),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_relationOption)),
+			bundle.RelationKeyRelationKey:    domain.String(bundle.RelationKeyTag.String()),
+		})
+	}
+	objs = append(objs, spaceindex.TestObject{
+		bundle.RelationKeyId:             domain.String("type-page"),
+		bundle.RelationKeyName:           domain.String("Page"),
+		bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_objectType)),
+	})
+	return objs
+}
+
+// benchSubscribeRequest mimics a typical client list subscription: a layout filter,
+// a text sort, pagination and a dozen requested keys some of which are object relations.
+func benchSubscribeRequest() SubscribeRequest {
+	return SubscribeRequest{
+		SpaceId: testSpaceId,
+		SubId:   benchSubId,
+		Filters: []database.FilterRequest{
+			{
+				RelationKey: bundle.RelationKeyResolvedLayout,
+				Condition:   model.BlockContentDataviewFilter_In,
+				Value:       domain.Int64List([]int64{int64(model.ObjectType_basic)}),
+			},
+		},
+		Sorts: []database.SortRequest{
+			{
+				RelationKey: bundle.RelationKeyName,
+				Type:        model.BlockContentDataviewSort_Asc,
+				Format:      model.RelationFormat_longtext,
+			},
+		},
+		Limit: 100,
+		Keys: []string{
+			bundle.RelationKeyId.String(),
+			bundle.RelationKeyName.String(),
+			bundle.RelationKeyDescription.String(),
+			bundle.RelationKeySnippet.String(),
+			bundle.RelationKeyIconEmoji.String(),
+			bundle.RelationKeyResolvedLayout.String(),
+			bundle.RelationKeyType.String(),
+			bundle.RelationKeyCreator.String(),
+			bundle.RelationKeyTag.String(),
+			bundle.RelationKeyDone.String(),
+			bundle.RelationKeyLastModifiedDate.String(),
+		},
+	}
+}
+
+func BenchmarkSubscriptionSearch(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("objects=%d", n), func(b *testing.B) {
+			fx := newBenchFixture(b)
+			fx.store.AddObjects(b, testSpaceId, genBenchObjects(n))
+			req := benchSubscribeRequest()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Search unsubscribes the previous subscription with the same id,
+				// so each iteration measures full init (plus teardown of the previous one)
+				resp, err := fx.Search(req)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(resp.Records) == 0 {
+					b.Fatal("no records")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSubscriptionOnChange measures processing of a batch of changed records
+// that belong to the active window of an existing subscription.
+func BenchmarkSubscriptionOnChange(b *testing.B) {
+	const batchSize = 10
+	for _, n := range []int{1000, 10000} {
+		b.Run(fmt.Sprintf("objects=%d", n), func(b *testing.B) {
+			fx := newBenchFixture(b)
+			fx.store.AddObjects(b, testSpaceId, genBenchObjects(n))
+			_, err := fx.Search(benchSubscribeRequest())
+			require.NoError(b, err)
+
+			fx.lock.Lock()
+			spaceSubs := fx.spaceSubs[testSpaceId]
+			fx.lock.Unlock()
+
+			ids := make([]string, batchSize)
+			for i := range ids {
+				ids[i] = benchObjectId(i)
+			}
+			records, err := spaceSubs.objectStore.QueryByIds(ids)
+			require.NoError(b, err)
+			require.Len(b, records, batchSize)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				entries := make([]*entry, 0, len(records))
+				for _, r := range records {
+					det := r.Details.Copy()
+					det.SetString(bundle.RelationKeyName, fmt.Sprintf("Object renamed %06d", i))
+					det.SetInt64(bundle.RelationKeyLastModifiedDate, int64(1700000000+i))
+					entries = append(entries, newEntry(det.GetString(bundle.RelationKeyId), det))
+				}
+				spaceSubs.onChange(entries)
+			}
+		})
+	}
+}
+
+// BenchmarkSubscriptionOnChangeMiss measures the cost of a batch of records
+// that do not match any subscription filter: the common case of unrelated
+// objects being indexed while subscriptions are active.
+func BenchmarkSubscriptionOnChangeMiss(b *testing.B) {
+	const batchSize = 10
+	for _, n := range []int{1000, 10000} {
+		b.Run(fmt.Sprintf("objects=%d", n), func(b *testing.B) {
+			fx := newBenchFixture(b)
+			fx.store.AddObjects(b, testSpaceId, genBenchObjects(n))
+			_, err := fx.Search(benchSubscribeRequest())
+			require.NoError(b, err)
+
+			fx.lock.Lock()
+			spaceSubs := fx.spaceSubs[testSpaceId]
+			fx.lock.Unlock()
+
+			records, err := spaceSubs.objectStore.QueryByIds([]string{benchObjectId(0)})
+			require.NoError(b, err)
+			require.Len(b, records, 1)
+			base := records[0].Details
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				entries := make([]*entry, 0, batchSize)
+				for j := 0; j < batchSize; j++ {
+					det := base.Copy()
+					det.SetString(bundle.RelationKeyId, fmt.Sprintf("miss-%06d-%06d", i, j))
+					det.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_relationOption))
+					entries = append(entries, newEntry(det.GetString(bundle.RelationKeyId), det))
+				}
+				spaceSubs.onChange(entries)
+			}
+		})
+	}
+}

--- a/core/subscription/bench_test.go
+++ b/core/subscription/bench_test.go
@@ -3,6 +3,7 @@ package subscription
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/anyproto/any-sync/app"
@@ -171,8 +172,33 @@ func BenchmarkSubscriptionSearch(b *testing.B) {
 					b.Fatal("no records")
 				}
 			}
+			b.StopTimer()
+			reportRetainedHeap(b, fx)
 		})
 	}
+}
+
+// reportRetainedHeap reports how much detail data the last subscription keeps
+// in the entry cache: the average number of detail keys per cached entry and
+// the process heap after GC
+func reportRetainedHeap(b *testing.B, fx *benchFixture) {
+	fx.lock.Lock()
+	spaceSubs := fx.spaceSubs[testSpaceId]
+	fx.lock.Unlock()
+	spaceSubs.m.Lock()
+	var totalKeys, entries int
+	for _, e := range spaceSubs.cache.entries {
+		entries++
+		totalKeys += e.data.Len()
+	}
+	spaceSubs.m.Unlock()
+	if entries > 0 {
+		b.ReportMetric(float64(totalKeys)/float64(entries), "keys/entry")
+	}
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	b.ReportMetric(float64(m.HeapAlloc)/(1<<20), "heap-MB")
 }
 
 // BenchmarkSubscriptionOnChange measures processing of a batch of changed records

--- a/core/subscription/cache.go
+++ b/core/subscription/cache.go
@@ -119,10 +119,37 @@ func (c *cache) Get(id string) *entry {
 
 func (c *cache) GetOrSet(e *entry) *entry {
 	if res, ok := c.entries[e.id]; ok {
+		res.mergeMissingData(e.data)
 		return res
 	}
 	c.entries[e.id] = e
 	return e
+}
+
+// mergeMissingData adds keys absent in the entry data: a cached entry is
+// projected to the keys of its subscriptions, while a newly subscribing one may
+// need more of them. Existing values win, since cache content is kept current
+// by change batches. Copy-on-write, so aliased readers of the old map are
+// unaffected
+func (e *entry) mergeMissingData(src *domain.Details) {
+	if src == nil || e.data == nil {
+		if e.data == nil {
+			e.data = src
+		}
+		return
+	}
+	var merged *domain.Details
+	for k, v := range src.Iterate() {
+		if !e.data.Has(k) {
+			if merged == nil {
+				merged = e.data.Copy()
+			}
+			merged.Set(k, v)
+		}
+	}
+	if merged != nil {
+		e.data = merged
+	}
 }
 
 func (c *cache) Set(e *entry) {

--- a/core/subscription/cache.go
+++ b/core/subscription/cache.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"maps"
+	"slices"
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/util/slice"
@@ -17,34 +18,35 @@ type entry struct {
 	id   string
 	data *domain.Details
 
+	// subIsActive and subFullDetailsSent are allocated lazily on the first SetSub:
+	// an entry is created for every record passing through the change pipeline,
+	// and most of them never join any subscription
 	subIds             []string
 	subIsActive        map[string]bool
 	subFullDetailsSent map[string]bool
 }
 
 func newEntry(id string, data *domain.Details) *entry {
-	return &entry{id: id, data: data, subIsActive: make(map[string]bool), subFullDetailsSent: make(map[string]bool)}
+	return &entry{id: id, data: data}
 }
 
 func (e *entry) Copy() *entry {
-	newSubIds := make([]string, len(e.subIds))
-	copy(newSubIds, e.subIds)
-	newSubIsActive := make(map[string]bool, len(e.subIsActive))
-	maps.Copy(newSubIsActive, e.subIsActive)
-	newSubFullDetailsSent := make(map[string]bool, len(e.subIsActive))
-	maps.Copy(newSubFullDetailsSent, e.subFullDetailsSent)
 	return &entry{
 		id:                 e.id,
 		data:               e.data,
-		subIds:             newSubIds,
-		subIsActive:        newSubIsActive,
-		subFullDetailsSent: newSubFullDetailsSent,
+		subIds:             slices.Clone(e.subIds),
+		subIsActive:        maps.Clone(e.subIsActive),
+		subFullDetailsSent: maps.Clone(e.subFullDetailsSent),
 	}
 }
 
 // SetSub marks provided subscription for the entry as active (within the current pagination window) or inactive
 func (e *entry) SetSub(subId string, isActive bool, isFullDetailSent bool) {
 	if pos := slice.FindPos(e.subIds, subId); pos == -1 {
+		if e.subIsActive == nil {
+			e.subIsActive = make(map[string]bool, 1)
+			e.subFullDetailsSent = make(map[string]bool, 1)
+		}
 		e.subIds = append(e.subIds, subId)
 		e.subIsActive[subId] = isActive
 		e.subFullDetailsSent[subId] = isFullDetailSent

--- a/core/subscription/collection.go
+++ b/core/subscription/collection.go
@@ -1,13 +1,11 @@
 package subscription
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
 	"github.com/anyproto/any-store/anyenc"
 	"github.com/anyproto/any-store/query"
-	"github.com/cheggaaa/mb/v3"
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
@@ -31,7 +29,7 @@ type collectionObserver struct {
 	cache             *cache
 	objectStore       spaceindex.Store
 	collectionService CollectionService
-	recBatch          *mb.MB[database.Record]
+	recBatch          *recordsBuffer
 	recBatchMutex     sync.Mutex
 
 	spaceSubscription *spaceSubscriptions
@@ -135,11 +133,11 @@ func (c *collectionObserver) updateIds(ids []string) {
 		}
 	}
 	for _, e := range entries {
-		err := c.recBatch.Add(context.Background(), database.Record{
+		err := c.recBatch.Add(database.Record{
 			Details: e.data,
 		})
 		if err != nil {
-			log.Info("failed to add entities to mb: ", err)
+			log.Info("failed to add entities to records buffer: ", err)
 		}
 	}
 }

--- a/core/subscription/collection.go
+++ b/core/subscription/collection.go
@@ -120,19 +120,35 @@ func (c *collectionObserver) updateIds(ids []string) {
 	}
 	c.ids = ids
 	c.lock.Unlock()
-	// removed objects may be gone from the store, so take them from the entry
-	// cache; added ones must come from the store with full details, because
-	// cached entries are projected to the keys of other subscriptions and may
-	// lack keys this subscription filters by
-	entries := c.spaceSubscription.fetchEntriesLocked(removed)
-	if recs, err := c.objectStore.QueryByIds(added); err != nil {
-		log.Error("collection observer: can't query added ids:", err)
-	} else {
-		for _, rec := range recs {
-			entries = append(entries, newEntry(rec.Details.GetString(bundle.RelationKeyId), rec.Details))
+	// the pushed records are re-evaluated against the filters of every
+	// subscription of the space, so they must carry full store details: cached
+	// entries are projected to their subscriptions' keys and could make
+	// unrelated filters misfire. Only removed objects missing from the store
+	// (deleted) fall back to their cached entry, just to trigger the removal
+	changedIds := append(removed, added...)
+	recs, err := c.objectStore.QueryByIds(changedIds)
+	if err != nil {
+		log.Error("collection observer: can't query by ids:", err)
+	}
+	storeEntries := make(map[string]*entry, len(recs))
+	for _, rec := range recs {
+		id := rec.Details.GetString(bundle.RelationKeyId)
+		storeEntries[id] = newEntry(id, rec.Details)
+	}
+	var missingRemoved []string
+	for _, id := range removed {
+		if _, ok := storeEntries[id]; !ok {
+			missingRemoved = append(missingRemoved, id)
 		}
 	}
-	for _, e := range entries {
+	for _, e := range c.spaceSubscription.fetchEntriesLocked(missingRemoved) {
+		storeEntries[e.id] = e
+	}
+	for _, id := range changedIds {
+		e, ok := storeEntries[id]
+		if !ok {
+			continue
+		}
 		err := c.recBatch.Add(database.Record{
 			Details: e.data,
 		})
@@ -226,7 +242,9 @@ func (s *spaceSubscriptions) newCollectionSub(req SubscribeRequest, f *database.
 	if !ssub.disableDep {
 		ssub.forceSubIds = filterDepIds
 	}
-	s.registerSubKeys(ssub.id, requiredKeys)
+	if requiredKeys != nil {
+		s.registerSubKeys(ssub.id, requiredKeys)
+	}
 
 	sub := &collectionSub{
 		sortedSub: ssub,
@@ -237,9 +255,11 @@ func (s *spaceSubscriptions) newCollectionSub(req SubscribeRequest, f *database.
 	filtered := entries[:0]
 	for _, e := range entries {
 		if f.FilterObj.FilterObject(e.data) {
-			// filters were evaluated against the full details; retain only the
-			// keys the subscription needs before the entry enters the cache
-			e.data = e.data.CopyOnlyKeys(requiredKeys...)
+			if requiredKeys != nil {
+				// filters were evaluated against the full details; retain only the
+				// keys the subscription needs before the entry enters the cache
+				e.data = e.data.CopyOnlyKeys(requiredKeys...)
+			}
 			filtered = append(filtered, e)
 		}
 	}

--- a/core/subscription/collection.go
+++ b/core/subscription/collection.go
@@ -91,12 +91,20 @@ func (c *collectionObserver) close() {
 	c.collectionService.UnsubscribeFromCollection(c.collectionID, c.subID)
 }
 
+// listEntries reads the collection objects from the store rather than from the
+// entry cache: cached entries are projected to the keys of their subscriptions
+// and may lack keys this subscription filters or sorts by
 func (c *collectionObserver) listEntries() []*entry {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	entries := c.spaceSubscription.fetchEntries(c.ids)
-	res := make([]*entry, len(entries))
-	copy(res, entries)
+	recs, err := c.objectStore.QueryByIds(c.ids)
+	if err != nil {
+		log.Error("collection observer: can't query by ids:", err)
+	}
+	res := make([]*entry, 0, len(recs))
+	for _, rec := range recs {
+		res = append(res, newEntry(rec.Details.GetString(bundle.RelationKeyId), rec.Details))
+	}
 	return res
 }
 
@@ -114,7 +122,18 @@ func (c *collectionObserver) updateIds(ids []string) {
 	}
 	c.ids = ids
 	c.lock.Unlock()
-	entries := c.spaceSubscription.fetchEntriesLocked(append(removed, added...))
+	// removed objects may be gone from the store, so take them from the entry
+	// cache; added ones must come from the store with full details, because
+	// cached entries are projected to the keys of other subscriptions and may
+	// lack keys this subscription filters by
+	entries := c.spaceSubscription.fetchEntriesLocked(removed)
+	if recs, err := c.objectStore.QueryByIds(added); err != nil {
+		log.Error("collection observer: can't query added ids:", err)
+	} else {
+		for _, rec := range recs {
+			entries = append(entries, newEntry(rec.Details.GetString(bundle.RelationKeyId), rec.Details))
+		}
+	}
 	for _, e := range entries {
 		err := c.recBatch.Add(context.Background(), database.Record{
 			Details: e.data,
@@ -193,7 +212,7 @@ func (c *collectionSub) reorder(ctx *opCtx, depDetails []*domain.Details) {
 	c.sortedSub.reorder(ctx, depDetails)
 }
 
-func (s *spaceSubscriptions) newCollectionSub(req SubscribeRequest, f *database.Filters, filterDepIds []string) (*collectionSub, error) {
+func (s *spaceSubscriptions) newCollectionSub(req SubscribeRequest, f *database.Filters, filterDepIds []string, requiredKeys []domain.RelationKey) (*collectionSub, error) {
 	obs, err := s.newCollectionObserver(req.SpaceId, req.CollectionId, req.SubId)
 	if err != nil {
 		return nil, err
@@ -209,6 +228,7 @@ func (s *spaceSubscriptions) newCollectionSub(req SubscribeRequest, f *database.
 	if !ssub.disableDep {
 		ssub.forceSubIds = filterDepIds
 	}
+	s.registerSubKeys(ssub.id, requiredKeys)
 
 	sub := &collectionSub{
 		sortedSub: ssub,
@@ -219,6 +239,9 @@ func (s *spaceSubscriptions) newCollectionSub(req SubscribeRequest, f *database.
 	filtered := entries[:0]
 	for _, e := range entries {
 		if f.FilterObj.FilterObject(e.data) {
+			// filters were evaluated against the full details; retain only the
+			// keys the subscription needs before the entry enters the cache
+			e.data = e.data.CopyOnlyKeys(requiredKeys...)
 			filtered = append(filtered, e)
 		}
 	}

--- a/core/subscription/collection_test.go
+++ b/core/subscription/collection_test.go
@@ -3,15 +3,28 @@ package subscription
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/cheggaaa/mb/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
 )
+
+func waitRecords(t *testing.T, b *recordsBuffer, min int) []database.Record {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var out []database.Record
+	for len(out) < min {
+		batch, err := b.Wait(ctx)
+		require.NoError(t, err)
+		out = append(out, batch...)
+	}
+	return out
+}
 
 func Test_newCollectionObserver(t *testing.T) {
 	spaceId := "spaceId"
@@ -41,7 +54,7 @@ func Test_newCollectionObserver(t *testing.T) {
 				bundle.RelationKeySpaceId: domain.String(spaceId),
 			},
 		})
-		batcher := mb.New[database.Record](0)
+		batcher := newRecordsBuffer()
 		c := &spaceSubscriptions{
 			collectionService: collectionService,
 			objectStore:       store,
@@ -56,8 +69,7 @@ func Test_newCollectionObserver(t *testing.T) {
 		assert.NoError(t, err)
 		ch <- []string{"id1", "id2"}
 		close(observer.closeCh)
-		msgs, err := batcher.NewCond().WithMin(3).Wait(context.Background())
-		assert.NoError(t, err)
+		msgs := waitRecords(t, batcher, 3)
 
 		var receivedIds []string
 		for _, msg := range msgs {
@@ -65,8 +77,7 @@ func Test_newCollectionObserver(t *testing.T) {
 			receivedIds = append(receivedIds, id)
 		}
 		assert.Equal(t, []string{"id0", "id1", "id2"}, receivedIds)
-		err = batcher.Close()
-		assert.NoError(t, err)
+		batcher.Close()
 	})
 	t.Run("fetch entries from object store", func(t *testing.T) {
 		// given
@@ -87,7 +98,7 @@ func Test_newCollectionObserver(t *testing.T) {
 				bundle.RelationKeySpaceId: domain.String(spaceId),
 			},
 		})
-		batcher := mb.New[database.Record](0)
+		batcher := newRecordsBuffer()
 		c := &spaceSubscriptions{
 			collectionService: collectionService,
 			objectStore:       store,
@@ -103,8 +114,7 @@ func Test_newCollectionObserver(t *testing.T) {
 		expectedIds := []string{"id1", "id2"}
 		ch <- expectedIds
 		close(observer.closeCh)
-		msgs, err := batcher.NewCond().WithMin(2).Wait(context.Background())
-		assert.NoError(t, err)
+		msgs := waitRecords(t, batcher, 2)
 
 		var receivedIds []string
 		for _, msg := range msgs {
@@ -112,7 +122,6 @@ func Test_newCollectionObserver(t *testing.T) {
 			receivedIds = append(receivedIds, id)
 		}
 		assert.Equal(t, expectedIds, receivedIds)
-		err = batcher.Close()
-		assert.NoError(t, err)
+		batcher.Close()
 	})
 }

--- a/core/subscription/collection_test.go
+++ b/core/subscription/collection_test.go
@@ -15,22 +15,32 @@ import (
 
 func Test_newCollectionObserver(t *testing.T) {
 	spaceId := "spaceId"
-	t.Run("fetch entries from cache", func(t *testing.T) {
+	t.Run("removed ids are fetched from cache, added ids from store", func(t *testing.T) {
 		// given
 		collectionService := NewMockCollectionService(t)
 		collectionID := "collectionId"
 		subId := "subId"
 		ch := make(chan []string)
-		collectionService.EXPECT().SubscribeForCollection(collectionID, subId).Return([]string{"id"}, ch, nil)
+		collectionService.EXPECT().SubscribeForCollection(collectionID, subId).Return([]string{"id0"}, ch, nil)
 		store := spaceindex.NewStoreFixture(t)
+		// id0 is part of the collection, so its (projected) entry sits in the cache;
+		// it may be already deleted from the store, but its removal must still be observed
 		cache := newCache()
-		cache.Set(&entry{id: "id1", data: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-			bundle.RelationKeyId: domain.String("id1"),
+		cache.Set(&entry{id: "id0", data: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId: domain.String("id0"),
 		})})
-
-		cache.Set(&entry{id: "id2", data: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-			bundle.RelationKeyId: domain.String("id2"),
-		})})
+		// added objects are read from the store: cached entries are projected to other
+		// subscriptions' keys and could lack keys this subscription filters by
+		store.AddObjects(t, []spaceindex.TestObject{
+			{
+				bundle.RelationKeyId:      domain.String("id1"),
+				bundle.RelationKeySpaceId: domain.String(spaceId),
+			},
+			{
+				bundle.RelationKeyId:      domain.String("id2"),
+				bundle.RelationKeySpaceId: domain.String(spaceId),
+			},
+		})
 		batcher := mb.New[database.Record](0)
 		c := &spaceSubscriptions{
 			collectionService: collectionService,
@@ -44,10 +54,9 @@ func Test_newCollectionObserver(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
-		expectedIds := []string{"id1", "id2"}
-		ch <- expectedIds
+		ch <- []string{"id1", "id2"}
 		close(observer.closeCh)
-		msgs, err := batcher.NewCond().WithMin(2).Wait(context.Background())
+		msgs, err := batcher.NewCond().WithMin(3).Wait(context.Background())
 		assert.NoError(t, err)
 
 		var receivedIds []string
@@ -55,7 +64,7 @@ func Test_newCollectionObserver(t *testing.T) {
 			id := msg.Details.GetString(bundle.RelationKeyId)
 			receivedIds = append(receivedIds, id)
 		}
-		assert.Equal(t, expectedIds, receivedIds)
+		assert.Equal(t, []string{"id0", "id1", "id2"}, receivedIds)
 		err = batcher.Close()
 		assert.NoError(t, err)
 	})

--- a/core/subscription/context.go
+++ b/core/subscription/context.go
@@ -72,12 +72,56 @@ type opCtx struct {
 	// keysBufIdx indexes keysBuf by id
 	keysBufIdx map[string]int
 
+	// subKeys is shared with spaceSubscriptions (guarded by its lock): subscription
+	// id -> relation keys retained in cached entries for that subscription
+	subKeys map[string][]domain.RelationKey
+
 	c *cache
 }
 
 const defaultOutput = "_default"
 
+// projectEntries trims the details of entries that are about to be cached down
+// to the union of relation keys required by their subscriptions: this is the
+// long-lived memory of the subscription system, there is no point retaining
+// keys nobody reads. Entries with a subscription missing from the registry are
+// kept intact (fail-safe)
+func (ctx *opCtx) projectEntries() {
+	for _, e := range ctx.entries {
+		subIds := e.SubIds()
+		if len(subIds) == 0 {
+			continue
+		}
+		totalKeys := 0
+		unknownSub := false
+		for _, subId := range subIds {
+			keys, ok := ctx.subKeys[subId]
+			if !ok {
+				unknownSub = true
+				break
+			}
+			totalKeys += len(keys)
+		}
+		if unknownSub {
+			continue
+		}
+		projected := domain.NewDetailsWithSize(totalKeys)
+		for _, subId := range subIds {
+			for _, k := range ctx.subKeys[subId] {
+				if v, ok := e.data.TryGet(k); ok {
+					projected.Set(k, v)
+				}
+			}
+		}
+		e.data = projected
+	}
+}
+
 func (ctx *opCtx) apply() {
+	// trim entries before diffing and caching, so both the amend events diff and
+	// the cache operate on the retained key set
+	ctx.projectEntries()
+
 	addEvent := func(subId string, ev *pb.EventMessage) {
 		_, ok := ctx.outputs[subId]
 		if ok {

--- a/core/subscription/context.go
+++ b/core/subscription/context.go
@@ -58,11 +58,19 @@ type opCtx struct {
 	entries  []*entry
 	groups   []opGroup
 
+	// entriesIdx indexes entries by id; built lazily on the first getEntry call
+	// (entries are assigned wholesale at the start of a batch) and kept in sync
+	// by appendEntry afterwards
+	entriesIdx      map[string]int
+	entriesIdxValid bool
+
 	keysBuf []struct {
 		id     string
 		subIds []string
 		keys   []domain.RelationKey
 	}
+	// keysBufIdx indexes keysBuf by id
+	keysBufIdx map[string]int
 
 	c *cache
 }
@@ -163,16 +171,8 @@ func (ctx *opCtx) apply() {
 // EventMessageValueOfObjectDetailsSet
 func (ctx *opCtx) detailsEvents() {
 	var msgs []*pb.EventMessage
-	var getEntry = func(id string) *entry {
-		for _, e := range ctx.entries {
-			if e.id == id {
-				return e
-			}
-		}
-		return nil
-	}
 	for _, info := range ctx.keysBuf {
-		curr := getEntry(info.id)
+		curr := ctx.getEntry(info.id)
 		if curr == nil {
 			log.Errorf("entry present in changes but not in list: %v", info.id)
 			continue
@@ -324,40 +324,57 @@ func (ctx *opCtx) groupEventsDetailsAmend(v *pb.EventObjectDetailsAmend) {
 }
 
 func (ctx *opCtx) collectKeys(id string, subId string, keys []domain.RelationKey) {
-	var found bool
-	for i, kb := range ctx.keysBuf {
-		if kb.id == id {
-			found = true
-			for _, k := range keys {
-				if slice.FindPos(ctx.keysBuf[i].keys, k) == -1 {
-					ctx.keysBuf[i].keys = append(ctx.keysBuf[i].keys, k)
-				}
+	if i, ok := ctx.keysBufIdx[id]; ok {
+		kb := ctx.keysBuf[i]
+		for _, k := range keys {
+			if slice.FindPos(ctx.keysBuf[i].keys, k) == -1 {
+				ctx.keysBuf[i].keys = append(ctx.keysBuf[i].keys, k)
 			}
-			if slice.FindPos(kb.subIds, subId) == -1 {
-				ctx.keysBuf[i].subIds = append(kb.subIds, subId)
-				sort.Strings(ctx.keysBuf[i].subIds)
-			}
-			break
 		}
+		if slice.FindPos(kb.subIds, subId) == -1 {
+			ctx.keysBuf[i].subIds = append(kb.subIds, subId)
+			sort.Strings(ctx.keysBuf[i].subIds)
+		}
+		return
 	}
-	if !found {
-		keysCopy := make([]domain.RelationKey, len(keys))
-		copy(keysCopy, keys)
-		ctx.keysBuf = append(ctx.keysBuf, struct {
-			id     string
-			subIds []string
-			keys   []domain.RelationKey
-		}{id: id, keys: keysCopy, subIds: []string{subId}})
+	keysCopy := make([]domain.RelationKey, len(keys))
+	copy(keysCopy, keys)
+	ctx.keysBuf = append(ctx.keysBuf, struct {
+		id     string
+		subIds []string
+		keys   []domain.RelationKey
+	}{id: id, keys: keysCopy, subIds: []string{subId}})
+	if ctx.keysBufIdx == nil {
+		ctx.keysBufIdx = make(map[string]int)
 	}
+	ctx.keysBufIdx[id] = len(ctx.keysBuf) - 1
 }
 
 func (ctx *opCtx) getEntry(id string) *entry {
-	for _, e := range ctx.entries {
-		if e.id == id {
-			return e
+	if !ctx.entriesIdxValid {
+		if ctx.entriesIdx == nil {
+			ctx.entriesIdx = make(map[string]int, len(ctx.entries))
+		} else {
+			clear(ctx.entriesIdx)
 		}
+		for i, e := range ctx.entries {
+			ctx.entriesIdx[e.id] = i
+		}
+		ctx.entriesIdxValid = true
+	}
+	if i, ok := ctx.entriesIdx[id]; ok {
+		return ctx.entries[i]
 	}
 	return nil
+}
+
+// appendEntry must be used to add entries after batch processing has started,
+// so that the id index stays in sync
+func (ctx *opCtx) appendEntry(e *entry) {
+	ctx.entries = append(ctx.entries, e)
+	if ctx.entriesIdxValid {
+		ctx.entriesIdx[e.id] = len(ctx.entries) - 1
+	}
 }
 
 func (ctx *opCtx) reset() {
@@ -368,6 +385,8 @@ func (ctx *opCtx) reset() {
 	ctx.keysBuf = ctx.keysBuf[:0]
 	ctx.entries = ctx.entries[:0]
 	ctx.groups = ctx.groups[:0]
+	ctx.entriesIdxValid = false
+	clear(ctx.keysBufIdx)
 	if ctx.outputs == nil {
 		ctx.outputs = map[string][]*pb.EventMessage{
 			defaultOutput: nil,

--- a/core/subscription/context.go
+++ b/core/subscription/context.go
@@ -219,7 +219,7 @@ func (ctx *opCtx) appendObjectDetailsSetMessage(msgs []*pb.EventMessage, curr *e
 	msgs = append(msgs, event.NewMessage(ctx.spaceId, &pb.EventMessageValueOfObjectDetailsSet{
 		ObjectDetailsSet: &pb.EventObjectDetailsSet{
 			Id:      curr.id,
-			Details: curr.data.CopyOnlyKeys(keys...).ToProto(),
+			Details: curr.data.ToProtoOnlyKeys(keys...),
 			SubIds:  subIds,
 		},
 	},

--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -31,9 +31,10 @@ func (ds *dependencyService) makeSubscriptionByEntries(subId string, allEntries,
 	depSubKeys := ds.depSubKeys(subId, keys)
 	depSub := ds.s.newSimpleSub(subId, depSubKeys, true)
 	depSub.forceIds = filterDepIds
+	ds.s.registerSubKeys(subId, append(slices.Clone(depSubKeys), bundle.RelationKeyId))
 	parentSubId := strings.TrimSuffix(subId, "/dep")
 	depIds := ds.depIdsByEntries(parentSubId, activeEntries, depKeys, depSub.forceIds)
-	depEntries := ds.depEntriesByEntries(&opCtx{entries: allEntries}, depIds)
+	depEntries := ds.depEntriesByEntries(&opCtx{entries: allEntries, subKeys: ds.s.subKeys}, depIds)
 	depSub.init(depEntries)
 	return depSub
 }

--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -86,7 +86,7 @@ func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, depIds []string) (d
 				missIds = append(missIds, id)
 			}
 			if e != nil {
-				ctx.entries = append(ctx.entries, e)
+				ctx.appendEntry(e)
 			}
 		}
 		if e != nil {
@@ -100,7 +100,7 @@ func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, depIds []string) (d
 		}
 		for _, r := range records {
 			e := newEntry(r.Details.GetString(bundle.RelationKeyId), r.Details)
-			ctx.entries = append(ctx.entries, e)
+			ctx.appendEntry(e)
 			depEntries = append(depEntries, e)
 		}
 	}

--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
-	"github.com/anyproto/anytype-heart/util/slice"
 )
 
 func newDependencyService(s *spaceSubscriptions) *dependencyService {
@@ -51,18 +50,25 @@ func (ds *dependencyService) refillSubscription(ctx *opCtx, subId string, depSub
 func (ds *dependencyService) depIdsByEntries(
 	subId string, entries []*entry, depKeys []domain.RelationKey, forceIds []string,
 ) (depIds []string) {
-	depIds = forceIds
+	// clone to avoid appending into the caller's backing array
+	depIds = slices.Clone(forceIds)
+	seen := make(map[string]struct{}, len(forceIds))
+	for _, id := range forceIds {
+		seen[id] = struct{}{}
+	}
 	for _, e := range entries {
 		for _, k := range depKeys {
 			isSortKey := ds.sorts.isSortKey(subId, k)
 			for _, depId := range e.data.WrapToStringList(k) {
-				if depId != "" {
-					if slice.FindPos(depIds, depId) == -1 && depId != e.id {
-						depIds = append(depIds, depId)
-					}
-					if isSortKey {
-						ds.addDepOrderObject(depId, subId)
-					}
+				if depId == "" {
+					continue
+				}
+				if _, ok := seen[depId]; !ok && depId != e.id {
+					seen[depId] = struct{}{}
+					depIds = append(depIds, depId)
+				}
+				if isSortKey {
+					ds.addDepOrderObject(depId, subId)
 				}
 			}
 		}

--- a/core/subscription/dep.go
+++ b/core/subscription/dep.go
@@ -31,10 +31,12 @@ func (ds *dependencyService) makeSubscriptionByEntries(subId string, allEntries,
 	depSubKeys := ds.depSubKeys(subId, keys)
 	depSub := ds.s.newSimpleSub(subId, depSubKeys, true)
 	depSub.forceIds = filterDepIds
-	ds.s.registerSubKeys(subId, append(slices.Clone(depSubKeys), bundle.RelationKeyId))
+	if len(depSubKeys) > 0 {
+		ds.s.registerSubKeys(subId, append(slices.Clone(depSubKeys), bundle.RelationKeyId))
+	}
 	parentSubId := strings.TrimSuffix(subId, "/dep")
 	depIds := ds.depIdsByEntries(parentSubId, activeEntries, depKeys, depSub.forceIds)
-	depEntries := ds.depEntriesByEntries(&opCtx{entries: allEntries, subKeys: ds.s.subKeys}, depIds)
+	depEntries := ds.depEntriesByEntries(&opCtx{entries: allEntries, subKeys: ds.s.subKeys}, subId, depSubKeys, depIds)
 	depSub.init(depEntries)
 	return depSub
 }
@@ -42,7 +44,7 @@ func (ds *dependencyService) makeSubscriptionByEntries(subId string, allEntries,
 func (ds *dependencyService) refillSubscription(ctx *opCtx, subId string, depSub *simpleSub, entries []*entry, depKeys []domain.RelationKey) {
 	depIds := ds.depIdsByEntries(subId, entries, depKeys, depSub.forceIds)
 	if !depSub.isEqualIds(depIds) {
-		depEntries := ds.depEntriesByEntries(ctx, depIds)
+		depEntries := ds.depEntriesByEntries(ctx, depSub.id, depSub.keys, depIds)
 		depSub.refill(ctx, depEntries)
 	}
 	return
@@ -77,11 +79,17 @@ func (ds *dependencyService) depIdsByEntries(
 	return
 }
 
-func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, depIds []string) (depEntries []*entry) {
+// depEntriesByEntries resolves dependent entries for subId, which must end up
+// holding the given keys. A cached entry may be projected to the keys of other
+// subscriptions: when it does not belong to subId yet and lacks some of the
+// keys, the object is re-read from the store and the missing keys are merged in
+func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, subId string, keys []domain.RelationKey, depIds []string) (depEntries []*entry) {
 	if len(depIds) == 0 {
 		return
 	}
 	var missIds []string
+	// cached entries projected below the required keys, to refresh from the store
+	var staleEntries map[string]*entry
 	for _, id := range depIds {
 		var e *entry
 
@@ -89,6 +97,15 @@ func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, depIds []string) (d
 		if e = ctx.getEntry(id); e == nil {
 			if e = ds.s.cache.Get(id); e != nil {
 				e = e.Copy()
+				// an entry already in this subscription retains its keys by
+				// construction: absent ones are genuinely absent in the store
+				if !e.IsInSub(subId) && !entryDataHasKeys(e.data, keys) {
+					if staleEntries == nil {
+						staleEntries = map[string]*entry{}
+					}
+					staleEntries[id] = e
+					missIds = append(missIds, id)
+				}
 			} else {
 				missIds = append(missIds, id)
 			}
@@ -106,12 +123,26 @@ func (ds *dependencyService) depEntriesByEntries(ctx *opCtx, depIds []string) (d
 			log.Errorf("can't query by id: %v", err)
 		}
 		for _, r := range records {
-			e := newEntry(r.Details.GetString(bundle.RelationKeyId), r.Details)
+			id := r.Details.GetString(bundle.RelationKeyId)
+			if stale, ok := staleEntries[id]; ok {
+				stale.mergeMissingData(r.Details)
+				continue
+			}
+			e := newEntry(id, r.Details)
 			ctx.appendEntry(e)
 			depEntries = append(depEntries, e)
 		}
 	}
 	return
+}
+
+func entryDataHasKeys(data *domain.Details, keys []domain.RelationKey) bool {
+	for _, k := range keys {
+		if !data.Has(k) {
+			return false
+		}
+	}
+	return true
 }
 
 func (ds *dependencyService) addDepOrderObject(dependentObjectId, subId string) {

--- a/core/subscription/projection_test.go
+++ b/core/subscription/projection_test.go
@@ -2,6 +2,8 @@ package subscription
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,8 +13,49 @@ import (
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/database"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
+
+// TestConcurrentSearch runs concurrent subscriptions with object-relation sorts
+// on one space: required-keys computation touches the dependency service
+// relation format cache and must stay under the space lock (run with -race)
+func TestConcurrentSearch(t *testing.T) {
+	fx := NewInternalTestService(t)
+	fx.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:      domain.String("obj1"),
+			bundle.RelationKeyName:    domain.String("first"),
+			bundle.RelationKeyCreator: domain.StringList([]string{"creator1"}),
+		},
+		{
+			bundle.RelationKeyId:   domain.String("creator1"),
+			bundle.RelationKeyName: domain.String("creator"),
+		},
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := fx.Search(SubscribeRequest{
+				SpaceId: testSpaceId,
+				SubId:   fmt.Sprintf("concurrent-%d", i),
+				Sorts: []database.SortRequest{{
+					RelationKey: bundle.RelationKeyCreator,
+					Type:        model.BlockContentDataviewSort_Asc,
+					Format:      model.RelationFormat_object,
+				}},
+				Keys:     []string{bundle.RelationKeyId.String(), bundle.RelationKeyName.String()},
+				Internal: true,
+			})
+			assert.NoError(t, err)
+		}(i)
+	}
+	wg.Wait()
+}
 
 // TestEntryProjection verifies that cached entries retain only the union of
 // keys required by their subscriptions and that events stay complete for every
@@ -139,4 +182,64 @@ func TestEntryProjection(t *testing.T) {
 		msgs2, err := resp2.Output.NewCond().WithMin(1).Wait(ctx2)
 		assert.Error(t, err, "no events expected for sub-description, got %v", msgs2)
 	})
+}
+
+// TestDepEntriesRegainProjectedKeys verifies that a dependency entry served
+// from the cache is refreshed from the store when another subscription's
+// projection trimmed away keys this subscription needs.
+func TestDepEntriesRegainProjectedKeys(t *testing.T) {
+	fx := NewInternalTestService(t)
+	fx.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:                  domain.String("opt1"),
+			bundle.RelationKeyName:                domain.String("urgent"),
+			bundle.RelationKeyRelationKey:         domain.String(bundle.RelationKeyTag.String()),
+			bundle.RelationKeyRelationOptionColor: domain.String("red"),
+		},
+		{
+			bundle.RelationKeyId:   domain.String("task1"),
+			bundle.RelationKeyName: domain.String("task"),
+			bundle.RelationKeyTag:  domain.StringList([]string{"opt1"}),
+		},
+	})
+
+	// the first subscription caches opt1 projected to {id, name}
+	respA, err := fx.Search(SubscribeRequest{
+		SpaceId: testSpaceId,
+		SubId:   "sub-option",
+		Filters: []database.FilterRequest{{
+			RelationKey: bundle.RelationKeyId,
+			Condition:   model.BlockContentDataviewFilter_Equal,
+			Value:       domain.String("opt1"),
+		}},
+		Keys:     []string{bundle.RelationKeyId.String(), bundle.RelationKeyName.String()},
+		Internal: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, respA.Records, 1)
+
+	// the second subscription depends on opt1 via tag and requests its color:
+	// the projected cache entry must be refreshed from the store
+	respB, err := fx.Search(SubscribeRequest{
+		SpaceId: testSpaceId,
+		SubId:   "sub-task",
+		Filters: []database.FilterRequest{{
+			RelationKey: bundle.RelationKeyId,
+			Condition:   model.BlockContentDataviewFilter_Equal,
+			Value:       domain.String("task1"),
+		}},
+		Keys: []string{
+			bundle.RelationKeyId.String(),
+			bundle.RelationKeyName.String(),
+			bundle.RelationKeyTag.String(),
+			bundle.RelationKeyRelationOptionColor.String(),
+		},
+		Internal: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, respB.Records, 1)
+	require.Len(t, respB.Dependencies, 1)
+	dep := respB.Dependencies[0]
+	assert.Equal(t, "opt1", dep.GetString(bundle.RelationKeyId))
+	assert.Equal(t, "red", dep.GetString(bundle.RelationKeyRelationOptionColor))
 }

--- a/core/subscription/projection_test.go
+++ b/core/subscription/projection_test.go
@@ -1,0 +1,142 @@
+package subscription
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+)
+
+// TestEntryProjection verifies that cached entries retain only the union of
+// keys required by their subscriptions and that events stay complete for every
+// subscription regardless of projection.
+func TestEntryProjection(t *testing.T) {
+	fx := NewInternalTestService(t)
+	fx.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:          domain.String("obj1"),
+			bundle.RelationKeyName:        domain.String("first"),
+			bundle.RelationKeyDescription: domain.String("first description"),
+			bundle.RelationKeySnippet:     domain.String("first snippet"),
+			bundle.RelationKeyIconEmoji:   domain.String("📦"),
+		},
+	})
+
+	resp1, err := fx.Search(SubscribeRequest{
+		SpaceId:  testSpaceId,
+		SubId:    "sub-name",
+		Keys:     []string{bundle.RelationKeyId.String(), bundle.RelationKeyName.String()},
+		Internal: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp1.Records, 1)
+	assert.True(t, resp1.Records[0].Has(bundle.RelationKeyName))
+	assert.False(t, resp1.Records[0].Has(bundle.RelationKeyDescription))
+
+	resp2, err := fx.Search(SubscribeRequest{
+		SpaceId:  testSpaceId,
+		SubId:    "sub-description",
+		Keys:     []string{bundle.RelationKeyId.String(), bundle.RelationKeyDescription.String()},
+		Internal: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp2.Records, 1)
+	assert.True(t, resp2.Records[0].Has(bundle.RelationKeyDescription))
+	assert.False(t, resp2.Records[0].Has(bundle.RelationKeyName))
+
+	getCachedEntryData := func(t *testing.T) *domain.Details {
+		s := fx.Service.(*service)
+		s.lock.Lock()
+		spaceSubs := s.spaceSubs[testSpaceId]
+		s.lock.Unlock()
+		require.NotNil(t, spaceSubs)
+		spaceSubs.m.Lock()
+		defer spaceSubs.m.Unlock()
+		e := spaceSubs.cache.Get("obj1")
+		require.NotNil(t, e)
+		return e.data
+	}
+
+	t.Run("cached entry holds only the union of required keys", func(t *testing.T) {
+		data := getCachedEntryData(t)
+		assert.True(t, data.Has(bundle.RelationKeyId))
+		assert.True(t, data.Has(bundle.RelationKeyName))
+		assert.True(t, data.Has(bundle.RelationKeyDescription))
+		assert.False(t, data.Has(bundle.RelationKeySnippet), "snippet is not requested by any subscription")
+		assert.False(t, data.Has(bundle.RelationKeyIconEmoji), "iconEmoji is not requested by any subscription")
+	})
+
+	collectAmendKeys := func(t *testing.T, output interface {
+		Wait(ctx context.Context) ([]*pb.EventMessage, error)
+	}) map[string]struct{} {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		msgs, err := output.Wait(ctx)
+		require.NoError(t, err)
+		keys := map[string]struct{}{}
+		for _, msg := range msgs {
+			amend := msg.GetObjectDetailsAmend()
+			require.NotNil(t, amend, "expected only amend events, got %T", msg.Value)
+			for _, kv := range amend.Details {
+				keys[kv.Key] = struct{}{}
+			}
+		}
+		return keys
+	}
+
+	t.Run("both subscriptions get their keys amended after one change", func(t *testing.T) {
+		fx.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          domain.String("obj1"),
+				bundle.RelationKeyName:        domain.String("second"),
+				bundle.RelationKeyDescription: domain.String("second description"),
+				bundle.RelationKeySnippet:     domain.String("second snippet"),
+				bundle.RelationKeyIconEmoji:   domain.String("📦"),
+			},
+		})
+		time.Sleep(batchTime)
+
+		keys1 := collectAmendKeys(t, resp1.Output.NewCond().WithMin(1))
+		assert.Contains(t, keys1, bundle.RelationKeyName.String())
+		assert.NotContains(t, keys1, bundle.RelationKeySnippet.String())
+
+		keys2 := collectAmendKeys(t, resp2.Output.NewCond().WithMin(1))
+		assert.Contains(t, keys2, bundle.RelationKeyDescription.String())
+		assert.NotContains(t, keys2, bundle.RelationKeySnippet.String())
+
+		data := getCachedEntryData(t)
+		assert.Equal(t, "second", data.GetString(bundle.RelationKeyName))
+		assert.Equal(t, "second description", data.GetString(bundle.RelationKeyDescription))
+		assert.False(t, data.Has(bundle.RelationKeySnippet))
+	})
+
+	t.Run("change of a key no subscription needs produces no events", func(t *testing.T) {
+		fx.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:          domain.String("obj1"),
+				bundle.RelationKeyName:        domain.String("second"),
+				bundle.RelationKeyDescription: domain.String("second description"),
+				bundle.RelationKeySnippet:     domain.String("third snippet"),
+				bundle.RelationKeyIconEmoji:   domain.String("🚀"),
+			},
+		})
+		time.Sleep(2 * batchTime)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+		msgs, err := resp1.Output.NewCond().WithMin(1).Wait(ctx)
+		assert.Error(t, err, "no events expected for sub-name, got %v", msgs)
+
+		ctx2, cancel2 := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel2()
+		msgs2, err := resp2.Output.NewCond().WithMin(1).Wait(ctx2)
+		assert.Error(t, err, "no events expected for sub-description, got %v", msgs2)
+	})
+}

--- a/core/subscription/recordsbuffer.go
+++ b/core/subscription/recordsbuffer.go
@@ -1,0 +1,91 @@
+package subscription
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/database"
+)
+
+var errRecordsBufferClosed = errors.New("records buffer closed")
+
+// recordsBuffer coalesces store update records by object id: a pending older
+// version of an object is replaced by the newer one, so the buffer holds at
+// most one record per distinct object no matter how fast updates arrive. This
+// bounds the memory of the change pipeline during mass indexing, when the
+// consumer (recordsHandler) drains it once per batch interval
+type recordsBuffer struct {
+	mu     sync.Mutex
+	byId   map[string]int
+	batch  []database.Record
+	signal chan struct{}
+	closed bool
+}
+
+func newRecordsBuffer() *recordsBuffer {
+	return &recordsBuffer{
+		byId:   make(map[string]int),
+		signal: make(chan struct{}, 1),
+	}
+}
+
+// Add queues the record, replacing a pending older version of the same object.
+// It never blocks
+func (b *recordsBuffer) Add(rec database.Record) error {
+	id := rec.Details.GetString(bundle.RelationKeyId)
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return errRecordsBufferClosed
+	}
+	if i, ok := b.byId[id]; ok {
+		b.batch[i] = rec
+	} else {
+		b.batch = append(b.batch, rec)
+		b.byId[id] = len(b.batch) - 1
+	}
+	b.mu.Unlock()
+	select {
+	case b.signal <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+// Wait blocks until at least one record is queued or the context is canceled,
+// then returns the whole pending batch. The returned slice is owned by the
+// caller
+func (b *recordsBuffer) Wait(ctx context.Context) ([]database.Record, error) {
+	for {
+		b.mu.Lock()
+		if b.closed {
+			b.mu.Unlock()
+			return nil, errRecordsBufferClosed
+		}
+		if len(b.batch) > 0 {
+			batch := b.batch
+			b.batch = make([]database.Record, 0, len(batch))
+			clear(b.byId)
+			b.mu.Unlock()
+			return batch, nil
+		}
+		b.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-b.signal:
+		}
+	}
+}
+
+func (b *recordsBuffer) Close() {
+	b.mu.Lock()
+	b.closed = true
+	b.mu.Unlock()
+	select {
+	case b.signal <- struct{}{}:
+	default:
+	}
+}

--- a/core/subscription/recordsbuffer_test.go
+++ b/core/subscription/recordsbuffer_test.go
@@ -1,0 +1,113 @@
+package subscription
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/database"
+)
+
+func bufferRecord(id string, name string) database.Record {
+	return database.Record{Details: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+		bundle.RelationKeyId:   domain.String(id),
+		bundle.RelationKeyName: domain.String(name),
+	})}
+}
+
+func TestRecordsBuffer(t *testing.T) {
+	t.Run("coalesces multiple updates of one object to the latest", func(t *testing.T) {
+		// given
+		b := newRecordsBuffer()
+
+		// when
+		require.NoError(t, b.Add(bufferRecord("id1", "v1")))
+		require.NoError(t, b.Add(bufferRecord("id2", "other")))
+		require.NoError(t, b.Add(bufferRecord("id1", "v2")))
+		require.NoError(t, b.Add(bufferRecord("id1", "v3")))
+
+		// then
+		batch, err := b.Wait(context.Background())
+		require.NoError(t, err)
+		require.Len(t, batch, 2)
+		assert.Equal(t, "v3", batch[0].Details.GetString(bundle.RelationKeyName))
+		assert.Equal(t, "id1", batch[0].Details.GetString(bundle.RelationKeyId))
+		assert.Equal(t, "id2", batch[1].Details.GetString(bundle.RelationKeyId))
+	})
+
+	t.Run("coalescing restarts after a batch is consumed", func(t *testing.T) {
+		// given
+		b := newRecordsBuffer()
+		require.NoError(t, b.Add(bufferRecord("id1", "v1")))
+		_, err := b.Wait(context.Background())
+		require.NoError(t, err)
+
+		// when
+		require.NoError(t, b.Add(bufferRecord("id1", "v2")))
+
+		// then
+		batch, err := b.Wait(context.Background())
+		require.NoError(t, err)
+		require.Len(t, batch, 1)
+		assert.Equal(t, "v2", batch[0].Details.GetString(bundle.RelationKeyName))
+	})
+
+	t.Run("wait is unblocked by an asynchronous add", func(t *testing.T) {
+		// given
+		b := newRecordsBuffer()
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			_ = b.Add(bufferRecord("id1", "v1"))
+		}()
+
+		// when
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		batch, err := b.Wait(ctx)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, batch, 1)
+	})
+
+	t.Run("wait respects context cancellation", func(t *testing.T) {
+		// given
+		b := newRecordsBuffer()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+
+		// when
+		_, err := b.Wait(ctx)
+
+		// then
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("close unblocks wait and rejects adds", func(t *testing.T) {
+		// given
+		b := newRecordsBuffer()
+		done := make(chan error, 1)
+		go func() {
+			_, err := b.Wait(context.Background())
+			done <- err
+		}()
+
+		// when
+		time.Sleep(10 * time.Millisecond)
+		b.Close()
+
+		// then
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, errRecordsBufferClosed)
+		case <-time.After(5 * time.Second):
+			t.Fatal("wait was not unblocked by close")
+		}
+		require.ErrorIs(t, b.Add(bufferRecord("id1", "v1")), errRecordsBufferClosed)
+	})
+}

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -453,25 +453,34 @@ func (s *spaceSubscriptions) Search(req SubscribeRequest) (*SubscribeResponse, e
 		return nil, fmt.Errorf("new database filters: %w", err)
 	}
 
+	var sourceKeys []domain.RelationKey
 	if len(req.Source) > 0 {
-		sourceFilter, err := s.filtersFromSource(req.Source)
+		sourceFilter, keys, err := s.filtersFromSource(req.Source)
 		if err != nil {
 			return nil, fmt.Errorf("can't make filter from source: %w", err)
 		}
 		f.FilterObj = database.FiltersAnd{f.FilterObj, sourceFilter}
-	}
-
-	requiredKeys := s.requiredKeysForRequest(req)
-	keySet := make(map[string]struct{}, len(requiredKeys))
-	for _, k := range requiredKeys {
-		keySet[string(k)] = struct{}{}
-	}
-	qryEntries := func() ([]*entry, error) {
-		return queryEntries(s.objectStore, f, keySet)
+		sourceKeys = keys
 	}
 
 	s.m.Lock()
 	defer s.m.Unlock()
+
+	// requiredKeys stays nil for requests without keys: such subscriptions are
+	// not registered for projection and their entries keep full details.
+	// Computed under s.m: it touches the dependency service relation format cache
+	var requiredKeys []domain.RelationKey
+	var keySet map[string]struct{}
+	if len(req.Keys) > 0 {
+		requiredKeys = s.requiredKeysForRequest(req, sourceKeys)
+		keySet = make(map[string]struct{}, len(requiredKeys))
+		for _, k := range requiredKeys {
+			keySet[string(k)] = struct{}{}
+		}
+	}
+	qryEntries := func() ([]*entry, error) {
+		return queryEntries(s.objectStore, f, keySet)
+	}
 
 	filterDepIds := s.depIdsFromFilter(req.Filters)
 	if existing, ok := s.getSubscription(req.SubId); ok {
@@ -492,13 +501,14 @@ func (s *spaceSubscriptions) Search(req SubscribeRequest) (*SubscribeResponse, e
 }
 
 // requiredKeysForRequest returns the relation keys that must be retained in
-// cached entries of this subscription: requested keys, sort keys and filter
+// cached entries of this subscription: requested keys, sort, filter and source
 // keys (filters can be re-evaluated against retained data on collection
 // updates), plus id. When sorting by an object-format relation, name and
 // orderId of the dependent objects are retained too, as the dependency
-// subscription orders by them (see dependencyService.depSubKeys)
-func (s *spaceSubscriptions) requiredKeysForRequest(req SubscribeRequest) []domain.RelationKey {
-	res := make([]domain.RelationKey, 0, len(req.Keys)+len(req.Sorts)+len(req.Filters)+3)
+// subscription orders by them (see dependencyService.depSubKeys).
+// Must be called under s.m: it touches the dependency service relation format cache
+func (s *spaceSubscriptions) requiredKeysForRequest(req SubscribeRequest, extraKeys []domain.RelationKey) []domain.RelationKey {
+	res := make([]domain.RelationKey, 0, len(req.Keys)+len(req.Sorts)+len(req.Filters)+len(extraKeys)+3)
 	seen := make(map[domain.RelationKey]struct{}, cap(res))
 	add := func(k domain.RelationKey) {
 		if k == "" {
@@ -516,6 +526,9 @@ func (s *spaceSubscriptions) requiredKeysForRequest(req SubscribeRequest) []doma
 	add(bundle.RelationKeyId)
 	for _, k := range req.Keys {
 		add(domain.RelationKey(k))
+	}
+	for _, k := range extraKeys {
+		add(k)
 	}
 	var addFilters func(filters []database.FilterRequest)
 	addFilters = func(filters []database.FilterRequest) {
@@ -544,7 +557,9 @@ func (s *spaceSubscriptions) subscribeForQuery(req SubscribeRequest, f *database
 	} else {
 		sub.forceSubIds = filterDepIds
 	}
-	s.registerSubKeys(sub.id, requiredKeys)
+	if requiredKeys != nil {
+		s.registerSubKeys(sub.id, requiredKeys)
+	}
 	s.setSubscription(sub.id, sub)
 
 	// FIXME Nested subscriptions disabled now. We should enable them only by client's request
@@ -723,7 +738,9 @@ func (s *spaceSubscriptions) SubscribeIdsReq(req pb.RpcObjectSubscribeIdsRequest
 
 	s.m.Lock()
 	sub := s.newIdsSub(req.SubId, slice.StringsInto[domain.RelationKey](req.Keys), req.NoDepSubscription)
-	s.registerSubKeys(req.SubId, s.requiredKeysForRequest(SubscribeRequest{Keys: req.Keys}))
+	if len(req.Keys) > 0 {
+		s.registerSubKeys(req.SubId, s.requiredKeysForRequest(SubscribeRequest{Keys: req.Keys}, nil))
+	}
 	sub.addIds(req.Ids)
 	s.m.Unlock()
 
@@ -789,12 +806,14 @@ func (s *spaceSubscriptions) SubscribeGroups(req SubscribeGroupsRequest) (*pb.Rp
 		return nil, err
 	}
 
+	var sourceKeys []domain.RelationKey
 	if len(req.Source) > 0 {
-		sourceFilter, err := s.filtersFromSource(req.Source)
+		sourceFilter, keys, err := s.filtersFromSource(req.Source)
 		if err != nil {
 			return nil, fmt.Errorf("can't make filter from source: %w", err)
 		}
 		flt.FilterObj = database.FiltersAnd{flt.FilterObj, sourceFilter}
+		sourceKeys = keys
 	}
 
 	var colObserver *collectionObserver
@@ -850,7 +869,7 @@ func (s *spaceSubscriptions) SubscribeGroups(req SubscribeGroupsRequest) (*pb.Rp
 		s.registerSubKeys(subId, s.requiredKeysForRequest(SubscribeRequest{
 			Keys:    []string{req.RelationKey},
 			Filters: req.Filters,
-		}))
+		}, sourceKeys))
 
 		entries := make([]*entry, 0, len(tagGrouper.Records))
 		for _, r := range tagGrouper.Records {
@@ -1017,11 +1036,14 @@ func (s *spaceSubscriptions) onChangeWithinContext(entries []*entry, proc func(c
 	return dur
 }
 
-func (s *spaceSubscriptions) filtersFromSource(sources []string) (database.Filter, error) {
+// filtersFromSource also returns the relation keys the produced filter reads,
+// so they can be retained in projected entries
+func (s *spaceSubscriptions) filtersFromSource(sources []string) (database.Filter, []domain.RelationKey, error) {
 	var relTypeFilter database.FiltersOr
 	var (
 		relKeys        []string
 		typeUniqueKeys []string
+		filterKeys     []domain.RelationKey
 	)
 
 	var err error
@@ -1032,7 +1054,7 @@ func (s *spaceSubscriptions) filtersFromSource(sources []string) (database.Filte
 			log.Info("Using object id instead of uniqueKey is deprecated in the Source")
 			uk, err = s.objectStore.GetUniqueKeyById(source)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 		switch uk.SmartblockType() {
@@ -1050,17 +1072,19 @@ func (s *spaceSubscriptions) filtersFromSource(sources []string) (database.Filte
 			Value:       domain.StringList(typeUniqueKeys),
 		}, s.objectStore)
 		if err != nil {
-			return nil, fmt.Errorf("make nested filter: %w", err)
+			return nil, nil, fmt.Errorf("make nested filter: %w", err)
 		}
 		relTypeFilter = append(relTypeFilter, nestedFiler)
+		filterKeys = append(filterKeys, bundle.RelationKeyType)
 	}
 
 	for _, relKey := range relKeys {
 		relTypeFilter = append(relTypeFilter, database.FilterExists{
 			Key: domain.RelationKey(relKey),
 		})
+		filterKeys = append(filterKeys, domain.RelationKey(relKey))
 	}
-	return relTypeFilter, nil
+	return relTypeFilter, filterKeys, nil
 }
 
 func (s *spaceSubscriptions) depIdsFromFilter(filters []database.FilterRequest) (depIds []string) {

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -319,7 +319,7 @@ func (s *service) getSpaceSubscriptions(spaceId string) (*spaceSubscriptions, er
 		subscriptions:     make(map[string]subscription, 20),
 		subKeys:           subKeys,
 		customOutput:      map[string]*internalSubOutput{},
-		recBatch:          mb.New[database.Record](0),
+		recBatch:          newRecordsBuffer(),
 		objectStore:       index,
 		kanban:            s.kanban,
 		collectionService: s.collectionService,
@@ -346,7 +346,7 @@ type spaceSubscriptions struct {
 	subKeys map[string][]domain.RelationKey
 
 	customOutput map[string]*internalSubOutput
-	recBatch     *mb.MB[database.Record]
+	recBatch     *recordsBuffer
 
 	// Deps
 	objectStore       spaceindex.Store
@@ -370,11 +370,10 @@ func (s *spaceSubscriptions) Run() (err error) {
 	// SubscribeForAll only stores the callback; it is invoked later, on the
 	// goroutine of whoever writes object details (sendUpdatesToSubscriptions).
 	// So there is no synchronous registration error to surface here, and the
-	// add error (only non-nil once the batch is closed or s.ctx is cancelled,
-	// i.e. on shutdown) must be handled inside the callback — capturing it in
-	// a shared variable raced concurrent writers against this goroutine.
+	// add error (only non-nil once the buffer is closed, i.e. on shutdown)
+	// must be handled inside the callback
 	s.objectStore.SubscribeForAll(func(rec database.Record) {
-		if addErr := s.recBatch.Add(s.ctx, rec); addErr != nil {
+		if addErr := s.recBatch.Add(rec); addErr != nil {
 			log.With("error", addErr).Errorf("subscribe-for-all: add record to batch")
 		}
 	})
@@ -944,38 +943,19 @@ func (s *spaceSubscriptions) SubscriptionIDs() []string {
 
 func (s *spaceSubscriptions) recordsHandler() {
 	var entries []*entry
-	// id -> index of the latest entry for this id within the current batch
-	entryIdx := make(map[string]int)
 	for {
+		// the buffer coalesces by object id, so the batch holds one latest record per object
 		records, err := s.recBatch.Wait(s.ctx)
 		if err != nil {
 			return
 		}
-		if len(records) == 0 {
-			return
-		}
+		entries = entries[:0]
 		for _, rec := range records {
-			id := rec.Details.GetString(bundle.RelationKeyId)
-			// nil previous version
-			if i, ok := entryIdx[id]; ok {
-				entries[i] = nil
-			}
-			entries = append(entries, newEntry(id, rec.Details))
-			entryIdx[id] = len(entries) - 1
+			entries = append(entries, newEntry(rec.Details.GetString(bundle.RelationKeyId), rec.Details))
 		}
-		// filter nil entries
-		filtered := entries[:0]
-		for _, e := range entries {
-			if e != nil {
-				filtered = append(filtered, e)
-			}
-		}
-		log.Debugf("batch rewrite: %d->%d", len(entries), len(filtered))
-		if s.onChange(filtered) < batchTime {
+		if s.onChange(entries) < batchTime {
 			time.Sleep(batchTime)
 		}
-		entries = entries[:0]
-		clear(entryIdx)
 	}
 }
 

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -579,14 +579,21 @@ func initSubEntries(objectStore spaceindex.Store, f *database.Filters, sub *sort
 	return nil
 }
 
+// queryEntries streams matching documents directly into entries, skipping the
+// intermediate records slice and the store-side sort: the subscription orders
+// entries itself in the skip-list
 func queryEntries(objectStore spaceindex.Store, f *database.Filters) ([]*entry, error) {
-	records, err := objectStore.QueryRaw(f, 0, 0)
+	var entries []*entry
+	err := objectStore.QueryRawIterate(f.FilterObj, func(doc *anyenc.Value) error {
+		details, err := domain.NewDetailsFromAnyEnc(doc)
+		if err != nil {
+			return fmt.Errorf("unmarshal details: %w", err)
+		}
+		entries = append(entries, newEntry(details.GetString(bundle.RelationKeyId), details))
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("objectStore query error: %w", err)
-	}
-	entries := make([]*entry, 0, len(records))
-	for _, r := range records {
-		entries = append(entries, newEntry(r.Details.GetString(bundle.RelationKeyId), r.Details))
 	}
 	return entries, nil
 }

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -853,14 +853,8 @@ func (s *spaceSubscriptions) SubscriptionIDs() []string {
 
 func (s *spaceSubscriptions) recordsHandler() {
 	var entries []*entry
-	nilIfExists := func(id string) {
-		for i, e := range entries {
-			if e != nil && e.id == id {
-				entries[i] = nil
-				return
-			}
-		}
-	}
+	// id -> index of the latest entry for this id within the current batch
+	entryIdx := make(map[string]int)
 	for {
 		records, err := s.recBatch.Wait(s.ctx)
 		if err != nil {
@@ -872,8 +866,11 @@ func (s *spaceSubscriptions) recordsHandler() {
 		for _, rec := range records {
 			id := rec.Details.GetString(bundle.RelationKeyId)
 			// nil previous version
-			nilIfExists(id)
+			if i, ok := entryIdx[id]; ok {
+				entries[i] = nil
+			}
 			entries = append(entries, newEntry(id, rec.Details))
+			entryIdx[id] = len(entries) - 1
 		}
 		// filter nil entries
 		filtered := entries[:0]
@@ -887,6 +884,7 @@ func (s *spaceSubscriptions) recordsHandler() {
 			time.Sleep(batchTime)
 		}
 		entries = entries[:0]
+		clear(entryIdx)
 	}
 }
 

--- a/core/subscription/service.go
+++ b/core/subscription/service.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -311,17 +312,19 @@ func (s *service) getSpaceSubscriptions(spaceId string) (*spaceSubscriptions, er
 		return spaceSubs, nil
 	}
 	cache := newCache()
+	subKeys := make(map[string][]domain.RelationKey, 20)
 	spaceSubs := &spaceSubscriptions{
 		cache:             cache,
 		subscriptionKeys:  make([]string, 0, 20),
 		subscriptions:     make(map[string]subscription, 20),
+		subKeys:           subKeys,
 		customOutput:      map[string]*internalSubOutput{},
 		recBatch:          mb.New[database.Record](0),
 		objectStore:       index,
 		kanban:            s.kanban,
 		collectionService: s.collectionService,
 		eventSender:       s.eventSender,
-		ctxBuf:            &opCtx{spaceId: spaceId, c: cache},
+		ctxBuf:            &opCtx{spaceId: spaceId, c: cache, subKeys: subKeys},
 		arenaPool:         s.arenaPool,
 	}
 	spaceSubs.ds = newDependencyService(spaceSubs)
@@ -336,6 +339,11 @@ func (s *service) getSpaceSubscriptions(spaceId string) (*spaceSubscriptions, er
 type spaceSubscriptions struct {
 	subscriptionKeys []string
 	subscriptions    map[string]subscription
+	// subKeys maps subscription id to the relation keys retained in cached
+	// entries for it; entries are projected to the union over their
+	// subscriptions on every change batch (see opCtx.projectEntries).
+	// Guarded by m
+	subKeys map[string][]domain.RelationKey
 
 	customOutput map[string]*internalSubOutput
 	recBatch     *mb.MB[database.Record]
@@ -397,7 +405,25 @@ func (s *spaceSubscriptions) setSubscription(id string, sub subscription) {
 
 func (s *spaceSubscriptions) deleteSubscription(id string) {
 	delete(s.subscriptions, id)
+	s.deregisterSubKeys(id)
 	s.subscriptionKeys = slice.RemoveMut(s.subscriptionKeys, id)
+}
+
+// registerSubKeys must be called under s.m
+func (s *spaceSubscriptions) registerSubKeys(subId string, keys []domain.RelationKey) {
+	if s.subKeys == nil {
+		s.subKeys = make(map[string][]domain.RelationKey)
+		if s.ctxBuf != nil && s.ctxBuf.subKeys == nil {
+			s.ctxBuf.subKeys = s.subKeys
+		}
+	}
+	s.subKeys[subId] = keys
+}
+
+// deregisterSubKeys must be called under s.m
+func (s *spaceSubscriptions) deregisterSubKeys(subId string) {
+	delete(s.subKeys, subId)
+	delete(s.subKeys, subId+"/dep")
 }
 
 func (s *spaceSubscriptions) iterateSubscriptions(proc func(sub subscription)) {
@@ -436,8 +462,13 @@ func (s *spaceSubscriptions) Search(req SubscribeRequest) (*SubscribeResponse, e
 		f.FilterObj = database.FiltersAnd{f.FilterObj, sourceFilter}
 	}
 
+	requiredKeys := s.requiredKeysForRequest(req)
+	keySet := make(map[string]struct{}, len(requiredKeys))
+	for _, k := range requiredKeys {
+		keySet[string(k)] = struct{}{}
+	}
 	qryEntries := func() ([]*entry, error) {
-		return queryEntries(s.objectStore, f)
+		return queryEntries(s.objectStore, f, keySet)
 	}
 
 	s.m.Lock()
@@ -456,20 +487,65 @@ func (s *spaceSubscriptions) Search(req SubscribeRequest) (*SubscribeResponse, e
 	}
 
 	if req.CollectionId != "" {
-		return s.subscribeForCollection(req, f, filterDepIds)
+		return s.subscribeForCollection(req, f, filterDepIds, requiredKeys)
 	}
-	return s.subscribeForQuery(req, f, qryEntries, filterDepIds)
+	return s.subscribeForQuery(req, f, qryEntries, filterDepIds, requiredKeys)
+}
+
+// requiredKeysForRequest returns the relation keys that must be retained in
+// cached entries of this subscription: requested keys, sort keys and filter
+// keys (filters can be re-evaluated against retained data on collection
+// updates), plus id. When sorting by an object-format relation, name and
+// orderId of the dependent objects are retained too, as the dependency
+// subscription orders by them (see dependencyService.depSubKeys)
+func (s *spaceSubscriptions) requiredKeysForRequest(req SubscribeRequest) []domain.RelationKey {
+	res := make([]domain.RelationKey, 0, len(req.Keys)+len(req.Sorts)+len(req.Filters)+3)
+	seen := make(map[domain.RelationKey]struct{}, cap(res))
+	add := func(k domain.RelationKey) {
+		if k == "" {
+			return
+		}
+		// nested keys like "type.uniqueKey" address other objects; retain the head segment
+		if i := strings.IndexByte(string(k), '.'); i >= 0 {
+			k = k[:i]
+		}
+		if _, ok := seen[k]; !ok {
+			seen[k] = struct{}{}
+			res = append(res, k)
+		}
+	}
+	add(bundle.RelationKeyId)
+	for _, k := range req.Keys {
+		add(domain.RelationKey(k))
+	}
+	var addFilters func(filters []database.FilterRequest)
+	addFilters = func(filters []database.FilterRequest) {
+		for _, f := range filters {
+			add(f.RelationKey)
+			addFilters(f.NestedFilters)
+		}
+	}
+	addFilters(req.Filters)
+	for _, srt := range req.Sorts {
+		add(srt.RelationKey)
+		if s.ds.isRelationObject(srt.RelationKey) {
+			add(bundle.RelationKeyName)
+			add(bundle.RelationKeyOrderId)
+		}
+	}
+	return res
 }
 
 // subscribeForQuery creates a new sorted subscription for the given query.
 // Caller must hold s.m locked; this method temporarily unlocks it during the query and re-locks before returning.
-func (s *spaceSubscriptions) subscribeForQuery(req SubscribeRequest, f *database.Filters, queryEntries func() ([]*entry, error), filterDepIds []string) (*SubscribeResponse, error) {
+func (s *spaceSubscriptions) subscribeForQuery(req SubscribeRequest, f *database.Filters, queryEntries func() ([]*entry, error), filterDepIds []string, requiredKeys []domain.RelationKey) (*SubscribeResponse, error) {
 	sub := s.newSortedSub(req.SubId, slice.StringsInto[domain.RelationKey](req.Keys), f.FilterObj, f.Order, int(req.Limit), int(req.Offset))
 	if req.NoDepSubscription {
 		sub.disableDep = true
 	} else {
 		sub.forceSubIds = filterDepIds
 	}
+	s.registerSubKeys(sub.id, requiredKeys)
 	s.setSubscription(sub.id, sub)
 
 	// FIXME Nested subscriptions disabled now. We should enable them only by client's request
@@ -481,6 +557,7 @@ func (s *spaceSubscriptions) subscribeForQuery(req SubscribeRequest, f *database
 			f, ok := nestedFilter.(*database.FilterNestedIn)
 			if ok {
 				childSub := s.newSortedSub(req.SubId+fmt.Sprintf("-nested-%d", nestedCount), []domain.RelationKey{bundle.RelationKeyId}, f.FilterForNestedObjects, nil, 0, 0)
+				s.registerSubKeys(childSub.id, []domain.RelationKey{bundle.RelationKeyId})
 				err := initSubEntries(s.objectStore, &database.Filters{FilterObj: f.FilterForNestedObjects}, childSub)
 				if err != nil {
 					return fmt.Errorf("init nested sub %s entries: %w", childSub.id, err)
@@ -569,7 +646,7 @@ func (s *spaceSubscriptions) subscribeForQuery(req SubscribeRequest, f *database
 }
 
 func initSubEntries(objectStore spaceindex.Store, f *database.Filters, sub *sortedSub) error {
-	entries, err := queryEntries(objectStore, f)
+	entries, err := queryEntries(objectStore, f, nil)
 	if err != nil {
 		return err
 	}
@@ -581,11 +658,12 @@ func initSubEntries(objectStore spaceindex.Store, f *database.Filters, sub *sort
 
 // queryEntries streams matching documents directly into entries, skipping the
 // intermediate records slice and the store-side sort: the subscription orders
-// entries itself in the skip-list
-func queryEntries(objectStore spaceindex.Store, f *database.Filters) ([]*entry, error) {
+// entries itself in the skip-list. A non-nil keys set limits decoding to those
+// keys, the rest of the document is never materialized
+func queryEntries(objectStore spaceindex.Store, f *database.Filters, keys map[string]struct{}) ([]*entry, error) {
 	var entries []*entry
 	err := objectStore.QueryRawIterate(f.FilterObj, func(doc *anyenc.Value) error {
-		details, err := domain.NewDetailsFromAnyEnc(doc)
+		details, err := domain.NewDetailsFromAnyEncWithKeys(doc, keys)
 		if err != nil {
 			return fmt.Errorf("unmarshal details: %w", err)
 		}
@@ -598,8 +676,8 @@ func queryEntries(objectStore spaceindex.Store, f *database.Filters) ([]*entry, 
 	return entries, nil
 }
 
-func (s *spaceSubscriptions) subscribeForCollection(req SubscribeRequest, f *database.Filters, filterDepIds []string) (*SubscribeResponse, error) {
-	sub, err := s.newCollectionSub(req, f, filterDepIds)
+func (s *spaceSubscriptions) subscribeForCollection(req SubscribeRequest, f *database.Filters, filterDepIds []string, requiredKeys []domain.RelationKey) (*SubscribeResponse, error) {
+	sub, err := s.newCollectionSub(req, f, filterDepIds, requiredKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -646,6 +724,7 @@ func (s *spaceSubscriptions) SubscribeIdsReq(req pb.RpcObjectSubscribeIdsRequest
 
 	s.m.Lock()
 	sub := s.newIdsSub(req.SubId, slice.StringsInto[domain.RelationKey](req.Keys), req.NoDepSubscription)
+	s.registerSubKeys(req.SubId, s.requiredKeysForRequest(SubscribeRequest{Keys: req.Keys}))
 	sub.addIds(req.Ids)
 	s.m.Unlock()
 
@@ -769,6 +848,10 @@ func (s *spaceSubscriptions) SubscribeGroups(req SubscribeGroupsRequest) (*pb.Rp
 		} else {
 			sub = s.newGroupSub(subId, domain.RelationKey(req.RelationKey), flt, groups)
 		}
+		s.registerSubKeys(subId, s.requiredKeysForRequest(SubscribeRequest{
+			Keys:    []string{req.RelationKey},
+			Filters: req.Filters,
+		}))
 
 		entries := make([]*entry, 0, len(tagGrouper.Records))
 		for _, r := range tagGrouper.Records {
@@ -849,6 +932,7 @@ func (s *spaceSubscriptions) UnsubscribeAll() (err error) {
 	}
 	s.subscriptions = make(map[string]subscription)
 	s.subscriptionKeys = s.subscriptionKeys[:0]
+	clear(s.subKeys)
 	return
 }
 
@@ -1024,5 +1108,6 @@ func (s *spaceSubscriptions) Close(ctx context.Context) (err error) {
 		delete(s.subscriptions, subId)
 	}
 	s.subscriptionKeys = s.subscriptionKeys[:0]
+	clear(s.subKeys)
 	return
 }

--- a/core/subscription/sorted.go
+++ b/core/subscription/sorted.go
@@ -178,7 +178,9 @@ func (s *sortedSub) onChange(ctx *opCtx) {
 		})
 		s.parentFilter.IDs = idsForParentFilter
 
-		ctx.entries = append(ctx.entries, parentEntries...)
+		for _, e := range parentEntries {
+			ctx.appendEntry(e)
+		}
 		s.parent.onChange(ctx)
 	}
 }

--- a/core/subscription/sorted.go
+++ b/core/subscription/sorted.go
@@ -249,7 +249,9 @@ func (s *sortedSub) onSklChange(ctx *opCtx) {
 	}
 
 	wasAddOrRemove, added, removed := s.diff.diff(ctx, s.id, s.keys)
-	s.ds.depEntriesByEntries(ctx, added)
+	// pull the entries added to this subscription into the context, so their
+	// details events can be built; the keys must cover this subscription's keys
+	s.ds.depEntriesByEntries(ctx, s.id, s.keys, added)
 
 	hasChanges := false
 	for _, e := range ctx.entries {

--- a/core/subscription/sorted.go
+++ b/core/subscription/sorted.go
@@ -167,7 +167,7 @@ func (s *sortedSub) onChange(ctx *opCtx) {
 	s.onSklChange(ctx)
 
 	if s.parent != nil {
-		parentEntries, err := queryEntries(s.objectStore, &database.Filters{FilterObj: s.parent.filter})
+		parentEntries, err := queryEntries(s.objectStore, &database.Filters{FilterObj: s.parent.filter}, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/lib/localstore/objectstore/spaceindex/invalid.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/invalid.go
@@ -51,6 +51,10 @@ func (s *invalidStore) QueryRaw(f *database.Filters, limit int, offset int) (rec
 	return nil, s.err
 }
 
+func (s *invalidStore) QueryRawIterate(filter database.Filter, proc func(doc *anyenc.Value) error) error {
+	return s.err
+}
+
 func (s *invalidStore) QueryAndCount(q database.Query) (records []database.Record, total int, err error) {
 	return nil, 0, s.err
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -163,6 +163,33 @@ func (s *dsObjectStore) QueryRaw(filters *database.Filters, limit int, offset in
 	return s.queryAnyStore(s.componentCtx, filters.FilterObj, filters.Order, uint(limit), uint(offset))
 }
 
+func (s *dsObjectStore) QueryRawIterate(filter database.Filter, proc func(doc *anyenc.Value) error) error {
+	if filter == nil {
+		return fmt.Errorf("filter cannot be nil")
+	}
+	iter, err := s.objects.Find(filter.AnystoreFilter()).Iter(s.componentCtx)
+	if err != nil {
+		return fmt.Errorf("find: %w", err)
+	}
+	defer iter.Close()
+
+	for iter.Next() {
+		doc, err := iter.Doc()
+		if err != nil {
+			return fmt.Errorf("get doc: %w", err)
+		}
+		err = proc(doc.Value())
+		if err != nil {
+			return fmt.Errorf("process doc: %w", err)
+		}
+	}
+	err = iter.Err()
+	if err != nil {
+		return fmt.Errorf("iterate: %w", err)
+	}
+	return nil
+}
+
 type injectionHit struct {
 	id      string
 	details *domain.Details

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -11,6 +11,7 @@ import (
 
 	anystore "github.com/anyproto/any-store"
 	"github.com/anyproto/any-store/anyenc"
+	"github.com/anyproto/any-store/query"
 	"github.com/samber/lo"
 	"golang.org/x/exp/slices"
 	"golang.org/x/text/collate"
@@ -698,6 +699,8 @@ func (s *dsObjectStore) QueryObjectIds(q database.Query) (ids []string, total in
 }
 
 func (s *dsObjectStore) QueryByIds(ids []string) (records []database.Record, err error) {
+	detailsById := make(map[string]*domain.Details, len(ids))
+	storeIds := make([]string, 0, len(ids))
 	for _, id := range ids {
 		// Don't use spaceID because expected objects are virtual
 		if sbt, err := typeprovider.SmartblockTypeFromID(id); err == nil {
@@ -711,23 +714,58 @@ func (s *dsObjectStore) QueryByIds(ids []string) (records []database.Record, err
 					continue
 				}
 				details.SetString(bundle.RelationKeyId, id)
-				records = append(records, database.Record{Details: details})
+				detailsById[id] = details
 				continue
 			}
 		}
-		doc, err := s.objects.FindId(s.componentCtx, id)
-		if err != nil {
-			log.With("id", id).Infof("QueryByIds failed to find id: %s", err.Error())
-			continue
-		}
-		details, err := domain.NewDetailsFromAnyEnc(doc.Value())
-		if err != nil {
-			log.With("id", id).Errorf("QueryByIds failed to extract details: %s", err.Error())
-			continue
-		}
-		records = append(records, database.Record{Details: details})
+		storeIds = append(storeIds, id)
 	}
-	return
+
+	if len(storeIds) > 0 {
+		// fetch all indexable objects in a single query instead of per-id lookups
+		arena := s.arenaPool.Get()
+		defer func() {
+			arena.Reset()
+			s.arenaPool.Put(arena)
+		}()
+		inVals := make([]*anyenc.Value, 0, len(storeIds))
+		for _, id := range storeIds {
+			inVals = append(inVals, arena.NewString(id))
+		}
+		filter := query.Key{
+			Path:   []string{bundle.RelationKeyId.String()},
+			Filter: query.NewInValue(inVals...),
+		}
+		iter, err := s.objects.Find(filter).Iter(s.componentCtx)
+		if err != nil {
+			return nil, fmt.Errorf("find by ids: %w", err)
+		}
+		defer iter.Close()
+		for iter.Next() {
+			doc, err := iter.Doc()
+			if err != nil {
+				return nil, fmt.Errorf("get doc: %w", err)
+			}
+			details, err := domain.NewDetailsFromAnyEnc(doc.Value())
+			if err != nil {
+				log.Errorf("QueryByIds failed to extract details: %s", err.Error())
+				continue
+			}
+			detailsById[details.GetString(bundle.RelationKeyId)] = details
+		}
+		if err = iter.Err(); err != nil {
+			return nil, fmt.Errorf("iterate by ids: %w", err)
+		}
+	}
+
+	// keep the order of the requested ids, skipping missing ones
+	records = make([]database.Record, 0, len(detailsById))
+	for _, id := range ids {
+		if details, ok := detailsById[id]; ok {
+			records = append(records, database.Record{Details: details})
+		}
+	}
+	return records, nil
 }
 
 func (s *dsObjectStore) QueryByIdsAndSubscribeForChanges(ids []string, sub database.Subscription) (records []database.Record, closeFunc func(), err error) {

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -54,6 +54,10 @@ type Store interface {
 	// It applies the same implicit filters as Query. Fulltext queries are not supported.
 	QueryAndCount(q database.Query) (records []database.Record, total int, err error)
 	QueryRaw(f *database.Filters, limit int, offset int) (records []database.Record, err error)
+	// QueryRawIterate streams raw anyenc documents matching the filter, without sorting
+	// and without materializing them into records. The document is only valid within
+	// the callback; decode or copy what is needed
+	QueryRawIterate(filter database.Filter, proc func(doc *anyenc.Value) error) error
 	QueryByIds(ids []string) (records []database.Record, err error)
 	QueryByIdsAndSubscribeForChanges(ids []string, subscription database.Subscription) (records []database.Record, close func(), err error)
 	QueryObjectIds(q database.Query) (ids []string, total int, err error)

--- a/pkg/lib/localstore/objectstore/spaceindex/update.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/update.go
@@ -61,10 +61,13 @@ func (s *dsObjectStore) SubscribeForAll(callback func(rec database.Record)) {
 }
 
 func (s *dsObjectStore) sendUpdatesToSubscriptions(id string, details *domain.Details) {
-	detCopy := details.Copy()
-	detCopy.SetString(bundle.RelationKeyId, id)
 	s.lock.RLock()
 	defer s.lock.RUnlock()
+	if s.onChangeCallback == nil && len(s.subscriptions) == 0 {
+		return
+	}
+	detCopy := details.Copy()
+	detCopy.SetString(bundle.RelationKeyId, id)
 	if s.onChangeCallback != nil {
 		s.onChangeCallback(database.Record{
 			Details: detCopy,


### PR DESCRIPTION
## Summary

Refactors the subscription system (`ObjectSearchSubscribe`, `core/subscription`) to cut memory allocations and steady-state heap usage, in reviewable phases (one commit each):

- **Benchmarks first** (`core/subscription/bench_test.go`): subscription init, in-window change batches, no-match batches, plus `keys/entry` and `heap-MB` cache-retention metrics.
- **Low-risk allocation fixes**: lazy entry bookkeeping maps, map-based batch dedup (was O(n²)), skip `details.Copy()` when no subscription listens to store updates, `CopyOnlyKeys` O(keys) instead of O(fields×keys), id indexes for `opCtx` entries/keysBuf, set-based dep-id dedup (also fixes latent `forceIds` slice aliasing).
- **Iterator-based init**: new `spaceindex.QueryRawIterate` streams raw anyenc docs without store-side sort (the skip-list orders entries anyway) or an intermediate `[]database.Record`; `QueryByIds` becomes one `In(ids)` query instead of per-id lookups; `ToProtoOnlyKeys` removes an intermediate map copy from every DetailsSet event.
- **Entry projection (the main heap win)**: each subscription registers the relation keys it needs (requested ∪ sort ∪ filter ∪ source keys, + name/orderId for object-relation sorts); cached entries are decoded and retained only for the union over their subscriptions, instead of keeping the full details of every matching object for the life of the subscription. Client events stay wire-identical: amend/unset payloads are already filtered to per-sub keys (`state.StructDiffIntoEventsWithSubIds`).
- **Coalescing change buffer**: `recBatch` (unbounded `mb.MB` of full-detail copies) replaced with a latest-wins-per-object buffer, bounding pipeline memory during mass indexing.

## Results (M2, 10k objects, 11 requested keys, limit 100)

| Metric | Before | After |
|---|---|---|
| Search (subscribe) | 112 ms / 35.7 MB / 762k allocs | 80 ms / 21.1 MB / 451k allocs |
| Cache retention | ~26 keys/entry (full object) | ~11 keys/entry |
| No-match change batch | 111 allocs | 91 allocs |
| In-window change batch | 201 allocs | 251 allocs (re-projection of changed entries — trade for the smaller resident cache) |

## Review hardening

A multi-agent code review of the branch surfaced three must-fix issues, all addressed in the last commit with regression tests:
- required-keys computation moved under the space lock (data race on the dependency service relation-format cache with concurrent Search calls; `TestConcurrentSearch` under `-race`),
- the collection observer pushes full store details for changed membership (projected cache entries fed into the pipeline could make filters of unrelated subscriptions misfire); only deleted objects fall back to the cache,
- dependency entries served from the cache are refreshed from the store when another subscription's projection trimmed keys they need (`TestDepEntriesRegainProjectedKeys`),
- subscriptions with an empty `Keys` list are excluded from projection entirely (fail-safe full retention).

Consciously accepted (no behavior worse than before): a same-batch join of a second subscription can include its keys in the sibling's amend (values correct; DetailsSet already leaked union keys pre-refactor); `QueryByIds` returns shared `*Details` for duplicate input ids and fails on iterator doc errors instead of skipping one id.

## Notes

- Entries belonging to an unregistered subscription keep full details as a fail-safe; the disabled nested-subscriptions path is registered minimally and stays dead.
- The in-repo integration suite (`make test-integration`) currently does not build on develop itself (stale `tests/testing_test.go` vs the `RpcWalletCreateSession` oneof) — verified pre-existing, not from this branch. Running the external e2e suite against this branch before merge is recommended.
- Verified: full subscription/objectstore/domain suites green incl. `-race`; broad sweep over `QueryByIds`/subscription consumers (block editor, export, syncstatus, files, acl, api, space) green; rebased on latest develop (lazy cross-space subscriptions, fulltext rework) with suites re-run.

Closes GO-7315