### PR TITLE
GO-7311 Reuse empty focused block when pasting a multi-block range

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -1376,16 +1376,16 @@ func TestPasteIntoEmptyStyledBlock(t *testing.T) {
 			require.NotNil(t, targetBlock, "target block should not be deleted")
 			assert.Equal(t, tc.style, targetBlock.Model().GetText().Style, "target block style should be preserved")
 			
-			// For multi-block paste: target stays empty, blocks inserted separately
-			// For single-block paste: text merges into target (intoBlock mode)
+			// The empty focused block is reused for the first paste line (both for
+			// single- and multi-block paste) instead of being left as a stray empty
+			// paragraph above the pasted content; remaining paste blocks are inserted
+			// below. The block keeps its own style.
+			assert.Equal(t, tc.pasteBlocks[0].GetText().Text, targetBlock.Model().GetText().Text, "first paste text should be merged into target")
 			if len(tc.pasteBlocks) > 1 {
-				assert.Equal(t, "", targetBlock.Model().GetText().Text, "target block should remain empty for multi-block paste")
-				require.NotEmpty(t, blockIds, "pasted blocks should be inserted")
-				firstPasteBlock := sb.Doc.Pick(blockIds[0])
-				require.NotNil(t, firstPasteBlock, "first paste block should exist in state")
-				assert.Equal(t, tc.pasteBlocks[0].GetText().Text, firstPasteBlock.Model().GetText().Text, "first paste block text should be preserved")
-			} else {
-				assert.Equal(t, tc.pasteBlocks[0].GetText().Text, targetBlock.Model().GetText().Text, "single block text should merge into target")
+				require.NotEmpty(t, blockIds, "remaining paste blocks should be inserted")
+				lastPasteBlock := sb.Doc.Pick(blockIds[len(blockIds)-1])
+				require.NotNil(t, lastPasteBlock, "last paste block should exist in state")
+				assert.Equal(t, tc.pasteBlocks[len(tc.pasteBlocks)-1].GetText().Text, lastPasteBlock.Model().GetText().Text, "remaining paste block text should be preserved")
 			}
 		})
 	}

--- a/core/block/editor/clipboard/paste.go
+++ b/core/block/editor/clipboard/paste.go
@@ -268,6 +268,12 @@ func (p *pasteCtrl) singleRange() (err error) {
 		p.mode.removeSelection = true
 		if wasEmpty && firstPasteText != nil {
 			p.mode.removeSelection = false
+			// Reuse the empty focused block for the first paste line instead of
+			// leaving it as a stray empty paragraph above the pasted content.
+			// Reverts the multi-block carve-out from GO-6615 "Keep target toggle
+			// block"; the single-block toggle case is handled by intoBlock mode.
+			selText.SetText(firstPasteText.GetText(), firstPasteText.Model().GetText().Marks)
+			p.ps.Unlink(firstPasteText.Model().Id)
 		}
 	}
 	return


### PR DESCRIPTION
## What

Fixes a paste regression: pasting a **multi-block** clipboard into an **empty focused block** leaves a stray empty paragraph above the pasted content instead of reusing the empty block.

Found while adding integration tests for the GO-7311 multi-block-range copy/cut feature (#3166): copying from the middle of one block to the middle of the next and pasting into an empty block produced `["", "block", "second"]` instead of `["block", "second"]`.

## Root cause

`singleRange()` in `core/block/editor/clipboard/paste.go` handles multi-block paste (single-block paste routes to `intoBlock`). For an originally-empty focused block it set `removeSelection = false` (keep the block) but did **not** fill it. The fill (`SetText` + `Unlink`) had been removed by `6338baf8` ("GO-6615 Keep target toggle block"), which intentionally carved out only the multi-block path. So the empty target was kept but never populated, and `insertUnderSelection` dropped the pasted blocks beneath it.

## Fix

Re-add the exact two lines `6338baf8` removed, so the empty focused block absorbs the first paste line (text + marks) and the remaining blocks insert below:

```go
if wasEmpty && firstPasteText != nil {
    p.mode.removeSelection = false
    selText.SetText(firstPasteText.GetText(), firstPasteText.Model().GetText().Marks)
    p.ps.Unlink(firstPasteText.Model().Id)
}
```

This makes single- and multi-block paste into an empty block behave consistently (both reuse the block in place). The **GO-6615 "Empty Toggle … header" case is unaffected** — single-block paste routes through `intoBlock`/`RangeTextPaste`, never `singleRange`, and styled empty blocks still keep their style (the `isPlaceInEmptyParagraph` guard).

## Tests

- `TestPasteIntoEmptyStyledBlock`: restored the multi-block assertions to expect the first paste line merged into the target (reverting the `6338baf8` test edit). All styled cases (bullet/toggle/callout/checkbox) pass with style preserved.
- `go test ./core/block/editor/clipboard/...` — green (incl. `Test_CopyAndCutMultiBlockRange`).
- Integration reproducer in anytype-suite (`multi-block-range-paste-into-empty.test.ts`, PR anyproto/anytype-suite#48) passes against a server built from this branch.