### PR TITLE
GO-7290 Chat read counters: causal-ordinal CORE (Option D, Stage 1)

### DIFF
--- a/cmd/readcounter-bandsize/main.go
+++ b/cmd/readcounter-bandsize/main.go
@@ -1,0 +1,217 @@
+// Command readcounter-bandsize measures the "band" / concurrency structure of
+// real chat change DAGs, to decide whether Option B (the hybrid read counter:
+// cheap dominance fast path + bounded DAG fallback on the ambiguous band) is
+// cheap enough in practice — i.e. whether "Property M" (forks merge promptly, so
+// the band is small) holds on real data.
+//
+// See docs/superpowers/specs/2026-06-03-read-counter-hybrid-design.md.
+//
+// Usage:
+//
+//	go run ./cmd/readcounter-bandsize -db <path-to-changes-db> [-tree id] [-top N] [-bandlimit N]
+//
+// The DB is any any-store database that holds the any-sync object-tree "changes"
+// collection (the per-space CRDT store). The live app DB may be locked — copy it
+// first and point -db at the copy.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-sync/util/storeutil"
+)
+
+// Doc keys of the object-tree "changes" collection (any-sync objecttree/storage.go).
+const (
+	collChanges = "changes"
+	keyID       = "id"
+	keyOrder    = "o" // OrderId (lexid; replica-invariant order)
+	keyPrev     = "p" // PrevIds (parents)
+	keyTree     = "t" // TreeId
+	keyAddSeq   = "q" // AddSeq (device-local; not used by any metric)
+)
+
+func main() {
+	dbPath := flag.String("db", "", "path to the any-store DB holding the 'changes' collection (copy of a space CRDT store)")
+	treeID := flag.String("tree", "", "analyze only this tree id (default: all)")
+	top := flag.Int("top", 15, "analyze the N largest trees (0 = all)")
+	bandLimit := flag.Int("bandlimit", 60000, "skip the exact O(N^2/64) band for trees larger than this (structural metrics still printed)")
+	flag.Parse()
+
+	if *dbPath == "" {
+		fmt.Fprintln(os.Stderr, "usage: readcounter-bandsize -db <path-to-changes-db> [-tree id] [-top N] [-bandlimit N]")
+		fmt.Fprintln(os.Stderr, "the DB must contain the any-sync object-tree 'changes' collection;")
+		fmt.Fprintln(os.Stderr, "copy the running app's space store DB first (the live one may be locked).")
+		os.Exit(2)
+	}
+	if err := run(*dbPath, *treeID, *top, *bandLimit); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run(dbPath, treeFilter string, top, bandLimit int) error {
+	ctx := context.Background()
+	db, err := anystore.Open(ctx, dbPath, nil)
+	if err != nil {
+		return fmt.Errorf("open db %q: %w", dbPath, err)
+	}
+	defer func() { _ = db.Close() }()
+
+	names, err := db.GetCollectionNames(ctx)
+	if err != nil {
+		return fmt.Errorf("list collections: %w", err)
+	}
+	if !contains(names, collChanges) {
+		return fmt.Errorf("collection %q not found; collections present: %v (point -db at the object-tree store)", collChanges, names)
+	}
+	coll, err := db.OpenCollection(ctx, collChanges)
+	if err != nil {
+		return fmt.Errorf("open collection %q: %w", collChanges, err)
+	}
+
+	trees, err := loadTrees(ctx, coll, treeFilter)
+	if err != nil {
+		return err
+	}
+	if len(trees) == 0 {
+		fmt.Println("no trees found")
+		return nil
+	}
+
+	type treeChanges struct {
+		id string
+		n  []ChangeNode
+	}
+	sorted := make([]treeChanges, 0, len(trees))
+	for id, n := range trees {
+		sorted = append(sorted, treeChanges{id, n})
+	}
+	sort.Slice(sorted, func(i, j int) bool { return len(sorted[i].n) > len(sorted[j].n) })
+	if top > 0 && treeFilter == "" && len(sorted) > top {
+		sorted = sorted[:top]
+	}
+
+	fmt.Printf("DB %s — %d trees total, analyzing %d\n\n", dbPath, len(trees), len(sorted))
+	agg := make([]TreeMetrics, 0, len(sorted))
+	for _, t := range sorted {
+		m := ComputeMetrics(t.id, t.n, len(t.n) <= bandLimit)
+		agg = append(agg, m)
+		printMetrics(m, bandLimit)
+	}
+	printVerdict(agg)
+	return nil
+}
+
+func loadTrees(ctx context.Context, coll anystore.Collection, treeFilter string) (map[string][]ChangeNode, error) {
+	iter, err := coll.Find(nil).Iter(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("iter changes: %w", err)
+	}
+	defer func() { _ = iter.Close() }()
+
+	trees := map[string][]ChangeNode{}
+	for iter.Next() {
+		doc, err := iter.Doc()
+		if err != nil {
+			return nil, fmt.Errorf("read doc: %w", err)
+		}
+		v := doc.Value()
+		tid := v.GetString(keyTree)
+		if treeFilter != "" && tid != treeFilter {
+			continue
+		}
+		trees[tid] = append(trees[tid], ChangeNode{
+			Id:      v.GetString(keyID),
+			OrderId: v.GetString(keyOrder),
+			PrevIds: storeutil.StringsFromArrayValue(v, keyPrev),
+			AddSeq:  uint64(v.GetInt(keyAddSeq)),
+		})
+	}
+	return trees, iter.Err()
+}
+
+func printMetrics(m TreeMetrics, bandLimit int) {
+	concPct := 0.0
+	if m.N > 0 {
+		concPct = 100 * float64(m.ConcurrentPos) / float64(m.N)
+	}
+	fmt.Printf("tree %s\n", short(m.TreeID))
+	fmt.Printf("  N=%d roots=%d heads=%d merges=%d (maxMergeWidth=%d)\n",
+		m.N, m.Roots, m.Heads, m.Merges, m.MaxMergeWidth)
+	fmt.Printf("  open-width: max=%d  concurrent-positions=%.2f%% (%d/%d)  longest-unmerged-run=%d\n",
+		m.MaxOpenWidth, concPct, m.ConcurrentPos, m.N, m.LongestConcurrent)
+	fmt.Printf("  fork-span(OrderId gap): p50=%d p95=%d max=%d\n", m.ForkSpanP50, m.ForkSpanP95, m.ForkSpanMax)
+	if m.BandComputed {
+		fmt.Printf("  band(single-head): max=%d p50=%d p95=%d mean=%.3f  nonzero-heads=%d/%d\n",
+			m.BandMax, m.BandP50, m.BandP95, m.BandMean, m.BandNonZero, m.N)
+	} else {
+		fmt.Printf("  band: SKIPPED (N>%d; raise -bandlimit to force)\n", bandLimit)
+	}
+	fmt.Println()
+}
+
+func printVerdict(agg []TreeMetrics) {
+	maxBand, maxWidth, maxRun := 0, 0, 0
+	bandComputed := false
+	for _, m := range agg {
+		if m.BandComputed {
+			bandComputed = true
+			if m.BandMax > maxBand {
+				maxBand = m.BandMax
+			}
+		}
+		if m.MaxOpenWidth > maxWidth {
+			maxWidth = m.MaxOpenWidth
+		}
+		if m.LongestConcurrent > maxRun {
+			maxRun = m.LongestConcurrent
+		}
+	}
+	fmt.Println("=== verdict ===")
+	fmt.Printf("max open-width across analyzed trees: %d\n", maxWidth)
+	fmt.Printf("longest unmerged run (consecutive width>=2): %d\n", maxRun)
+	if !bandComputed {
+		fmt.Println("band not computed (all trees above -bandlimit); rerun with a higher -bandlimit on a sample")
+		return
+	}
+	fmt.Printf("max single-head band: %d\n\n", maxBand)
+	// The bounded fallback does O(band) work only when band>0 (else two index
+	// scans). band is always <= the tree size, so Option B is never worse than the
+	// old whole-tree cold-start walk; the question is only absolute cost.
+	switch {
+	case maxBand == 0:
+		fmt.Println("No concurrency at all: the dominance fast path is exact everywhere; the fallback never runs.")
+	case maxBand <= 200:
+		fmt.Println("Property M holds: bands are small; the bounded fallback is a handful of lookups.")
+		fmt.Printf("=> Option B is cheap (worst case ~%d lookups vs the old whole-tree cold-start walk).\n", maxBand)
+	case maxBand <= 5000:
+		fmt.Println("Moderate bands on the most concurrent trees, but still far below tree size.")
+		fmt.Println("=> Option B remains far cheaper than the old whole-tree approach; spot-check the widest trees.")
+	default:
+		fmt.Println("WARNING: very large bands — a few trees sustain near-tree-wide concurrency.")
+		fmt.Println("=> the fallback approaches a full-tree walk for those; consider the")
+		fmt.Println("   device-key version-vector (option C1) for the long term, with B for legacy.")
+	}
+}
+
+func short(s string) string {
+	if len(s) > 24 {
+		return s[:10] + "…" + s[len(s)-10:]
+	}
+	return s
+}
+
+func contains(ss []string, x string) bool {
+	for _, s := range ss {
+		if s == x {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/readcounter-bandsize/metrics.go
+++ b/cmd/readcounter-bandsize/metrics.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"sort"
+)
+
+// ChangeNode is the minimal projection of a stored CRDT change needed to
+// analyze the read-counter band: its id, its parents (PrevIds), and its
+// replica-invariant order key (OrderId). AddSeq is carried for completeness but
+// is deliberately NOT used by any metric here — the whole point is that the band
+// and the convergent semantics are a function of (DAG, OrderId) only.
+type ChangeNode struct {
+	Id      string
+	PrevIds []string
+	OrderId string
+	AddSeq  uint64
+}
+
+// TreeMetrics summarizes the concurrency structure of one change DAG and the
+// per-single-head "band" distribution. The band(H) for a head H is the number of
+// events that sort at-or-before H in OrderId but are NOT causal ancestors of H —
+// i.e. exactly the events the dominance read-counter can misclassify, and the
+// extra work Option B's bounded fallback would do if the user's frontier were {H}.
+// See docs/superpowers/specs/2026-06-03-read-counter-hybrid-design.md.
+type TreeMetrics struct {
+	TreeID string
+	N      int // number of changes
+	Roots  int // changes with no in-tree parent
+	Heads  int // current heads (tips) of the whole DAG
+
+	// Merge structure (cheap proxy for Property M: forks merge promptly).
+	Merges        int // changes with >=2 parents (a merge of concurrent branches)
+	MaxMergeWidth int // max number of parents on any change
+
+	// Open-width over the OrderId sweep: at each prefix, how many "open" tips exist.
+	// Property M predicts width is 1 almost everywhere with rare, shallow spikes.
+	MaxOpenWidth      int         // peak concurrent open tips
+	WidthHist         map[int]int // open-width -> number of OrderId positions at that width
+	ConcurrentPos     int         // positions with open width >= 2
+	LongestConcurrent int         // longest consecutive run of open width >= 2 (longest unmerged stretch)
+
+	// Fork span: for each merge, the OrderId-index gap back to its earliest merged
+	// parent — how far apart (in global order) the merged tips were. Small => shallow.
+	ForkSpanP50 int
+	ForkSpanP95 int
+	ForkSpanMax int
+
+	// Band(single-head) distribution over all heads H (band(H) = rank(H) - |past(H)|).
+	BandComputed bool
+	BandMax      int
+	BandP50      int
+	BandP95      int
+	BandMean     float64
+	BandNonZero  int // number of heads H with band(H) > 0
+}
+
+// ComputeMetrics analyzes one tree's changes. If computeBand is false (or N is
+// above the caller's threshold), the O(N) structural metrics are still produced;
+// only the O(N^2/64) exact band distribution is skipped.
+func ComputeMetrics(treeID string, nodes []ChangeNode, computeBand bool) TreeMetrics {
+	m := TreeMetrics{TreeID: treeID, N: len(nodes), WidthHist: map[int]int{}}
+	if len(nodes) == 0 {
+		return m
+	}
+
+	// Sort by OrderId. Because OrderId is a linear extension of causality, this is
+	// a topological order: every parent precedes its children.
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].OrderId < nodes[j].OrderId })
+
+	idToIndex := make(map[string]int, len(nodes))
+	for i, n := range nodes {
+		idToIndex[n.Id] = i
+	}
+
+	// remainingChildren[i] = how many in-tree changes list node i as a parent.
+	remainingChildren := make([]int, len(nodes))
+	for _, n := range nodes {
+		for _, p := range n.PrevIds {
+			if pi, ok := idToIndex[p]; ok {
+				remainingChildren[pi]++
+			}
+		}
+		if pc := inTreeParents(n.PrevIds, idToIndex); pc == 0 {
+			m.Roots++
+		}
+		if len(n.PrevIds) >= 2 {
+			m.Merges++
+		}
+		if len(n.PrevIds) > m.MaxMergeWidth {
+			m.MaxMergeWidth = len(n.PrevIds)
+		}
+	}
+
+	// Open-width sweep + fork spans.
+	liveHeads := make(map[string]struct{}, 16)
+	var forkSpans []int
+	curRun := 0
+	for i, n := range nodes {
+		minParentIdx := -1
+		mergedParents := 0
+		for _, p := range n.PrevIds {
+			if pi, ok := idToIndex[p]; ok {
+				delete(liveHeads, p) // p is no longer a tip
+				mergedParents++
+				if minParentIdx == -1 || pi < minParentIdx {
+					minParentIdx = pi
+				}
+			}
+		}
+		liveHeads[n.Id] = struct{}{}
+		w := len(liveHeads)
+		m.WidthHist[w]++
+		if w > m.MaxOpenWidth {
+			m.MaxOpenWidth = w
+		}
+		if w >= 2 {
+			m.ConcurrentPos++
+			curRun++
+			if curRun > m.LongestConcurrent {
+				m.LongestConcurrent = curRun
+			}
+		} else {
+			curRun = 0
+		}
+		// A merge (>=2 in-tree parents) closes a fork; record its OrderId span.
+		if mergedParents >= 2 && minParentIdx >= 0 {
+			forkSpans = append(forkSpans, i-minParentIdx)
+		}
+	}
+	m.Heads = len(liveHeads)
+	m.ForkSpanP50, m.ForkSpanP95, m.ForkSpanMax = pctl(forkSpans, 50), pctl(forkSpans, 95), maxInt(forkSpans)
+
+	if !computeBand {
+		return m
+	}
+
+	// Exact per-single-head band via causal-past popcounts.
+	// past[i] = bitset of ancestors-or-self of node i (indices). pastSize = popcount.
+	// band(i) = rank(i) - pastSize(i), rank(i)=i+1 (events with OrderId<=OrderId(i)).
+	// We free a node's bitset once its last child has consumed it, so live memory is
+	// O(openWidth * N/64), not O(N^2/64).
+	m.BandComputed = true
+	past := make([]bitset, len(nodes))
+	bands := make([]int, len(nodes))
+	var bandSum, bandMax, nonZero int
+	for i, n := range nodes {
+		b := newBitset(len(nodes))
+		for _, p := range n.PrevIds {
+			if pi, ok := idToIndex[p]; ok {
+				b.or(past[pi])
+				remainingChildren[pi]--
+				if remainingChildren[pi] == 0 {
+					past[pi] = nil // free: no future node references it
+				}
+			}
+		}
+		b.set(i)
+		pastSize := b.count()
+		band := (i + 1) - pastSize
+		if band < 0 {
+			band = 0 // defensive; cannot happen since past(i) ⊆ {OrderId<=OrderId(i)}
+		}
+		bands[i] = band
+		bandSum += band
+		if band > bandMax {
+			bandMax = band
+		}
+		if band > 0 {
+			nonZero++
+		}
+		if remainingChildren[i] == 0 {
+			past[i] = nil // leaf: free immediately
+		} else {
+			past[i] = b
+		}
+	}
+	m.BandMax = bandMax
+	m.BandNonZero = nonZero
+	m.BandMean = float64(bandSum) / float64(len(nodes))
+	m.BandP50 = pctl(bands, 50)
+	m.BandP95 = pctl(bands, 95)
+	return m
+}
+
+func inTreeParents(prevIds []string, idToIndex map[string]int) int {
+	c := 0
+	for _, p := range prevIds {
+		if _, ok := idToIndex[p]; ok {
+			c++
+		}
+	}
+	return c
+}
+
+// --- tiny bitset ---
+
+type bitset []uint64
+
+func newBitset(n int) bitset { return make(bitset, (n+63)/64) }
+func (b bitset) set(i int)   { b[i>>6] |= 1 << (uint(i) & 63) }
+func (b bitset) or(o bitset) {
+	if o == nil {
+		return
+	}
+	for i := range o {
+		b[i] |= o[i]
+	}
+}
+func (b bitset) count() int {
+	c := 0
+	for _, w := range b {
+		c += popcount(w)
+	}
+	return c
+}
+
+func popcount(x uint64) int {
+	c := 0
+	for x != 0 {
+		x &= x - 1
+		c++
+	}
+	return c
+}
+
+// --- small stats helpers ---
+
+func pctl(xs []int, p int) int {
+	if len(xs) == 0 {
+		return 0
+	}
+	s := append([]int(nil), xs...)
+	sort.Ints(s)
+	idx := (p * (len(s) - 1)) / 100
+	return s[idx]
+}
+
+func maxInt(xs []int) int {
+	mx := 0
+	for _, x := range xs {
+		mx = max(mx, x)
+	}
+	return mx
+}

--- a/cmd/readcounter-bandsize/metrics_test.go
+++ b/cmd/readcounter-bandsize/metrics_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func node(id, order string, prev ...string) ChangeNode {
+	return ChangeNode{Id: id, OrderId: order, PrevIds: prev}
+}
+
+// A purely linear history has width 1 everywhere and a zero band: the dominance
+// fast path is already exact and Option B's fallback never runs.
+func TestMetrics_LinearNoBand(t *testing.T) {
+	nodes := []ChangeNode{
+		node("G", "001"),
+		node("m1", "002", "G"),
+		node("m2", "003", "m1"),
+		node("m3", "004", "m2"),
+	}
+	m := ComputeMetrics("t", nodes, true)
+	assert.Equal(t, 4, m.N)
+	assert.Equal(t, 1, m.Roots)
+	assert.Equal(t, 1, m.Heads)
+	assert.Equal(t, 0, m.Merges)
+	assert.Equal(t, 1, m.MaxOpenWidth)
+	assert.Equal(t, 0, m.ConcurrentPos)
+	assert.Equal(t, 0, m.LongestConcurrent)
+	assert.True(t, m.BandComputed)
+	assert.Equal(t, 0, m.BandMax)
+	assert.Equal(t, 0, m.BandNonZero)
+}
+
+// The canonical cross-device case: G; a1 ∥ b1 both children of G, OrderId(a1) <
+// OrderId(b1). band(b1) = 1 (a1 is the concurrent-earlier event a frontier {b1}
+// does not cover) — exactly the message the dominance scheme can misclassify.
+func TestMetrics_ForkBandIsCanonicalA1B1(t *testing.T) {
+	nodes := []ChangeNode{
+		node("G", "001"),
+		node("a1", "002", "G"),
+		node("b1", "003", "G"),
+	}
+	m := ComputeMetrics("t", nodes, true)
+	assert.Equal(t, 2, m.Heads, "a1 and b1 are both tips")
+	assert.Equal(t, 2, m.MaxOpenWidth)
+	assert.Equal(t, 1, m.ConcurrentPos, "the position at b1 is width 2")
+	assert.Equal(t, 1, m.BandMax, "band(b1) = 1 (a1)")
+	assert.Equal(t, 1, m.BandNonZero)
+}
+
+// Same fork but merged by a following change (Property M). The single-head band
+// for {b1} is still 1 (the user who read only b1 has a1 unread); once the user
+// reads the merge, band drops to 0 — but the per-head distribution still records
+// the transient 1.
+func TestMetrics_ForkMergeSpan(t *testing.T) {
+	nodes := []ChangeNode{
+		node("G", "001"),
+		node("a1", "002", "G"),
+		node("b1", "003", "G"),
+		node("m", "004", "a1", "b1"),
+	}
+	m := ComputeMetrics("t", nodes, true)
+	assert.Equal(t, 1, m.Heads, "merged back to one tip")
+	assert.Equal(t, 1, m.Merges)
+	assert.Equal(t, 2, m.MaxMergeWidth)
+	assert.Equal(t, 2, m.MaxOpenWidth)
+	assert.Equal(t, 2, m.ForkSpanMax, "merge index 3 - earliest parent index 1")
+	assert.Equal(t, 1, m.BandMax)
+	assert.Equal(t, 1, m.BandNonZero)
+}
+
+// Two parallel branches of depth 2 before merging: band grows with the depth of
+// the unmerged branch (band(b-side heads) = 2 = the two a-side events). This is
+// the signal that decides Option B: if real chats keep this small (forks merge
+// promptly), the bounded fallback is cheap.
+func TestMetrics_DeeperConcurrencyGrowsBand(t *testing.T) {
+	nodes := []ChangeNode{
+		node("G", "001"),
+		node("a1", "002", "G"),
+		node("a2", "003", "a1"),
+		node("b1", "004", "G"),
+		node("b2", "005", "b1"),
+		node("m", "006", "a2", "b2"),
+	}
+	m := ComputeMetrics("t", nodes, true)
+	assert.Equal(t, 1, m.Heads)
+	assert.Equal(t, 1, m.Merges)
+	assert.Equal(t, 2, m.MaxOpenWidth)
+	assert.Equal(t, 2, m.ConcurrentPos, "b1 and b2 positions are width 2")
+	assert.Equal(t, 2, m.LongestConcurrent, "the unmerged stretch is length 2")
+	assert.Equal(t, 3, m.ForkSpanMax, "merge index 5 - earliest parent (a2) index 2")
+	assert.Equal(t, 2, m.BandMax, "band(b1)=band(b2)=2 (a1,a2)")
+	assert.Equal(t, 2, m.BandNonZero)
+}
+
+// computeBand=false still yields the O(N) structural metrics.
+func TestMetrics_StructuralOnly(t *testing.T) {
+	nodes := []ChangeNode{
+		node("G", "001"),
+		node("a1", "002", "G"),
+		node("b1", "003", "G"),
+	}
+	m := ComputeMetrics("t", nodes, false)
+	assert.Equal(t, 2, m.MaxOpenWidth)
+	assert.False(t, m.BandComputed)
+	assert.Equal(t, 0, m.BandMax)
+}

--- a/core/block/chats/chatmodel/readcore.go
+++ b/core/block/chats/chatmodel/readcore.go
@@ -1,0 +1,175 @@
+package chatmodel
+
+import "container/heap"
+
+// This file implements the CORE of the causal-ordinal read model (Option D,
+// docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md §5):
+// the band computation. Read state is causal coverage by the seen-head frontier
+// F: read*(X) ⟺ ∃H∈F: X ⪯ H. The unread set decomposes (spec Theorem 1) into
+//
+//	tail = {counted X : OrderId(X) > maxF}        — an indexed range, repo-side
+//	band = {counted X : OrderId(X) ≤ maxF, X ⋠ F} — computed here
+//
+// ComputeBand walks the change DAG backward from the local heads and the
+// frontier simultaneously, in decreasing OrderId, stopping at the read
+// boundary. It returns band CANDIDATES — unread change ids at or below the
+// frontier cut. Filtering candidates to live counted messages is the caller's
+// (repository's) job: this layer sees only the DAG.
+//
+// Everything here is a pure function of (DAG, frontier-as-id-set): no AddSeq,
+// no apply order, no device-local input — which is exactly why the result is
+// identical on every device of the account (spec §2).
+
+// ChangeMeta is the minimal projection of a CRDT change the read model needs:
+// its parents and its replica-invariant order key.
+type ChangeMeta struct {
+	PrevIds []string
+	OrderId string
+}
+
+// ChangeResolver resolves a change id from local storage. ok=false means the
+// change is not locally present — for a frontier head that makes it PENDING
+// (omitted from the cut: fewer reads, safe over-count of unread).
+type ChangeResolver func(id string) (ChangeMeta, bool)
+
+// BandResult is the outcome of one band computation.
+type BandResult struct {
+	// MaxFrontierOrderId is the cut: max OrderId over the RESOLVED frontier
+	// heads. Empty when no head resolved — then everything is tail and the
+	// band is empty by definition.
+	MaxFrontierOrderId string
+	// Candidates are unread change ids with OrderId ≤ MaxFrontierOrderId
+	// (any change type; the caller filters to live counted messages).
+	Candidates []string
+	// ResolvedHeads / PendingHeads partition the input frontier.
+	ResolvedHeads []string
+	PendingHeads  []string
+	// Visited counts walked changes (observability: the walk-size bound).
+	Visited int
+}
+
+const (
+	markUnread = 1
+	markRead   = 2
+)
+
+type bandEntry struct {
+	id      string
+	orderId string
+}
+
+// bandHeap pops the LARGEST OrderId first (ties broken by id for determinism;
+// OrderIds are unique per change in production).
+type bandHeap []bandEntry
+
+func (h bandHeap) Len() int { return len(h) }
+func (h bandHeap) Less(i, j int) bool {
+	if h[i].orderId != h[j].orderId {
+		return h[i].orderId > h[j].orderId
+	}
+	return h[i].id > h[j].id
+}
+func (h bandHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *bandHeap) Push(x any)        { *h = append(*h, x.(bandEntry)) }
+func (h *bandHeap) Pop() any          { old := *h; n := len(old); e := old[n-1]; *h = old[:n-1]; return e }
+
+// ComputeBand computes the band for one counter's frontier.
+//
+// Mechanics (spec §5 / hybrid design §5): a single backward traversal in
+// strictly decreasing OrderId, two sticky-upgradeable colors. Frontier heads
+// seed READ; local heads seed UNREAD. A READ pop colors its parents READ
+// (downgrading tentative UNREADs — correct: a parent of a read change is
+// causally before it, hence read). An UNREAD pop is emitted as a band
+// candidate when at/below the cut, and extends the traversal to its unmarked
+// parents. The loop stops when no UNREAD entries remain in the heap: every
+// open branch has merged into the read region, so no further band member is
+// reachable (READ-only expansion can never mint an UNREAD).
+//
+// Decreasing-OrderId order guarantees colors are final by pop time: if X is
+// truly read, it has a witness path X = vk ≺ … ≺ v0 = H ∈ F, every vi has
+// OrderId > OrderId(X) (OrderId extends ≺), so the whole path pops first and
+// READ propagates parent-ward to X before X pops.
+func ComputeBand(frontier []string, localHeads []string, resolve ChangeResolver) BandResult {
+	var res BandResult
+	marks := make(map[string]int, len(frontier)+len(localHeads))
+	h := &bandHeap{}
+	unreadLeft := 0
+
+	for _, id := range frontier {
+		meta, ok := resolve(id)
+		if !ok {
+			res.PendingHeads = append(res.PendingHeads, id)
+			continue
+		}
+		res.ResolvedHeads = append(res.ResolvedHeads, id)
+		if meta.OrderId > res.MaxFrontierOrderId {
+			res.MaxFrontierOrderId = meta.OrderId
+		}
+		if marks[id] == 0 {
+			marks[id] = markRead
+			heap.Push(h, bandEntry{id: id, orderId: meta.OrderId})
+		}
+	}
+	// No resolved head: there is no cut — every unread change is in the tail
+	// (handled by the indexed range query); the band is empty by definition.
+	if res.MaxFrontierOrderId == "" {
+		return res
+	}
+
+	for _, id := range localHeads {
+		if marks[id] != 0 {
+			continue // already a frontier head (read)
+		}
+		meta, ok := resolve(id)
+		if !ok {
+			continue
+		}
+		marks[id] = markUnread
+		unreadLeft++
+		heap.Push(h, bandEntry{id: id, orderId: meta.OrderId})
+	}
+
+	for h.Len() > 0 && unreadLeft > 0 {
+		e := heap.Pop(h).(bandEntry)
+		res.Visited++
+		meta, _ := resolve(e.id) // pushed ⇒ resolvable
+		if marks[e.id] == markRead {
+			for _, p := range meta.PrevIds {
+				switch marks[p] {
+				case markRead:
+					// already known read
+				case markUnread:
+					// tentative unread proven covered: parent of a read change
+					marks[p] = markRead
+					unreadLeft--
+				default:
+					pm, ok := resolve(p)
+					if !ok {
+						continue
+					}
+					marks[p] = markRead
+					heap.Push(h, bandEntry{id: p, orderId: pm.OrderId})
+				}
+			}
+			continue
+		}
+		// unread pop
+		unreadLeft--
+		if e.orderId <= res.MaxFrontierOrderId {
+			res.Candidates = append(res.Candidates, e.id)
+		}
+		for _, p := range meta.PrevIds {
+			if marks[p] != 0 {
+				continue // read boundary reached, or already queued
+			}
+			pm, ok := resolve(p)
+			if !ok {
+				continue
+			}
+			marks[p] = markUnread
+			unreadLeft++
+			heap.Push(h, bandEntry{id: p, orderId: pm.OrderId})
+		}
+	}
+	return res
+}

--- a/core/block/chats/chatmodel/readcore_test.go
+++ b/core/block/chats/chatmodel/readcore_test.go
@@ -1,0 +1,258 @@
+package chatmodel
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- synthetic DAG helpers ----------------------------------------------
+
+// testDag holds a synthetic change DAG with OrderIds that are a valid linear
+// extension of causality: nodes are declared parents-first and OrderId is the
+// zero-padded declaration index, so string comparison == topological order
+// (the invariant production lexids satisfy).
+type testDag struct {
+	order []string // ids in OrderId order
+	meta  map[string]ChangeMeta
+}
+
+func newDag() *testDag { return &testDag{meta: map[string]ChangeMeta{}} }
+
+func (d *testDag) add(id string, prev ...string) *testDag {
+	for _, p := range prev {
+		if _, ok := d.meta[p]; !ok {
+			panic("parent declared after child: " + p)
+		}
+	}
+	d.meta[id] = ChangeMeta{PrevIds: prev, OrderId: fmt.Sprintf("o%04d", len(d.order))}
+	d.order = append(d.order, id)
+	return d
+}
+
+func (d *testDag) resolver() ChangeResolver {
+	return func(id string) (ChangeMeta, bool) {
+		m, ok := d.meta[id]
+		return m, ok
+	}
+}
+
+// heads = nodes no other node lists as a parent.
+func (d *testDag) heads() []string {
+	referenced := map[string]bool{}
+	for _, m := range d.meta {
+		for _, p := range m.PrevIds {
+			referenced[p] = true
+		}
+	}
+	var hs []string
+	for _, id := range d.order {
+		if !referenced[id] {
+			hs = append(hs, id)
+		}
+	}
+	return hs
+}
+
+// ---- the oracle: literal read* ------------------------------------------
+
+// oracleBand recomputes the band by definition: the causal down-set of the
+// resolved frontier (DFS over parents), then {x : g(x) ≤ maxF ∧ x ∉ closure}.
+// Deliberately independent of ComputeBand's traversal.
+func oracleBand(d *testDag, frontier []string, resolve ChangeResolver) (maxF string, band []string) {
+	closure := map[string]bool{}
+	var stack []string
+	for _, h := range frontier {
+		m, ok := resolve(h)
+		if !ok {
+			continue // pending
+		}
+		if m.OrderId > maxF {
+			maxF = m.OrderId
+		}
+		if !closure[h] {
+			closure[h] = true
+			stack = append(stack, h)
+		}
+	}
+	for len(stack) > 0 {
+		id := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		m, _ := resolve(id)
+		for _, p := range m.PrevIds {
+			if _, ok := resolve(p); ok && !closure[p] {
+				closure[p] = true
+				stack = append(stack, p)
+			}
+		}
+	}
+	if maxF == "" {
+		return "", nil
+	}
+	for _, id := range d.order {
+		if d.meta[id].OrderId <= maxF && !closure[id] {
+			band = append(band, id)
+		}
+	}
+	return maxF, band
+}
+
+func assertMatchesOracle(t *testing.T, d *testDag, frontier []string) BandResult {
+	t.Helper()
+	got := ComputeBand(frontier, d.heads(), d.resolver())
+	wantMaxF, wantBand := oracleBand(d, frontier, d.resolver())
+	require.Equal(t, wantMaxF, got.MaxFrontierOrderId, "cut must match oracle")
+	assert.ElementsMatch(t, wantBand, got.Candidates, "band must match the read* complement below the cut")
+	return got
+}
+
+// ---- named scenarios ------------------------------------------------------
+
+// Linear history: the band is empty for ANY frontier position — the dominance
+// of the common case. Reading mid-chain leaves the tail to the indexed range.
+func TestComputeBand_LinearAlwaysEmpty(t *testing.T) {
+	d := newDag().add("G").add("m1", "G").add("m2", "m1").add("m3", "m2").add("m4", "m3")
+	for _, f := range [][]string{{"m4"}, {"m2"}, {"G"}} {
+		got := assertMatchesOracle(t, d, f)
+		assert.Empty(t, got.Candidates, "frontier %v", f)
+	}
+}
+
+// The canonical cross-device case: a1 ∥ b1 under G, frontier {b1}. a1 sorts
+// before b1 but is NOT covered → it is the band. This is the message the
+// (OrderId, AddSeq) watermark mis-classified depending on local apply order;
+// here the result is a pure function of (DAG, frontier).
+func TestComputeBand_CanonicalConcurrentSibling(t *testing.T) {
+	d := newDag().add("G").add("a1", "G").add("b1", "G")
+	got := assertMatchesOracle(t, d, []string{"b1"})
+	assert.Equal(t, []string{"a1"}, got.Candidates)
+
+	// reading the OTHER branch instead: a1 covered, b1 is past the cut (tail) —
+	// band empty.
+	got = assertMatchesOracle(t, d, []string{"a1"})
+	assert.Empty(t, got.Candidates)
+}
+
+// A merge closes the band: after reading the merge change, both branches are
+// in its causal past.
+func TestComputeBand_MergeCloses(t *testing.T) {
+	d := newDag().add("G").add("a1", "G").add("b1", "G").add("mm", "a1", "b1")
+	got := assertMatchesOracle(t, d, []string{"mm"})
+	assert.Empty(t, got.Candidates)
+}
+
+// Multi-head frontier: both branch tips read (e.g. merged from two devices'
+// read markers) — covered without any merge change existing.
+func TestComputeBand_MultiHeadFrontier(t *testing.T) {
+	d := newDag().add("G").add("a1", "G").add("a2", "a1").add("b1", "G").add("b2", "b1")
+	got := assertMatchesOracle(t, d, []string{"a2", "b2"})
+	assert.Empty(t, got.Candidates)
+
+	// partial multi-head: {a2, b1} leaves b2 past the cut? No: g(b2) > g(b1)
+	// but g(b2) > g(a2)? declaration order: b2 is last → tail. Band empty.
+	got = assertMatchesOracle(t, d, []string{"a2", "b1"})
+	assert.Empty(t, got.Candidates)
+
+	// {b2, a1}: a2 has g < g(b2) and is not covered → band = {a2}.
+	got = assertMatchesOracle(t, d, []string{"b2", "a1"})
+	assert.Equal(t, []string{"a2"}, got.Candidates)
+}
+
+// A pending (not-yet-local) frontier head is omitted from the cut — fewer
+// reads, never false reads (the safe direction). Matches the existing
+// pending-head behavior of the seen-heads machinery.
+func TestComputeBand_PendingHeadOmitted(t *testing.T) {
+	d := newDag().add("G").add("a1", "G").add("b1", "G")
+	got := ComputeBand([]string{"b1", "ghost"}, d.heads(), d.resolver())
+	assert.Equal(t, []string{"ghost"}, got.PendingHeads)
+	assert.Equal(t, []string{"b1"}, got.ResolvedHeads)
+	assert.Equal(t, []string{"a1"}, got.Candidates, "same as frontier {b1}")
+
+	// frontier entirely pending → no cut, band empty (everything is tail).
+	got = ComputeBand([]string{"ghost"}, d.heads(), d.resolver())
+	assert.Empty(t, got.MaxFrontierOrderId)
+	assert.Empty(t, got.Candidates)
+}
+
+// Late in-past insert: a change landing BELOW an old frontier cut joins the
+// band on recompute (and by spec Theorem 3 can be appended without any
+// ancestry check in the incremental path — pinned here by recompute equality).
+func TestComputeBand_LateInPastInsert(t *testing.T) {
+	d := newDag().add("G").add("m1", "G").add("m2", "m1")
+	got := assertMatchesOracle(t, d, []string{"m2"})
+	assert.Empty(t, got.Candidates)
+
+	// late arrival anchored at G: sorts… not below m2 in this synthetic
+	// encoding (OrderId = declaration index), so model it properly: rebuild
+	// the dag with the late change in its true topological slot.
+	d2 := newDag().add("G").add("late", "G").add("m1", "G").add("m2", "m1")
+	got = assertMatchesOracle(t, d2, []string{"m2"})
+	assert.Equal(t, []string{"late"}, got.Candidates, "in-past insert below the cut is unread")
+}
+
+// markunread-to-ancient shape: an old frontier in a long chat. The band stays
+// tiny (one concurrent straggler below the old cut); the tail is the range
+// query's job. Also pins the walk-size bound: O(tail + band + boundary).
+func TestComputeBand_AncientFrontier(t *testing.T) {
+	// straggler is declared in its true topological slot — right after G — so
+	// its OrderId is BELOW the old cut (an in-past insert, concurrent with the
+	// whole chain).
+	d := newDag().add("G").add("straggler", "G")
+	prev := "G"
+	for i := 0; i < 50; i++ {
+		id := fmt.Sprintf("m%02d", i)
+		d.add(id, prev)
+		prev = id
+	}
+	got := assertMatchesOracle(t, d, []string{"m05"})
+	assert.Equal(t, []string{"straggler"}, got.Candidates)
+	assert.LessOrEqual(t, got.Visited, 52+2, "walk bounded by tail+band+boundary, not repeated work")
+}
+
+// ---- the property test ----------------------------------------------------
+
+// Randomized DAGs × randomized frontiers (including pending heads) — the walk
+// must equal the literal read* complement below the cut, every time.
+// Deterministic seed: failures are reproducible.
+func TestComputeBand_PropertyMatchesOracle(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xD_2026_0610))
+	for iter := 0; iter < 3000; iter++ {
+		d := newDag().add("n000")
+		n := 2 + rng.Intn(30)
+		for i := 1; i < n; i++ {
+			id := fmt.Sprintf("n%03d", i)
+			// 1..3 parents sampled from earlier nodes ⇒ valid DAG, OrderId a
+			// linear extension by construction.
+			k := 1 + rng.Intn(3)
+			seen := map[string]bool{}
+			var prev []string
+			for j := 0; j < k; j++ {
+				p := d.order[rng.Intn(len(d.order))]
+				if !seen[p] {
+					seen[p] = true
+					prev = append(prev, p)
+				}
+			}
+			d.add(id, prev...)
+		}
+		// frontier: 0..3 random nodes, ~15% replaced by a pending ghost
+		var frontier []string
+		for j := 0; j < rng.Intn(4); j++ {
+			if rng.Intn(100) < 15 {
+				frontier = append(frontier, fmt.Sprintf("ghost%d", j))
+			} else {
+				frontier = append(frontier, d.order[rng.Intn(len(d.order))])
+			}
+		}
+		got := ComputeBand(frontier, d.heads(), d.resolver())
+		wantMaxF, wantBand := oracleBand(d, frontier, d.resolver())
+		require.Equalf(t, wantMaxF, got.MaxFrontierOrderId, "iter %d: cut", iter)
+		sort.Strings(got.Candidates)
+		sort.Strings(wantBand)
+		require.Equalf(t, wantBand, got.Candidates, "iter %d: band\nfrontier=%v dag=%v", iter, frontier, d.meta)
+	}
+}

--- a/core/block/chats/chatrepository/corecount_test.go
+++ b/core/block/chats/chatrepository/corecount_test.go
@@ -1,0 +1,91 @@
+package chatrepository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+const coreMe = "me"
+
+func addCoreMsg(t *testing.T, fx *fixture, id, orderId, creator string, hasMention bool) {
+	t.Helper()
+	msg := &chatmodel.Message{ChatMessage: &model.ChatMessage{
+		Id:      id,
+		OrderId: orderId,
+		Creator: creator,
+		Message: &model.ChatMessageMessageContent{Text: id},
+	}}
+	msg.HasMention = hasMention
+	require.NoError(t, fx.repo.AddTestMessage(context.Background(), msg))
+}
+
+// CountCoreUnread implements the CORE decomposition's repository half:
+// tail = counted live messages with _o.id > maxF (indexed), band = counted
+// live messages among the walk's candidates. Counted = peer + counter filter.
+// No read flags are consulted anywhere.
+func TestCountCoreUnread(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("tail plus band, own excluded everywhere", func(t *testing.T) {
+		fx := newFixture(t)
+		addCoreMsg(t, fx, "p1", "o01", "alice", false) // below cut, in band (concurrent)
+		addCoreMsg(t, fx, "p2", "o02", "bob", false)   // below cut, covered (not in band)
+		addCoreMsg(t, fx, "p3", "o03", "carol", false) // past cut -> tail
+		addCoreMsg(t, fx, "own", "o04", coreMe, false) // own -> never counted
+
+		got, err := fx.repo.CountCoreUnread(ctx, chatmodel.CounterTypeMessage, "o02", []string{"p1"}, coreMe)
+		require.NoError(t, err)
+		assert.Equal(t, 2, got, "tail{p3} + band{p1}; own past the cut excluded")
+
+		// an own message in the band candidates must not be counted either
+		got, err = fx.repo.CountCoreUnread(ctx, chatmodel.CounterTypeMessage, "o04", []string{"p1", "own"}, coreMe)
+		require.NoError(t, err)
+		assert.Equal(t, 1, got, "band{p1}; own filtered, no tail past o04")
+	})
+
+	t.Run("band candidates that are not live messages are ignored", func(t *testing.T) {
+		fx := newFixture(t)
+		addCoreMsg(t, fx, "p1", "o01", "alice", false)
+		// "sysChange" is a band candidate from the DAG walk that has no message
+		// row (system/non-message change, or a deleted message) -> not counted.
+		got, err := fx.repo.CountCoreUnread(ctx, chatmodel.CounterTypeMessage, "o05", []string{"p1", "sysChange"}, coreMe)
+		require.NoError(t, err)
+		assert.Equal(t, 1, got)
+	})
+
+	t.Run("mention counter only sees hasMention rows", func(t *testing.T) {
+		fx := newFixture(t)
+		addCoreMsg(t, fx, "m1", "o01", "alice", true)  // mention below cut, in band
+		addCoreMsg(t, fx, "p1", "o02", "alice", false) // plain below cut, in band
+		addCoreMsg(t, fx, "m2", "o03", "bob", true)    // mention in tail
+		addCoreMsg(t, fx, "p2", "o04", "bob", false)   // plain in tail
+		addCoreMsg(t, fx, "mo", "o05", coreMe, true)   // own mention -> excluded
+
+		got, err := fx.repo.CountCoreUnread(ctx, chatmodel.CounterTypeMention, "o02", []string{"m1", "p1"}, coreMe)
+		require.NoError(t, err)
+		assert.Equal(t, 2, got, "mention tail{m2} + mention band{m1}; p1/p2/own-mention excluded")
+
+		got, err = fx.repo.CountCoreUnread(ctx, chatmodel.CounterTypeMessage, "o02", []string{"m1", "p1"}, coreMe)
+		require.NoError(t, err)
+		assert.Equal(t, 4, got, "message counter sees mentions and plain alike")
+	})
+
+	t.Run("no resolved frontier counts every peer message", func(t *testing.T) {
+		fx := newFixture(t)
+		addCoreMsg(t, fx, "p1", "o01", "alice", false)
+		addCoreMsg(t, fx, "p2", "o02", "bob", false)
+		addCoreMsg(t, fx, "own", "o03", coreMe, false)
+
+		// maxF == "": no cut -> everything counted is unread; band must be
+		// ignored even if (incorrectly) provided.
+		got, err := fx.repo.CountCoreUnread(ctx, chatmodel.CounterTypeMessage, "", []string{"p1"}, coreMe)
+		require.NoError(t, err)
+		assert.Equal(t, 2, got)
+	})
+}

--- a/core/block/chats/chatrepository/repository.go
+++ b/core/block/chats/chatrepository/repository.go
@@ -174,6 +174,14 @@ type Repository interface {
 	GetReadMessagesAfter(ctx context.Context, afterOrderId string, counterType chatmodel.CounterType) ([]string, error)
 	GetUnreadMessageIdsInRange(ctx context.Context, afterOrderId, beforeOrderId string, lastStateId string, counterType chatmodel.CounterType) ([]string, error)
 	GetAllUnreadMessages(ctx context.Context, counterType chatmodel.CounterType) ([]string, error)
+	// CountCoreUnread counts unread per the causal-ordinal CORE decomposition
+	// (Option D spec Theorem 1): counted live messages past the frontier cut
+	// (indexed _o.id range) plus counted live band members. Counted = peer
+	// (creator != myIdentity) matching the counter's filter — explicit here,
+	// unlike the bool path where own messages are excluded by being inserted
+	// read=true. Empty maxFrontierOrderId means no resolved frontier: every
+	// counted message is unread and the band must be empty.
+	CountCoreUnread(ctx context.Context, counterType chatmodel.CounterType, maxFrontierOrderId string, bandCandidates []string, myIdentity string) (int, error)
 	GetMessagesForIndexing(ctx context.Context, afterOrderId string) ([]*chatmodel.Message, error)
 	SetReadFlag(ctx context.Context, chatObjectId string, msgIds []string, counterType chatmodel.CounterType, value bool) ([]string, error)
 	GetMessages(ctx context.Context, req GetMessagesRequest) ([]*chatmodel.Message, error)
@@ -426,6 +434,45 @@ func (s *repository) GetAllUnreadMessages(ctx context.Context, counterType chatm
 		msgIds = append(msgIds, doc.Value().GetString("id"))
 	}
 	return msgIds, iter.Err()
+}
+
+func (s *repository) CountCoreUnread(ctx context.Context, counterType chatmodel.CounterType, maxFrontierOrderId string, bandCandidates []string, myIdentity string) (int, error) {
+	handler := newReadHandler(counterType)
+	counted := query.And{
+		query.Not{Filter: query.Key{Path: []string{chatmodel.CreatorKey}, Filter: query.NewComp(query.CompOpEq, myIdentity)}},
+	}
+	if mf := handler.getMessagesFilter(); mf != nil {
+		counted = append(counted, mf)
+	}
+
+	tail := counted
+	if maxFrontierOrderId != "" {
+		tail = append(append(query.And{}, counted...),
+			query.Key{Path: []string{chatmodel.OrderKey, "id"}, Filter: query.NewComp(query.CompOpGt, maxFrontierOrderId)})
+	}
+	count, err := s.collection.Find(tail).Count(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count tail: %w", err)
+	}
+
+	// Band members exist only below a resolved cut; with no cut the tail above
+	// already covered everything.
+	if maxFrontierOrderId != "" && len(bandCandidates) > 0 {
+		arena := s.arenaPool.Get()
+		defer s.arenaPool.Put(arena)
+		vals := make([]*anyenc.Value, 0, len(bandCandidates))
+		for _, id := range bandCandidates {
+			vals = append(vals, arena.NewString(id))
+		}
+		band := append(append(query.And{}, counted...),
+			query.Key{Path: []string{"id"}, Filter: query.NewInValue(vals...)})
+		bandCount, err := s.collection.Find(band).Count(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("count band: %w", err)
+		}
+		count += bandCount
+	}
+	return count, nil
 }
 
 func (s *repository) GetMessagesForIndexing(ctx context.Context, afterOrderId string) ([]*chatmodel.Message, error) {

--- a/core/block/editor/chatobject/chathandler.go
+++ b/core/block/editor/chatobject/chathandler.go
@@ -109,7 +109,7 @@ func (d *ChatHandler) BeforeCreate(ctx context.Context, ch storestate.ChangeOp) 
 	msg.OrderId = ch.Change.Order
 
 	if d.readCore != nil {
-		d.readCore.onMessageCreated(ch.Change.Id, msg.OrderId, msg.Creator, msg.HasMention)
+		d.readCore.onMessageCreated(ch.Change.Id, msg.OrderId, msg.Creator)
 	}
 
 	prevOrderId, err := d.repository.GetPrevOrderId(ctx, ch.Change.Order)

--- a/core/block/editor/chatobject/chathandler.go
+++ b/core/block/editor/chatobject/chathandler.go
@@ -38,6 +38,9 @@ type ChatHandler struct {
 	reactionsCounterEpoch int64
 	// forceNotRead forces handler to mark all messages as not read. It's useful for unit testing
 	forceNotRead bool
+	// readCore receives Theorem-3 incremental band updates for the
+	// causal-ordinal read model; nil-safe (unset in bare handler tests).
+	readCore *readCoreManager
 }
 
 // canModerateAt reports whether the change author had Owner or Admin permission
@@ -104,6 +107,10 @@ func (d *ChatHandler) BeforeCreate(ctx context.Context, ch storestate.ChangeOp) 
 	}
 	msg.HasMention = isMentioned
 	msg.OrderId = ch.Change.Order
+
+	if d.readCore != nil {
+		d.readCore.onMessageCreated(ch.Change.Id, msg.OrderId, msg.Creator, msg.HasMention)
+	}
 
 	prevOrderId, err := d.repository.GetPrevOrderId(ctx, ch.Change.Order)
 	if err != nil {
@@ -183,6 +190,10 @@ func (d *ChatHandler) BeforeDelete(ctx context.Context, ch storestate.ChangeOp) 
 	if err = d.indexerStore.AddChatMessageDeleteToIndexQueue(context.Background(), d.chatFullId, messageId); err != nil {
 		log.With(zap.String("chatId", d.chatFullId.ObjectID), zap.String("messageId", messageId), zap.Error(err)).
 			Error("failed to add message to fulltext delete queue")
+	}
+
+	if d.readCore != nil {
+		d.readCore.onMessageDeleted(messageId)
 	}
 
 	return storestate.DeleteModeDelete, nil

--- a/core/block/editor/chatobject/chatobject.go
+++ b/core/block/editor/chatobject/chatobject.go
@@ -99,6 +99,7 @@ type storeObject struct {
 	subscription            chatsubscription.Manager
 	crdtDb                  anystore.DB
 	chatHandler             *ChatHandler
+	readCore                *readCoreManager
 	repository              chatrepository.Repository
 	detailsComponent        *detailsComponent
 	statService             debugstat.StatService
@@ -255,6 +256,11 @@ func (s *storeObject) Init(ctx *smartblock.InitContext) error {
 		return fmt.Errorf("get subscription manager: %w", err)
 	}
 
+	// The cache manager is inert until the causal-ordinal shadow runs its
+	// first walk (no db collection is created, the handler hooks are cheap
+	// no-ops), so it costs nothing while readCoreShadowEnabled is off.
+	s.readCore = newReadCoreManager(s.crdtDb, storeSource.Id(), s.accountService.AccountID())
+
 	s.chatHandler = &ChatHandler{
 		repository:            s.repository,
 		subscription:          s.subscription,
@@ -264,6 +270,7 @@ func (s *storeObject) Init(ctx *smartblock.InitContext) error {
 		myParticipantId:       myParticipantId,
 		aclList:               storeSource.AclList(),
 		reactionsCounterEpoch: s.reactionsCounterEpoch,
+		readCore:              s.readCore,
 	}
 
 	stateStore, err := storestate.New(ctx.Ctx, s.Id(), s.crdtDb, s.chatHandler, storestate.DefaultHandler{Name: EditorCollectionName, ModifyMode: storestate.ModifyModeUpsert})

--- a/core/block/editor/chatobject/readcore.go
+++ b/core/block/editor/chatobject/readcore.go
@@ -1,0 +1,73 @@
+package chatobject
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+	"github.com/anyproto/anytype-heart/core/block/source"
+)
+
+// readCoreShadowEnabled gates the causal-ordinal (Option D) CORE shadow: when
+// on, after read-state updates the CORE unread count — computed from the
+// frontier + band, with no per-message read flags — is compared against the
+// bool path and divergences are logged. Default off; the bool path remains the
+// source of truth until cutover (spec §7 Stage 3).
+var readCoreShadowEnabled = false
+
+// computeReadCoreCount computes the CORE unread count for one counter:
+// tail (counted live messages past the frontier cut) + band (counted live
+// messages at/below the cut not causally covered by the frontier), per spec
+// Theorem 1. Returns ok=false when the source does not expose the snapshot
+// (e.g. test mocks) or the counter's diff manager is not initialized.
+//
+// The DAG walk runs inside the source's snapshot callback — under the object
+// tree lock — and only the resulting id sets leave it.
+func (s *storeObject) computeReadCoreCount(ctx context.Context, counterType chatmodel.CounterType) (coreCount, boolCount int, ok bool, err error) {
+	provider, isProvider := s.storeSource.(source.ReadCoreSnapshotProvider)
+	if !isProvider {
+		return 0, 0, false, nil
+	}
+	var band chatmodel.BandResult
+	if !provider.ReadCoreSnapshot(counterType.DiffManagerName(), func(frontier, localHeads []string, resolve func(id string) ([]string, string, bool)) {
+		band = chatmodel.ComputeBand(frontier, localHeads, func(id string) (chatmodel.ChangeMeta, bool) {
+			prevIds, orderId, rok := resolve(id)
+			return chatmodel.ChangeMeta{PrevIds: prevIds, OrderId: orderId}, rok
+		})
+	}) {
+		return 0, 0, false, nil
+	}
+	coreCount, err = s.repository.CountCoreUnread(ctx, counterType, band.MaxFrontierOrderId, band.Candidates, s.accountService.AccountID())
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("count core unread: %w", err)
+	}
+	boolIds, err := s.repository.GetAllUnreadMessages(ctx, counterType)
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("get bool unread: %w", err)
+	}
+	return coreCount, len(boolIds), true, nil
+}
+
+// shadowReadCoreCount runs the CORE computation alongside the bool path and
+// logs a divergence. Non-fatal by design: shadow observability only.
+func (s *storeObject) shadowReadCoreCount(ctx context.Context, counterType chatmodel.CounterType) {
+	if !readCoreShadowEnabled {
+		return
+	}
+	core, boolN, ok, err := s.computeReadCoreCount(ctx, counterType)
+	if err != nil {
+		log.Error("read-core shadow", zap.Error(err))
+		return
+	}
+	if !ok {
+		return
+	}
+	if core != boolN {
+		log.Warn("read-core shadow diverged from bool path",
+			zap.String("counter", counterType.DiffManagerName()),
+			zap.Int("core", core),
+			zap.Int("bool", boolN))
+	}
+}

--- a/core/block/editor/chatobject/readcore.go
+++ b/core/block/editor/chatobject/readcore.go
@@ -37,13 +37,15 @@ func (s *storeObject) computeReadCoreCount(ctx context.Context, counterType chat
 		walkRes  chatmodel.BandResult
 		frontier []string
 	)
-	if !provider.ReadCoreSnapshot(counterType.DiffManagerName(), func(rawFrontier, localHeads []string, resolve func(id string) ([]string, string, bool)) {
+	// D4: one frontier — both counters are served from the MESSAGE diff
+	// manager's seen heads; the mention distinction is a query-time filter.
+	if !provider.ReadCoreSnapshot(chatmodel.CounterTypeMessage.DiffManagerName(), func(rawFrontier, localHeads []string, resolve func(id string) ([]string, string, bool)) {
 		frontier = append([]string(nil), rawFrontier...)
 		// Cached state is reused when the frontier is unchanged and fully
 		// resolved — then the band was kept current incrementally (Theorem 3)
 		// and no walk happens at all.
 		if s.readCore != nil {
-			if mF, ids, hit := s.readCore.cachedCut(counterType, rawFrontier); hit {
+			if mF, ids, hit := s.readCore.cachedCut(rawFrontier); hit {
 				maxF, bandIds = mF, ids
 				return
 			}
@@ -60,8 +62,8 @@ func (s *storeObject) computeReadCoreCount(ctx context.Context, counterType chat
 	// Cache bookkeeping strictly outside the tree lock: persistence does db
 	// writes, and the stale check reads the cold-start copy.
 	if walked && s.readCore != nil {
-		s.readCore.logIfStale(ctx, counterType, walkRes, frontier)
-		s.readCore.refresh(counterType, frontier, walkRes)
+		s.readCore.logIfStale(ctx, walkRes, frontier)
+		s.readCore.refresh(frontier, walkRes)
 		s.readCore.persistDirty(ctx)
 	}
 	coreCount, err = s.repository.CountCoreUnread(ctx, counterType, maxF, bandIds, s.accountService.AccountID())

--- a/core/block/editor/chatobject/readcore.go
+++ b/core/block/editor/chatobject/readcore.go
@@ -30,16 +30,41 @@ func (s *storeObject) computeReadCoreCount(ctx context.Context, counterType chat
 	if !isProvider {
 		return 0, 0, false, nil
 	}
-	var band chatmodel.BandResult
-	if !provider.ReadCoreSnapshot(counterType.DiffManagerName(), func(frontier, localHeads []string, resolve func(id string) ([]string, string, bool)) {
-		band = chatmodel.ComputeBand(frontier, localHeads, func(id string) (chatmodel.ChangeMeta, bool) {
+	var (
+		maxF     string
+		bandIds  []string
+		walked   bool
+		walkRes  chatmodel.BandResult
+		frontier []string
+	)
+	if !provider.ReadCoreSnapshot(counterType.DiffManagerName(), func(rawFrontier, localHeads []string, resolve func(id string) ([]string, string, bool)) {
+		frontier = append([]string(nil), rawFrontier...)
+		// Cached state is reused when the frontier is unchanged and fully
+		// resolved — then the band was kept current incrementally (Theorem 3)
+		// and no walk happens at all.
+		if s.readCore != nil {
+			if mF, ids, hit := s.readCore.cachedCut(counterType, rawFrontier); hit {
+				maxF, bandIds = mF, ids
+				return
+			}
+		}
+		walkRes = chatmodel.ComputeBand(rawFrontier, localHeads, func(id string) (chatmodel.ChangeMeta, bool) {
 			prevIds, orderId, rok := resolve(id)
 			return chatmodel.ChangeMeta{PrevIds: prevIds, OrderId: orderId}, rok
 		})
+		maxF, bandIds = walkRes.MaxFrontierOrderId, walkRes.Candidates
+		walked = true
 	}) {
 		return 0, 0, false, nil
 	}
-	coreCount, err = s.repository.CountCoreUnread(ctx, counterType, band.MaxFrontierOrderId, band.Candidates, s.accountService.AccountID())
+	// Cache bookkeeping strictly outside the tree lock: persistence does db
+	// writes, and the stale check reads the cold-start copy.
+	if walked && s.readCore != nil {
+		s.readCore.logIfStale(ctx, counterType, walkRes, frontier)
+		s.readCore.refresh(counterType, frontier, walkRes)
+		s.readCore.persistDirty(ctx)
+	}
+	coreCount, err = s.repository.CountCoreUnread(ctx, counterType, maxF, bandIds, s.accountService.AccountID())
 	if err != nil {
 		return 0, 0, false, fmt.Errorf("count core unread: %w", err)
 	}

--- a/core/block/editor/chatobject/readcore_crossdevice_test.go
+++ b/core/block/editor/chatobject/readcore_crossdevice_test.go
@@ -1,0 +1,362 @@
+package chatobject
+
+import (
+	"context"
+	"math/rand"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-sync/commonspace/object/accountdata"
+	"github.com/anyproto/any-sync/commonspace/object/acl/list"
+	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+)
+
+// Cross-device convergence gate for the causal-ordinal read model (Option D,
+// docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
+// §11 test 1). This is the dimension the previous scenario harness could not
+// express: each "device" here is a REAL storage-backed objecttree.ObjectTree
+// that received the same change DAG in a DIFFERENT batch/apply order, so all
+// device-local artifacts (AddSeq, lexid OrderId strings, arrival order)
+// genuinely differ — and the read model's output must not.
+//
+// Context this gate records: the (OrderId, AddSeq) watermark prototype
+// classified the canonical a1∥b1 case differently per apply order (read on
+// the device that applied a1 first, unread on the other — a permanent 0 vs 1
+// count divergence; theory doc §5.3). ComputeBand consumes no device-local
+// input, so both devices must agree, and agree with the literal read*.
+
+// dagChange is a synthetic change: id + parents. Ids are author-chosen and
+// stable, so the hash-tiebroken sibling order — and thus the OrderId
+// COMPARISON order — is deterministic across devices (lexid strings differ).
+type dagChange struct {
+	ID   string
+	Prev []string
+}
+
+type deviceTree struct {
+	tree    objecttree.ObjectTree
+	orderOf map[string]string // changeId -> this device's OrderId string
+}
+
+func deviceAclList(t testing.TB) list.AclList {
+	keys, err := accountdata.NewRandom()
+	require.NoError(t, err)
+	acl, err := list.NewInMemoryDerivedAcl("spaceId", keys)
+	require.NoError(t, err)
+	return acl
+}
+
+func deviceAnystore(t testing.TB) anystore.DB {
+	db, err := anystore.Open(context.Background(), filepath.Join(t.TempDir(), "tree.db"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// buildDeviceTree materializes the DAG into a real objecttree by applying the
+// non-root changes in the given per-device batches — one AddRawChanges call
+// per batch, mirroring how sync delivers changes in arrival-order groups.
+// dag[0] is the root. Batches must be causally valid (parents in earlier
+// batches or the same batch); every change must appear in exactly one batch.
+func buildDeviceTree(t testing.TB, dag []dagChange, batches [][]string) *deviceTree {
+	ctx := context.Background()
+	require.NotEmpty(t, dag)
+	require.Empty(t, dag[0].Prev, "dag[0] is the root and must have no Prev")
+	rootId := dag[0].ID
+
+	byId := map[string]dagChange{}
+	for _, c := range dag {
+		byId[c.ID] = c
+	}
+
+	acl := deviceAclList(t)
+	mcc := objecttree.NewMockChangeCreator(func() anystore.DB { return deviceAnystore(t) })
+	storage := mcc.CreateNewTreeStorage(t.(*testing.T), rootId, acl.Head().Id, false)
+	if setter, ok := storage.(interface{ SetAddSeq(*atomic.Uint64) }); ok {
+		setter.SetAddSeq(&atomic.Uint64{})
+	}
+	tree, err := objecttree.BuildTestableTree(storage, acl)
+	require.NoError(t, err)
+	tree.SetFlusher(objecttree.MarkNewChangeFlusher())
+
+	applied := map[string]bool{rootId: true}
+	for _, batch := range batches {
+		var raws []*treechangeproto.RawTreeChangeWithId
+		for _, id := range batch {
+			c, ok := byId[id]
+			require.Truef(t, ok, "batch references unknown change %s", id)
+			require.NotEmpty(t, c.Prev, "root must not be in batches")
+			raws = append(raws, mcc.CreateRaw(c.ID, acl.Head().Id, rootId, false, c.Prev...))
+			applied[id] = true
+		}
+		// expected heads after this batch = heads of the applied prefix
+		_, err = tree.AddRawChanges(ctx, objecttree.RawChangesPayload{
+			NewHeads:   prefixHeads(dag, applied),
+			RawChanges: raws,
+		})
+		require.NoError(t, err)
+	}
+	for _, c := range dag {
+		require.Truef(t, applied[c.ID], "change %s missing from batches", c.ID)
+	}
+
+	orderOf := map[string]string{}
+	require.NoError(t, tree.IterateRoot(nil, func(ch *objecttree.Change) bool {
+		orderOf[ch.Id] = ch.OrderId
+		return true
+	}))
+	return &deviceTree{tree: tree, orderOf: orderOf}
+}
+
+// prefixHeads = applied changes not referenced as Prev by any applied change.
+func prefixHeads(dag []dagChange, applied map[string]bool) []string {
+	referenced := map[string]bool{}
+	for _, c := range dag {
+		if !applied[c.ID] {
+			continue
+		}
+		for _, p := range c.Prev {
+			referenced[p] = true
+		}
+	}
+	var heads []string
+	for _, c := range dag {
+		if applied[c.ID] && !referenced[c.ID] {
+			heads = append(heads, c.ID)
+		}
+	}
+	return heads
+}
+
+// storageResolver adapts a device's tree storage to chatmodel.ChangeResolver —
+// the exact production read (StorageChange.PrevIds / OrderId, point lookups).
+func storageResolver(t testing.TB, dt *deviceTree) chatmodel.ChangeResolver {
+	ctx := context.Background()
+	return func(id string) (chatmodel.ChangeMeta, bool) {
+		ch, err := dt.tree.Storage().Get(ctx, id)
+		if err != nil {
+			return chatmodel.ChangeMeta{}, false
+		}
+		return chatmodel.ChangeMeta{PrevIds: ch.PrevIds, OrderId: ch.OrderId}, true
+	}
+}
+
+func bandOn(t testing.TB, dt *deviceTree, frontier []string) []string {
+	got := chatmodel.ComputeBand(frontier, dt.tree.Heads(), storageResolver(t, dt))
+	sort.Strings(got.Candidates)
+	return got.Candidates
+}
+
+// readClosure = literal read*: the causal down-set of the frontier on the DAG
+// (device-independent by construction — computed from the declared DAG).
+func readClosure(dag []dagChange, frontier []string) map[string]bool {
+	byId := map[string]dagChange{}
+	for _, c := range dag {
+		byId[c.ID] = c
+	}
+	closure := map[string]bool{}
+	stack := append([]string(nil), frontier...)
+	for len(stack) > 0 {
+		id := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if closure[id] {
+			continue
+		}
+		if _, ok := byId[id]; !ok {
+			continue
+		}
+		closure[id] = true
+		stack = append(stack, byId[id].Prev...)
+	}
+	return closure
+}
+
+// assertOrderComparisonsConverge pins the precondition the whole model rests
+// on: per-device OrderId STRINGS may differ, but every pairwise comparison
+// sign is identical across devices.
+func assertOrderComparisonsConverge(t *testing.T, devices []*deviceTree) {
+	t.Helper()
+	var ids []string
+	for id := range devices[0].orderOf {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, d := range devices[1:] {
+		require.Equal(t, len(devices[0].orderOf), len(d.orderOf), "devices must hold the same change-set")
+		for i := 0; i < len(ids); i++ {
+			for j := i + 1; j < len(ids); j++ {
+				a := strings.Compare(devices[0].orderOf[ids[i]], devices[0].orderOf[ids[j]])
+				b := strings.Compare(d.orderOf[ids[i]], d.orderOf[ids[j]])
+				require.Equalf(t, a, b, "OrderId comparison for (%s,%s) must converge across devices", ids[i], ids[j])
+			}
+		}
+	}
+}
+
+// TestReadCore_CrossDeviceConvergence_Canonical is the gate for the exact
+// case that produced the permanent 0-vs-1 watermark divergence:
+// G; a1 ∥ b1; device A received a1 then b1, device B received b1 then a1
+// (so on A: AddSeq(a1) < AddSeq(b1); on B the reverse). Frontier = {b1}
+// (synced as ids). Both devices must report band {a1} — a1 unread everywhere.
+func TestReadCore_CrossDeviceConvergence_Canonical(t *testing.T) {
+	dag := []dagChange{
+		{ID: "G"},
+		{ID: "a1", Prev: []string{"G"}},
+		{ID: "b1", Prev: []string{"G"}},
+	}
+	devA := buildDeviceTree(t, dag, [][]string{{"a1"}, {"b1"}})
+	devB := buildDeviceTree(t, dag, [][]string{{"b1"}, {"a1"}})
+	assertOrderComparisonsConverge(t, []*deviceTree{devA, devB})
+
+	frontier := []string{"b1"}
+	bandA := bandOn(t, devA, frontier)
+	bandB := bandOn(t, devB, frontier)
+
+	assert.Equal(t, []string{"a1"}, bandA, "device A: a1 is concurrent with the read head -> unread")
+	assert.Equal(t, bandA, bandB, "both devices must compute the identical unread band")
+
+	closure := readClosure(dag, frontier)
+	assert.False(t, closure["a1"], "oracle: a1 is not in the causal past of b1")
+}
+
+// TestReadCore_CrossDeviceConvergence_BranchesAndLateInsert exercises a richer
+// shape: two branches, a merge on one side, a late in-past insert, multi-head
+// frontiers — across three devices with different batch deliveries.
+func TestReadCore_CrossDeviceConvergence_BranchesAndLateInsert(t *testing.T) {
+	dag := []dagChange{
+		{ID: "G"},
+		{ID: "a1", Prev: []string{"G"}},
+		{ID: "a2", Prev: []string{"a1"}},
+		{ID: "b1", Prev: []string{"G"}},
+		{ID: "b2", Prev: []string{"b1"}},
+		{ID: "mm", Prev: []string{"a2", "b2"}}, // merge
+		{ID: "c1", Prev: []string{"G"}},        // late in-past insert (third branch)
+	}
+	devices := []*deviceTree{
+		buildDeviceTree(t, dag, [][]string{{"a1", "a2"}, {"b1", "b2"}, {"mm"}, {"c1"}}),
+		buildDeviceTree(t, dag, [][]string{{"b1"}, {"c1"}, {"b2", "a1"}, {"a2", "mm"}}),
+		buildDeviceTree(t, dag, [][]string{{"c1", "a1", "b1", "a2", "b2", "mm"}}), // one batch
+	}
+	assertOrderComparisonsConverge(t, devices)
+
+	frontiers := [][]string{
+		{"b2"},         // one branch read: other branch's below-cut part + c1 are order-dependent on g
+		{"a2", "b1"},   // multi-head
+		{"mm"},         // merge read: only c1 can remain (if below the cut)
+		{"mm", "c1"},   // everything read
+		{"b2", "ghost"}, // pending head omitted
+	}
+	for _, f := range frontiers {
+		want := bandOn(t, devices[0], f)
+		for i, d := range devices[1:] {
+			assert.Equalf(t, want, bandOn(t, d, f), "frontier %v: device %d diverged", f, i+1)
+		}
+		// oracle: candidates must be exactly the non-covered changes at/below
+		// the per-device cut — verified on device 0 (cut position is
+		// comparison-invariant, so the set is the same on all).
+		closure := readClosure(dag, f)
+		maxF := ""
+		for _, h := range f {
+			if o, ok := devices[0].orderOf[h]; ok && o > maxF {
+				maxF = o
+			}
+		}
+		var oracle []string
+		for id, o := range devices[0].orderOf {
+			if maxF != "" && o <= maxF && !closure[id] {
+				oracle = append(oracle, id)
+			}
+		}
+		sort.Strings(oracle)
+		if oracle == nil {
+			oracle = []string{}
+		}
+		got := want
+		if got == nil {
+			got = []string{}
+		}
+		assert.Equalf(t, oracle, got, "frontier %v: band must equal the read* complement below the cut", f)
+	}
+}
+
+// TestReadCore_CrossDeviceConvergence_RandomDeliveries fuzzes the delivery
+// dimension: a fixed concurrent DAG delivered to pairs of devices in random
+// valid batch partitions; for random frontiers the band id-set must be
+// identical on both. Deterministic seed.
+func TestReadCore_CrossDeviceConvergence_RandomDeliveries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds many real trees")
+	}
+	dag := []dagChange{
+		{ID: "G"},
+		{ID: "a1", Prev: []string{"G"}},
+		{ID: "a2", Prev: []string{"a1"}},
+		{ID: "b1", Prev: []string{"G"}},
+		{ID: "b2", Prev: []string{"b1"}},
+		{ID: "c1", Prev: []string{"G"}},
+		{ID: "m1", Prev: []string{"a2", "b1"}},
+	}
+	nonRoot := []dagChange{}
+	for _, c := range dag[1:] {
+		nonRoot = append(nonRoot, c)
+	}
+	rng := rand.New(rand.NewSource(0xD_C40))
+
+	randomBatches := func() [][]string {
+		// random topological order of non-root changes…
+		remaining := append([]dagChange(nil), nonRoot...)
+		placed := map[string]bool{"G": true}
+		var order []string
+		for len(remaining) > 0 {
+			var ready []int
+			for i, c := range remaining {
+				ok := true
+				for _, p := range c.Prev {
+					if !placed[p] {
+						ok = false
+						break
+					}
+				}
+				if ok {
+					ready = append(ready, i)
+				}
+			}
+			pick := ready[rng.Intn(len(ready))]
+			order = append(order, remaining[pick].ID)
+			placed[remaining[pick].ID] = true
+			remaining = append(remaining[:pick], remaining[pick+1:]...)
+		}
+		// …cut into random batches
+		var batches [][]string
+		for start := 0; start < len(order); {
+			end := start + 1 + rng.Intn(len(order)-start)
+			batches = append(batches, order[start:end])
+			start = end
+		}
+		return batches
+	}
+
+	allIds := []string{"a1", "a2", "b1", "b2", "c1", "m1"}
+	for iter := 0; iter < 12; iter++ {
+		devA := buildDeviceTree(t, dag, randomBatches())
+		devB := buildDeviceTree(t, dag, randomBatches())
+		assertOrderComparisonsConverge(t, []*deviceTree{devA, devB})
+		for fIter := 0; fIter < 6; fIter++ {
+			var frontier []string
+			for j := 0; j < 1+rng.Intn(2); j++ {
+				frontier = append(frontier, allIds[rng.Intn(len(allIds))])
+			}
+			require.Equalf(t, bandOn(t, devA, frontier), bandOn(t, devB, frontier),
+				"iter %d frontier %v: devices diverged (deliveries A vs B differ)", iter, frontier)
+		}
+	}
+}

--- a/core/block/editor/chatobject/readcore_shadow_test.go
+++ b/core/block/editor/chatobject/readcore_shadow_test.go
@@ -1,0 +1,116 @@
+package chatobject
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+	"github.com/anyproto/anytype-heart/core/block/source/mock_source"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// fakeReadCoreProvider wraps the fixture's mock source (which satisfies
+// source.Store) and additionally implements source.ReadCoreSnapshotProvider
+// over a synthetic DAG — the production store's shape (the store IS the Store
+// and ALSO exposes the snapshot).
+type fakeReadCoreProvider struct {
+	*mock_source.MockStore
+	frontier   []string
+	localHeads []string
+	metas      map[string]chatmodel.ChangeMeta
+	calls      int
+}
+
+func (f *fakeReadCoreProvider) ReadCoreSnapshot(name string, fn func(frontier []string, localHeads []string, resolve func(id string) ([]string, string, bool))) bool {
+	f.calls++
+	fn(f.frontier, f.localHeads, func(id string) ([]string, string, bool) {
+		m, ok := f.metas[id]
+		return m.PrevIds, m.OrderId, ok
+	})
+	return true
+}
+
+func (fx *fixture) addPeerRowWithRead(t *testing.T, id, orderId, creator string, read bool) {
+	t.Helper()
+	msg := &chatmodel.Message{ChatMessage: &model.ChatMessage{
+		Id:      id,
+		OrderId: orderId,
+		Creator: creator,
+		Read:    read,
+		Message: &model.ChatMessageMessageContent{Text: id},
+	}}
+	require.NoError(t, fx.repository.AddTestMessage(context.Background(), msg))
+}
+
+// canonicalProviderDag: G; a1 ∥ b1 (the cross-device shape), frontier {b1}.
+// Per read*, a1 is unread (concurrent with the read head) — the CORE band.
+func canonicalProviderDag(mock *mock_source.MockStore) *fakeReadCoreProvider {
+	return &fakeReadCoreProvider{
+		MockStore:  mock,
+		frontier:   []string{"b1"},
+		localHeads: []string{"a1", "b1"},
+		metas: map[string]chatmodel.ChangeMeta{
+			"G":  {OrderId: "o01"},
+			"a1": {PrevIds: []string{"G"}, OrderId: "o02"},
+			"b1": {PrevIds: []string{"G"}, OrderId: "o03"},
+		},
+	}
+}
+
+func TestReadCoreShadow_DisabledIsNoOp(t *testing.T) {
+	fx := newFixture(t)
+	prov := canonicalProviderDag(fx.source)
+	fx.storeSource = prov
+
+	fx.shadowReadCoreCount(context.Background(), chatmodel.CounterTypeMessage)
+
+	assert.Zero(t, prov.calls, "disabled shadow must not consult the snapshot provider")
+}
+
+func TestComputeReadCoreCount_NonProviderDegrades(t *testing.T) {
+	fx := newFixture(t)
+	// the default mock source does NOT implement ReadCoreSnapshotProvider
+	_, _, ok, err := fx.computeReadCoreCount(context.Background(), chatmodel.CounterTypeMessage)
+	require.NoError(t, err)
+	assert.False(t, ok, "non-provider source degrades to a no-op")
+}
+
+// TestComputeReadCoreCount_AgreeAndDiverge pins both shadow outcomes on the
+// canonical a1∥b1 shape:
+//   - bool path in the convergent state (a1 unread) -> CORE agrees;
+//   - bool path mis-flagged (a1 read while not causally covered — the class of
+//     state an apply-order-dependent marker produces) -> CORE reports 1 vs
+//     bool 0, exactly the divergence the shadow exists to surface.
+func TestComputeReadCoreCount_AgreeAndDiverge(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("agree", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.storeSource = canonicalProviderDag(fx.source)
+		fx.addPeerRowWithRead(t, "a1", "o02", "alice", false) // unread, matches read*
+		fx.addPeerRowWithRead(t, "b1", "o03", "bob", true)    // covered by frontier
+
+		core, boolN, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, 1, core, "band{a1}: concurrent with the read head")
+		assert.Equal(t, core, boolN, "bool path agrees in the convergent state")
+	})
+
+	t.Run("diverge", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.storeSource = canonicalProviderDag(fx.source)
+		fx.addPeerRowWithRead(t, "a1", "o02", "alice", true) // wrongly flagged read
+		fx.addPeerRowWithRead(t, "b1", "o03", "bob", true)
+
+		core, boolN, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, 1, core, "read* says a1 is unread regardless of the flag")
+		assert.Equal(t, 0, boolN)
+		assert.NotEqual(t, core, boolN, "the divergence the shadow logs")
+	})
+}

--- a/core/block/editor/chatobject/readcore_shadow_test.go
+++ b/core/block/editor/chatobject/readcore_shadow_test.go
@@ -23,10 +23,12 @@ type fakeReadCoreProvider struct {
 	metas        map[string]chatmodel.ChangeMeta
 	calls        int
 	resolveCalls int
+	names        []string // diff manager names the snapshot was asked for
 }
 
 func (f *fakeReadCoreProvider) ReadCoreSnapshot(name string, fn func(frontier []string, localHeads []string, resolve func(id string) ([]string, string, bool))) bool {
 	f.calls++
+	f.names = append(f.names, name)
 	fn(f.frontier, f.localHeads, func(id string) ([]string, string, bool) {
 		f.resolveCalls++
 		m, ok := f.metas[id]
@@ -35,15 +37,17 @@ func (f *fakeReadCoreProvider) ReadCoreSnapshot(name string, fn func(frontier []
 	return true
 }
 
-func (fx *fixture) addPeerRowWithRead(t *testing.T, id, orderId, creator string, read bool) {
+func (fx *fixture) addPeerRowWithRead(t *testing.T, id, orderId, creator string, read, hasMention bool) {
 	t.Helper()
 	msg := &chatmodel.Message{ChatMessage: &model.ChatMessage{
-		Id:      id,
-		OrderId: orderId,
-		Creator: creator,
-		Read:    read,
-		Message: &model.ChatMessageMessageContent{Text: id},
+		Id:          id,
+		OrderId:     orderId,
+		Creator:     creator,
+		Read:        read,
+		MentionRead: read,
+		Message:     &model.ChatMessageMessageContent{Text: id},
 	}}
+	msg.HasMention = hasMention
 	require.NoError(t, fx.repository.AddTestMessage(context.Background(), msg))
 }
 
@@ -92,8 +96,8 @@ func TestComputeReadCoreCount_AgreeAndDiverge(t *testing.T) {
 	t.Run("agree", func(t *testing.T) {
 		fx := newFixture(t)
 		fx.storeSource = canonicalProviderDag(fx.source)
-		fx.addPeerRowWithRead(t, "a1", "o02", "alice", false) // unread, matches read*
-		fx.addPeerRowWithRead(t, "b1", "o03", "bob", true)    // covered by frontier
+		fx.addPeerRowWithRead(t, "a1", "o02", "alice", false, false) // unread, matches read*
+		fx.addPeerRowWithRead(t, "b1", "o03", "bob", true, false)    // covered by frontier
 
 		core, boolN, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
 		require.NoError(t, err)
@@ -105,8 +109,8 @@ func TestComputeReadCoreCount_AgreeAndDiverge(t *testing.T) {
 	t.Run("diverge", func(t *testing.T) {
 		fx := newFixture(t)
 		fx.storeSource = canonicalProviderDag(fx.source)
-		fx.addPeerRowWithRead(t, "a1", "o02", "alice", true) // wrongly flagged read
-		fx.addPeerRowWithRead(t, "b1", "o03", "bob", true)
+		fx.addPeerRowWithRead(t, "a1", "o02", "alice", true, false) // wrongly flagged read
+		fx.addPeerRowWithRead(t, "b1", "o03", "bob", true, false)
 
 		core, boolN, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
 		require.NoError(t, err)
@@ -126,8 +130,8 @@ func TestComputeReadCoreCount_CacheAndIncremental(t *testing.T) {
 	fx := newFixture(t)
 	prov := canonicalProviderDag(fx.source)
 	fx.storeSource = prov
-	fx.addPeerRowWithRead(t, "a1", "o02", "alice", false)
-	fx.addPeerRowWithRead(t, "b1", "o03", "bob", true)
+	fx.addPeerRowWithRead(t, "a1", "o02", "alice", false, false)
+	fx.addPeerRowWithRead(t, "b1", "o03", "bob", true, false)
 
 	// first call: cold in-process state -> walks
 	core, _, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
@@ -147,8 +151,8 @@ func TestComputeReadCoreCount_CacheAndIncremental(t *testing.T) {
 	// fires the Theorem-3 hook — the count updates with STILL no walk
 	prov.metas["p0"] = chatmodel.ChangeMeta{PrevIds: []string{"G"}, OrderId: "o01x"}
 	prov.localHeads = []string{"a1", "b1", "p0"}
-	fx.addPeerRowWithRead(t, "p0", "o01x", "carol", false)
-	fx.readCore.onMessageCreated("p0", "o01x", "carol", false)
+	fx.addPeerRowWithRead(t, "p0", "o01x", "carol", false, false)
+	fx.readCore.onMessageCreated("p0", "o01x", "carol")
 
 	core, _, _, err = fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
 	require.NoError(t, err)
@@ -161,4 +165,35 @@ func TestComputeReadCoreCount_CacheAndIncremental(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, prov.resolveCalls, walked, "frontier change must re-walk")
 	assert.Equal(t, 1, core, "only the in-past insert p0 stays unread")
+}
+
+// TestComputeReadCoreCount_MentionIsFilterOverMessageFrontier pins D4: the
+// mention counter shares THE (message) frontier — the snapshot is taken from
+// the messages diff manager even for the mention counter, and the mention
+// count is the same unread set filtered by hasMention. "Message read but its
+// mention unread" cannot exist.
+func TestComputeReadCoreCount_MentionIsFilterOverMessageFrontier(t *testing.T) {
+	ctx := context.Background()
+	fx := newFixture(t)
+	prov := canonicalProviderDag(fx.source)
+	fx.storeSource = prov
+	fx.addPeerRowWithRead(t, "a1", "o02", "alice", false, true) // unread mention in the band
+	fx.addPeerRowWithRead(t, "b1", "o03", "bob", true, false)   // covered plain message
+
+	core, boolN, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMention)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 1, core, "mention count = unread ∧ hasMention over the shared band")
+	assert.Equal(t, 1, boolN, "legacy mentionRead flags agree in the aligned state")
+	for _, name := range prov.names {
+		assert.Equal(t, chatmodel.CounterTypeMessage.DiffManagerName(), name,
+			"D4: even the mention counter snapshots the MESSAGE frontier")
+	}
+
+	// the same band serves the message counter without re-walking
+	walked := prov.resolveCalls
+	coreMsg, _, _, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+	require.NoError(t, err)
+	assert.Equal(t, 1, coreMsg, "message counter sees the mention row too")
+	assert.Equal(t, walked, prov.resolveCalls, "one shared frontier -> one shared cache, no second walk")
 }

--- a/core/block/editor/chatobject/readcore_shadow_test.go
+++ b/core/block/editor/chatobject/readcore_shadow_test.go
@@ -18,15 +18,17 @@ import (
 // and ALSO exposes the snapshot).
 type fakeReadCoreProvider struct {
 	*mock_source.MockStore
-	frontier   []string
-	localHeads []string
-	metas      map[string]chatmodel.ChangeMeta
-	calls      int
+	frontier     []string
+	localHeads   []string
+	metas        map[string]chatmodel.ChangeMeta
+	calls        int
+	resolveCalls int
 }
 
 func (f *fakeReadCoreProvider) ReadCoreSnapshot(name string, fn func(frontier []string, localHeads []string, resolve func(id string) ([]string, string, bool))) bool {
 	f.calls++
 	fn(f.frontier, f.localHeads, func(id string) ([]string, string, bool) {
+		f.resolveCalls++
 		m, ok := f.metas[id]
 		return m.PrevIds, m.OrderId, ok
 	})
@@ -113,4 +115,50 @@ func TestComputeReadCoreCount_AgreeAndDiverge(t *testing.T) {
 		assert.Equal(t, 0, boolN)
 		assert.NotEqual(t, core, boolN, "the divergence the shadow logs")
 	})
+}
+
+// TestComputeReadCoreCount_CacheAndIncremental pins the runtime-flow contract
+// (spec §5): the walk runs only when the frontier changes; between frontier
+// changes the band is maintained incrementally (Theorem 3) and queries reuse
+// the cache — observed here via the provider's resolve-call counter.
+func TestComputeReadCoreCount_CacheAndIncremental(t *testing.T) {
+	ctx := context.Background()
+	fx := newFixture(t)
+	prov := canonicalProviderDag(fx.source)
+	fx.storeSource = prov
+	fx.addPeerRowWithRead(t, "a1", "o02", "alice", false)
+	fx.addPeerRowWithRead(t, "b1", "o03", "bob", true)
+
+	// first call: cold in-process state -> walks
+	core, _, ok, err := fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 1, core, "band{a1}")
+	assert.Positive(t, prov.resolveCalls, "first call must walk")
+
+	// second call, same frontier: cache hit, zero walking
+	walked := prov.resolveCalls
+	core, _, _, err = fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+	require.NoError(t, err)
+	assert.Equal(t, 1, core)
+	assert.Equal(t, walked, prov.resolveCalls, "unchanged frontier must not re-walk")
+
+	// a late in-past insert arrives: the tree gains the change, the handler
+	// fires the Theorem-3 hook — the count updates with STILL no walk
+	prov.metas["p0"] = chatmodel.ChangeMeta{PrevIds: []string{"G"}, OrderId: "o01x"}
+	prov.localHeads = []string{"a1", "b1", "p0"}
+	fx.addPeerRowWithRead(t, "p0", "o01x", "carol", false)
+	fx.readCore.onMessageCreated("p0", "o01x", "carol", false)
+
+	core, _, _, err = fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+	require.NoError(t, err)
+	assert.Equal(t, 2, core, "band{a1,p0} after the incremental append")
+	assert.Equal(t, walked, prov.resolveCalls, "incremental maintenance must not trigger a walk")
+
+	// frontier advances (user read a1 too): cache miss -> one fresh walk
+	prov.frontier = []string{"a1", "b1"}
+	core, _, _, err = fx.computeReadCoreCount(ctx, chatmodel.CounterTypeMessage)
+	require.NoError(t, err)
+	assert.Greater(t, prov.resolveCalls, walked, "frontier change must re-walk")
+	assert.Equal(t, 1, core, "only the in-past insert p0 stays unread")
 }

--- a/core/block/editor/chatobject/readcorestate.go
+++ b/core/block/editor/chatobject/readcorestate.go
@@ -15,18 +15,24 @@ import (
 	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
 )
 
-// readCoreManager caches, per counter, the causal-ordinal CORE read-state
-// (spec §5 "Runtime flows"): the frontier cut (maxF) and the band — unread
-// change ids at/below the cut. Between frontier changes the band is maintained
-// incrementally by the Theorem-3 rule: a newly attached change can never be a
-// causal ancestor of an already-resolved frontier head (parent-first
-// attachment), so an arriving counted message at/below the cut joins the band
-// with NO ancestry check; everything past the cut is the indexed tail's job.
+// readCoreManager caches the causal-ordinal CORE read-state (spec §5 "Runtime
+// flows"): the frontier cut (maxF) and the band — unread change ids at/below
+// the cut. Per decision D4 there is exactly ONE frontier (the message
+// frontier) and ONE cached state: the mention counter is the same unread set
+// filtered by hasMention at query time, so both counters are served from this
+// state. Per decision D5 the frontier is monotone (markunread is deprecated),
+// so there are no regression flows.
+//
+// Between frontier changes the band is maintained incrementally by the
+// Theorem-3 rule: a newly attached change can never be a causal ancestor of an
+// already-resolved frontier head (parent-first attachment), so an arriving
+// counted message at/below the cut joins the band with NO ancestry check;
+// everything past the cut is the indexed tail's job.
 //
 // The cache is device-local, persisted in crdt.db (collection
-// "<objectId>readcore", one doc per counter). In the shadow stage a persisted
-// doc is NOT trusted as live state across restarts — in-past inserts could
-// have arrived while the process was down; the first use in a process always
+// "<objectId>readcore", a single doc). In the shadow stage a persisted doc is
+// NOT trusted as live state across restarts — in-past inserts could have
+// arrived while the process was down; the first use in a process always
 // re-walks and the persisted copy serves as a cold-start staleness signal
 // (logged once). Trusting it outright needs the Stage-2 apply-cursor
 // (lastAddSeq gap replay), at which point cold start becomes O(gap).
@@ -43,11 +49,11 @@ type readCoreManager struct {
 	coll       anystore.Collection // opened lazily on first persistence use
 	myIdentity string
 
-	states      map[chatmodel.CounterType]*readCoreCounterState
+	state       readCoreState
 	staleLogged bool
 }
 
-type readCoreCounterState struct {
+type readCoreState struct {
 	valid        bool
 	maxF         string // "" = no resolved frontier (no cut, band must be empty)
 	frontierHash string
@@ -56,15 +62,13 @@ type readCoreCounterState struct {
 	dirty        bool
 }
 
+const readCoreCacheDocId = "core"
+
 func newReadCoreManager(db anystore.DB, objectId, myIdentity string) *readCoreManager {
 	return &readCoreManager{
 		db:         db,
 		collName:   objectId + "readcore",
 		myIdentity: myIdentity,
-		states: map[chatmodel.CounterType]*readCoreCounterState{
-			chatmodel.CounterTypeMessage: {},
-			chatmodel.CounterTypeMention: {},
-		},
 	}
 }
 
@@ -79,11 +83,11 @@ func readCoreFrontierHash(frontier []string) string {
 // given raw frontier AND has no pending heads. A pending head may become
 // resolvable at any moment and move the cut without the frontier ids changing,
 // so pending always forces a re-walk (rare; safe over-count meanwhile).
-func (m *readCoreManager) cachedCut(counter chatmodel.CounterType, frontier []string) (maxF string, band []string, ok bool) {
+func (m *readCoreManager) cachedCut(frontier []string) (maxF string, band []string, ok bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	st := m.states[counter]
-	if st == nil || !st.valid || len(st.pending) > 0 || st.frontierHash != readCoreFrontierHash(frontier) {
+	st := &m.state
+	if !st.valid || len(st.pending) > 0 || st.frontierHash != readCoreFrontierHash(frontier) {
 		return "", nil, false
 	}
 	band = make([]string, 0, len(st.band))
@@ -93,16 +97,12 @@ func (m *readCoreManager) cachedCut(counter chatmodel.CounterType, frontier []st
 	return st.maxF, band, true
 }
 
-// refresh replaces the counter's state with a fresh walk result. Persistence
-// is deferred to persistDirty (never under the tree lock).
-func (m *readCoreManager) refresh(counter chatmodel.CounterType, frontier []string, walk chatmodel.BandResult) {
+// refresh replaces the state with a fresh walk result. Persistence is
+// deferred to persistDirty (never under the tree lock).
+func (m *readCoreManager) refresh(frontier []string, walk chatmodel.BandResult) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	st := m.states[counter]
-	if st == nil {
-		st = &readCoreCounterState{}
-		m.states[counter] = st
-	}
+	st := &m.state
 	st.valid = true
 	st.maxF = walk.MaxFrontierOrderId
 	st.frontierHash = readCoreFrontierHash(frontier)
@@ -115,59 +115,54 @@ func (m *readCoreManager) refresh(counter chatmodel.CounterType, frontier []stri
 }
 
 // onMessageCreated applies the Theorem-3 incremental rule for a freshly
-// materialized message (called from ChatHandler.BeforeCreate, where creator /
-// hasMention / orderId are final). Own messages are never counted. No-op until
-// the first walk validated the state, and when there is no cut.
-func (m *readCoreManager) onMessageCreated(id, orderId, creator string, hasMention bool) {
+// materialized message (called from ChatHandler.BeforeCreate). Own messages
+// are never counted; the mention/message distinction is a query-time filter
+// (D4), so the shared band tracks every counted peer message below the cut.
+// No-op until the first walk validated the state, and when there is no cut.
+func (m *readCoreManager) onMessageCreated(id, orderId, creator string) {
 	if creator == m.myIdentity {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for counter, st := range m.states {
-		if !st.valid || st.maxF == "" || orderId > st.maxF {
-			continue // tail (or no state): the indexed range covers it
-		}
-		if counter == chatmodel.CounterTypeMention && !hasMention {
-			continue
-		}
-		st.band[id] = struct{}{}
-		st.dirty = true
+	st := &m.state
+	if !st.valid || st.maxF == "" || orderId > st.maxF {
+		return // tail (or no state): the indexed range covers it
 	}
+	st.band[id] = struct{}{}
+	st.dirty = true
 }
 
-// onMessageDeleted drops a deleted message from the cached bands (the live
+// onMessageDeleted drops a deleted message from the cached band (the live
 // collection stops counting it in the tail automatically).
 func (m *readCoreManager) onMessageDeleted(id string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, st := range m.states {
-		if !st.valid {
-			continue
-		}
-		if _, inBand := st.band[id]; inBand {
-			delete(st.band, id)
-			st.dirty = true
-		}
+	st := &m.state
+	if !st.valid {
+		return
+	}
+	if _, inBand := st.band[id]; inBand {
+		delete(st.band, id)
+		st.dirty = true
 	}
 }
 
-// persistDirty writes changed states to the device-local cache collection.
+// persistDirty writes a changed state to the device-local cache collection.
 // Best-effort: failures are logged, never propagated (the cache is
 // reconstructible by a walk).
 func (m *readCoreManager) persistDirty(ctx context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for counter, st := range m.states {
-		if !st.valid || !st.dirty {
-			continue
-		}
-		if err := m.persistLocked(ctx, counter, st); err != nil {
-			log.Warn("readcore: persist cache", zap.Error(err))
-			return
-		}
-		st.dirty = false
+	st := &m.state
+	if !st.valid || !st.dirty {
+		return
 	}
+	if err := m.persistLocked(ctx, st); err != nil {
+		log.Warn("readcore: persist cache", zap.Error(err))
+		return
+	}
+	st.dirty = false
 }
 
 func (m *readCoreManager) collection(ctx context.Context) (anystore.Collection, error) {
@@ -182,14 +177,14 @@ func (m *readCoreManager) collection(ctx context.Context) (anystore.Collection, 
 	return coll, nil
 }
 
-func (m *readCoreManager) persistLocked(ctx context.Context, counter chatmodel.CounterType, st *readCoreCounterState) error {
+func (m *readCoreManager) persistLocked(ctx context.Context, st *readCoreState) error {
 	coll, err := m.collection(ctx)
 	if err != nil {
 		return err
 	}
 	arena := &anyenc.Arena{}
 	doc := arena.NewObject()
-	doc.Set("id", arena.NewString(counter.DiffManagerName()))
+	doc.Set("id", arena.NewString(readCoreCacheDocId))
 	doc.Set("maxF", arena.NewString(st.maxF))
 	doc.Set("hash", arena.NewString(st.frontierHash))
 	doc.Set("pending", storeutil.NewStringArrayValue(st.pending, arena))
@@ -212,14 +207,14 @@ type persistedCacheState struct {
 	band         []string
 }
 
-func (m *readCoreManager) loadPersisted(ctx context.Context, counter chatmodel.CounterType) (persistedCacheState, bool) {
+func (m *readCoreManager) loadPersisted(ctx context.Context) (persistedCacheState, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	coll, err := m.collection(ctx)
 	if err != nil {
 		return persistedCacheState{}, false
 	}
-	doc, err := coll.FindId(ctx, counter.DiffManagerName())
+	doc, err := coll.FindId(ctx, readCoreCacheDocId)
 	if err != nil {
 		return persistedCacheState{}, false
 	}
@@ -235,8 +230,8 @@ func (m *readCoreManager) loadPersisted(ctx context.Context, counter chatmodel.C
 // logIfStale compares a fresh walk against the persisted cold-start copy and
 // logs once per process when they differ — the staleness signal that decides
 // when the Stage-2 apply-cursor (trustable cold start) is worth shipping.
-func (m *readCoreManager) logIfStale(ctx context.Context, counter chatmodel.CounterType, walk chatmodel.BandResult, frontier []string) {
-	persisted, ok := m.loadPersisted(ctx, counter)
+func (m *readCoreManager) logIfStale(ctx context.Context, walk chatmodel.BandResult, frontier []string) {
+	persisted, ok := m.loadPersisted(ctx)
 	if !ok {
 		return
 	}
@@ -251,7 +246,6 @@ func (m *readCoreManager) logIfStale(ctx context.Context, counter chatmodel.Coun
 		persisted.maxF != walk.MaxFrontierOrderId ||
 		strings.Join(persisted.band, "\x00") != strings.Join(fresh, "\x00") {
 		m.staleLogged = true
-		log.Info("readcore: persisted cache was stale at cold start",
-			zap.String("counter", counter.DiffManagerName()))
+		log.Info("readcore: persisted cache was stale at cold start")
 	}
 }

--- a/core/block/editor/chatobject/readcorestate.go
+++ b/core/block/editor/chatobject/readcorestate.go
@@ -1,0 +1,257 @@
+package chatobject
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-store/anyenc"
+	"github.com/anyproto/any-sync/util/storeutil"
+	"go.uber.org/zap"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+)
+
+// readCoreManager caches, per counter, the causal-ordinal CORE read-state
+// (spec §5 "Runtime flows"): the frontier cut (maxF) and the band — unread
+// change ids at/below the cut. Between frontier changes the band is maintained
+// incrementally by the Theorem-3 rule: a newly attached change can never be a
+// causal ancestor of an already-resolved frontier head (parent-first
+// attachment), so an arriving counted message at/below the cut joins the band
+// with NO ancestry check; everything past the cut is the indexed tail's job.
+//
+// The cache is device-local, persisted in crdt.db (collection
+// "<objectId>readcore", one doc per counter). In the shadow stage a persisted
+// doc is NOT trusted as live state across restarts — in-past inserts could
+// have arrived while the process was down; the first use in a process always
+// re-walks and the persisted copy serves as a cold-start staleness signal
+// (logged once). Trusting it outright needs the Stage-2 apply-cursor
+// (lastAddSeq gap replay), at which point cold start becomes O(gap).
+//
+// Locking: callers inside the source's ReadCoreSnapshot callback hold the
+// object-tree lock and then take m.mu; the handler hooks take only m.mu.
+// No path acquires the tree lock while holding m.mu — no inversion.
+// Persistence never runs under the tree lock (persistDirty is called after
+// the snapshot callback returns).
+type readCoreManager struct {
+	mu         sync.Mutex
+	db         anystore.DB
+	collName   string
+	coll       anystore.Collection // opened lazily on first persistence use
+	myIdentity string
+
+	states      map[chatmodel.CounterType]*readCoreCounterState
+	staleLogged bool
+}
+
+type readCoreCounterState struct {
+	valid        bool
+	maxF         string // "" = no resolved frontier (no cut, band must be empty)
+	frontierHash string
+	pending      []string // frontier ids not locally resolvable at walk time
+	band         map[string]struct{}
+	dirty        bool
+}
+
+func newReadCoreManager(db anystore.DB, objectId, myIdentity string) *readCoreManager {
+	return &readCoreManager{
+		db:         db,
+		collName:   objectId + "readcore",
+		myIdentity: myIdentity,
+		states: map[chatmodel.CounterType]*readCoreCounterState{
+			chatmodel.CounterTypeMessage: {},
+			chatmodel.CounterTypeMention: {},
+		},
+	}
+}
+
+// readCoreFrontierHash identifies a raw frontier as a set (order-insensitive).
+func readCoreFrontierHash(frontier []string) string {
+	ids := append([]string(nil), frontier...)
+	sort.Strings(ids)
+	return strings.Join(ids, "\x00")
+}
+
+// cachedCut returns the cached (maxF, band) when the state is valid for the
+// given raw frontier AND has no pending heads. A pending head may become
+// resolvable at any moment and move the cut without the frontier ids changing,
+// so pending always forces a re-walk (rare; safe over-count meanwhile).
+func (m *readCoreManager) cachedCut(counter chatmodel.CounterType, frontier []string) (maxF string, band []string, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.states[counter]
+	if st == nil || !st.valid || len(st.pending) > 0 || st.frontierHash != readCoreFrontierHash(frontier) {
+		return "", nil, false
+	}
+	band = make([]string, 0, len(st.band))
+	for id := range st.band {
+		band = append(band, id)
+	}
+	return st.maxF, band, true
+}
+
+// refresh replaces the counter's state with a fresh walk result. Persistence
+// is deferred to persistDirty (never under the tree lock).
+func (m *readCoreManager) refresh(counter chatmodel.CounterType, frontier []string, walk chatmodel.BandResult) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.states[counter]
+	if st == nil {
+		st = &readCoreCounterState{}
+		m.states[counter] = st
+	}
+	st.valid = true
+	st.maxF = walk.MaxFrontierOrderId
+	st.frontierHash = readCoreFrontierHash(frontier)
+	st.pending = append([]string(nil), walk.PendingHeads...)
+	st.band = make(map[string]struct{}, len(walk.Candidates))
+	for _, id := range walk.Candidates {
+		st.band[id] = struct{}{}
+	}
+	st.dirty = true
+}
+
+// onMessageCreated applies the Theorem-3 incremental rule for a freshly
+// materialized message (called from ChatHandler.BeforeCreate, where creator /
+// hasMention / orderId are final). Own messages are never counted. No-op until
+// the first walk validated the state, and when there is no cut.
+func (m *readCoreManager) onMessageCreated(id, orderId, creator string, hasMention bool) {
+	if creator == m.myIdentity {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for counter, st := range m.states {
+		if !st.valid || st.maxF == "" || orderId > st.maxF {
+			continue // tail (or no state): the indexed range covers it
+		}
+		if counter == chatmodel.CounterTypeMention && !hasMention {
+			continue
+		}
+		st.band[id] = struct{}{}
+		st.dirty = true
+	}
+}
+
+// onMessageDeleted drops a deleted message from the cached bands (the live
+// collection stops counting it in the tail automatically).
+func (m *readCoreManager) onMessageDeleted(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, st := range m.states {
+		if !st.valid {
+			continue
+		}
+		if _, inBand := st.band[id]; inBand {
+			delete(st.band, id)
+			st.dirty = true
+		}
+	}
+}
+
+// persistDirty writes changed states to the device-local cache collection.
+// Best-effort: failures are logged, never propagated (the cache is
+// reconstructible by a walk).
+func (m *readCoreManager) persistDirty(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for counter, st := range m.states {
+		if !st.valid || !st.dirty {
+			continue
+		}
+		if err := m.persistLocked(ctx, counter, st); err != nil {
+			log.Warn("readcore: persist cache", zap.Error(err))
+			return
+		}
+		st.dirty = false
+	}
+}
+
+func (m *readCoreManager) collection(ctx context.Context) (anystore.Collection, error) {
+	if m.coll != nil {
+		return m.coll, nil
+	}
+	coll, err := m.db.Collection(ctx, m.collName)
+	if err != nil {
+		return nil, err
+	}
+	m.coll = coll
+	return coll, nil
+}
+
+func (m *readCoreManager) persistLocked(ctx context.Context, counter chatmodel.CounterType, st *readCoreCounterState) error {
+	coll, err := m.collection(ctx)
+	if err != nil {
+		return err
+	}
+	arena := &anyenc.Arena{}
+	doc := arena.NewObject()
+	doc.Set("id", arena.NewString(counter.DiffManagerName()))
+	doc.Set("maxF", arena.NewString(st.maxF))
+	doc.Set("hash", arena.NewString(st.frontierHash))
+	doc.Set("pending", storeutil.NewStringArrayValue(st.pending, arena))
+	band := make([]string, 0, len(st.band))
+	for id := range st.band {
+		band = append(band, id)
+	}
+	sort.Strings(band)
+	doc.Set("band", storeutil.NewStringArrayValue(band, arena))
+	doc.Set("updatedAt", arena.NewNumberInt(int(time.Now().Unix())))
+	return coll.UpsertOne(ctx, doc)
+}
+
+// persistedCacheState is the deserialized cold-start cache doc (telemetry /
+// tests; not trusted as live state in the shadow stage — see the type comment).
+type persistedCacheState struct {
+	maxF         string
+	frontierHash string
+	pending      []string
+	band         []string
+}
+
+func (m *readCoreManager) loadPersisted(ctx context.Context, counter chatmodel.CounterType) (persistedCacheState, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	coll, err := m.collection(ctx)
+	if err != nil {
+		return persistedCacheState{}, false
+	}
+	doc, err := coll.FindId(ctx, counter.DiffManagerName())
+	if err != nil {
+		return persistedCacheState{}, false
+	}
+	v := doc.Value()
+	return persistedCacheState{
+		maxF:         v.GetString("maxF"),
+		frontierHash: v.GetString("hash"),
+		pending:      storeutil.StringsFromArrayValue(v, "pending"),
+		band:         storeutil.StringsFromArrayValue(v, "band"),
+	}, true
+}
+
+// logIfStale compares a fresh walk against the persisted cold-start copy and
+// logs once per process when they differ — the staleness signal that decides
+// when the Stage-2 apply-cursor (trustable cold start) is worth shipping.
+func (m *readCoreManager) logIfStale(ctx context.Context, counter chatmodel.CounterType, walk chatmodel.BandResult, frontier []string) {
+	persisted, ok := m.loadPersisted(ctx, counter)
+	if !ok {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.staleLogged {
+		return
+	}
+	fresh := append([]string(nil), walk.Candidates...)
+	sort.Strings(fresh)
+	if persisted.frontierHash != readCoreFrontierHash(frontier) ||
+		persisted.maxF != walk.MaxFrontierOrderId ||
+		strings.Join(persisted.band, "\x00") != strings.Join(fresh, "\x00") {
+		m.staleLogged = true
+		log.Info("readcore: persisted cache was stale at cold start",
+			zap.String("counter", counter.DiffManagerName()))
+	}
+}

--- a/core/block/editor/chatobject/readcorestate_test.go
+++ b/core/block/editor/chatobject/readcorestate_test.go
@@ -17,8 +17,8 @@ func newTestReadCore(t *testing.T) *readCoreManager {
 	return newReadCoreManager(deviceAnystore(t), "obj1", rcMe)
 }
 
-func bandIdsOf(m *readCoreManager, counter chatmodel.CounterType, frontier []string) []string {
-	_, ids, ok := m.cachedCut(counter, frontier)
+func bandIdsOf(m *readCoreManager, frontier []string) []string {
+	_, ids, ok := m.cachedCut(frontier)
 	if !ok {
 		return nil
 	}
@@ -28,49 +28,38 @@ func bandIdsOf(m *readCoreManager, counter chatmodel.CounterType, frontier []str
 
 // The Theorem-3 incremental rule: a newly attached change can never be an
 // ancestor of an already-resolved frontier head, so an arriving counted
-// message at/below the cut joins the band with no ancestry check.
+// message at/below the cut joins the (shared, D4) band with no ancestry check.
 func TestReadCoreManager_Theorem3Rule(t *testing.T) {
 	frontier := []string{"h1"}
 	seed := func(t *testing.T) *readCoreManager {
 		m := newTestReadCore(t)
-		m.refresh(chatmodel.CounterTypeMessage, frontier,
-			chatmodel.BandResult{MaxFrontierOrderId: "o05", ResolvedHeads: frontier})
-		m.refresh(chatmodel.CounterTypeMention, frontier,
-			chatmodel.BandResult{MaxFrontierOrderId: "o05", ResolvedHeads: frontier})
+		m.refresh(frontier, chatmodel.BandResult{MaxFrontierOrderId: "o05", ResolvedHeads: frontier})
 		return m
 	}
 
 	t.Run("peer message below the cut joins the band", func(t *testing.T) {
 		m := seed(t)
-		m.onMessageCreated("late", "o03", "alice", false)
-		assert.Equal(t, []string{"late"}, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
-		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMention, frontier), "no mention -> message band only")
-	})
-
-	t.Run("mention below the cut joins both bands", func(t *testing.T) {
-		m := seed(t)
-		m.onMessageCreated("late", "o03", "alice", true)
-		assert.Equal(t, []string{"late"}, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
-		assert.Equal(t, []string{"late"}, bandIdsOf(m, chatmodel.CounterTypeMention, frontier))
+		m.onMessageCreated("late", "o03", "alice")
+		assert.Equal(t, []string{"late"}, bandIdsOf(m, frontier))
 	})
 
 	t.Run("tail arrival is not band-tracked", func(t *testing.T) {
 		m := seed(t)
-		m.onMessageCreated("tip", "o09", "alice", true)
-		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier), "g > maxF is the indexed tail's job")
+		m.onMessageCreated("tip", "o09", "alice")
+		assert.Empty(t, bandIdsOf(m, frontier), "g > maxF is the indexed tail's job")
 	})
 
 	t.Run("own message never joins", func(t *testing.T) {
 		m := seed(t)
-		m.onMessageCreated("mine", "o03", rcMe, true)
-		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+		m.onMessageCreated("mine", "o03", rcMe)
+		assert.Empty(t, bandIdsOf(m, frontier))
 	})
 
 	t.Run("no cut means no band tracking", func(t *testing.T) {
 		m := newTestReadCore(t)
-		m.refresh(chatmodel.CounterTypeMessage, nil, chatmodel.BandResult{}) // no resolved frontier
-		m.onMessageCreated("x", "o01", "alice", false)
-		maxF, ids, ok := m.cachedCut(chatmodel.CounterTypeMessage, nil)
+		m.refresh(nil, chatmodel.BandResult{}) // no resolved frontier
+		m.onMessageCreated("x", "o01", "alice")
+		maxF, ids, ok := m.cachedCut(nil)
 		require.True(t, ok)
 		assert.Empty(t, maxF)
 		assert.Empty(t, ids)
@@ -78,17 +67,16 @@ func TestReadCoreManager_Theorem3Rule(t *testing.T) {
 
 	t.Run("invalid state ignores arrivals", func(t *testing.T) {
 		m := newTestReadCore(t)
-		m.onMessageCreated("x", "o01", "alice", false) // before any walk
-		_, _, ok := m.cachedCut(chatmodel.CounterTypeMessage, frontier)
+		m.onMessageCreated("x", "o01", "alice") // before any walk
+		_, _, ok := m.cachedCut(frontier)
 		assert.False(t, ok)
 	})
 
-	t.Run("delete removes from bands", func(t *testing.T) {
+	t.Run("delete removes from the band", func(t *testing.T) {
 		m := seed(t)
-		m.onMessageCreated("late", "o03", "alice", true)
+		m.onMessageCreated("late", "o03", "alice")
 		m.onMessageDeleted("late")
-		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
-		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMention, frontier))
+		assert.Empty(t, bandIdsOf(m, frontier))
 	})
 }
 
@@ -98,28 +86,28 @@ func TestReadCoreManager_CachedCut(t *testing.T) {
 	m := newTestReadCore(t)
 	frontier := []string{"h2", "h1"} // raw order must not matter
 
-	m.refresh(chatmodel.CounterTypeMessage, frontier, chatmodel.BandResult{
+	m.refresh(frontier, chatmodel.BandResult{
 		MaxFrontierOrderId: "o05",
 		Candidates:         []string{"c1"},
 		ResolvedHeads:      []string{"h1", "h2"},
 	})
 
-	maxF, ids, ok := m.cachedCut(chatmodel.CounterTypeMessage, []string{"h1", "h2"})
+	maxF, ids, ok := m.cachedCut([]string{"h1", "h2"})
 	require.True(t, ok, "order-insensitive frontier identity")
 	assert.Equal(t, "o05", maxF)
 	assert.Equal(t, []string{"c1"}, ids)
 
-	_, _, ok = m.cachedCut(chatmodel.CounterTypeMessage, []string{"h1", "h3"})
+	_, _, ok = m.cachedCut([]string{"h1", "h3"})
 	assert.False(t, ok, "different frontier -> walk required")
 
 	// pending heads always force a re-walk: they may resolve at any moment
 	// and move the cut without the frontier ids changing.
-	m.refresh(chatmodel.CounterTypeMessage, frontier, chatmodel.BandResult{
+	m.refresh(frontier, chatmodel.BandResult{
 		MaxFrontierOrderId: "o05",
 		ResolvedHeads:      []string{"h1"},
 		PendingHeads:       []string{"h2"},
 	})
-	_, _, ok = m.cachedCut(chatmodel.CounterTypeMessage, frontier)
+	_, _, ok = m.cachedCut(frontier)
 	assert.False(t, ok)
 }
 
@@ -130,22 +118,22 @@ func TestReadCoreManager_PersistRoundtrip(t *testing.T) {
 	db := deviceAnystore(t)
 	m1 := newReadCoreManager(db, "obj1", rcMe)
 	frontier := []string{"h1"}
-	m1.refresh(chatmodel.CounterTypeMessage, frontier, chatmodel.BandResult{
+	m1.refresh(frontier, chatmodel.BandResult{
 		MaxFrontierOrderId: "o05",
 		Candidates:         []string{"b2", "b1"},
 		ResolvedHeads:      frontier,
 	})
-	m1.onMessageCreated("late", "o02", "alice", false)
+	m1.onMessageCreated("late", "o02", "alice")
 	m1.persistDirty(ctx)
 
 	m2 := newReadCoreManager(db, "obj1", rcMe)
-	persisted, ok := m2.loadPersisted(ctx, chatmodel.CounterTypeMessage)
+	persisted, ok := m2.loadPersisted(ctx)
 	require.True(t, ok)
 	assert.Equal(t, "o05", persisted.maxF)
 	assert.Equal(t, readCoreFrontierHash(frontier), persisted.frontierHash)
 	assert.Equal(t, []string{"b1", "b2", "late"}, persisted.band, "sorted, incremental append included")
 
-	_, _, live := m2.cachedCut(chatmodel.CounterTypeMessage, frontier)
+	_, _, live := m2.cachedCut(frontier)
 	assert.False(t, live, "persisted state is not trusted as live until the first in-process walk")
 }
 
@@ -166,24 +154,24 @@ func TestReadCoreManager_IncrementalEqualsFreshWalk(t *testing.T) {
 
 	m := newTestReadCore(t)
 	walk := chatmodel.ComputeBand(frontier, heads, resolve)
-	m.refresh(chatmodel.CounterTypeMessage, frontier, walk)
-	assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier), "linear history: empty band")
+	m.refresh(frontier, walk)
+	assert.Empty(t, bandIdsOf(m, frontier), "linear history: empty band")
 
 	// a late in-past insert arrives (concurrent branch below the cut)
 	metas["late"] = chatmodel.ChangeMeta{PrevIds: []string{"G"}, OrderId: "o02x"}
 	heads = []string{"m2", "late"}
-	m.onMessageCreated("late", "o02x", "alice", false)
+	m.onMessageCreated("late", "o02x", "alice")
 
 	fresh := chatmodel.ComputeBand(frontier, heads, resolve)
 	sort.Strings(fresh.Candidates)
-	assert.Equal(t, fresh.Candidates, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier),
+	assert.Equal(t, fresh.Candidates, bandIdsOf(m, frontier),
 		"incremental band == fresh walk after the in-past insert")
 
 	// and a tail arrival changes neither
 	metas["tip"] = chatmodel.ChangeMeta{PrevIds: []string{"m2"}, OrderId: "o04"}
 	heads = []string{"tip", "late"}
-	m.onMessageCreated("tip", "o04", "bob", false)
+	m.onMessageCreated("tip", "o04", "bob")
 	fresh = chatmodel.ComputeBand(frontier, heads, resolve)
 	sort.Strings(fresh.Candidates)
-	assert.Equal(t, fresh.Candidates, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+	assert.Equal(t, fresh.Candidates, bandIdsOf(m, frontier))
 }

--- a/core/block/editor/chatobject/readcorestate_test.go
+++ b/core/block/editor/chatobject/readcorestate_test.go
@@ -1,0 +1,189 @@
+package chatobject
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+)
+
+const rcMe = "me"
+
+func newTestReadCore(t *testing.T) *readCoreManager {
+	return newReadCoreManager(deviceAnystore(t), "obj1", rcMe)
+}
+
+func bandIdsOf(m *readCoreManager, counter chatmodel.CounterType, frontier []string) []string {
+	_, ids, ok := m.cachedCut(counter, frontier)
+	if !ok {
+		return nil
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// The Theorem-3 incremental rule: a newly attached change can never be an
+// ancestor of an already-resolved frontier head, so an arriving counted
+// message at/below the cut joins the band with no ancestry check.
+func TestReadCoreManager_Theorem3Rule(t *testing.T) {
+	frontier := []string{"h1"}
+	seed := func(t *testing.T) *readCoreManager {
+		m := newTestReadCore(t)
+		m.refresh(chatmodel.CounterTypeMessage, frontier,
+			chatmodel.BandResult{MaxFrontierOrderId: "o05", ResolvedHeads: frontier})
+		m.refresh(chatmodel.CounterTypeMention, frontier,
+			chatmodel.BandResult{MaxFrontierOrderId: "o05", ResolvedHeads: frontier})
+		return m
+	}
+
+	t.Run("peer message below the cut joins the band", func(t *testing.T) {
+		m := seed(t)
+		m.onMessageCreated("late", "o03", "alice", false)
+		assert.Equal(t, []string{"late"}, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMention, frontier), "no mention -> message band only")
+	})
+
+	t.Run("mention below the cut joins both bands", func(t *testing.T) {
+		m := seed(t)
+		m.onMessageCreated("late", "o03", "alice", true)
+		assert.Equal(t, []string{"late"}, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+		assert.Equal(t, []string{"late"}, bandIdsOf(m, chatmodel.CounterTypeMention, frontier))
+	})
+
+	t.Run("tail arrival is not band-tracked", func(t *testing.T) {
+		m := seed(t)
+		m.onMessageCreated("tip", "o09", "alice", true)
+		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier), "g > maxF is the indexed tail's job")
+	})
+
+	t.Run("own message never joins", func(t *testing.T) {
+		m := seed(t)
+		m.onMessageCreated("mine", "o03", rcMe, true)
+		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+	})
+
+	t.Run("no cut means no band tracking", func(t *testing.T) {
+		m := newTestReadCore(t)
+		m.refresh(chatmodel.CounterTypeMessage, nil, chatmodel.BandResult{}) // no resolved frontier
+		m.onMessageCreated("x", "o01", "alice", false)
+		maxF, ids, ok := m.cachedCut(chatmodel.CounterTypeMessage, nil)
+		require.True(t, ok)
+		assert.Empty(t, maxF)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("invalid state ignores arrivals", func(t *testing.T) {
+		m := newTestReadCore(t)
+		m.onMessageCreated("x", "o01", "alice", false) // before any walk
+		_, _, ok := m.cachedCut(chatmodel.CounterTypeMessage, frontier)
+		assert.False(t, ok)
+	})
+
+	t.Run("delete removes from bands", func(t *testing.T) {
+		m := seed(t)
+		m.onMessageCreated("late", "o03", "alice", true)
+		m.onMessageDeleted("late")
+		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+		assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMention, frontier))
+	})
+}
+
+// cachedCut contract: misses on frontier change, on pending heads, and before
+// the first walk; hits with the incrementally maintained band otherwise.
+func TestReadCoreManager_CachedCut(t *testing.T) {
+	m := newTestReadCore(t)
+	frontier := []string{"h2", "h1"} // raw order must not matter
+
+	m.refresh(chatmodel.CounterTypeMessage, frontier, chatmodel.BandResult{
+		MaxFrontierOrderId: "o05",
+		Candidates:         []string{"c1"},
+		ResolvedHeads:      []string{"h1", "h2"},
+	})
+
+	maxF, ids, ok := m.cachedCut(chatmodel.CounterTypeMessage, []string{"h1", "h2"})
+	require.True(t, ok, "order-insensitive frontier identity")
+	assert.Equal(t, "o05", maxF)
+	assert.Equal(t, []string{"c1"}, ids)
+
+	_, _, ok = m.cachedCut(chatmodel.CounterTypeMessage, []string{"h1", "h3"})
+	assert.False(t, ok, "different frontier -> walk required")
+
+	// pending heads always force a re-walk: they may resolve at any moment
+	// and move the cut without the frontier ids changing.
+	m.refresh(chatmodel.CounterTypeMessage, frontier, chatmodel.BandResult{
+		MaxFrontierOrderId: "o05",
+		ResolvedHeads:      []string{"h1"},
+		PendingHeads:       []string{"h2"},
+	})
+	_, _, ok = m.cachedCut(chatmodel.CounterTypeMessage, frontier)
+	assert.False(t, ok)
+}
+
+// Persistence round-trip + the shadow-stage trust policy: the persisted doc
+// restores for telemetry but is NOT live state (a fresh process re-walks).
+func TestReadCoreManager_PersistRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	db := deviceAnystore(t)
+	m1 := newReadCoreManager(db, "obj1", rcMe)
+	frontier := []string{"h1"}
+	m1.refresh(chatmodel.CounterTypeMessage, frontier, chatmodel.BandResult{
+		MaxFrontierOrderId: "o05",
+		Candidates:         []string{"b2", "b1"},
+		ResolvedHeads:      frontier,
+	})
+	m1.onMessageCreated("late", "o02", "alice", false)
+	m1.persistDirty(ctx)
+
+	m2 := newReadCoreManager(db, "obj1", rcMe)
+	persisted, ok := m2.loadPersisted(ctx, chatmodel.CounterTypeMessage)
+	require.True(t, ok)
+	assert.Equal(t, "o05", persisted.maxF)
+	assert.Equal(t, readCoreFrontierHash(frontier), persisted.frontierHash)
+	assert.Equal(t, []string{"b1", "b2", "late"}, persisted.band, "sorted, incremental append included")
+
+	_, _, live := m2.cachedCut(chatmodel.CounterTypeMessage, frontier)
+	assert.False(t, live, "persisted state is not trusted as live until the first in-process walk")
+}
+
+// The equality gate for incremental maintenance: after Theorem-3 appends and
+// deletes, the cached band must equal a fresh walk over the updated DAG.
+func TestReadCoreManager_IncrementalEqualsFreshWalk(t *testing.T) {
+	metas := map[string]chatmodel.ChangeMeta{
+		"G":  {OrderId: "o01"},
+		"m1": {PrevIds: []string{"G"}, OrderId: "o02"},
+		"m2": {PrevIds: []string{"m1"}, OrderId: "o03"},
+	}
+	resolve := func(id string) (chatmodel.ChangeMeta, bool) {
+		m, ok := metas[id]
+		return m, ok
+	}
+	frontier := []string{"m2"}
+	heads := []string{"m2"}
+
+	m := newTestReadCore(t)
+	walk := chatmodel.ComputeBand(frontier, heads, resolve)
+	m.refresh(chatmodel.CounterTypeMessage, frontier, walk)
+	assert.Empty(t, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier), "linear history: empty band")
+
+	// a late in-past insert arrives (concurrent branch below the cut)
+	metas["late"] = chatmodel.ChangeMeta{PrevIds: []string{"G"}, OrderId: "o02x"}
+	heads = []string{"m2", "late"}
+	m.onMessageCreated("late", "o02x", "alice", false)
+
+	fresh := chatmodel.ComputeBand(frontier, heads, resolve)
+	sort.Strings(fresh.Candidates)
+	assert.Equal(t, fresh.Candidates, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier),
+		"incremental band == fresh walk after the in-past insert")
+
+	// and a tail arrival changes neither
+	metas["tip"] = chatmodel.ChangeMeta{PrevIds: []string{"m2"}, OrderId: "o04"}
+	heads = []string{"tip", "late"}
+	m.onMessageCreated("tip", "o04", "bob", false)
+	fresh = chatmodel.ComputeBand(frontier, heads, resolve)
+	sort.Strings(fresh.Candidates)
+	assert.Equal(t, fresh.Candidates, bandIdsOf(m, chatmodel.CounterTypeMessage, frontier))
+}

--- a/core/block/editor/chatobject/reading.go
+++ b/core/block/editor/chatobject/reading.go
@@ -125,6 +125,7 @@ func (s *storeObject) markReadMessages(changeIds []string, counterType chatmodel
 		s.subscription.Flush(false)
 		s.triggerParentUnreadUpdate()
 	}
+	s.shadowReadCoreCount(s.componentCtx, counterType)
 	return nil
 }
 

--- a/core/block/source/interface.go
+++ b/core/block/source/interface.go
@@ -161,3 +161,17 @@ type StaticSourceParams struct {
 	State     *state.State
 	CreatorId string
 }
+
+// ReadCoreSnapshotProvider exposes, under the object-tree lock, the inputs the
+// causal-ordinal read model (Option D) needs for one counter: the diff
+// manager's seen heads (the read frontier), the current tree heads, and
+// change-meta resolution from tree storage. The resolve callback is valid only
+// inside f — it reads tree storage and must not be retained (the tree lock is
+// released when f returns).
+//
+// Implemented by the sourceimpl store; consumers type-assert. Kept off the
+// Store interface so existing mocks stay untouched while the read model runs
+// in shadow.
+type ReadCoreSnapshotProvider interface {
+	ReadCoreSnapshot(name string, f func(frontier []string, localHeads []string, resolve func(id string) (prevIds []string, orderId string, ok bool))) bool
+}

--- a/core/block/source/sourceimpl/store.go
+++ b/core/block/source/sourceimpl/store.go
@@ -186,6 +186,31 @@ func (s *store) InitDiffManager(ctx context.Context, name string, seenHeads []st
 	return
 }
 
+// ReadCoreSnapshot implements source.ReadCoreSnapshotProvider: it hands f the
+// causal-ordinal read model's inputs for one diff manager — seen heads
+// (frontier), current tree heads, and change-meta resolution — all under the
+// object-tree lock, mirroring the seen-heads KV subscription's locking
+// discipline (tree storage reads share a parser and are only safe under the
+// tree lock). Returns false when the diff manager is absent or uninitialized.
+func (s *store) ReadCoreSnapshot(name string, f func(frontier []string, localHeads []string, resolve func(id string) (prevIds []string, orderId string, ok bool))) bool {
+	manager, ok := s.diffManagers[name]
+	if !ok || manager.diffManager == nil {
+		return false
+	}
+	s.ObjectTree.Lock()
+	defer s.ObjectTree.Unlock()
+	storage := s.ObjectTree.Storage()
+	ctx := context.Background()
+	f(manager.diffManager.SeenHeads(), s.ObjectTree.Heads(), func(id string) ([]string, string, bool) {
+		ch, err := storage.Get(ctx, id)
+		if err != nil {
+			return nil, "", false
+		}
+		return ch.PrevIds, ch.OrderId, true
+	})
+	return true
+}
+
 func (s *store) ReadDoc(ctx context.Context, receiver source.ChangeReceiver, empty bool) (doc state.Doc, err error) {
 	s.receiver = receiver
 	setter, ok := s.ObjectTree.(synctree.ListenerSetter)

--- a/docs/superpowers/specs/2026-06-03-chat-read-counter-computed-theory.md
+++ b/docs/superpowers/specs/2026-06-03-chat-read-counter-computed-theory.md
@@ -1,0 +1,828 @@
+# Chat Read-Counter "Computed Query" Redesign — Theory and Proof
+
+Status: theory note grounding the computed-query redesign. Self-contained.
+Branch: `go-7290-chat-read-counter-computed`.
+Scope: the two-axis `(OrderId, AddSeq)` dominance read model and its
+two-query enumeration in `GetUnreadMessagesComputed`.
+
+> Conventions. "Verified" = read directly in the cited source.
+> "Inferred" = derived from verified facts by argument. "Assumed" = relied on
+> but not proven here (every such item is listed in §7). Citations are
+> `path:line` at the head HEAD of this branch.
+
+---
+
+## §0. What is actually being asked, and what a correct answer must satisfy
+
+The redesign replaces the materialized `read`/`mentionRead` boolean on each chat
+message row with a *computed* predicate: a message is read iff its stored
+coordinate `(OrderId, firstAddSeq)` is dominated by the resolved seen frontier.
+`GetUnreadMessagesComputed`
+(`core/block/chats/chatrepository/repository.go:452`) enumerates the unread set
+by running two single-field index queries, unioning them, and filtering by the
+in-memory dominance predicate `chatmodel.Dominated`
+(`core/block/chats/chatmodel/readcoord.go:23`).
+
+A correct theory must establish two *logically distinct* claims, which the task
+(and the code comments) are careful to separate:
+
+- **(A) Algorithmic coverage.** The two-query union + filter computes *exactly*
+  the set `{peer X : ¬Dominated(X, F)}` for the given frontier `F`. This is a
+  statement about the SQL/anystore enumeration faithfully realizing the math. It
+  is independent of how `OrderId`/`AddSeq` were assigned.
+
+- **(B) Semantic / order-of-adding invariance.** Given a *normalized* tree
+  (fixed, convergent `OrderId` for every change) and a *fixed frontier as a set
+  of change ids*, is the computed read/unread set invariant under the local
+  apply order — i.e. under the different `AddSeq` assignments that are all valid
+  topological extensions of the same DAG? This is a statement about the *model*,
+  not the enumeration.
+
+The honest result, proven below: **(A) holds unconditionally.** **(B) does NOT
+hold unconditionally**; it fails exactly on one configuration — a message `X`
+concurrent with a seen head `H∈F` such that `OrderId(X) ≤ OrderId(H)` and no
+causally-related head also covers `X` — and that configuration is precisely the
+already-accepted concurrent-merge divergence class recorded in the sign-off gate
+(`S-concurrent-merge-divergence`, `S-cat12`, `S-cat19`). We characterize the
+exact condition under which (B) holds and prove it there.
+
+---
+
+## §1. How Anytype uses trees
+
+### 1.1 The object as a CRDT change DAG
+
+An Anytype object is a Merkle-DAG of *changes*. Each change is a signed node
+carrying `PreviousIds` (its parents / causal predecessors), a payload, an author
+identity, and an ACL head reference. The set of changes with no successor are the
+*heads*. A chat is such an object; **a chat message is a change**, and the
+message *row* in the materialized store is the projection of that change's
+payload.
+
+There are two distinct stores:
+
+- **The changes DB (`crdt.db`)** — the raw object-tree: `objecttree.Storage`
+  holds each `StorageChange` with its `Id`, `PrevIds`, `OrderId`, `AddSeq`,
+  snapshot info, and raw bytes
+  (`commonspace/object/tree/objecttree/storage.go:38-49`).
+- **The materialized any-store docs (`store.db`)** — the chat message rows,
+  collection `{chatObjectId}chats`
+  (`core/block/chats/chatrepository/repository.go:129`). A row carries the
+  decoded message *plus* the read-model coordinates: `_o.id` (= OrderId) and
+  `firstAddSeq` (`core/block/chats/chatmodel/chatmodel.go:50,58`).
+
+### 1.2 How a change is created and applied
+
+There are two code paths that turn a change into a materialized row. They differ
+in one field that the entire read model rests on — `AddSeq` — so we name them
+precisely:
+
+- **LIVE-PUSH** (`store.PushStoreChange`,
+  `core/block/source/sourceimpl/store.go:303`). A change authored *locally now*.
+  `AddContentWithValidator` builds the change, assigns its `OrderId`
+  (`objecttree.go:273`), and calls a *validator* callback *before* the change is
+  committed to storage. Inside that callback the handler runs with
+  **`AddSeq = 0`** — the comment at `store.go:333-337` states this explicitly:
+  "AddSeq is 0 here: it is assigned only after AddAll". After the callback,
+  `AddAll` assigns the real `AddSeq` (§2), and `store.go:351` records it as
+  `MaxLastAddSeq` via `tx.UpdateMaxAddSeq`.
+
+- **REPLAY** (`storeApply.Apply`,
+  `core/block/source/sourceimpl/store_apply.go:22`). Changes received from sync /
+  another device, or loaded from disk, applied in a batch via
+  `IterateAfterAddSeq` (`store_apply.go:31`). Here each change already has its
+  real `AddSeq` read straight from storage
+  (`objecttree.go:732: ch.AddSeq = sc.AddSeq`), and it is threaded through
+  `storestate.ChangeSet.AddSeq` (`store_apply.go:65`) into the handler.
+
+In both paths the chat handler `BeforeCreate`
+(`core/block/editor/chatobject/chathandler.go:73`) stamps the row:
+
+```
+msg.OrderId    = ch.Change.Order   // chathandler.go:106
+msg.FirstAddSeq = ch.Change.AddSeq // chathandler.go:107
+```
+
+So `firstAddSeq` on a row is the change's `AddSeq` *as observed by the path that
+materialized it*: 0 for a row created on the live-push path, the real per-batch
+value for a row created on the replay path. (§2 and §6 show why this asymmetry is
+benign: live-push rows are always own messages, which are excluded from the
+counter.)
+
+### 1.3 `AddRawChanges → AddAll`, reduce/iterate, snapshot/root
+
+A batch of received raw changes enters via `ObjectTree.AddRawChanges`, which
+*reduces* them into the tree: unattached changes wait until their parents attach
+(`tree.go:312` wait-list), each attached change is appended to each parent's
+`Next` list **kept sorted by change Id** (`tree.go:295-308`), and the tree is
+re-iterated to (re)assign `OrderId` to any change lacking one
+(`updateHeads`, `tree.go:431-479`). The root (first DAG entry, the snapshot)
+always has an `OrderId` (`tree.go:217-220`) and is skipped by the read model
+(`store_apply.go:52-55` treats the root `TreeChangeInfo` as a no-op).
+
+---
+
+## §2. How changes come from offline — when `AddSeq` is 0 vs real
+
+The design rests on this distinction, so we state it as precisely as the code
+allows.
+
+**Verified — `AddSeq` is a per-space, per-`AddAll`-batch counter.**
+`storage.AddAll` does `seq := s.addSeq.Add(1)` *once*, then assigns that single
+`seq` to **every** change in the batch
+(`commonspace/object/tree/objecttree/storage.go:297-299`; identical in
+`AddAllNoError`, `:331-333`). `addSeq` is a shared `*atomic.Uint64` for the
+space (`storage.go:87`, settable via `SetAddSeq`, `:368`). The head entry's
+`LastAddSeq` is updated to `seq` (`storage.go:312,346`). On reload the counter is
+restored from that persisted maximum (the replay path reads
+`tx.GetMaxAddSeq()` at `store_apply.go:29` and advances it per change at `:32`).
+
+Two consequences, both load-bearing:
+
+1. **`AddSeq` is monotone in apply (batch) order, and equal within a batch.** All
+   changes added in the same `AddAll` share one `AddSeq`; a later batch gets a
+   strictly larger one.
+2. **`AddSeq` is a linear extension of the causal DAG on each device.** A change
+   is attached (and thus stored) only after all its parents
+   (`tree.go` wait-list, `:312-320`), and a parent is in the same or an earlier
+   batch. Therefore *ancestor ⟹ AddSeq ≤ descendant's AddSeq*, with strict `<`
+   when they are in different batches and `=` when in the same batch. (Inferred
+   from the attach-after-parents invariant + the per-batch counter.)
+
+**When `AddSeq` is 0 vs real (verified):**
+
+- 0 — only transiently, inside the live-push validator callback, before `AddAll`
+  runs (`store.go:333-337`). A row materialized at that instant stores
+  `firstAddSeq = 0`.
+- real — on the replay path always (`store_apply.go:65`), and after `AddAll` for
+  the live-pushed change (`store.go:351`).
+
+**A peer's message always arrives via REPLAY**, hence is stamped with a real
+`AddSeq` at row creation. (Inferred: a peer message is not authored locally;
+it enters only through sync/disk, which is the replay path.) An own message can
+be materialized on the live-push path with `firstAddSeq = 0` — but own messages
+are excluded from the counter (§4, §6), so the 0 never reaches the dominance
+test for a counted row.
+
+**The same change can get DIFFERENT `AddSeq` on different devices.** Device P may
+receive `{m1, x1}` in one batch (both get `seq=k`), while device Q receives `x1`
+in batch `k'` and `m1` later in batch `k'+3` (so `AddSeq_Q(x1) < AddSeq_Q(m1)`).
+Nothing constrains the *relative* `AddSeq` of two concurrent changes across
+devices. This is the asymmetry the proof turns on. (Inferred from the per-batch
+counter being driven by *local* receive order, which sync does not fix for
+concurrent changes.)
+
+---
+
+## §3. The two primitives — formal definitions
+
+Fix an object with change set `C` and causal (DAG) partial order `≺` ("`a ≺ b`"
+= `a` is a proper ancestor of `b`). Write `a ∥ b` when `a ⊀ b ∧ b ⊀ a ∧ a ≠ b`
+(concurrent). For a *replica* (device) `r`, let `C_r ⊆ C` be the changes present
+on `r`.
+
+### 3.1 `OrderId` (lexid)
+
+`OrderId : C → Σ*` maps each change to a lexid string
+(`var lexId = lexid.Must(...)`, `tree.go:23`; mirrored at
+`storestate/state.go:29`). It is assigned by the tree's deterministic traversal:
+on the live-push path `OrderId = lexId.Next(OrderId(lastIteratedHead))`
+(`objecttree.go:273`); on the reduce path `updateHeads` fills gaps with
+`lexId.NextBefore` and the tail with `lexId.Next`
+(`tree.go:441-472`), where the iteration order is the reverse-postorder DFS
+`topSort` (`treeiterator.go:46-79`) over `Next` lists **sorted by change Id**
+(`tree.go:295-308`).
+
+We use two properties.
+
+> **Property O1 (topological / linear extension).** For all `a, b ∈ C`,
+> `a ≺ b ⟹ OrderId(a) < OrderId(b)` (string `<`).
+
+*Verified by construction + test.* `updateHeads` assigns OrderIds strictly
+increasing along the traversal, and the traversal is topological (a change is
+emitted only after all its `Next` are finished, `treeiterator.go:54-74`).
+`TestBuildScenarioTree_BranchMergeDeterministic`
+(`core/block/editor/chatobject/scenario_harness_test.go:121-123`) asserts
+`orderOf[prev] < orderOf[child]` for both a linear and a merge parent. We take
+O1 as established for the materialized fields; the deepest internal lexid
+arithmetic (`NextBefore` always yielding a strictly-in-between string) is an
+any-sync invariant (§7, A7).
+
+> **Property O2 (replica-invariant comparison / convergence).** For all
+> `a, b ∈ C` present on two replicas `r, s`,
+> `sign(OrderId_r(a) ⟂ OrderId_r(b)) = sign(OrderId_s(a) ⟂ OrderId_s(b))`. The
+> string *values* are local, but the *comparison sign* converges.
+
+*Inferred from the construction.* The traversal that induces the order depends
+only on (i) the DAG shape and (ii) the sibling tiebreak, which is the change Id
+(`tree.go:295-308`). Change Ids are content/signature-derived and identical for
+the same change on every replica. Hence two replicas holding the same sub-DAG
+visit the changes in the same relative order, so the induced linear order — and
+thus every pairwise comparison sign — agrees. (The absolute strings differ
+because gap-filling depends on which neighbors were present when a change was
+inserted; only the *order* is claimed to converge. This is the standard lexid
+contract; see §7, A7. `TestBuildScenarioTree_BranchMergeDeterministic:119`
+checks the weaker fact that two *identical* builds produce identical strings.)
+
+`OrderId` is stored on the message row as `_o.id`
+(`chathandler.go:106` → `chatmodel.OrderKey`/`"_o"`,
+`chatmodel.go:50`; read back at `repository.go:479`).
+
+### 3.2 `AddSeq`
+
+`AddSeq_r : C_r → ℕ` is the per-space, per-batch local apply counter of §2
+(`storage.go:297`). Its invariants:
+
+> **Property S1 (linear extension of `≺`, per device).** For all `a, b ∈ C_r`,
+> `a ≺ b ⟹ AddSeq_r(a) ≤ AddSeq_r(b)`, strict when `a, b` are in different
+> apply batches, equal when in the same batch.
+
+*Verified / inferred*, §2 consequence 2 (attach-after-parents +
+per-batch counter).
+
+> **Property S2 (device-local; concurrent pairs unconstrained).** For `a ∥ b`,
+> the relation between `AddSeq_r(a)` and `AddSeq_r(b)` is determined by `r`'s
+> *receive batching* and may differ across devices: any of `<`, `=` (same
+> batch), `>` is possible, and a different device may realize a different one.
+
+*Inferred*, §2 ("same change, different AddSeq").
+
+> **Property S3 (live-push = 0; restored from max on load).** A change
+> materialized inside the live-push validator stores `AddSeq = 0`
+> (`store.go:333-337`); otherwise the real value
+> (`store_apply.go:65`, `store.go:351`); the counter is restored from the
+> persisted `MaxLastAddSeq` on reload (`store_apply.go:29`).
+
+*Verified.*
+
+`AddSeq` is stored on the row as `firstAddSeq` (`chathandler.go:107`;
+`chatmodel.go:478` marshals it as a number; read back at `repository.go:480`,
+`chatmodel.go:585`).
+
+### 3.3 Their relationship — the key asymmetry
+
+Both `OrderId` and `AddSeq_r` are linear extensions of the *same* causal partial
+order `≺` (O1, S1). The difference is:
+
+- `OrderId` extends `≺` using a **replica-invariant** tiebreak on concurrent
+  pairs (the change Id, O2). The order of concurrent changes is fixed across all
+  replicas.
+- `AddSeq_r` extends `≺` using a **replica-local** tiebreak on concurrent pairs
+  (the receive-batch order, S2). The order of concurrent changes is *not* fixed.
+
+This asymmetry is the entire content of §5(B): on a fixed normalized tree the
+`OrderId` axis is invariant, but the `AddSeq` axis is not — so any read decision
+that depends on the `AddSeq` comparison *between two concurrent changes* is
+order-dependent.
+
+---
+
+## §4. The read model
+
+### 4.1 Frontier and the dominance predicate
+
+Reading is tracked by a **seen frontier** `F`: a set of change ids the user has
+read up to, persisted (synced) as a `KeyValueService` value per counter
+(`store.go:420-433`). At runtime the source resolves each id to its local
+coordinate via `resolvePair` (`store.go:115-121`, using lock-free
+`Storage().Get`), prunes the resolved set to its maximal pairs
+(`watermark.prune`, `readwatermark.go:93-105`), and exposes the result as
+`GetReadFrontier` (`store.go:442-452`). So at the point the computed query runs,
+`F` is a set of resolved coordinates `(OrderId, AddSeq)`.
+
+> **Definition (read).** For a change `X` with coordinate
+> `x = (OrderId(X), AddSeq(X))`,
+>
+>     read(X)  ⟺  Dominated(x, F)  ⟺  ∃ H ∈ F :  x.OrderId ≤ H.OrderId  ∧  x.AddSeq ≤ H.AddSeq.
+
+This is exactly `chatmodel.Dominated` (`readcoord.go:23-30`) and the source-side
+`dominated` (`readwatermark.go:14-21`); the two are byte-identical predicates.
+
+**Why both axes (verified intent, `readcoord.go:13-22`, `readwatermark.go:11-13`):**
+
+- The **`OrderId` axis** is the convergent timeline cut: "`X` is at or before
+  some head in the replicated order." Because `OrderId` comparisons converge
+  (O2), this part of the decision is identical on all devices.
+- The **`AddSeq` axis** guards *late in-past inserts*: a change with a *small*
+  `OrderId` (so it falls inside the timeline already read) but which *arrived
+  after* the user read past that point. Such a change has an `AddSeq` larger than
+  the head's, so `x.AddSeq ≤ H.AddSeq` fails and it correctly stays unread. The
+  `LargeAddSeqBoundary` test (`computed_edgecases_test.go:77-112`) pins this: a
+  row at `(o01, MaxInt64)` with frontier `(o09, 3)` stays unread because its
+  `AddSeq` exceeds the head's, even though its `OrderId` is the smallest.
+
+> **Lemma 0 (frontier monotonicity).** `Dominated(x, F)` is monotone in `F`:
+> `F ⊆ F' ⟹ (Dominated(x,F) ⟹ Dominated(x,F'))`. Pruning `F` to maximal pairs
+> does not change `Dominated` for any `x`.
+
+*Proof.* `Dominated` is an existential over `F`; adding heads can only make it
+true. For pruning: a pair `p` is dropped only when another kept pair `q` has
+`p.OrderId ≤ q.OrderId ∧ p.AddSeq ≤ q.AddSeq` (`readwatermark.go:99`). Any `x`
+dominated by `p` (`x ≤ p` on both axes) is then dominated by `q` by transitivity
+of `≤`. ∎ (Stated in code at `readwatermark.go:89-92`, `readcoord.go:19-22`.)
+
+### 4.2 The two-query enumeration
+
+`GetUnreadMessagesComputed` (`repository.go:452-523`), for a counter and a
+resolved frontier `F`:
+
+1. Compute `maxF = max_{H∈F} H.OrderId` and `minF = min_{H∈F} H.AddSeq`
+   (`repository.go:494-502`).
+2. **Query A (timeline tail):** rows with `_o.id > maxF`
+   (`repository.go:505`).
+3. **Query B (recent arrivals):** rows with `firstAddSeq > int64(minF)`
+   (`repository.go:508`).
+4. Union into a `map[id]candidate` (dedup by id, `repository.go:460,477`).
+5. For each candidate: drop if `creator == myIdentity` (own = read,
+   `repository.go:515`); drop if `Dominated(coord, F)`
+   (`repository.go:518`); the rest are unread.
+6. The counter filter `getMessagesFilter()` is `AND`-ed into both queries:
+   `nil` for messages, `hasMention == true` for mentions
+   (`repository.go:454,463`; `readhandler.go:47-49,68-70`).
+7. Empty frontier ⟹ enumerate *all* rows (`repository.go:488-492`) and (since
+   nothing dominates) return every peer counter-matching row.
+
+---
+
+## §5. The proof
+
+### §5.1 — (A) Algorithmic coverage
+
+Let `M` be the set of message rows in the collection, each with coordinate
+`coord(m)` and `creator(m)`. Let `counter(m)` be true iff `m` matches the counter
+filter (always true for messages; `hasMention` for mentions). Define the **target
+unread set**
+
+    U(F) = { m ∈ M : counter(m) ∧ creator(m) ≠ myIdentity ∧ ¬Dominated(coord(m), F) }.
+
+> **Theorem A.** `GetUnreadMessagesComputed` returns exactly `U(F)` (as a set).
+
+We prove it via three lemmas, splitting the non-empty-frontier case from the
+empty-frontier case.
+
+> **Lemma A1 (band decomposition / superset).** For any `x` and non-empty `F`,
+>
+>     ¬Dominated(x, F)  ⟹  x.OrderId > maxF  ∨  x.AddSeq > minF.
+
+*Proof.* Contrapositive. Suppose `x.OrderId ≤ maxF` and `x.AddSeq ≤ minF`. Let
+`H*` attain `maxF = H*.OrderId`. Then `x.OrderId ≤ H*.OrderId`. And
+`x.AddSeq ≤ minF ≤ H*.AddSeq` (since `minF` is the *minimum* AddSeq over `F`, it
+is `≤` every head's AddSeq, in particular `H*`'s). So `H*` dominates `x`, i.e.
+`Dominated(x, F)`. ∎
+
+Lemma A1 is the formal version of the comment "their union is a superset of the
+unread set" (`repository.go:503-504`). It says: every non-dominated `x` is caught
+by Query A or Query B. Note the choice of `maxF`/`minF` is exactly what makes a
+*single* head `H*` witness the implication — using `max OrderId` with `max AddSeq`
+would be unsound (the two extremes could come from different heads). The code
+takes `min` AddSeq, which is correct here.
+
+> **Lemma A2 (candidate set = all non-dominated counter-matching peer rows that
+> the two queries can reach, with no false negatives).** Let `Cand` be the map
+> built by the two `collect` calls. For every `m ∈ M` with `counter(m)` and
+> `¬Dominated(coord(m), F)`: `m ∈ Cand`.
+
+*Proof.* By A1, `coord(m).OrderId > maxF` or `coord(m).AddSeq > minF`.
+- If `OrderId > maxF`: Query A's predicate `_o.id > maxF`
+  (`CompOpGt`, `repository.go:505`) matches `m`; with the counter filter
+  `AND`-ed (`repository.go:463`), and `counter(m)` true, `m` is collected.
+- If `AddSeq > minF`: Query B's predicate is `firstAddSeq > int64(minF)`
+  (`repository.go:508`). Since `minF ≥ 0` and `coord(m).AddSeq > minF ≥ 0`, the
+  value `coord(m).AddSeq` fits in the non-negative range and the cast
+  `int64(minF)` preserves the comparison (`minF ≤ MaxInt64` by S-bound, §7 A6;
+  the `LargeAddSeqBoundary` test exercises `MaxInt64`,
+  `computed_edgecases_test.go:78`). So `m` is matched and collected.
+Either way `m ∈ Cand`. (No false negatives.) ∎
+
+> **Lemma A3 (filter soundness + dedup).** The post-filter
+> (`repository.go:514-521`) returns from `Cand` exactly those `m` with
+> `creator(m) ≠ myIdentity ∧ ¬Dominated(coord(m), F)`, each once.
+
+*Proof.* The loop iterates the map (keys are ids → no duplicates: a row matching
+both queries is written under its id twice but stored once, `repository.go:477`;
+`TestGetUnreadMessagesComputed_CandidateDedup` confirms,
+`computed_edgecases_test.go:189-206`). It skips `creator == myIdentity`
+(`:515`) and skips `Dominated(coord, F)` (`:518`). `coord` is read back from the
+stored fields `_o.id` and `firstAddSeq` (`:479-480`), which equal the values
+written at `chathandler.go:106-107`. Counter membership was enforced at collect
+time (A2's filter), so every surviving `m` satisfies `counter(m)`. ∎
+
+*Proof of Theorem A (non-empty `F`).*
+- (`⊆`) Every returned `m` satisfies `counter(m)` (collect filter),
+  `creator(m) ≠ myIdentity` and `¬Dominated` (A3). So returned `⊆ U(F)`.
+- (`⊇`) Take `m ∈ U(F)`. Then `counter(m)`, `creator ≠ myIdentity`,
+  `¬Dominated`. By A2, `m ∈ Cand`. In the filter, `creator ≠ myIdentity` and
+  `¬Dominated` both hold, so `m` is returned (A3). So `U(F) ⊆ returned`.
+Hence returned `= U(F)`. ∎
+
+*Empty-frontier case.* When `F = ∅`, the code collects all rows
+(`Exists{}` on `id`, `repository.go:490`) with the counter filter, then filters:
+`Dominated(x, ∅)` is false for every `x` (empty existential), so the result is
+`{ m : counter(m) ∧ creator(m) ≠ myIdentity }`, which equals `U(∅)`. Confirmed by
+`TestGetUnreadMessagesComputed_AddSeqZeroRows/empty frontier`
+(`computed_edgecases_test.go:175-182`). ∎
+
+**Coverage of the enumerated boundary conditions** (each is a sub-case of A1–A3,
+plus a pinning test):
+
+- `firstAddSeq = 0` / absent rows. A row with `AddSeq = 0` can never satisfy
+  Query B (`firstAddSeq > minF`, `minF ≥ 0` ⇒ needs `0 > minF`, impossible). It
+  is reachable only via Query A, i.e. only if `OrderId > maxF`. If its OrderId is
+  inside the read prefix it is (by A1, since `0 ≤ minF`) dominated and correctly
+  *not* returned. This is exactly the intent at `repository.go:445-447` and is
+  pinned by `TestGetUnreadMessagesComputed_AddSeqZeroRows`
+  (`computed_edgecases_test.go:155-183`). Absent `firstAddSeq` decodes as 0
+  (`GetInt`, `repository.go:480`; `chatmodel.go:585`) — same treatment — and is
+  the case `BackfillFirstAddSeq` exists to repair (§6, `repository.go:530`).
+- Equal coordinates. `Dominated` uses `≤` on both axes, so a row exactly equal to
+  a head is dominated (read). Query A is strict `>` so it does not surface a row
+  *at* `maxF`; such an in-past row with a higher AddSeq is surfaced by Query B
+  instead. `TestGetUnreadMessagesComputed_QueryABoundaryGt`
+  (`computed_edgecases_test.go:215-232`) pins both directions and proves Query B
+  is load-bearing at the boundary.
+- Duplicate / non-maximal heads in `F`. The `max`/`min` reduction
+  (`repository.go:494-502`) is invariant to duplicates; and Lemma 0 says
+  `Dominated` is invariant to non-maximal heads.
+  `TestGetUnreadMessagesComputed_DuplicateFrontierCoords`
+  (`computed_edgecases_test.go:118-147`).
+- `int64(minF)` encoding. Lemma A2 handles the cast; the near-ceiling test
+  exercises `MaxInt64`.
+- Own-exclusion and mention sub-filter. A3 + the counter filter; pinned by
+  `TestGetUnreadMessagesComputed_OwnMentionExcluded`
+  (`computed_edgecases_test.go:238-264`) and
+  `..._MentionFrontierIndependentOfMessages` (`:272-294`).
+
+**Empirical corroboration.** The differential gate
+`TestGetUnreadMessagesComputed_DifferentialVsBool` and the edge-case suite assert
+`computed == bool path == oracle` over fixed message sets and frontier shapes
+(`computed_edgecases_test.go:61-71`). A scratch fuzz harness over 20k randomized
+message sets × independent message/mention frontiers
+(`zz_shortcut_fuzz_scratch_test.go:93-182` — present in the working tree but
+*untracked* / not committed; its header marks it transient) asserts the
+*contract* reproduction
+(`SAFE == REAL` always, `:163-167`) — i.e. given the *real* per-row AddSeq, the
+two-query enumeration matches the dominance oracle on every trial. (This same
+fuzz also demonstrates the §5(B) phenomenon; see below.) Theorem A is the closed
+form of what these tests sample. ∎
+
+### §5.2 — (B) Semantic / order-of-adding invariance
+
+Now fix a **normalized tree**: the DAG and every `OrderId` are fixed (a
+deterministic function of the DAG, O1/O2). Fix a frontier **as a set of change
+ids** `F₀ ⊆ C`. Vary the local apply order: this varies the `AddSeq` assignment
+over the set `T` of all valid topological extensions of `≺` consistent with the
+per-batch rule (S1). For each `A ∈ T`, resolve `F₀` to coordinates using `A`,
+giving frontier `F(A)`, and let
+
+    Unread(A) = { peer counter-matching X : ¬Dominated( (OrderId(X), A(X)), F(A) ) }.
+
+The question: is `Unread(A)` the same for all `A ∈ T`?
+
+#### The reduction
+
+Because `OrderId` is fixed, the only thing that varies is `A`. For a fixed
+candidate `X` and head `H ∈ F₀`, the head's contribution to dominating `X` is the
+conjunction
+
+    OrderId(X) ≤ OrderId(H)   ∧   A(X) ≤ A(H).
+
+The first conjunct is fixed across `A`. So **the dominance of `X` by `H` can
+change with `A` iff the second conjunct, `A(X) ≤ A(H)`, can change with `A`,**
+and this matters only when the first conjunct holds.
+
+Classify the pair `(X, H)` by `≺`:
+
+> **Lemma B1 (causal pairs are order-stable).**
+> - If `X ≺ H`: by S1, `A(X) ≤ A(H)` for *every* `A`. Combined with O1
+>   (`OrderId(X) < OrderId(H)`), `H` dominates `X` under every `A`.
+> - If `H ≺ X`: by S1, `A(H) ≤ A(X)`; and by O1 `OrderId(H) < OrderId(X)`, so
+>   `H` does not dominate `X` under any `A` (the OrderId conjunct already fails,
+>   strictly).
+> - If `X = H`: trivially dominated under every `A`.
+
+*Proof.* Direct from O1 and S1. ∎
+
+> **Lemma B2 (concurrent pairs can flip).** If `X ∥ H`, then by S2 there exist
+> `A, A' ∈ T` with `A(X) ≤ A(H)` and `A'(X) > A'(H)`. Hence the conjunct
+> `A(X) ≤ A(H)` is *not* invariant. If additionally `OrderId(X) ≤ OrderId(H)`,
+> then `H` dominates `X` under `A` but not under `A'` (assuming no *other* head
+> dominates `X`).
+
+*Proof.* S2 gives an apply order placing `X`'s batch before `H`'s (so
+`A(X) < A(H)`, or `=` if co-batched) and another placing `H`'s strictly before
+`X`'s (`A'(H) < A'(X)`). Both are valid topological extensions because `X ∥ H`
+imposes no causal constraint between them. The dominance conclusion is then a
+direct evaluation of `Dominated`. ∎
+
+#### The verdict
+
+> **Theorem B (exact invariance condition).** `Unread(A)` is invariant over all
+> `A ∈ T` **iff** for every candidate `X` and every head `H ∈ F₀` with
+> `X ∥ H` and `OrderId(X) ≤ OrderId(H)`, `X` is *causally covered*: there exists
+> a head `H' ∈ F₀` with `X ≺ H'` or `X = H'`.
+>
+> Equivalently — define the **order-stable read set**
+>
+>     Stable(F₀) = { X : ∃ H' ∈ F₀, X ⪯ H' }   (the causal down-set of F₀, ⪯ = ≺ or =)
+>
+> Then `Unread(A) = { peer counter-matching X : X ∉ Stable(F₀) }` for *all* `A`
+> iff no candidate `X` lies in the "ambiguous band"
+>
+>     Amb(F₀) = { X ∉ Stable(F₀) : ∃ H ∈ F₀, X ∥ H ∧ OrderId(X) ≤ OrderId(H) }.
+
+*Proof.*
+
+(⇐, sufficiency) Suppose `Amb(F₀) = ∅` for the candidate set. Take any candidate
+`X`. Two cases.
+- `X ∈ Stable(F₀)`: some `H' ⪯`-covers `X`, i.e. `X ⪯ H'`. By Lemma B1, `H'`
+  dominates `X` under *every* `A`. So `X` is read under every `A` — invariant
+  (and excluded from `Unread`).
+- `X ∉ Stable(F₀)`: for every head `H`, `X ⋠ H`, so either `H ≺ X` (Lemma B1:
+  `H` never dominates `X`) or `X ∥ H`. For the concurrent heads, since
+  `X ∉ Amb(F₀)`, we must have `OrderId(X) > OrderId(H)` for *all* of them — so
+  the OrderId conjunct fails for every head, and `X` is *not* dominated under any
+  `A` (the AddSeq axis is irrelevant when the OrderId axis already fails). So `X`
+  is unread under every `A` — invariant.
+In both cases the membership of `X` in `Unread(A)` does not depend on `A`. Hence
+`Unread(A)` is constant, and equals `{peer counter-matching X : X ∉ Stable(F₀)}`
+(the `Stable` members are read, the rest unread). ∎
+
+(⇒, necessity) Suppose some candidate `X ∈ Amb(F₀)`: `X ∉ Stable(F₀)`, and there
+is a head `H` with `X ∥ H` and `OrderId(X) ≤ OrderId(H)`. By Lemma B2 there are
+`A, A'` with `H` dominating `X` under `A` but not `A'`. Could another head rescue
+invariance? No: since `X ∉ Stable(F₀)`, *no* head causally covers `X` (Lemma B1's
+"always dominates" case is unavailable), and any *other* concurrent head `H₂`
+either also flips (same argument) or never dominates `X` (if
+`OrderId(X) > OrderId(H₂)`). We can choose `A'` to additionally place `X` after
+*all* concurrent heads' batches, so that under `A'` no head dominates `X` (each
+concurrent head fails the AddSeq conjunct, each `H ≺ X`-or-`OrderId` head already
+fails). Then `X ∈ Unread(A')` but `X ∉ Unread(A)`. So `Unread` is not invariant.
+∎
+
+#### Plain-language reading, and the concrete configuration
+
+Theorem B says: **the computed read/unread result is invariant under apply order
+exactly for changes that are either (a) causal ancestors of a seen head — always
+read — or (b) `OrderId`-after every seen head they are concurrent with — always
+unread. The single order-dependent configuration is a message `X` that is
+*concurrent* with a seen head `H`, sorts at-or-before it in the convergent order
+(`OrderId(X) ≤ OrderId(H)`), and is not causally covered by any other seen
+head.** For such an `X`, whether it counts as read depends on the device-local
+`AddSeq` relationship between `X` and `H`, which depends on the order in which
+that device received them.
+
+This is *exactly* the accepted concurrent-merge divergence:
+
+- `S-concurrent-merge-divergence` (`scenario_catalog_test.go:31-47`): `m1 ∥ x1`,
+  both children of `G`; device reads `x1` so `F₀ = {x1}`. `m1 ∉ Stable({x1})`
+  (m1 is not an ancestor of x1). If `OrderId(m1) ≤ OrderId(x1)` then
+  `m1 ∈ Amb({x1})` and its read-state is order-dependent. The sign-off records
+  the watermark result as `m1` read (count 0) vs the DAG-ancestor baseline's
+  `m1` unread (count 1) — `watermark_signoff.md:11-13` — and marks it an
+  **accepted** divergence (`scenario_signoff_test.go:20-23`).
+- `S-cat12-dag-ancestor-vs-orderid-prefix` (`scenario_catalog_test.go:296-317`):
+  `early ∥ seen` (both children of `e1`), reading `seen`; `early` is the
+  concurrent message that "sorts before the seen head" (the `Intent` text,
+  `:316`). Divergence at step 3 (`watermark_signoff.md:98`).
+- `S-cat19-msg-mention-concurrent` (`:476-507`): the per-counter analogue
+  (divergences at steps 2 and 4, `watermark_signoff.md:151-153`).
+
+These three — and *only* these three — are the catalog's accepted divergences
+(`scenario_signoff_test.go:20-23`; `TestComputed_EqualsWatermark`
+`scenario_computed_test.go:169-196` proves the band-decomposition computed engine
+reproduces the watermark exactly on all of them, so the computed query inherits
+the same three).
+
+#### Two important qualifications, proven
+
+1. **The batch-granularity of `AddSeq` shrinks `Amb` but does not empty it.** If a
+   device receives `X` and `H` in the *same* `AddAll` batch, then `A(X) = A(H)`
+   (S1 equal case), so `A(X) ≤ A(H)` holds and — when `OrderId(X) ≤ OrderId(H)` —
+   `H` dominates `X` *on that device*. This is why the scenario harness, which
+   adds the whole DAG in one `AddRawChanges` call (`scenario_harness_test.go:174`,
+   one `AddAll` ⇒ one `seq`, `storage.go:331`), sees `m1` *read* in
+   `S-concurrent-merge-divergence`: co-batching forces `AddSeq(m1) = AddSeq(x1)`,
+   collapsing the dominance decision onto the OrderId axis alone. But a *different*
+   device that received `x1` in an earlier batch than `m1` (a genuine late in-past
+   insert of a concurrent change) has `AddSeq(m1) > AddSeq(x1)` and sees `m1`
+   *unread*. So the divergence is real across devices, exactly as Theorem B's
+   necessity proof constructs. (Verified: `storage.go:331-333` per-batch; harness
+   single batch at `scenario_harness_test.go:174`.)
+
+2. **Empirical confirmation that the AddSeq *value* matters.** The scratch fuzz
+   (`zz_shortcut_fuzz_scratch_test.go`, untracked working-tree harness) compares,
+   on identical message sets and
+   frontiers, two `firstAddSeq` policies that agree on the *read bool* but differ
+   on the stored AddSeq: `REAL` (the true AddSeq) vs `SHORTCUT` (zero the AddSeq
+   on rows the bool marks read). It *reports* (does not fail on) every divergence
+   (`:168-174,177`). The SHORTCUT diverges from REAL on a non-trivial fraction of
+   trials — i.e. changing the AddSeq coordinate of a row, holding OrderId and the
+   frontier fixed, *changes* the computed unread set. That is the direct
+   observable shadow of Theorem B / Lemma B2: dominance is genuinely
+   AddSeq-sensitive, hence apply-order-sensitive, in the ambiguous band. (The
+   `SAFE` policy, which only zeroes rows read in *every* counter, equals REAL
+   always — `:163-167` — which is the §6 statement that zero-AddSeq is safe
+   precisely for own / fully-read rows.)
+
+#### Why this is acceptable (the design contract)
+
+The model deliberately chooses **(OrderId, AddSeq) dominance** over **strict
+DAG-ancestor** semantics (`scenario_catalog_test.go:9-13` documents that the
+*intended* contract is dominance, and the DAG baseline is the foil). The product
+meaning of dominance is: "a message is read if it is at-or-before the read point
+in the convergent timeline *and* was already present when the user read that
+point." For a concurrent message that sorts before the seen head and was *already
+present* on the reading device when the head was read (co-batched or earlier),
+treating it as read is the desired behavior — the user saw it. For one that
+arrived *later* (the late in-past insert), keeping it unread is also desired.
+Theorem B shows these are the *only* two outcomes, and that they are stable except
+in the genuinely-ambiguous "concurrent and earlier-or-equal-order and not
+otherwise covered" band — where the device-local arrival order *is* the product's
+ground truth for "was it already there." The non-invariance is faithful encoding of per-device observation **only when the
+read and the dominance computation happen on the same device** — a qualification
+§5.3 shows fails for a single user's *synced* devices, where this acceptability
+argument is materially weaker (arguably wrong) and the divergence becomes a
+*permanent* cross-device disagreement on the unread count.
+
+#### §5.3 — Re-examining acceptability for the cross-device (single-user) case
+
+The §5.2 steelman treats each device's answer as a legitimate per-device
+observation. That holds when the read and the dominance check happen on the
+*same* device. It is materially weaker for a single user whose devices *sync read
+state* — the entire purpose of the seen-heads sync.
+
+**Concrete repro** (real any-sync trees, real `AddSeq`; empirically confirmed).
+`G; a1 ∥ b1`, both children of `G`, `OrderId(a1) < OrderId(b1)`.
+- Device B applies `b1` (AddSeq 1); user reads up to `b1` (synced frontier id-set
+  `{b1}`); `a1` syncs in *later* (AddSeq 2). On B: `a1`=(Ord_a1, **2**),
+  `b1`=(Ord_b1, **1**).
+- Device A applies `a1` (AddSeq 1) then `b1` (AddSeq 2); receives only head-id
+  `{b1}`. On A: `a1`=(Ord_a1, **1**), `b1`=(Ord_b1, **2**).
+- Both hold `{G,a1,b1}` and frontier `{b1}`:
+  - **Device A: `a1` READ** (`1 ≤ 2`) → unread count **0**.
+  - **Device B: `a1` UNREAD** (`2 ≤ 1` false) → unread count **1**.
+  Permanent: nothing further syncs, the watermark `marked` set never un-sets
+  (`readwatermark.go:76`), the device-local AddSeq is stable. No convergence.
+
+**Why this is not benign.** The read happened on device B, where `a1` was
+*absent* — the user never saw `a1`. Device A nonetheless reports `a1` read,
+derived purely from the order *A* happened to receive `a1` vs `b1` over the
+network, which has no bearing on what the user saw on B. The AddSeq axis is meant
+to encode "was X already present when the user read the head"; across a *synced*
+read it instead encodes "was X already present in *this* device's arrival order,"
+and those coincide only when the read happened locally. So the under-counting
+device fabricates a read the user never made — the dangerous direction (a real
+unread silently shown read).
+
+**Status of the "accepted" label.** The three sign-off divergences are recorded
+as watermark-vs-DAG-baseline *on one device* (`watermark_signoff.md:11-13`). The
+cross-device manifestation — two of one user's devices disagreeing on the
+*count* — is the same root mechanism but a configuration the sign-off gate
+**cannot express**: the harness builds one shared tree and loads the whole DAG in
+one `AddRawChanges` (one `AddAll` ⇒ one shared AddSeq,
+`scenario_harness_test.go:174`), deterministically co-batching concurrent changes
+and collapsing the decision onto OrderId. The bug lives entirely in the
+per-device-AddSeq dimension the harness collapses — so it is currently
+**untested**, and it **contradicts** the design's written claim that cross-device
+is "consistent for the same change-set ... divergence only during sync lag"
+(`2026-05-16-chat-read-counter-design.md:37`): the divergence is *permanent*, not
+sync lag.
+
+**Therefore** this should be treated as an *open product decision* made with the
+cross-device framing explicit — not a pre-settled benign divergence. The only
+replica-invariant cut is `OrderId`; a convergent fix would demote `AddSeq` to a
+guard consulted only for *causally-related* pairs, or handle the
+concurrent-late-arrival case with an OrderId-only rule (both larger changes,
+flagged not designed). Whatever is decided applies *identically* to the bool
+watermark and the computed redesign (`TestComputed_EqualsWatermark`), so it is a
+model decision, not a redesign blocker.
+
+---
+
+## §6. Edge-case coverage table
+
+For each case: the mechanism, and the precise condition under which it is
+covered. "Covered" = the computed result equals the intended dominance semantics.
+
+| Case | Covered? | Mechanism / precise condition | Evidence |
+|---|---|---|---|
+| Own messages | Yes, unconditionally | `creator == myIdentity` skipped before the dominance test (`repository.go:515`); own rows are also marked read on insert (`chathandler.go:84-90`). Their `firstAddSeq` may be 0 (live-push, S3) but never reaches the counted set. | `computed_edgecases_test.go:238-264` |
+| Pre-feature `firstAddSeq = 0` / absent | Yes, with the §5.1 caveat | Absent decodes to 0 (`repository.go:480`); a 0-AddSeq peer row is reachable only via Query A and is dominated iff its OrderId is in the read prefix. `BackfillFirstAddSeq` (`repository.go:530-570`) stamps real values idempotently so future rows use the real AddSeq axis. Condition: backfill has resolved the change, OR the row's OrderId already decides it. | `computed_edgecases_test.go:155-183`; `repository.go:525-585` |
+| Mention vs message counters | Yes, unconditionally | Independent frontiers (separate diff managers, `chatobject.go:286,292`), shared `firstAddSeq` field, distinct counter filter (`hasMention`) `AND`-ed into both queries (`repository.go:463`; `readhandler.go:68-70`). | `computed_edgecases_test.go:272-294`; `..._OwnMentionExcluded` |
+| markunread (frontier regression) | Yes | `MarkMessagesAsUnread` re-derives a *smaller* seen set; `InitDiffManager` builds a *fresh* watermark per init (`store.go:218-223`) so the frontier shrinks rather than accumulating; the computed query reads the (smaller) `GetReadFrontier`. Dominance monotonicity (Lemma 0) ⇒ fewer reads. | `store.go:213-241`; catalog `S-cat17`, `S-cat8` (MATCH, `watermark_signoff.md:133-138,63-68`) |
+| Offline batch with reordering | Conditional — see §5(B) | Invariant *except* for candidates in `Amb(F₀)` (concurrent with a seen head, `OrderId ≤` it, not causally covered). Those are the accepted divergences. | Theorem B; `scenario_signoff_test.go:20-23` |
+| In-past insert (small OrderId, late arrival) | Yes, unconditionally | Caught by Query B (`firstAddSeq > minF`, `repository.go:508`); stays unread because its AddSeq exceeds the head's. This is the *raison d'être* of the AddSeq axis. | `computed_edgecases_test.go:77-112,215-232` |
+| Unresolvable / not-yet-local seen head | Yes (eventually) | An id in `F₀` not present locally is deferred to `pending` (`readwatermark.go:54-59`) and *omitted* from the resolved frontier the computed query sees, so it cannot cause false reads; when the change later lands, `updateInDiffManagers` re-advances and re-resolves it (`store.go:405-409`). Condition: the head's change eventually syncs in. | `store.go:374-409`; catalog `S-cat7`, `S-cat16` (MATCH) |
+| Snapshot / compaction | Yes (within the model) | The root/snapshot change is skipped by the read model (`store_apply.go:52-55`); message rows persist across snapshots with their `(OrderId, firstAddSeq)`. OrderId of the root is always set (`tree.go:217-220`). Compaction does not re-key existing rows. (Assumption A8: compaction preserves the stored `firstAddSeq` and the OrderId comparison order of surviving rows.) | `store_apply.go:49-57`; `tree.go:274-277` |
+
+---
+
+## §7. Assumptions and boundaries
+
+Numbered; each marked **always** (with the establishing reason) or **conditional**
+(with the condition).
+
+1. **A1 — Heads frontier resolves to the read coordinates the rows were stamped
+   with.** *Always.* `chathandler.go:106-107` stamps `_o.id`/`firstAddSeq` from
+   `ch.Change.Order`/`ch.Change.AddSeq`; `resolvePair` reads the same
+   `(OrderId, AddSeq)` from tree storage (`store.go:115-121`). Same source ⇒ one
+   coordinate space. (The scenario harness reproduces this by stamping
+   `firstAddSeq` from the same tree the frontier resolves against,
+   `scenario_harness_test.go:390-396`.)
+
+2. **A2 — `OrderId` is a linear extension of `≺` (Property O1).** *Always.*
+   Construction in `updateHeads`/traversal (`tree.go:441-472`,
+   `treeiterator.go`), checked by `scenario_harness_test.go:121-123`.
+
+3. **A3 — `OrderId` comparisons converge across replicas (Property O2).**
+   *Always, conditional on A7.* Follows from the sibling tiebreak being the
+   replica-invariant change Id (`tree.go:295-308`) and the lexid order being
+   determined by the traversal. The *value*-level convergence of `NextBefore`
+   gap-fills is an any-sync lexid contract (A7).
+
+4. **A4 — `AddSeq` is a per-device linear extension of `≺` (Property S1),
+   constant within a batch, strictly increasing across batches.** *Always.*
+   Per-batch counter `storage.go:297-299,331-333`; attach-after-parents
+   `tree.go:312-320`.
+
+5. **A5 — A peer (counted) message always carries a *real* `AddSeq` on its row.**
+   *Always.* Peer messages enter only via replay (`store_apply.go:65`), never via
+   the live-push validator. The only `firstAddSeq = 0` peer rows are *pre-feature*
+   rows, handled by A6/backfill (§6) — and even then the OrderId axis covers them
+   when they are in the read prefix.
+
+6. **A6 — `minF` and every counted row's `AddSeq` fit in `int64`** (so
+   `int64(minF)` in Query B and the `GetInt` decode are exact). *Conditional but
+   effectively always.* `AddSeq` is a `uint64` apply counter; reaching `2^63`
+   batches is not physically attainable. The boundary is exercised at `MaxInt64`
+   (`computed_edgecases_test.go:78`). A pre-feature `firstAddSeq = 0` is the only
+   value below the real range and is handled separately.
+
+7. **A7 — lexid `Next`/`NextBefore` produce strictly-ordered strings consistent
+   across replicas given the same neighbor order.** *Assumed (any-sync layer).*
+   This is the foundation of O1/O2 at the *string-value* level. It lives in
+   `github.com/anyproto/lexid` and `objecttree` (`lexId.Next`, `tree.go:469`;
+   `lexId.NextBefore`, `tree.go:450`). Not proven here; would be verified in the
+   `lexid` package and `objecttree` order tests. If A7 failed, O1/O2 (and hence
+   all of §5) would not hold.
+
+8. **A8 — Snapshot/compaction preserves surviving rows' `firstAddSeq` and the
+   relative `OrderId` order.** *Conditional.* The read model assumes a message
+   row's `(OrderId, firstAddSeq)` is stable once written and that compaction does
+   not reorder survivors. Verified only indirectly (catalog restart cases
+   `S-cat11`, `S-cat23` MATCH); a dedicated compaction test is not in the cited
+   suite.
+
+9. **A9 — The frontier passed to `GetUnreadMessagesComputed` is the *resolved,
+   pruned* seen frontier** (`GetReadFrontier`, `store.go:442-452`). *Always, by
+   wiring.* Lemma 0 makes the *pruned-ness* immaterial to correctness; it only
+   bounds size.
+
+10. **A10 — Production status: the computed query runs in *shadow* mode, not yet
+    authoritative.** *Boundary, not an assumption used in the proof.*
+    `shadowComputedReadCountEnabled = false` by default
+    (`chatobject.go:228`); when enabled, `shadowComputedReadCount`
+    (`chatobject.go:234-262`) runs the computed enumeration alongside the bool
+    path and logs count divergences. The bool `read`/`mentionRead` remains the
+    live source of truth until rollout. So Theorem A's *exactness* and Theorem
+    B's *order-(non)invariance* are properties of the predicate the shadow
+    computes and the watermark engine already ships
+    (`readwatermark.go`); they characterize the behavior the system will adopt
+    when the flag flips, and they match the shipped watermark counter (proven
+    equal by `TestComputed_EqualsWatermark`, `scenario_computed_test.go:169`).
+
+11. **A11 — `≺` is the same on all replicas (a global causal order exists).**
+    *Always.* The DAG is content-addressed and append-only; `PreviousIds` are
+    immutable parts of a signed change. Two replicas holding a change hold the
+    same parents. (Foundational CRDT property; relied on throughout §5(B).)
+
+---
+
+## §8. Summary of the verdict
+
+- **(A) Algorithmic coverage:** `GetUnreadMessagesComputed` computes *exactly*
+  `{peer, counter-matching X : ¬Dominated(X, F)}` — Theorem A — for any frontier,
+  including the empty frontier, `AddSeq = 0`/absent rows, equal coordinates,
+  duplicate heads, the `int64` boundary, own-exclusion, and the mention
+  sub-filter. This holds unconditionally (given A1, A6) and is corroborated by the
+  differential/edge/fuzz tests.
+
+- **(B) Order-of-adding invariance:** *Not* unconditional. On a fixed normalized
+  tree with a fixed frontier-as-id-set `F₀`, the computed unread set is invariant
+  over all valid local apply orders **iff** no candidate lies in the ambiguous
+  band `Amb(F₀)` = {concurrent with some head `H∈F₀`, `OrderId ≤ OrderId(H)`, and
+  not causally covered by any head} (Theorem B). That band is exactly the
+  concurrent-message-sorting-before-a-seen-head configuration, i.e. the three
+  catalog cases `S-concurrent-merge-divergence`, `S-cat12`, `S-cat19` accepted by
+  the sign-off gate. Everything *outside* the band — causal ancestors of a head
+  (always read) and OrderId-after every concurrent head (always unread) — is
+  fully order-invariant. The math is bounded to that single configuration; whether
+  it is a *defect* is an open product decision, not a settled fact. §5.3 shows the
+  cross-device manifestation — two of one user's synced devices reporting different
+  unread *counts*, the under-counting device fabricating a read from its own
+  irrelevant local arrival order — is materially more serious than the
+  single-device "accepted divergence" framing, is undocumented and untested (the
+  sign-off harness cannot express per-device AddSeq), and contradicts design §3
+  l.37. Accept-and-document vs. fix-toward-OrderId-convergence is unresolved. It
+  applies identically to the bool watermark and the computed query, so it is a
+  model decision, not a redesign blocker.

--- a/docs/superpowers/specs/2026-06-03-read-counter-formal-problem.md
+++ b/docs/superpowers/specs/2026-06-03-read-counter-formal-problem.md
@@ -1,0 +1,319 @@
+# Convergent, Index-Cheap Read Counters over a Replicated Causal DAG — A Formal Problem
+
+## 0. Purpose and how to read this
+
+This is a **self-contained, domain-free problem statement** for a strong reasoning
+solver. No knowledge of any particular product, database, or codebase is required;
+all needed structure is defined in §1. The optional appendix sketches the concrete
+system this abstracts, but the core (§1–§9) stands alone.
+
+We ask the solver to:
+
+1. **Confirm or correct** the two base results, Theorem A and Theorem B (§5), and
+   their corollary.
+2. **Solve the open problem in §8**: design a read-counter scheme that is
+   *simultaneously* **cheap** (no graph traversal at query time, no mutable
+   per-event state) and **convergent** across a user's replicas — or **prove it
+   impossible** under those constraints and characterize the best achievable.
+
+The tension in one line: the only *correct, convergent* scheme we know requires a
+graph walk (too slow); the only *cheap* scheme we know is non-convergent across
+devices. Bridge them, or prove the gap is fundamental.
+
+---
+
+## 1. Model and notation
+
+### 1.1 Events and the causal DAG
+
+- A growing set `V` of immutable **events**. Each event names a set of **parents**
+  (other events). This induces a DAG; let `≺` be its transitive closure, a strict
+  **partial order** ("causally precedes"). Write `⪯` for "`≺` or `=`", and `X ∥ Y`
+  for **concurrent** (`X ⋠ Y` and `Y ⋠ X`).
+- Events are **content-addressed and append-only**, so `≺` is **replica-invariant**:
+  any two replicas that both hold `X, Y` agree on which of `X ≺ Y`, `Y ≺ X`,
+  `X ∥ Y` holds. The DAG only grows; edges are immutable.
+
+### 1.2 Replicas and delivery
+
+- One **user** owns several **replicas** (devices). Each replica `r` holds a subset
+  of `V` that grows monotonically toward `V` (eventual, lossless delivery).
+- Events may arrive in **different orders** and grouped into different **batches**
+  on different replicas. There is no global arrival order.
+
+### 1.3 Two linear extensions of `≺` (the crux)
+
+Both schemes below number events with a *total* order that extends `≺`. The whole
+problem turns on the difference between these two:
+
+- **Global order `⊏` (convergent).** A canonical **linear extension of `≺`**: a
+  deterministic function of the DAG that is **identical on every replica**. It
+  extends `≺` (`X ≺ Y ⟹ X ⊏ Y`) and, being total, also orders **concurrent**
+  events by a fixed deterministic tiebreak. Store its key as `g(X)` (a comparable
+  scalar). *Because it is total, `g` orders concurrent `x ∥ h` too — this is the
+  source of "over-reading" below.*
+
+- **Local rank `aᵣ` (device-local).** Each replica `r` assigns each event an
+  integer `aᵣ(X)` = its position in `r`'s **arrival/apply** linearization. Its
+  properties:
+  - **(S1)** extends `≺`: `X ≺ Y ⟹ aᵣ(X) < aᵣ(Y)` on every replica;
+  - **(S1-batch)** events delivered in one batch share a single rank value (ties);
+  - **(S2)** **not replica-invariant for concurrent events**: if `X ∥ Y`, the sign
+    of `aᵣ(X) − aᵣ(Y)` may differ between replicas (it encodes local arrival order).
+
+  Note: a linear extension of `≺` that were *also* replica-invariant would be
+  essentially `⊏` itself. So `aᵣ`'s *only* information beyond `g` is local and
+  concurrency-sensitive — exactly the part that does not converge.
+
+### 1.4 The read frontier
+
+- The user marks "read up to here." The state is a **set** `F ⊆ V` of frontier
+  events ("heads" — the maximal events the user has read).
+- `F` is **synced across the user's replicas as a set of event-IDs**, *not* as
+  coordinates. So every replica eventually holds the same `F` (as IDs) but
+  **resolves** each `H ∈ F` to its *local* coordinates: `g(H)` (shared) and
+  `aᵣ(H)` (local).
+- `F` **evolves**: it grows as the user reads more, and it can **regress** (a
+  "mark-unread" operation shrinks the read region). An ID in `F` may reference an
+  event **not yet locally present** (delivered late).
+
+### 1.5 Counted events and filters
+
+- A fixed, locally-known boolean selects the **counted** events (e.g. exclude the
+  user's own events; or restrict to a labeled sub-class). The **counter** = number
+  of counted events that are unread. The product also needs the **set** of unread
+  event-IDs, not only the count.
+
+---
+
+## 2. What "read" should mean — the ground truth
+
+The intended semantics is **causal coverage**:
+
+> **`read*(X) ⟺ ∃ H ∈ F : X ⪯ H`**  — `X` is read iff it causally precedes (or is)
+> some event the user marked read; i.e. `X` is in the **causal down-set** of `F`.
+
+`read*` is a function of `(≺, F-as-set)` **only**, hence **replica-invariant /
+convergent**: once two replicas hold the same events and the same `F`, they compute
+the identical read set and count. This is the correctness baseline.
+
+Unread count `U = #{ counted X : ¬read*(X) }`.
+
+---
+
+## 3. Constraints (why the obvious implementations are disallowed)
+
+A valid implementation must satisfy all three:
+
+- **(C1) No graph traversal at query time.** The read/unread status of events, and
+  the unread count/enumeration, must be answerable from **per-event stored scalar
+  labels** plus the (resolved) frontier, via **indexed range queries** — *not* by
+  traversing `≺` at query time. (Traversal is `O(|V|)` and dominates cold-start
+  latency.)
+- **(C2) No mutable per-event read flag.** We may not store a boolean "read" per
+  event and flip it on each read action. Read status must be **computed on demand**.
+  (Each read marks many events; flag writes are write-amplified and costly.)
+- **(C3) Cheap.** Count and unread-enumeration in `O(polylog |V|)` index operations
+  plus `O(#unread)` output — a few indexed range scans, sub-linear in `|V|`.
+
+**Allowed:** per-event **immutable** labels assigned once at event creation
+(these do *not* violate C2). Disallowed: anything updated per read action, or any
+per-query walk of `≺`.
+
+The ground-truth scheme `read*` computes a causal down-set, which needs `≺` at
+query time ⇒ it violates **C1/C3**. That is exactly why an index-cheap proxy was
+sought.
+
+---
+
+## 4. The scheme under study — scalar "dominance"
+
+Store two immutable scalars per event: the global key `g(X)` and the local rank
+`aᵣ(X)`. Define
+
+> **`read_d(X) ⟺ ∃ H ∈ F : g(X) ≤ g(H) ∧ aᵣ(X) ≤ aᵣ(H)`**  — *dominance* on two axes.
+
+**Cheap enumeration.** With `gmax = max_{H∈F} g(H)` and `amin = min_{H∈F} aᵣ(H)`,
+
+  `¬read_d(X) ⟹ g(X) > gmax ∨ aᵣ(X) > amin`,
+
+so the unread set is contained in (range `g > gmax`) ∪ (range `aᵣ > amin`) — **two
+indexed range scans** — after which the dominated events and the non-counted events
+are filtered out. This satisfies **C1–C3**.
+
+Intuition: `g` is the convergent "timeline position"; `aᵣ` is a freshness guard so
+that an event with a *small* `g` that *arrived late* (after the user read past that
+position) stays unread.
+
+---
+
+## 5. Base theorems to confirm (or correct)
+
+**Theorem A (cheap enumeration is exact for `read_d`).** The two-range union, minus
+the dominated events, minus non-counted events, equals exactly
+`{ counted X : ¬read_d(X) }` — for every `F` (including `|F| > 1`, empty `F`, equal
+`g`-keys, tied ranks, and integer-encoding boundaries).
+
+**Theorem B (when does `read_d` equal the ground truth `read*`?).** Define the
+causal down-set `Stable(F) = { X : ∃ H ∈ F, X ⪯ H }` and the **ambiguous band**
+
+  `Amb(F) = { X ∉ Stable(F) : ∃ H ∈ F, X ∥ H ∧ g(X) ≤ g(H) }`.
+
+Then:
+- for every `X ∉ Amb(F)`: `read_d(X) = read*(X)` (`= [X ∈ Stable(F)]`),
+  **independent of the local ranks `aᵣ`**;
+- for `X ∈ Amb(F)`: `read_d(X)` **depends on `aᵣ`** and can take either value.
+
+Hence `read_d = read*` (equivalently, `read_d` is rank-/apply-order-invariant)
+**iff `Amb(F) = ∅`**.
+
+Supporting lemmas:
+- **(B1) causal pairs are stable.** If `X ⪯ H` or `H ⪯ X`, then `g` and *every*
+  `aᵣ` decide `(X, H)` the same way on every replica (both extend `≺`). So such
+  pairs never flip.
+- **(B2) concurrent pairs can flip.** If `X ∥ H`, there exist apply orders giving
+  `aᵣ(X) ≤ aᵣ(H)` and others giving `aᵣ(X) > aᵣ(H)` (S2). Combined with
+  `g(X) ≤ g(H)`, `H` dominates `X` under one and not the other.
+
+**Corollary (the multi-device defect).** For `X ∈ Amb(F)`, since `aᵣ` is
+replica-local (S2), two replicas of the same user holding the **same** `V` and the
+**same** `F` can compute `read_d(X)` **differently** ⇒ a **permanent** divergence of
+the unread count between the user's devices that **does not heal** after full
+delivery. `read*` has no such divergence.
+
+*(Please confirm A, B, the lemmas, and the corollary, or produce a counterexample.)*
+
+---
+
+## 6. Minimal worked example (abstract)
+
+Two concurrent events `x ∥ h`, both children of a common parent, with `g(x) < g(h)`.
+Frontier `F = {h}` (the user marked `h` read). `x` is delivered late on one replica.
+
+- **Ground truth `read*(x)`:** `x ∥ h ⇒ x ⋠ h ⇒ x ∉ Stable({h}) ⇒ x UNREAD`, on
+  **every** replica. Count = 1 everywhere. (The user read `h`; `x` is on a branch
+  they never read.)
+- **Dominance `read_d(x)`:**
+  - Replica **B** received `h` first (`a_B(h)=1`) then `x` (`a_B(x)=2`):
+    `a_B(x) ≤ a_B(h)`? `2 ≤ 1` false ⇒ `x` **unread** ⇒ count 1.
+  - Replica **A** received `x` first (`a_A(x)=1`) then `h` (`a_A(h)=2`):
+    `g(x) < g(h)` ✓ and `a_A(x) ≤ a_A(h)` ✓ ⇒ `x` **read** ⇒ count 0.
+  - **A = 0, B = 1, permanently.** `x ∈ Amb({h})`.
+
+(If `x` and `h` arrive in the **same batch** on a replica, their ranks tie (S1-batch)
+and the decision collapses onto `g` ⇒ `x` read there. So the divergence requires
+**split-batch** delivery across devices — the normal case when two devices receive
+two concurrent events over the network independently.)
+
+---
+
+## 7. The property we need — convergence
+
+> **(P2) Convergence.** For any two replicas of one user with equal local event sets
+> and equal `F`-as-ID-set, the computed unread set (hence count) is identical.
+
+`read*` satisfies P2 (it ignores all local data). `read_d` violates P2 exactly on
+`Amb(F)`. The two known schemes trade off:
+
+| scheme | cheap (C1–C3) | convergent (P2) | faithful to intent |
+|---|:---:|:---:|:---:|
+| causal down-set `read*` (graph walk) | ✗ (needs `≺` at query) | ✓ | ✓ |
+| scalar dominance `read_d` | ✓ | ✗ (on `Amb(F)`) | ✓ off band, ✗ on band |
+
+---
+
+## 8. The open problem — the missing piece
+
+Find a scheme `(L, read_L)` such that:
+
+1. each event carries an **immutable label `L(X)`** assigned at creation (respects
+   **C2**), and `L(X)` is **replica-invariant** (same on every replica, never
+   updated);
+2. `read_L(X, F)` is computable under **C1 and C3** — indexed range queries over
+   stored scalars + the resolved frontier, no per-query traversal of `≺`, and the
+   unread set is **cheaply enumerable and countable**;
+3. `read_L = read*` — i.e. **convergent (P2)** and faithful to causal coverage; at
+   minimum it must decide the ambiguous band `Amb(F)` the way `read*` does
+   (`x ∥ h`, `g(x) ≤ g(h)` ⇒ **unread**).
+
+In words: **recover the convergence of the causal-down-set scheme at the cost
+profile of the scalar-dominance scheme.**
+
+**Equivalent core question.** The global order `g` alone over-reads (it orders a
+concurrent `x` before `h`). The single local axis that fixed that (`aᵣ`) is
+non-convergent. *Is there a **replica-invariant** per-event encoding that
+distinguishes, among events with `g(X) ≤ g(H)`, those with `X ≺ H` (read) from those
+with `X ∥ H` (unread) — and that supports cheap **range** enumeration of the unread
+set — or is that impossible under C1/C3?*
+
+A complete answer is **either**:
+
+- **(a) A construction** with proofs that it meets **C1–C3** and **P2**, including
+  its space/time cost, and that it handles all of §9; **or**
+- **(b) An impossibility / lower bound** showing no scheme can meet **C1–C3** and
+  **P2** simultaneously (e.g. reduced to reachability-labeling lower bounds, or to
+  the DAG's width / antichain size), **together with the best achievable** — for
+  instance a **hybrid** that uses the cheap convergent-off-band test plus a bounded
+  causal check confined to `Amb(F)` (note `Amb(F) = ∅` for linear histories and is
+  small when concurrency at the frontier is rare), with the fallback cost
+  characterized; or a scheme parameterized by width `w` with cost growing in `w`.
+
+**Non-binding directions** the solver may use or discard: replica-invariant causal
+labels (version/vector clocks, Lamport-style, 2-hop labels, interval or
+chain-decomposition reachability labels) as a convergent replacement for `aᵣ`;
+restricting to **low-width (near-linear)** DAGs; precomputed per-event
+"concurrent-with-the-frontier" summaries (must stay **immutable** to respect C2);
+or a proof that *any* single replica-invariant total order is essentially `g` and
+therefore insufficient, forcing **≥ 2 dimensions**.
+
+---
+
+## 9. What a strong answer must address
+
+- Confirm or correct **Theorem A**, **Theorem B**, the lemmas, and the corollary.
+- Then deliver **(a)** a construction (with proofs + cost) or **(b)** an
+  impossibility result + the best achievable.
+- Explicitly handle:
+  - **multiple frontier heads** (`|F| > 1`);
+  - the **counted-subset filter**;
+  - **frontier evolution** — both **growth** and **regression** (mark-unread);
+  - **frontier IDs referencing not-yet-local events** — the scheme must not
+    *over-read* due to an unresolved head (a safe, eventually-consistent treatment
+    is acceptable here, but state it);
+  - cheap **enumeration / count** of the unread set, not only point queries;
+  - the **failure direction**: if any approximation is unavoidable, prefer
+    *over-counting unread* (showing a read item as unread) to *under-counting*
+    (silently hiding an unread item).
+
+---
+
+## Appendix A — Notation
+
+| symbol | meaning |
+|---|---|
+| `V`, `≺`, `⪯`, `∥` | events; causal partial order; "≺ or ="; concurrent |
+| `g(X)` (`⊏`) | global order key — a **convergent** (replica-invariant) linear extension of `≺` |
+| `aᵣ(X)` | local rank on replica `r` — arrival/apply linear extension of `≺`, **device-local** for concurrent events |
+| `F` | read frontier (set of "head" events), synced as IDs, resolved to local coordinates |
+| `read*` | ground truth: `∃H∈F: X ⪯ H` (causal down-set) — convergent but needs a graph walk |
+| `read_d` | dominance proxy: `∃H∈F: g(X) ≤ g(H) ∧ aᵣ(X) ≤ aᵣ(H)` — cheap but non-convergent on `Amb(F)` |
+| `Stable(F)` | causal down-set `{X : ∃H∈F, X ⪯ H}` |
+| `Amb(F)` | ambiguous band `{X ∉ Stable(F) : ∃H∈F, X ∥ H ∧ g(X) ≤ g(H)}` |
+| C1 / C2 / C3 | no query-time graph walk / no mutable per-event flag / cheap (indexed) |
+| P2 | cross-replica convergence of the result |
+
+## Appendix B — (Optional) concrete instantiation
+
+This abstracts **unread-counters in a CRDT-based group chat** synced peer-to-peer
+across a user's devices. Events = chat messages (nodes of an append-only,
+content-addressed change DAG); `≺` = the change DAG's ancestry; `g` = a
+deterministic per-change order key; `aᵣ` = the device-local sequence in which
+changes were applied to local storage (assigned in arrival batches); `F` = the
+synced "read markers" (seen heads); counted events = messages from other authors
+(optionally a "mention" sub-class with its own frontier). The original, correct
+implementation computed `read*` by walking the DAG from the read markers — but that
+walk over the whole history on every cold start was the dominant startup cost, which
+motivated the scalar `read_d` proxy. The proxy is fast but exhibits the §6
+divergence between a user's own devices. The core problem (§8) is to regain
+convergence without reintroducing the per-query walk or a per-message read flag.
+*(This appendix is for grounding only; the problem in §1–§9 is fully abstract.)*

--- a/docs/superpowers/specs/2026-06-03-read-counter-hybrid-design.md
+++ b/docs/superpowers/specs/2026-06-03-read-counter-hybrid-design.md
@@ -1,0 +1,332 @@
+# Option B — Hybrid Convergent Read Counter: Design & Bounded-Walk Proof
+
+Status: design proposal. Companion to
+`2026-06-03-chat-read-counter-computed-theory.md` (theory, Theorems A/B, §5.3
+cross-device defect) and `2026-06-03-read-counter-formal-problem.md` (abstract
+problem). This document specifies the recommended fix and proves the one subtle
+part — the bounded fallback walk — including a correction to an earlier,
+incorrect band-detection rule.
+
+---
+
+## 1. Problem recap (one paragraph)
+
+The shipped read counter decides read/unread by **dominance** on two stored
+per-message scalars: `read_d(X) ⟺ ∃H∈F: g(X) ≤ g(H) ∧ a(X) ≤ a(H)`, where
+`g` = `OrderId` (a replica-invariant linear extension of the causal order `≺`) and
+`a` = `AddSeq` (a **device-local** linear extension). It is cheap (two indexed
+range scans) but, because `a` is device-local, it **permanently diverges across a
+user's devices** on the "ambiguous band" — concurrent messages that sort before a
+read head (theory §5.3; the canonical `a1∥b1` case). The pre-regression algorithm
+computed the **convergent** ground truth `read*(X) ⟺ ∃H∈F: X ⪯ H` (causal
+down-set of the frontier) by walking the whole change tree — correct but O(tree)
+on every cold start (~18.6s Android). **Option B keeps the cheap dominance fast
+path and repairs only the band, with a bounded causal walk — recovering exact,
+convergent `read*` without the whole-tree cost.**
+
+Notation: `g(·)`,`a(·)` as above; `F` = frontier (seen heads, synced as IDs,
+resolved locally); `Stable(F) = {X : ∃H∈F, X ⪯ H}` (causal down-set = the truly
+read set, `read*`); `maxF = max_{H∈F} g(H)`; `minF = min_{H∈F} a(H)`. "Counted" =
+peer (`creator ≠ me`) and counter-matching (messages: all; mentions: `hasMention`).
+Both `g` and `a` extend `≺` (so `X ⪯ Y ⟹ g(X) ≤ g(Y) ∧ a(X) ≤ a(Y)`); `g` is a
+total order and injective on distinct events.
+
+---
+
+## 2. The semantic decision (must be made explicitly)
+
+Option B computes **exact `read*` = causal-down-set semantics**. This is the
+convergent, pre-regression behavior, and it **eliminates** the three currently
+"accepted" single-device divergences (`S-concurrent-merge`, `S-cat12`, `S-cat19`)
+by making them MATCH the DAG baseline again. It **reverts** the design choice in
+`2026-05-16-chat-read-counter-design.md` §5 (dominance / "a concurrent message
+already present and sorting before the read head counts as read"). That choice is
+*intrinsically device-local* ("already present" depends on which device read), so
+it cannot be made convergent — adopting `read*` is the only convergent option.
+**Action required:** bless the semantic change and empty the sign-off gate's
+`watermarkAcceptedDivergence` map (`scenario_signoff_test.go:21-23`), flipping the
+three scenarios to MATCH.
+
+---
+
+## 3. Correctness foundation
+
+All proofs use only: `g,a` extend `≺`; `g` total & injective; `Stable(F)` is the
+causal down-set.
+
+**Lemma 1 (read ⇒ in the g-prefix).** `Stable(F) ⊆ {X : g(X) ≤ maxF}`.
+*Proof.* `X ∈ Stable(F) ⟹ X ⪯ H ⟹ g(X) ≤ g(H) ≤ maxF`. ∎
+
+**Lemma 2 (the g-tail is cleanly unread).** `g(X) > maxF ⟹ X ∉ Stable(F)`.
+*Proof.* If `X ∈ Stable(F)` then by Lemma 1 `g(X) ≤ maxF`, contradiction. ∎
+→ Every counted `X` with `g(X) > maxF` is unread. This is **Query A**, exact, no walk.
+
+**Theorem 1 (band identity).** Define `Band(F) = {X : g(X) ≤ maxF ∧ X ∉ Stable(F)}`.
+Then `Band(F)` equals the theory's ambiguous band `Amb(F)`, and **every** member is
+truly unread.
+*Proof.* Unread is immediate (`X ∉ Stable(F) ⟹ ¬read*(X)`). For `X ∈ Band(F)`, let
+`H*` achieve `g(H*) = maxF`. `X ∉ Stable(F) ⟹ X ⋠ H*`. If `H* ≺ X` then
+`g(H*) < g(X) ≤ maxF = g(H*)`, contradiction; so `H* ⊀ X`. Hence `X ∥ H*`, and
+`g(X) ≤ g(H*)`, i.e. `X ∈ Amb(F)`. Conversely `Amb(F) ⊆ Band(F)` (an `Amb` member
+is `∉ Stable` and has `g(X) ≤ g(H) ≤ maxF`). ∎
+
+**Corollary 1 (exact decomposition).**
+`{counted X : ¬read*(X)} = {counted X : g(X) > maxF} ⊎ {counted X : X ∈ Band(F)}`
+— Query A (cheap) disjoint-union the band. So computing the band exactly gives the
+exact, convergent count.
+
+**Lemma 3 (the fast path never over-reads unread).** `¬read_d(X) ⟹ ¬read*(X)`.
+*Proof.* If `read*(X)`, then `X ⪯ H` for some `H`, so `g(X) ≤ g(H)` and
+`a(X) ≤ a(H)` (both extend `≺`), hence `read_d(X)`. Contrapositive gives the claim. ∎
+→ The fast path's unread set is a **subset** of the true unread set: it can only
+*miss* unread items (the band members it marks read), never invent them. The
+missing items are exactly `Band(F) ∩ {read_d = read}`.
+
+**Lemma 4 (unread is descendant-closed).** If `X ∉ Stable(F)` and `X ⪯ Y` then
+`Y ∉ Stable(F)`.
+*Proof.* If `Y ∈ Stable(F)`, `Y ⪯ H`, then `X ⪯ Y ⪯ H ⟹ X ∈ Stable(F)`,
+contradiction. ∎ → The unread set is an **up-set** (order filter); its minimal
+elements ("unread roots") have **all parents read**.
+
+---
+
+## 4. Why the earlier `a`-based band rule is wrong (correction)
+
+A natural-looking shortcut (proposed in the mapping review) is to find the band by
+the index probe `{g(X) ≤ maxF ∧ a(X) > minF}` and resolve only those. **This is
+incorrect**: it misses band members with `a(X) ≤ minF`.
+
+**Counterexample — the canonical bug itself.** Device A: `G; a1 ∥ b1`,
+`g(a1) < g(b1)`, applied in order `a1`(a=1) then `b1`(a=2); `F = {b1}` so
+`maxF = g(b1)`, `minF = a(b1) = 2`. Here `a1 ∈ Band(F)` (concurrent with `b1`,
+`g(a1) < g(b1)`, `a1 ∉ Stable`), and it is the very message that is wrongly shown
+read on device A. But `a(a1) = 1 ≤ 2 = minF`, so `a1 ∉ {a > minF}` — the probe
+**skips the one event that needs fixing.** (Root cause: a band member can have
+*arrived early* locally; the `a`-axis carries no convergent signal here — that is
+the whole reason the dominance scheme fails.)
+
+**Consequence.** The band cannot be found by any `a`-axis index range. It must be
+found by **causal structure** (`g` + parent pointers). Theorem 1 gives the correct
+target: `Band(F) = {g ≤ maxF} \ Stable(F)`.
+
+---
+
+## 5. The bounded fallback walk
+
+Computing `Band(F) = {g ≤ maxF} \ Stable(F)` naively (enumerate `Stable(F)` and
+subtract) is O(|read history|) — the cost we must avoid. We bound it with one
+structural property of these trees.
+
+**Property M (merge-recency).** Every new change links **all** current heads as
+parents (`objecttree.go:378`, `TreeHeadIds: ot.tree.Heads()`). So any concurrent
+fork is merged by the next change created after both branches are visible;
+multiple heads exist only transiently, among changes created before they saw each
+other. Formally: if `P` is the common ancestor at a fork and a later change `M` is
+created with all heads visible, then both fork branches `⪯ M`.
+
+**Lemma 5 (band members are shallow — directly above the read boundary).** Every
+minimal element `X` of `Band(F)` (an "unread root") has **all parents in
+`Stable(F)`**.
+*Proof.* By Lemma 4 (up-set), the minimal unread elements have all parents read. A
+minimal `Band(F)` element is a minimal unread element with `g ≤ maxF`; its parents
+are read, i.e. in `Stable(F)`. ∎ → Unread roots hang **directly off** the read
+region (a read parent, an unread child). They are the fork points where the user's
+read history diverges from branches `F` does not cover. Under Property M these are
+located at the recent, not-yet-merged-into-`F` tips.
+
+**Algorithm (band enumeration).** Inputs: `F` (resolved), the local change store
+(point lookups `GetChange(id) → {PreviousIds, g, a}`), the local heads `Hloc`.
+
+```
+1. Seed a backward traversal from  S = Hloc ∪ F,  processed in DECREASING g order
+   (a max-heap keyed by g). Maintain two marks per visited event: READ, UNREAD.
+   - every H ∈ F (and every ancestor we reach via an F-marked node) is READ;
+   - every local head not (yet) shown READ starts UNREAD.
+2. Pop the event E with the largest g.
+   - If E is marked READ: mark all of E's parents READ; do NOT enqueue them for the
+     UNREAD logic (their whole past is read — Stable is a down-set). [Pruning P1]
+   - If E is marked UNREAD:
+       * if g(E) ≤ maxF and E is counted, EMIT E  (it is a band member);
+       * for each parent Pi: enqueue Pi. Its mark is READ if Pi ⪯ some F-head
+         (i.e. Pi is reached on an F-seeded branch), else UNREAD.
+3. Termination: stop when the heap is empty OR when every remaining event is READ
+   (all active branches have converged into the read region). [Pruning P2]
+4. Output:  unread = QueryA( g > maxF, counted )  ∪  EMITTED band.
+```
+
+The READ/UNREAD determination in step 2 is the co-traversal: an event is READ iff
+it is reachable backward from `F`. Seeding the *same* traversal from `F` marks the
+read down-set lazily; a branch from `Hloc` becomes READ the moment it meets an
+`F`-marked event. Both seeds advance in decreasing `g`, so they meet at the recent
+convergence point.
+
+**Theorem 2 (correctness).** The algorithm emits exactly `Band(F) ∩ counted`, hence
+(with Query A) computes exactly `{counted X : ¬read*(X)}`.
+*Proof.* (Soundness) An emitted `E` is UNREAD-marked, meaning no `F`-seeded branch
+reached it, i.e. `E` is not backward-reachable from `F` ⟺ `E ∉ Stable(F)`; with the
+emit guard `g(E) ≤ maxF`, `E ∈ Band(F)` (Theorem 1), and `E` is counted. (Complete-
+ness) Take any `B ∈ Band(F) ∩ counted`. By Lemma 4, `B` lies on an up-set whose
+top elements are local heads (`B ⪯` some head, and that head is unread by Lemma 4),
+so `B` is reachable from `Hloc` along an all-UNREAD descending path; the traversal
+from `Hloc` descends through UNREAD events (step 2, UNREAD branch enqueues parents)
+and reaches `B` before any pruning, because pruning P1 only stops at READ events and
+`B`'s path down from the head is all UNREAD (Lemma 4), and P2 only fires once all
+remaining are READ. Since `g(B) ≤ maxF` and `B` counted, `B` is emitted. ∎
+
+**Theorem 3 (bound).** The traversal visits only events in the **unmerged suffix**
+`U = {E : E is not ⪯-below the deepest fully-merged read event}`. Equivalently it
+visits `Band(F)` ∪ (their read-parent boundary) ∪ (the `g>maxF` unread tail
+reachable from `Hloc`). It never visits an event all of whose `g` is below the read
+convergence point. Under Property M, `|U| = O(W · D)` where `W` = peak concurrent
+width and `D` = depth from `F`'s heads to the convergence — both small for chat-like
+histories; in particular `U = ∅`-of-band when the history is linear at the frontier
+(`Band(F) = ∅`, fast path already exact).
+*Proof sketch.* Pruning P1 stops every branch at the first READ event, and `Stable`
+is a down-set, so no proper ancestor of a READ event is ever expanded for the UNREAD
+logic; the only READ events touched are the immediate parents of UNREAD events (the
+boundary). Thus visited = UNREAD events reachable from `Hloc` (= `Band(F)` ∪ the
+`g>maxF` unread tail, by Lemma 4) ∪ their parents. The UNREAD events are, by
+Property M and Lemma 5, confined to the recent unmerged suffix above `F`. ∎
+
+**Key contrast with the old cost.** The old `RemoveBefore(F)` + `BuildHistoryTree`
+visited the **whole** down-set / whole tree (O(read history)). This walk visits
+only the **unread up-set's recent root region** — it *stops at* the read boundary
+instead of traversing into it. Deep read history is never loaded.
+
+**Honest caveats.**
+- The tight bound **depends on Property M**. A pathological history with sustained
+  wide concurrency that never merges (many long-lived parallel branches) inflates
+  `U`. Property M makes that transient in practice, but the worst case is real —
+  hence the **measurement** in §8 before committing.
+- "Local heads" and parent pointers must be reachable by **point lookups** without
+  building the whole tree. `GetChange(id)` provides `PreviousIds` and the stored
+  `g`/`a` per change (point read from storage), and the current heads are known to
+  the open tree. The walk therefore costs `O(|U|)` point reads, not a tree rebuild.
+- Reuse: the descending parent-pointer traversal is exactly `changediffer.dfsPrev`
+  mechanics; this can reuse that code seeded from `Hloc ∪ F` and bounded by P1/P2,
+  rather than feeding it the whole tree.
+
+---
+
+## 6. Architecture & integration
+
+**Per-message stored state: unchanged.** Keep `g` (`OrderId`) and `a`
+(`firstAddSeq`/`AddSeq`) and their indexes. No new immutable label, no migration
+beyond the existing `firstAddSeq` backfill. No mutable read flag is introduced (the
+bool, if kept transitionally, is a shadow oracle only).
+
+**Read path = fast path ⊕ band repair.** Both the bool-watermark path
+(`readwatermark.go` `dominated` / `onRemove`) and the computed query
+(`repository.go` `GetUnreadMessagesComputed`) consume the same dominance predicate;
+both get the same wrapper:
+
+```
+unread_exact = QueryA(g > maxF, counted)                       // Lemma 2, cheap
+             ∪ bandWalk(F, Hloc)                               // §5, bounded
+read_exact(X) = ¬(X ∈ unread_exact)   // for per-message status / events
+```
+
+- **Count / enumeration:** `|unread_exact|` and its id-set come straight from the
+  decomposition (Corollary 1). The band walk runs only when its cheap precheck says
+  the band might be non-empty (see below); otherwise the fast path is returned as-is.
+- **Cheap "band possibly non-empty?" precheck (avoids the walk on linear
+  histories):** the band is non-empty only if the local tree has a head `h ∈ Hloc`
+  with `h ∉ Stable(F)` and `g(h) ≤ maxF`, OR more simply if `|Hloc| > |F-heads
+  covering them|`. Concretely: if every local head is `⪯`-covered by `F` (single
+  merged head that `F` already contains/covers), `Band(F) = ∅` and we skip the walk.
+  This is an O(|Hloc|) check. (Linear, fully-read-to-tip chats hit this and pay
+  nothing beyond the fast path.)
+- **Transition-delta / events:** when `F` advances `F_old → F_new`, the newly-read
+  set is `Stable(F_new) \ Stable(F_old)`; the band walk already classifies the
+  affected (recent) region, so read/unread *events* are derived from the
+  before/after band+QueryA membership of the touched ids — no per-message flag flip.
+
+**All three counters.** Messages and mentions share `g/a` with a `hasMention`
+filter, so the wrapper applies to both unchanged. Reactions (mid-redesign) use the
+same dominance shape and inherit the same band issue; the same wrapper applies once
+their coordinates are in place.
+
+**Failure direction (preserved-safe).** A frontier head whose change is not yet
+local is omitted from `F` (existing `pending` behavior, `readwatermark.go:54-59`),
+shrinking `Stable(F)` ⟹ **over-counting unread**, never hiding an unread. The band
+walk inherits this (an unresolved head contributes no READ marks).
+
+---
+
+## 7. Tests
+
+1. **Cross-device convergence gate (currently inexpressible).** Extend the scenario
+   harness so each device has its **own tree with its own `AddSeq` space** (today it
+   builds one shared tree in one `AddRawChanges`, collapsing the dimension —
+   `scenario_harness_test.go:174,357`). New test `TestHybrid_CrossDeviceConvergence`:
+   build device A apply-order `[a1],[b1]` and device B `[b1],[a1]`, `F={b1}`; assert
+   **equal** unread counts (today the dominance path gives 0 vs 1; hybrid gives 1 vs
+   1).
+2. **Band-rule regression guard.** Pin the §4 counterexample: assert the hybrid
+   emits `a1` as unread on device A, and that the `{a > minF}` rule would not
+   (documents why the corrected rule is needed).
+3. **Equivalence to ground truth.** Property test over random DAGs + frontiers +
+   apply orders: assert `hybrid == old changediffer.RemoveBefore` (exact `read*`)
+   on every replica, and that both are apply-order-invariant. This is the convergence
+   proof in code.
+4. **Bound test.** Assert the band walk visits `O(|U|)` changes (instrument the
+   point-lookup count) and `0` beyond the fast path when the history is linear to the
+   tip (`Band(F)=∅` precheck short-circuits).
+5. **Sign-off flip.** `S-concurrent-merge`/`S-cat12`/`S-cat19` move from
+   `watermarkAcceptedDivergence` to MATCH.
+
+---
+
+## 8. Cost & the decisive measurement
+
+- **Storage:** unchanged (reuse `g`,`a`). **Migration:** none beyond existing
+  backfill. **Blast radius:** anytype-heart only (no any-sync change).
+- **Query:** fast path (2 range scans) + band walk `O(|U|)` point reads, gated by
+  the O(|Hloc|) precheck → `0` extra for linear histories.
+- **Decisive measurement before committing** (de-risks Property M / Theorem 3):
+  instrument real DBs for the **band/unmerged-suffix size per query** — proxy:
+  `|Hloc|` distribution and `count(counted, g ≤ maxF, not ⪯ F)` per cold start /
+  sync tick. If big group chats sustain large `|U|`, the walk degrades toward the
+  old cost and the long-term answer becomes a **producing-device key + per-device
+  seq** (true version vector, `W = #devices`, bounded) going forward, paired with
+  this hybrid for legacy. If `|U|` is small (expected from Property M), the hybrid
+  is sufficient on its own.
+
+---
+
+## 9. Open questions / risks
+
+- **R1 — Property M strength.** The bound relies on forks merging promptly. Confirm
+  no chat workflow produces long-lived unmerged parallel branches; the §8
+  measurement settles it. (Correctness does NOT depend on M — only the cost does;
+  Theorem 2 holds regardless.)
+- **R2 — READ-membership co-traversal.** The cleanest implementation marks `Stable`
+  lazily by co-seeding from `F`. Verify the meet-in-the-middle terminates at the
+  convergence point and that `g`-ordered processing is the right discipline (it is:
+  processing by decreasing `g` guarantees a node is seen after all its descendants
+  on the active branches, so READ marks propagate down before we decide UNREAD).
+- **R3 — Semantic sign-off.** §2 reverts a deliberate product decision; needs an
+  explicit bless + the sign-off gate update. Not a silent change.
+- **R4 — Reactions interplay.** The reactions redesign (single-axis AddSeq,
+  `ClearUnreadReactions` over-clear) must adopt the same wrapper; coordinate so the
+  fix lands once at the model layer.
+- **R5 — Heads availability cheaply.** Confirm `Hloc` and per-change `PreviousIds`
+  are retrievable by point lookups at the moment the count is computed (cold start,
+  before/while the tree lazy-loads) without forcing a full tree build.
+
+---
+
+## Appendix — proof obligations summary (for review)
+
+| Claim | Statement | Status |
+|---|---|---|
+| Lemma 1 | `Stable(F) ⊆ {g ≤ maxF}` | proved |
+| Lemma 2 | `g > maxF ⟹ unread` (Query A exact) | proved |
+| Theorem 1 | `Band(F) = {g≤maxF}\Stable = Amb(F)`, all unread | proved |
+| Corollary 1 | exact unread = QueryA ⊎ Band | proved |
+| Lemma 3 | fast path has no false-unreads | proved |
+| Lemma 4 | unread is descendant-closed (up-set) | proved |
+| §4 | `{a > minF}` band rule is wrong (counterexample = `a1`) | proved |
+| Lemma 5 | band roots hang directly off the read region | proved |
+| Theorem 2 | bounded walk emits exactly `Band(F)∩counted` | proved (review R2) |
+| Theorem 3 | walk bounded by unmerged suffix `|U|` | proved under Property M |

--- a/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
+++ b/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
@@ -43,6 +43,24 @@ Decisions this spec rests on:
 - **D3:** the mutable per-message `read`/`mentionRead` bools and `SetReadFlag`
   are removed; read status is computed. `AddSeq` remains only as the replay
   cursor; it is no longer a read-model axis.
+- **D4 (product, 2026-06-10): one frontier, counters are filters.** Reading a
+  message reads everything attached to it (its mention, its reactions). There
+  is exactly ONE read frontier — the message frontier; the mention counter is
+  the same unread set filtered by `hasMention` (and Stage 4's reaction counter
+  is the same frontier filtered through reaction events). "Message read but
+  its mention unread" is unrepresentable by construction. The independent
+  mention diff manager (`diffManagerMentions`) and its seen-heads KV entry are
+  retired at cutover; until then the shadow measures how far the two legacy
+  frontiers drift apart in practice (expected: negligible — clients advance
+  both with the same ranges).
+- **D5 (product, 2026-06-10): `MarkMessagesAsUnread` is deprecated** (unused
+  by clients) and is NOT implemented in the computed model; the RPC is removed
+  at cutover (Stage 3). Consequence: the frontier is **monotone** — it only
+  grows — which removes every regression flow, regression event, and
+  regression-related cache invalidation from this design, and with them the
+  three known bool-vs-CORE divergence classes the legacy flow produced
+  (own-messages-flipped-unread, the g-prefix frontier swallow, and the
+  mention/messages diff-manager hardcode bug in `reading.go`).
 
 Notation (as in the companion docs): `≺`/`⪯` causal order; `X ∥ Y` concurrent;
 `g(X)` = OrderId (replica-invariant order); `F` = seen-head frontier (synced as a
@@ -268,8 +286,9 @@ marshal time (own messages: always read).
 merges); apply Theorem 3's O(1) `bandSet` rule; if the change is a delete of a
 band member, remove it from `bandIds`.
 
-**Frontier changes** (`MarkSeenHeads` advance, markunread re-seed, a pending
-head attaching, cross-device KV update):
+**Frontier changes** (`MarkSeenHeads` advance, a pending head attaching,
+cross-device KV update — the frontier is monotone per D5, there is no
+regression flow):
 1. Resolve heads (unresolved → pending, omitted — the existing safe over-count,
    `readwatermark.go:54-59`).
 2. Compute `maxF`; run the certificate (Theorem 2). If 0 → `bandIds = ∅`, done.
@@ -279,12 +298,12 @@ head attaching, cross-device KV update):
    lookups — paid once per frontier change, then cached. (The certificate makes
    the expensive case rare: a huge-tail cold frontier with `bandCreated = 0`
    skips the walk entirely.)
-4. Persist the cache; emit transition events:
-   - read-advance `F_old → F_new`: newly-read =
-     `(band_old ∖ band_new) ∪ (range (maxF_old, maxF_new] ∖ band_new)`
-   - markunread regression: newly-unread =
-     `(band_new ∖ band_old) ∪ (range (maxF_new, maxF_old] ∖ band_old)`
+4. Persist the cache; emit transition events. The frontier is monotone (D5),
+   so the only transition is the read-advance `F_old → F_new`: newly-read =
+   `(band_old ∖ band_new) ∪ (range (maxF_old, maxF_new] ∖ band_new)`.
    One range scan + two tiny set diffs — replaces `SetReadFlag.idsModified`.
+   (Newly-UNREAD events come only from arrivals — the Theorem-3 appends and
+   the tail — never from frontier movement.)
 
 **Unlabeled head** (legacy change, backfill not done): skip the certificate,
 run the walk (CORE mode) — still exact and convergent, just not O(1).
@@ -303,7 +322,10 @@ run the walk (CORE mode) — still exact and convergent, just not O(1).
    `OrderId`/`HasMention` stamping; sidecar writes in the same tx as doc writes.
 3. **Repository**: `unreadCount`/`unreadIds`/status from §5's query path;
    frontier-cache read/write; certificate query on the sidecar.
-4. **Removed** (after cutover soak): `read`/`mentionRead` bools + their indexes,
+4. **Removed** (after cutover soak): `MarkMessagesAsUnread` + its RPC chain
+   (D5; delete `reading.go:56-104` including its diff-manager hardcode bug),
+   the independent mention diff manager + its seen-heads KV entry (D4),
+   `read`/`mentionRead` bools + their indexes,
    `SetReadFlag`, `getReadFilter` paths, `firstAddSeq` field + index,
    `GetUnreadMessagesComputed`, `GetReadFrontier`/`ReadFrontierProvider`, the
    AddSeq conjunct of `dominated` (the watermark object may remain solely as the
@@ -339,10 +361,17 @@ The CORE works with zero labels — that makes the rollout safely incremental:
 
 ## 8. Mention counter
 
-Identical machinery with the `hasMention` filter and its **own frontier**
-(`diffManagerMentions`) → own `maxF`, own `bandIds`, `pastMention` label.
-Mention immutability post-create (§3) makes the fold exact. Own mentions are
-excluded by the counted predicate (own messages are never counted).
+**A filter, not a dimension (D4).** The mention counter shares THE frontier
+(the message frontier), the same `maxF`, the same band; the only difference is
+the `hasMention` predicate applied at query time (`CountCoreUnread`'s counter
+filter) — so mention-unread ⟺ unread ∧ hasMention, and "message read but its
+mention unread" cannot exist. One cached state serves both counters. The
+`pastMention` label remains (it feeds the mention zero-certificate), and
+mention immutability post-create (§3) keeps it exact. Own mentions are
+excluded by the counted predicate (own messages are never counted). The legacy
+independent mention diff manager exists only as the bool path's shadow oracle
+until cutover; the shadow soak doubles as the measurement of how far the two
+legacy frontiers actually drift in the wild.
 
 ---
 
@@ -395,8 +424,9 @@ New, in priority order:
    certificate soundness: `bandCreated(H*) = 0 ⟹ band = ∅` (Theorem 2).
 4. **Theorem 3 unit** — attach-after-resolve never needs an ancestry check;
    in-past insert lands in `bandSet`; delete removes it.
-5. **Frontier flows** — advance / markunread / pending-head-attach event diffs
-   match `SetReadFlag.idsModified` semantics (S-cat17 class).
+5. **Frontier flows** — advance / pending-head-attach event diffs match
+   `SetReadFlag.idsModified` semantics (the frontier is monotone per D5;
+   regression flows no longer exist).
 6. **Snapshot guard** — synthetic non-genesis snapshot → label-untrusted mode,
    over-count direction, loud log.
 7. **Sign-off flip** — `S-concurrent-merge`/`S-cat12`/`S-cat19` → MATCH;
@@ -426,9 +456,10 @@ without the O(tree) cold-start rebuild (~18.6 s) that motivated its removal.
   the subtlest code; pin with the Theorem 4 property test before relying on it.
   (Stage 1 doesn't need it — CORE has no fold.)
 - **R2 — frontier-change walk worst case** is O(unread + band) when the
-  certificate is non-zero on a huge-tail frontier (e.g. markunread-to-ancient in
-  a 100k chat with concurrency below the cut). Once per frontier change, cached;
-  still ≪ O(tree). Accepted.
+  certificate is non-zero on a huge-tail frontier (e.g. a long-dormant chat
+  with concurrency below the old cut). Once per frontier change, cached;
+  still ≪ O(tree). Accepted. (With D5 the frontier is monotone, so the
+  ancient-frontier case arises only from dormancy, never from regression.)
 - **R3 — sidecar growth** is unbounded-with-history by design (labels must
   outlive deletes). Acceptable at ~5 MB/100k; revisit only if chat trees grow
   orders beyond that.
@@ -466,8 +497,14 @@ transition detection in `handleReactionsModify`
 - **Counted entity:** a *reaction event* `r` — a counted reaction-add detected
   at apply — with coordinates `(g(r), msgId(r), reactor(r), emoji(r))`.
 - **Counter:** `|{ live messages m : ∃ counted reaction event r → m, ¬read*(r) }|`
-  against the reactions frontier `F_r` (the existing `diffManagerReactions`
-  seen-heads set, kept as-is).
+  against the reactions frontier `F_r`. **Per D4, `F_r` = THE frontier** (the
+  message frontier): reading a message reads its reactions, and reading any
+  newer message causally covers older reaction events automatically (every
+  later change links all heads). The legacy `diffManagerReactions` survives
+  only as the bool-era oracle until Stage 4 lands. Client-flow note for
+  cutover: "viewed the chat" must advance the frontier to the currently
+  visible heads (any change type), so a reaction that is itself a tree head
+  is covered when seen.
 - **Decomposition (Theorem 1, verbatim):** `r` unread ⟺ `g(r) > maxF_r` or
   `r ∈ bandSet_r(F_r)`. Reaction events are changes; nothing in §2 is
   message-specific. Theorem 3's O(1) maintenance applies unchanged.

--- a/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
+++ b/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
@@ -1,0 +1,433 @@
+# Option D — Causal Ordinals: Convergent O(1) Read Counters Without Read Flags
+
+Status: **implementation spec** (supersedes `2026-06-03-read-counter-hybrid-design.md`
+as the product design; reuses its §5 walk machinery internally).
+Companions: `2026-06-03-chat-read-counter-computed-theory.md` (Theorems A/B, §5.3
+cross-device defect), `2026-06-03-read-counter-formal-problem.md` (abstract problem),
+adversarial verification report (agent af41306, 2026-06-03 session).
+
+**Base note (2026-06-10).** This spec is implemented on branch
+`go-7290-chat-read-counter-causal-ordinals`, cut from `develop` @ `2f913ae15`.
+develop still runs the **old DiffManager** read counter (the `(OrderId, AddSeq)`
+watermark of PR #3154 was never merged; `readwatermark.go` is absent from
+develop). Consequences for this spec:
+- **D2 is a no-op user-visibly on this base**: develop already serves exact
+  `read*` (DAG-ancestor) semantics, so Option D changes no user-facing behavior —
+  it removes the O(tree) cold-start rebuild (~18.6 s Android) and the
+  `SetReadFlag` write amplification while *keeping* the semantics. There is no
+  accepted-divergence map to empty here; that paragraph applies only if the
+  watermark branch ever lands first.
+- §6's "Removed" list maps on this base to the **old-approach** surfaces: the
+  per-message `read`/`mentionRead` bools + `SetReadFlag`, and the
+  `objecttree.DiffManager` rebuild path (`NewDiffManager`/`BuildHistoryTree` at
+  init). The watermark/computed surfaces named in §6 exist only on the
+  prototype branches (`go-7290-chat-read-counter`,
+  `go-7290-chat-read-counter-computed`), which remain as reference material —
+  their scenario catalog, harness, and measurement tooling are carried over or
+  ported as §11 prescribes.
+
+Decisions this spec rests on:
+- **D1 (product, 2026-06-10):** snapshots will NOT be used for CRDT chat trees.
+  Verified current reality: chat store changes never set `IsSnapshot`
+  (`store.go:319-324`; only the genesis root is a snapshot, `change.go:55-61`),
+  any-sync v0.12.4 has no snapshot policy/compaction for object trees (only
+  whole-tree delete, `storage.go:351-362`; `reduceTree` is in-memory only,
+  `treereduce.go:31-32`), and a new device materializes **full history** locally
+  (`objecttree.go:820-849`, `loaditerator.go:106-125`). §10 turns D1 into a
+  guarded contract.
+- **D2 (product):** adopt **exact causal semantics** `read*(X) ⟺ ∃H∈F: X ⪯ H` —
+  the old convergent DiffManager semantics. This eliminates the three accepted
+  single-device divergences (`S-concurrent-merge`, `S-cat12`, `S-cat19` flip to
+  MATCH) and the permanent cross-device count divergence (theory §5.3). The
+  sign-off gate's `watermarkAcceptedDivergence` map is emptied.
+- **D3:** the mutable per-message `read`/`mentionRead` bools and `SetReadFlag`
+  are removed; read status is computed. `AddSeq` remains only as the replay
+  cursor; it is no longer a read-model axis.
+
+Notation (as in the companion docs): `≺`/`⪯` causal order; `X ∥ Y` concurrent;
+`g(X)` = OrderId (replica-invariant order); `F` = seen-head frontier (synced as a
+change-id set, resolved locally; unresolved heads pending); `maxF = max_{H∈F} g(H)`
+over resolved heads; `Stable(F) = {X : ∃H∈F, X ⪯ H}`; "counted" = peer
+(`creator ≠ me`) message matching the counter (messages: all; mentions:
+`hasMention`); `Hloc` = current local tree heads.
+
+---
+
+## 1. The design in one page
+
+Two layers. The CORE is self-sufficient (exact + convergent on its own); LABELS
+make it O(1) on the hot paths.
+
+**CORE — band-set decomposition.** For each counter, maintain one small
+device-local cached object per frontier:
+
+```
+bandSet(F) = { live counted messages m : g(m) ≤ maxF ∧ m ∉ Stable(F) }
+```
+
+— the (usually empty) set of unread messages *below* the frontier cut. Then:
+
+```
+unreadCount = COUNT(live counted, g > maxF)   [existing _o.id index]  +  |bandSet(F)|
+unreadIds   = RANGE(live counted, g > maxF)                           ∪  bandSet(F)
+status(X)   = g(X) > maxF ? UNREAD : (X ∈ bandSet(F) ? UNREAD : READ)
+```
+
+`bandSet` is recomputed by a bounded walk **only when F changes** (a user read /
+markunread — rare), is maintained **O(1) per arriving change** in between
+(Theorem 3 below), and is persisted, so queries — including cold start — never
+walk and never open the tree.
+
+**LABELS — causal ordinals.** Per change `X`, immutable, locally computed,
+never synced:
+
+```
+pastMsg(X)     = |strict-past(X) ∩ counted message-creates|     (message ordinal)
+pastMention(X) = |strict-past(X) ∩ my-mention creates|
+pastSize(X)    = |strict-past(X)|
+```
+
+Any function of the causal past is replica-invariant and immutable by
+construction (the past is content-addressed and append-only); per-account
+functions (`creator ≠ me`, mentions-of-me) are valid because convergence (P2) is
+only required across **one account's** devices, which compute the same function
+of the same DAG. Labels serve three jobs: the **zero-band certificate** (skip
+the walk entirely — the common case), the walk's **termination bound**, and
+**O(1) single-head counts** in the no-delete case.
+
+**Why this is exact and convergent.** `read*` and every quantity above is a
+function of (DAG, F-as-id-set) and the account — no device-local term (`AddSeq`
+appears nowhere). The count identity is Theorem 1; the O(1) maintenance is
+Theorem 3. The canonical cross-device case (`a1 ∥ b1`, `F={b1}`): `a1` is in
+`bandSet` on **every** device → unread = 1 everywhere (the watermark gave 0 vs 1
+permanently).
+
+---
+
+## 2. Correctness foundation
+
+All statements assume parent-first attachment (verified: a change attaches only
+when its full causal past is attached — `tree.go:248-275`, waitList
+`tree.go:239,258-263,313-325`) and OrderId stability of stored changes (the
+existing system-wide assumption, theory §7 A8).
+
+**Theorem 1 (count identity, delete-proof).** With the live message collection
+as the universe `U` (hard deletes remove rows — `state.go:323-324`),
+
+```
+|{m ∈ U : ¬read*(m)}| = |{m ∈ U : g(m) > maxF}| + |bandSet(F)|.
+```
+
+*Proof.* Split `U` by `g ≤ maxF` vs `g > maxF`. For `g(m) > maxF`: if
+`m ∈ Stable(F)` then `m ⪯ H` for some head, so `g(m) ≤ g(H) ≤ maxF` (g extends
+≺) — contradiction; hence every such `m` is unread (hybrid doc Lemma 2). For
+`g(m) ≤ maxF`: unread ⟺ `m ∉ Stable(F)` ⟺ `m ∈ bandSet(F)` by definition. The
+two parts are disjoint and exhaust `U`. Deletes are handled by construction:
+both terms range over the live collection / live set. ∎
+
+**Theorem 2 (zero-band certificate, sound under deletes).** Let `H*` be the
+resolved head with `g(H*) = maxF`. Define over the **create universe** (label
+sidecar rows, which deletes never remove):
+
+```
+bandCreated(H*) = createdRank(maxF) − pastMsg(H*) − [H* is a counted create]
+```
+
+where `createdRank(c)` = number of counted creates with `g ≤ c` (indexed count
+on the sidecar). Then `bandSet(F) ⊆ band_created(F) ⊆ band_created(H*)`, and
+`|band_created(H*)| = bandCreated(H*)`. Hence **`bandCreated(H*) = 0 ⟹
+bandSet(F) = ∅`** — and the walk is skipped.
+
+*Proof.* `Stable(F) ⊇ Stable({H*})` ⟹ band(F) ⊆ band({H*}) (more heads only
+cover more). Over creates, `band({H*}) = {creates : g ≤ maxF} ∖ (past(H*) ∪
+{H*})`, whose size is `createdRank − pastMsg − [H*]` because
+`past(H*) ∪ {H*} ⊆ {g ≤ maxF}` (Lemma 1) and `pastMsg` counts exactly the
+counted creates in the strict past. Deletes only shrink the live band relative
+to the created band. ∎
+
+The certificate is an exact count when no below-cut creates were deleted, and a
+sound upper bound always — which is all the fast path needs. It is also the
+walk's stop condition: terminate after emitting `bandCreated(H*)` members or
+when the boundary closes, whichever first.
+
+**Theorem 3 (O(1) incremental maintenance).** A change `X` newly attached to
+the local tree is never an ancestor of an already-resolved frontier head.
+Therefore the `bandSet` update rule on attach is, without any ancestry check:
+
+```
+if X is a counted live message and g(X) ≤ maxF:  bandSet += X    (in-past insert)
+if g(X) > maxF:                                  no action       (tail covers it)
+```
+
+*Proof.* Parent-first attachment: when head `H` attached, every ancestor of `H`
+was already attached. `X` attaches after `H`, so `X ⋠ H`. This holds for every
+resolved head; pending heads contribute nothing to `Stable` until they attach,
+and their attachment triggers a frontier re-resolve (§5). ∎
+
+This is also where the late in-past insert — the entire reason `AddSeq` existed —
+is handled *by construction*: the late arrival joins `bandSet` (stays unread,
+convergently), and **no existing label or cache entry changes**.
+
+**Theorem 4 (fold well-definedness / apply-order invariance).** Labels computed
+by the fold of §3 are identical on every replica of the account, regardless of
+batch partitioning or arrival order. *Proof sketch.* The fold consumes only
+`(parents' labels, parents' counted-flags)`; parent-first attachment guarantees
+parents are labeled first; by induction every label equals the closed-form
+`|strict-past ∩ ...|`, a pure function of the content-addressed DAG + account.
+The replay stream is OrderId-sorted (`GetAfterAddSeq(...).Sort(OrderKey)`,
+`storage.go:259-281`), which is parent-first since `g` extends `≺`. ∎ (Property
+test in §11 pins this with randomized batch splits.)
+
+---
+
+## 3. The label fold
+
+Computed at apply time for **every change** in the chat tree (messages, edits,
+deletes, reactions, system) — required because persisted seen heads can be
+arbitrary changes: `collectSeenHeads` walks all change types
+(`chatobject.go:802-821`), `MarkMessagesAsUnread` re-seeds from them
+(`reading.go:90-101`), and `readStoreTreeHook` marks `headsBeforeJoin`
+(`reading.go:218-232`).
+
+```
+counted(P)  = 1 iff P is a peer message-create for the counter (msg / my-mention)
+
+root:        pastMsg = pastMention = pastSize = 0
+k = 1 (P):   pastMsg(X) = pastMsg(P) + countedMsg(P)        (and analogously
+             pastMention, pastSize(X) = pastSize(P) + 1)     for the others)
+k ≥ 2:       past(X) = ⋃ᵢ (past(Pᵢ) ∪ {Pᵢ})  — union cardinalities via the
+             bounded meet-walk: dfsPrev from all parents with a shared visited
+             set, descending until the open branches converge into a common
+             covered region (the meet antichain); count counted creates seen
+             strictly above the meet per branch + the meet's own labels.
+             Bounded by the fork span (measured p50 = 2, p95 ≤ 28).
+```
+
+Notes:
+- On the **origin** device, every created change links all local heads
+  (`objecttree.go:378`), so `past(X)` = the entire local tree and the origin can
+  stamp from running totals — an optimization only; receivers always run the
+  fold (a received peer change links the *author's* heads, a subset of the
+  receiver's tree).
+- Mentions fold exactly like messages: `HasMention` is computed once at create
+  (`chathandler.go:101-105`) and **never recomputed on edit** (the `ContentKey`
+  modify path re-marshals without mention detection, `chathandler.go:227-234`) —
+  mention state is immutable post-create, so no cut-dependent edit logic exists.
+- Deletes: a delete change's past always contains its target's create (the
+  deleting device had the create attached; Property M). Deletes do **not** enter
+  `pastMsg` (the count identity uses the live collection, Theorem 1); the fold
+  just labels the delete change like any other (its own labels are needed if it
+  ever becomes a seen head).
+- Reactions: **out of scope** — the reactions counter keeps its existing path;
+  its dedup semantics ("messages with unread reactions") don't fit cardinality
+  labels cleanly.
+
+---
+
+## 4. Storage
+
+**Label sidecar** — new device-local collection in crdt.db (per chat object),
+never synced, rows immutable, **never deleted** (a deleted message's create
+change can still be a seen head, so labels must outlive the message row — this
+is why labels do NOT live on the `chats` docs; note the old `_change_orders`
+precedent is gone, migrated to `_meta` and dropped on init,
+`state.go:32-39,127-144`; the local-only-field precedent is `firstAddSeq`,
+`chatmodel.go:55-58`):
+
+```
+readlabels: { id (change id), o (OrderId), kind (countedMsg/countedMention/other),
+              pastMsg, pastMention, pastSize }
+index: (o)            — serves createdRank(cut) for the certificate
+```
+
+Size: ~40–60 B/row → ~5 MB for a 100k-change chat. Keyed by change id ⇒ stable
+under treemigrator renumber (`treemigrator.go:89-91` resets only AddSeq) — an
+explicit improvement over every AddSeq-based scheme.
+
+**Frontier cache** — device-local collection in crdt.db (NOT the synced
+seen-heads KV — that value is merged across devices, `store.go:183-195,420-437`):
+
+```
+readfrontier: { counterType, frontierHash (resolved head ids, sorted),
+                maxF, bandIds [], updatedAt }
+```
+
+Persisted ⇒ cold start reads it directly; no tree open, no walk.
+
+---
+
+## 5. Runtime flows
+
+**Query (count / ids / status)** — never walks, never opens the tree:
+indexed range COUNT/scan on the live `chats` collection (`_o.id` index exists,
+`repository.go:147`) + the cached `bandIds`. Status is stamped in-memory at
+marshal time (own messages: always read).
+
+**Change arrives (replay or live):** fold labels (§3, O(1) linear / meet-walk on
+merges); apply Theorem 3's O(1) `bandSet` rule; if the change is a delete of a
+band member, remove it from `bandIds`.
+
+**Frontier changes** (`MarkSeenHeads` advance, markunread re-seed, a pending
+head attaching, cross-device KV update):
+1. Resolve heads (unresolved → pending, omitted — the existing safe over-count,
+   `readwatermark.go:54-59`).
+2. Compute `maxF`; run the certificate (Theorem 2). If 0 → `bandIds = ∅`, done.
+3. Else run the bounded walk (hybrid doc §5 mechanics: backward from
+   `Hloc ∪ F` in decreasing `g`; F-reachable = read; stop at the read boundary),
+   self-terminated by the certificate bound. Worst case O(unread + band) point
+   lookups — paid once per frontier change, then cached. (The certificate makes
+   the expensive case rare: a huge-tail cold frontier with `bandCreated = 0`
+   skips the walk entirely.)
+4. Persist the cache; emit transition events:
+   - read-advance `F_old → F_new`: newly-read =
+     `(band_old ∖ band_new) ∪ (range (maxF_old, maxF_new] ∖ band_new)`
+   - markunread regression: newly-unread =
+     `(band_new ∖ band_old) ∪ (range (maxF_new, maxF_old] ∖ band_old)`
+   One range scan + two tiny set diffs — replaces `SetReadFlag.idsModified`.
+
+**Unlabeled head** (legacy change, backfill not done): skip the certificate,
+run the walk (CORE mode) — still exact and convergent, just not O(1).
+
+---
+
+## 6. Plumbing changes (verified against code)
+
+1. **`PreviousIds` into the handler.** `storestate.ChangeSet`/`Change` carry no
+   parent ids today (`state.go:83-104`; `store_apply.applyChange` drops them,
+   `store_apply.go:49-67`). Add `PrevIds []string` and thread it from
+   `objecttree.Change` through `ChangeSet` → `Change` → `ChangeOp` (same shape
+   as the existing `AddSeq` threading).
+2. **Hook** = `ChatHandler.BeforeCreate/BeforeModify/BeforeDelete`
+   (`chathandler.go:73,149,156`) — co-located with the existing
+   `OrderId`/`HasMention` stamping; sidecar writes in the same tx as doc writes.
+3. **Repository**: `unreadCount`/`unreadIds`/status from §5's query path;
+   frontier-cache read/write; certificate query on the sidecar.
+4. **Removed** (after cutover soak): `read`/`mentionRead` bools + their indexes,
+   `SetReadFlag`, `getReadFilter` paths, `firstAddSeq` field + index,
+   `GetUnreadMessagesComputed`, `GetReadFrontier`/`ReadFrontierProvider`, the
+   AddSeq conjunct of `dominated` (the watermark object may remain solely as the
+   seen-heads set manager), `shadowComputedReadCount` scaffolding.
+5. **Kept**: seen-heads KV sync + cross-device merge + pending re-resolution
+   (`store.go:374-433`), `MarkReadMessages`/`MarkSeenHeads` flow, AddSeq as the
+   replay cursor.
+
+---
+
+## 7. Migration & staged rollout
+
+The CORE works with zero labels — that makes the rollout safely incremental:
+
+- **Stage 1 (CORE):** ship `bandSet` + tail queries computing read state via the
+  walk at frontier changes (no certificate). Already exact + convergent; cold
+  start = cached frontier, no tree. The bool path runs as shadow oracle.
+- **Stage 2 (LABELS):** ship the fold for new changes + the **one-time async
+  per-tree backfill fold** for history (topological pass; the
+  `cmd/readcounter-bandsize` bitset machinery processed 76k real changes in
+  seconds), in the existing gated backfill slot (`chatobject.go:343-364`) with
+  the established hardening: resolve under the tree lock, async + batched,
+  per-object done-marker, update-by-id. Until a tree's done-marker is set, it
+  runs in CORE mode.
+- **Stage 3 (cutover):** counters served by D; bool kept one release as a
+  divergence-logging shadow; then D3 deletions land.
+
+---
+
+## 8. Mention counter
+
+Identical machinery with the `hasMention` filter and its **own frontier**
+(`diffManagerMentions`) → own `maxF`, own `bandIds`, `pastMention` label.
+Mention immutability post-create (§3) makes the fold exact. Own mentions are
+excluded by the counted predicate (own messages are never counted).
+
+---
+
+## 9. What AddSeq/OrderId remain for
+
+`OrderId` keeps every role it has (storage order, range queries, UI ordering,
+the tail cut). `AddSeq` returns to its original storage role — the replay
+cursor (`GetAfterAddSeq`) — and exits the read model entirely. The
+(OrderId, AddSeq) dominance predicate is retired with the bool.
+
+---
+
+## 10. The snapshot contract (guarding D1)
+
+D's labels under-count if history below a snapshot horizon becomes unreadable —
+the one *unsafe* failure direction in the design. D1 says this will not happen
+for chat trees; the contract makes it observable instead of assumed:
+
+- **Invariant (documented here + in chatobject):** chat store-trees retain full
+  change history locally; the only snapshot is the genesis root.
+- **Runtime guard:** at chat tree open, if the common snapshot is not the
+  genesis root (or the root change is absent from storage), log loudly + mark
+  the object **label-untrusted**: certificates disabled, walks attempt CORE
+  mode; if the walk hits a missing ancestor, fall back to
+  "everything `g > maxF` unread + band unknown → report the tail count only and
+  flag over-count" — degrading toward **over-counting unread** (the safe
+  direction), never silent under-count.
+- If any-sync ever introduces store-tree snapshotting, labels must be anchored
+  on snapshot changes (the snapshot creator stamps cumulative counts) — a
+  designed extension point, not an emergency.
+
+---
+
+## 11. Tests
+
+Carried forward: the full 25-scenario catalog via a D engine in the existing
+harness (replacing the computed/watermark engines' role), the repository
+differentials, and the marshal/property suites that remain meaningful.
+
+New, in priority order:
+1. **Cross-device convergence gate** — extend the harness to per-device trees
+   with independent apply orders (the dimension it currently collapses,
+   `scenario_harness_test.go:174`): device A applies `[a1],[b1]`, device B
+   `[b1],[a1]`, `F={b1}` → assert **equal** counts (D: 1 = 1; the watermark's
+   0 ≠ 1 documented as the fixed regression).
+2. **Fold invariance property test** — random DAGs, random batch partitions per
+   replica → identical labels (Theorem 4).
+3. **Count identity property test** — random DAGs + frontiers + deletes:
+   `tail + |bandSet|` ≡ brute-force `read*` complement (Theorem 1), and
+   certificate soundness: `bandCreated(H*) = 0 ⟹ band = ∅` (Theorem 2).
+4. **Theorem 3 unit** — attach-after-resolve never needs an ancestry check;
+   in-past insert lands in `bandSet`; delete removes it.
+5. **Frontier flows** — advance / markunread / pending-head-attach event diffs
+   match `SetReadFlag.idsModified` semantics (S-cat17 class).
+6. **Snapshot guard** — synthetic non-genesis snapshot → label-untrusted mode,
+   over-count direction, loud log.
+7. **Sign-off flip** — `S-concurrent-merge`/`S-cat12`/`S-cat19` → MATCH;
+   `watermarkAcceptedDivergence` emptied (D2).
+
+---
+
+## 12. Costs
+
+| Path | Cost |
+|---|---|
+| Count / ids / status query (incl. cold start) | O(1) + one indexed range; no tree, no walk |
+| Change apply | + one fold (O(1) linear; meet-walk O(fork-span p95 ≤ 28) on merges) + one sidecar write |
+| Frontier change | certificate O(log N); walk only if `bandCreated > 0` (≈13% of trees overall; ~0 for chats), self-terminated |
+| Storage | ~40–60 B/change sidecar + tiny frontier cache, local-only |
+| Migration | one async O(N) fold pass per tree (seconds at 76k changes), once |
+
+vs the watermark: same or better query cost, **convergent**, no `SetReadFlag`
+write amplification, no bool indexes. vs the old DiffManager: same semantics,
+without the O(tree) cold-start rebuild (~18.6 s) that motivated its removal.
+
+---
+
+## 13. Risks & open items
+
+- **R1 — meet-walk implementation** (k≥2 fold): the union-cardinality walk is
+  the subtlest code; pin with the Theorem 4 property test before relying on it.
+  (Stage 1 doesn't need it — CORE has no fold.)
+- **R2 — frontier-change walk worst case** is O(unread + band) when the
+  certificate is non-zero on a huge-tail frontier (e.g. markunread-to-ancient in
+  a 100k chat with concurrency below the cut). Once per frontier change, cached;
+  still ≪ O(tree). Accepted.
+- **R3 — sidecar growth** is unbounded-with-history by design (labels must
+  outlive deletes). Acceptable at ~5 MB/100k; revisit only if chat trees grow
+  orders beyond that.
+- **R4 — D1 dependency**: §10's guard is mandatory in the first shipped stage,
+  not a follow-up.
+- **R5 — reactions** stay on the legacy path; aligning them with D (or with the
+  watermark cleanup) is a separate design.

--- a/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
+++ b/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
@@ -218,9 +218,10 @@ Notes:
   `pastMsg` (the count identity uses the live collection, Theorem 1); the fold
   just labels the delete change like any other (its own labels are needed if it
   ever becomes a seen head).
-- Reactions: **out of scope** — the reactions counter keeps its existing path;
-  its dedup semantics ("messages with unread reactions") don't fit cardinality
-  labels cleanly.
+- Reactions: covered in **§14 (Stage 4)**. Reaction changes are folded like any
+  other change; the sidecar gains a `pastReact` column (counted reaction-add
+  events in the strict past). The dedup-to-messages machinery is §14's — only
+  the *deduped count* needs more than label arithmetic.
 
 ---
 
@@ -329,6 +330,10 @@ The CORE works with zero labels — that makes the rollout safely incremental:
   runs in CORE mode.
 - **Stage 3 (cutover):** counters served by D; bool kept one release as a
   divergence-logging shadow; then D3 deletions land.
+- **Stage 4 (reactions, §14):** the reaction counter moves onto the same
+  machinery (event sidecar + refcounted unread-message set), retiring the
+  per-message mutable reaction-unread state and `ClearUnreadReactions`.
+  Independent of Stages 1–3; does not block them.
 
 ---
 
@@ -429,5 +434,115 @@ without the O(tree) cold-start rebuild (~18.6 s) that motivated its removal.
   orders beyond that.
 - **R4 — D1 dependency**: §10's guard is mandatory in the first shipped stage,
   not a follow-up.
-- **R5 — reactions** stay on the legacy path; aligning them with D (or with the
-  watermark cleanup) is a separate design.
+- **R5 — reactions** are covered by §14 (Stage 4). Residual risk lives in the
+  two semantics pins (S1 event definition, S2 counted predicate) — both must be
+  resolved against current behavior **before** implementing Stage 4; the §14
+  machinery is otherwise the same as the message counter's.
+
+---
+
+## 14. Reactions counter (Stage 4)
+
+The reaction counter ("messages with at least one unread reaction",
+deduplicated per message) moves onto the same CORE machinery, with one extra
+sidecar row type and one honest limitation: **the deduped count is not pure
+label arithmetic**, because count-distinct over targets does not fold into
+cardinalities. Everything else carries over verbatim.
+
+### 14.1 Today's surfaces (develop base — what Stage 4 retires)
+
+Per-message mutable unread-reaction state cleared by
+`ClearUnreadReactions(maxOrderId)` (`repository.go:710-733` — the known
+over-clear hazard), `GetNewestUnreadReactionOrderId` recompute scans
+(`repository.go:734`; consumed by the subscription's `UnreadReactionOrderId`,
+`chatsubscription/manager.go:217-222,506,570`), `GetAllUnreadReactionChangeIds`,
+and the `diffManagerReactions` full-tree stream. The apply-time add/remove
+transition detection in `handleReactionsModify`
+(`chathandler.go:245-270` — `wasPresent`/`isPresent` → `onReactionAdded`)
+**stays**: it is exactly the event source §14.3 logs.
+
+### 14.2 Model
+
+- **Counted entity:** a *reaction event* `r` — a counted reaction-add detected
+  at apply — with coordinates `(g(r), msgId(r), reactor(r), emoji(r))`.
+- **Counter:** `|{ live messages m : ∃ counted reaction event r → m, ¬read*(r) }|`
+  against the reactions frontier `F_r` (the existing `diffManagerReactions`
+  seen-heads set, kept as-is).
+- **Decomposition (Theorem 1, verbatim):** `r` unread ⟺ `g(r) > maxF_r` or
+  `r ∈ bandSet_r(F_r)`. Reaction events are changes; nothing in §2 is
+  message-specific. Theorem 3's O(1) maintenance applies unchanged.
+
+### 14.3 Storage and flows
+
+**Event rows** — sibling sidecar collection in crdt.db, immutable, local-only,
+never deleted (they must survive message deletion; liveness is checked at
+count time against the `chats` collection):
+
+```
+reactevents: { changeId, o, msgId, reactor, emoji, op (add|remove) }
+index: (o)
+```
+
+Written from the existing apply-time transition detection (`onReactionAdded`
+and its remove counterpart). The `readlabels` fold (§3) gains a `pastReact`
+column: counted reaction-**add** events in the strict past.
+
+**Unread set** — cached, device-local, persisted (the `bandSet` pattern):
+
+```
+unreadReactionMsgs: { msgId → refcount of unread counted events }
+counter = |keys(unreadReactionMsgs) ∩ live messages|
+```
+
+- **Frontier change (`F_r`):** zero-certificate first —
+  `unreadAddEvents = addEventRank(∞) − pastReact(H*) − [H* itself a counted add]`
+  over the create universe of event rows (sound upper bound by the Theorem 2
+  argument: un-reacts and message deletes only shrink the live set). If 0 →
+  counter is 0, done. Else one indexed scan of event rows with `o > maxF_r`
+  plus the band walk for `F_r`, refcounted into the map. O(events since the
+  read point), once, then cached.
+- **Event arrives:** O(1) — add → `refcount++` (Theorem 3: it cannot be covered
+  by a resolved head); remove → `refcount−−` under net-state semantics (S1);
+  message delete → drop the key.
+- **Subscription:** `UnreadReactionOrderId` (newest unread event's `g`) is read
+  off the cached map — the `GetNewestUnreadReactionOrderId` repo scan goes away.
+
+### 14.4 Semantics pins (resolve against current behavior BEFORE Stage 4)
+
+- **S1 — event definition.** Two options with different convergence strength:
+  **(a) content-based toggle-event** (any peer toggle on a counted message is
+  notify-worthy, add and remove alike): a pure function of the change content →
+  *fully* replica-invariant, the strongest convergence. **(b) apply-time
+  add-detection** (today's `onReactionAdded`): matches current behavior
+  exactly, but the add/remove classification of two *concurrent toggles of the
+  same (emoji, identity)* depends on local apply order — a pre-existing corner
+  of the current system that (b) inherits and (a) eliminates. Decide after
+  checking what the toggle change op actually carries (full reactions state vs
+  delta). The per-device counter is internally consistent either way (cert and
+  set derive from the same local event log); cross-device convergence is exactly
+  as strong as the chosen event definition.
+- **S2 — counted predicate.** Peer reactor only (`reactor ≠ me`); whose
+  messages count (all vs own-only is a product choice — match current); the
+  existing `reactionsCounterEpoch` cutoff stays (change `Timestamp` is in the
+  signed change → replica-invariant → convergent).
+
+### 14.5 Tests (additions to §11)
+
+8. **Reactions differential** — random event logs + frontier moves: cached
+   refcount map ≡ brute-force recompute from the event rows; counter matches
+   the legacy `ClearUnreadReactions` path on linear histories (where legacy is
+   correct), and documents the over-clear divergence where legacy is not.
+9. **Reactions cross-device gate** — the per-device-tree harness (§11.1) with
+   concurrent reaction events: equal counters on both devices under S1(a);
+   under S1(b), equal except the documented concurrent-toggle corner.
+10. **Lifecycle** — un-react retraction per S1, message-delete drops the key,
+    epoch cutoff respected, event rows survive message deletion.
+
+### 14.6 Cost
+
+Zero-certificate O(1); recompute O(unread events since the read point), once
+per frontier change, cached + persisted; O(1) per arriving event; ~40 B per
+reaction event in the sidecar. Retired: the per-message mutable
+reaction-unread writes, `ClearUnreadReactions`'s clear-storms (and over-clear
+bug), the `GetNewestUnreadReactionOrderId` scans, and the last full-tree diff
+manager stream.

--- a/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
+++ b/docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md
@@ -52,7 +52,9 @@ Decisions this spec rests on:
   mention diff manager (`diffManagerMentions`) and its seen-heads KV entry are
   retired at cutover; until then the shadow measures how far the two legacy
   frontiers drift apart in practice (expected: negligible — clients advance
-  both with the same ranges).
+  both with the same ranges). Product confirmation (2026-06-10): clients
+  expose a single "readAll" action — there is no separate per-counter read
+  flow whose behavior the collapse could change.
 - **D5 (product, 2026-06-10): `MarkMessagesAsUnread` is deprecated** (unused
   by clients) and is NOT implemented in the computed model; the RPC is removed
   at cutover (Stage 3). Consequence: the frontier is **monotone** — it only


### PR DESCRIPTION
## Context

The existing chat read-counter on `develop` uses the old DiffManager DAG-ancestor walk (`changediffer.go` `RemoveBefore`/`dfsPrev`) — exact and cross-device convergent, but O(tree) on every cold start (~18.6s on large trees). A watermark replacement (PR #3154) was designed for speed but introduced a permanent cross-device count divergence for late-arriving concurrent messages (AddSeq is device-local for concurrent changes — non-convergent by construction). That PR never merged.

This branch introduces **Option D — causal-ordinal CORE**: a convergent, O(1)-query read model using the causal structure of the any-sync objecttree directly, with no per-message read flags. Since `develop` still runs the old DiffManager, Option D introduces **zero user-visible semantic change** in Stage 1 — it runs as a flag-gated shadow (`readCoreShadowEnabled = false`) alongside the existing path.

Design spec: `docs/superpowers/specs/2026-06-10-read-counter-option-d-causal-ordinals.md`

## Key design decisions recorded in spec

- **D1**: Chat CRDT trees never snapshot (confirmed — only genesis root in any-sync v0.12.4); removes Option D's only unsafe failure mode.
- **D4**: One frontier, counters are filters. Reading a message reads its attachments (mention, reactions). Mention-unread = unread ∧ hasMention at query time. "Message read but mention unread" is unrepresentable by construction. Single "readAll" confirmed by product — no per-counter read flow exists.
- **D5**: `MarkMessagesAsUnread` deprecated (unused by clients), removed at cutover. Frontier is **monotone** — no regression flows, no regression cache-invalidation. Eliminates all three known bool-vs-CORE soak-divergence classes.

## What's in this PR (Stage 1 — CORE, no labels)

**`chatmodel.ComputeBand`** — the core DAG walk: decreasing-OrderId two-color traversal, pure function of (DAG, frontier-id-set), no AddSeq anywhere. Frontier seeds READ, local heads seed UNREAD, stops at the read boundary, emits band candidates. Verified by a 3,000-iteration randomized property test against a literal `read*` closure oracle (deliberately different algorithm).

**Cross-device convergence gate** — the test the watermark would fail: per-device real storage-backed objecttrees via `objecttree.NewMockChangeCreator` + `BuildTestableTree`, one `AddRawChanges` per delivery batch so AddSeq and lexid strings genuinely differ per device. The canonical `a1∥b1` shape (the permanent 0-vs-1 divergence case) now gates at 1=1. Randomized delivery partitions over 12 pairs × 6 frontiers.

**Flag-gated shadow wiring** (`readCoreShadowEnabled = false`):
- `source.ReadCoreSnapshotProvider` — type-assert, kept off the `Store` interface (no mock churn). Snapshot delivered under the object-tree lock.
- `repository.CountCoreUnread` — tail (indexed `_o.id > maxF`) + band (In-filter); counted = peer + counter filter; own-exclusion explicit.
- `chatobject.shadowReadCoreCount` in `markReadMessages` — logs divergences, non-fatal.

**Frontier cache + Theorem-3 incremental maintenance** (`readCoreManager`):
- One cached state (D4: one frontier serves both counters).
- Walk runs only on frontier change; unchanged frontier reuses cache (zero resolve calls).
- Theorem-3 hook in `ChatHandler.BeforeCreate/BeforeDelete`: a newly attached change can never be an ancestor of a resolved frontier head (parent-first attachment), so an arriving message at/below the cut joins the band with no ancestry check.
- Persisted device-locally in crdt.db (`<objectId>readcore`). Inert until first walk — zero cost while flag is off.
- In the shadow stage, persisted state is NOT trusted across restarts (re-walks and logs staleness signal). Trustable cold start = Stage-2 apply-cursor.

## Soak rule (once shadow is enabled)

- `CORE > bool` → flag residue (missed `onRemove` event etc.); CORE is correct.
- `CORE < bool` → **real alarm** (no benign class remains after D5).

## Not in this PR (staged rollout)

- **Stage 2**: `readlabels` sidecar + `pastMsg`/`pastMention` fold at apply time + `PreviousIds` plumbing through `storestate.ChangeSet` + gated async backfill + apply-cursor trustable cold start.
- **Stage 3**: Cutover — counters served by D; bool path removed; `MarkMessagesAsUnread` + its RPC chain deleted.
- **Stage 4**: Reactions counter on the same machinery (§14 of spec).

## Test plan

- [ ] `go test ./core/block/chats/chatmodel/` — `ComputeBand` + 3k-iter oracle property test
- [ ] `go test ./core/block/editor/chatobject/ -run TestReadCore` — cross-device convergence gate (canonical + branches/merge/late-insert + randomized)
- [ ] `go test ./core/block/chats/chatrepository/` — `CountCoreUnread` tail/band/mention/own/no-frontier
- [ ] `go test ./core/block/editor/chatobject/ -run TestComputeReadCoreCount` — shadow disabled no-op, non-provider degrade, agree+diverge on canonical shape, cache+incremental (walk-skip via resolve-call counting), mention-is-filter-over-message-frontier (D4 gate)
- [ ] `go test ./core/block/editor/chatobject/` — full chatobject suite (no regressions)
- [ ] All seven affected suites green: `source`, `sourceimpl`, `chats`, `chatmodel`, `chatrepository`, `chatsubscription`, `chatobject`