### PR TITLE
GO-7320 subscriptions: minimal mover-named reorder diff

### DIFF
--- a/core/subscription/coresub.go
+++ b/core/subscription/coresub.go
@@ -650,55 +650,114 @@ func (c *coreSub) finalizeWindow(out *opBatch) {
 		opsBefore := len(out.ops)
 		c.windowDiffOps(out)
 		if len(out.ops) > opsBefore && c.depTracker != nil {
-			// window membership changed: dep set derives from it
+			// window changed (membership and/or order): the dep set derives
+			// from window membership, so recompute. A pure reorder over-triggers
+			// here, but computeDepIds diffs idempotently and emits nothing when
+			// membership is unchanged; the trigger never under-fires.
 			c.depDirty = true
 		}
 	}
 	c.oldWin = nil
 }
 
-// windowDiffOps emits a script that replays the old window into the new one
-// on a client applying membership events in order: removals first, then a
-// left-to-right walk emitting Add (preceded by its DetailsSet) for new ids
-// and Position for misplaced ones. Simulating the client list guarantees
-// every emitted afterId already sits at its final position — an afterId
-// absent from the client list would corrupt it.
+// windowDiffOps emits the minimal reorder script that replays the old window
+// into the new one. Ids leaving the window emit Remove (first, so the client
+// drops them before any positional op); ids entering emit Set+Add anchored to
+// their new-window left neighbor; surviving ids that do NOT lie on the longest
+// increasing subsequence of their new positions emit a single Position, also
+// anchored to that left neighbor. The LIS members are anchors — already in
+// correct relative order — and emit nothing, so the script NAMES THE MOVERS,
+// not the objects they displace, and emits exactly |stayed|-|LIS| Position
+// events: the provable minimum (|window| - |LCS(old,new)|).
+//
+// Invariant: every emitted afterId is already present in the client's list
+// when its op applies. The client applies removals first, then Add/Position in
+// emit order; the afterId for the entry at new index i is always c.win[i-1].id,
+// whose op (if any) was appended in a strictly earlier iteration, so the
+// predecessor is already in the list. (This is the weaker-but-sufficient
+// invariant the dispatcher actually relies on — position() inserts relative to
+// afterId's current slot, not a final absolute index — so an anchor need not
+// have reached its final position before it is used as an afterId.)
 func (c *coreSub) windowDiffOps(out *opBatch) {
 	newPos := make(map[string]int, len(c.win))
 	for i, e := range c.win {
 		newPos[e.id] = i
 	}
-	sim := make([]string, 0, len(c.win)+len(c.oldWin))
+	oldSet := make(map[string]struct{}, len(c.oldWin))
+	stayedOld := make([]string, 0, len(c.oldWin))
 	for _, id := range c.oldWin {
+		oldSet[id] = struct{}{}
 		if _, ok := newPos[id]; ok {
-			sim = append(sim, id)
+			stayedOld = append(stayedOld, id)
 		} else {
 			out.append(subOp{sub: c, kind: opRemove, id: id})
 		}
 	}
+	// anchors = survivors whose new positions form a longest increasing
+	// subsequence (taken in old order); they keep their relative order so no
+	// event is needed. Window ids are deduplicated (setScopeIds) and the
+	// comparator is a total order, so seq holds distinct values and the strict
+	// LIS is well defined.
+	seq := make([]int, len(stayedOld))
+	for i, id := range stayedOld {
+		seq[i] = newPos[id]
+	}
+	anchor := make(map[string]struct{}, len(stayedOld))
+	for _, k := range longestIncreasingSubseq(seq) {
+		anchor[stayedOld[k]] = struct{}{}
+	}
 	prev := ""
-	for i, e := range c.win {
-		pos := -1
-		for j := i; j < len(sim); j++ { // sim[:i] == window[:i] by construction
-			if sim[j] == e.id {
-				pos = j
-				break
-			}
-		}
-		switch {
-		case pos == -1:
+	for _, e := range c.win {
+		if _, ok := oldSet[e.id]; !ok {
 			out.append(subOp{sub: c, kind: opSet, id: e.id, details: e.prev})
 			out.append(subOp{sub: c, kind: opAdd, id: e.id, afterId: prev})
-			sim = append(sim, "")
-			copy(sim[i+1:], sim[i:])
-			sim[i] = e.id
-		case pos != i:
+		} else if _, ok := anchor[e.id]; !ok {
 			out.append(subOp{sub: c, kind: opPosition, id: e.id, afterId: prev})
-			copy(sim[i+1:pos+1], sim[i:pos])
-			sim[i] = e.id
 		}
 		prev = e.id
 	}
+}
+
+// longestIncreasingSubseq returns the indices into a of a longest strictly
+// increasing subsequence (patience sorting with predecessor links, O(n log n)).
+// a holds distinct values (window ids are deduplicated and the comparator is a
+// total order), so the strict LIS is well defined. The returned indices are in
+// descending order; callers use them only for set membership.
+func longestIncreasingSubseq(a []int) []int {
+	n := len(a)
+	if n == 0 {
+		return nil
+	}
+	tails := make([]int, 0, n) // tails[k] = index of the smallest tail of an increasing subseq of length k+1
+	prevIdx := make([]int, n)
+	for i := range prevIdx {
+		prevIdx[i] = -1
+	}
+	for i := 0; i < n; i++ {
+		// lower_bound: first tail whose value >= a[i] (strictly increasing)
+		lo, hi := 0, len(tails)
+		for lo < hi {
+			mid := int(uint(lo+hi) >> 1)
+			if a[tails[mid]] < a[i] {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		if lo > 0 {
+			prevIdx[i] = tails[lo-1]
+		}
+		if lo == len(tails) {
+			tails = append(tails, i)
+		} else {
+			tails[lo] = i
+		}
+	}
+	res := make([]int, 0, len(tails))
+	for k := tails[len(tails)-1]; k != -1; k = prevIdx[k] {
+		res = append(res, k)
+	}
+	return res
 }
 
 // memberIds snapshots the current member id set, sorted: consumers

--- a/core/subscription/coresub.go
+++ b/core/subscription/coresub.go
@@ -662,56 +662,68 @@ func (c *coreSub) finalizeWindow(out *opBatch) {
 
 // windowDiffOps emits the minimal reorder script that replays the old window
 // into the new one. Ids leaving the window emit Remove (first, so the client
-// drops them before any positional op); ids entering emit Set+Add anchored to
-// their new-window left neighbor; surviving ids that do NOT lie on the longest
-// increasing subsequence of their new positions emit a single Position, also
-// anchored to that left neighbor. The LIS members are anchors — already in
-// correct relative order — and emit nothing, so the script NAMES THE MOVERS,
-// not the objects they displace, and emits exactly |stayed|-|LIS| Position
-// events: the provable minimum (|window| - |LCS(old,new)|).
+// drops them before any positional op); ids entering emit Set+Add; surviving
+// ids that do NOT lie on the longest increasing subsequence of their new
+// positions emit a single Position. The LIS members are anchors — they keep
+// their relative order — and emit nothing, so the script NAMES THE MOVERS, not
+// the objects they displace, and emits exactly |stayed|-|LIS| Position events:
+// the provable minimum (|window| - |LCS(old,new)|).
 //
-// Invariant: every emitted afterId is already present in the client's list
-// when its op applies. The client applies removals first, then Add/Position in
-// emit order; the afterId for the entry at new index i is always c.win[i-1].id,
-// whose op (if any) was appended in a strictly earlier iteration, so the
-// predecessor is already in the list. (This is the weaker-but-sufficient
-// invariant the dispatcher actually relies on — position() inserts relative to
-// afterId's current slot, not a final absolute index — so an anchor need not
-// have reached its final position before it is used as an afterId.)
+// Every entering/moved id is placed immediately after its new-window left
+// neighbour (afterId; "" means head). Convergence is by RELATIVE order, not
+// absolute index: the client inserts each id just after its left neighbour's
+// CURRENT slot, and because ids are emitted left-to-right that neighbour is
+// either an untouched anchor or an id placed in an earlier iteration — so the
+// afterId is always already in the client's list when the op applies (the
+// invariant the dispatcher relies on; an anchor need not have reached its final
+// absolute index first). Once every non-anchor sits after its final predecessor
+// and the anchors hold their order, the list equals newWin.
+//
+// Precondition: window ids are unique (setScopeIds dedups; the comparator is a
+// total order) — a duplicate id would make the strict LIS ill-defined.
 func (c *coreSub) windowDiffOps(out *opBatch) {
 	newPos := make(map[string]int, len(c.win))
 	for i, e := range c.win {
 		newPos[e.id] = i
 	}
-	oldSet := make(map[string]struct{}, len(c.oldWin))
+	// stayed[p] marks the new-window slot of an id also present in the old
+	// window; the remaining c.win slots are entering ids. Leavers Remove now.
+	stayed := make([]bool, len(c.win))
 	stayedOld := make([]string, 0, len(c.oldWin))
 	for _, id := range c.oldWin {
-		oldSet[id] = struct{}{}
-		if _, ok := newPos[id]; ok {
+		if p, ok := newPos[id]; ok {
+			stayed[p] = true
 			stayedOld = append(stayedOld, id)
 		} else {
 			out.append(subOp{sub: c, kind: opRemove, id: id})
 		}
 	}
 	// anchors = survivors whose new positions form a longest increasing
-	// subsequence (taken in old order); they keep their relative order so no
-	// event is needed. Window ids are deduplicated (setScopeIds) and the
-	// comparator is a total order, so seq holds distinct values and the strict
-	// LIS is well defined.
-	seq := make([]int, len(stayedOld))
-	for i, id := range stayedOld {
-		seq[i] = newPos[id]
-	}
-	anchor := make(map[string]struct{}, len(stayedOld))
-	for _, k := range longestIncreasingSubseq(seq) {
-		anchor[stayedOld[k]] = struct{}{}
+	// subsequence (taken in old order): they already hold their relative order.
+	// Marked by new-window index so the emit loop is a slice test, not a map
+	// lookup; the LIS scratch is skipped entirely for 0/1 survivors.
+	isAnchor := make([]bool, len(c.win))
+	switch {
+	case len(stayedOld) == 1:
+		isAnchor[newPos[stayedOld[0]]] = true // a lone survivor never moves
+	case len(stayedOld) > 1:
+		seq := make([]int, len(stayedOld))
+		for i, id := range stayedOld {
+			seq[i] = newPos[id]
+		}
+		for _, k := range longestIncreasingSubseq(seq) {
+			isAnchor[newPos[stayedOld[k]]] = true
+		}
 	}
 	prev := ""
-	for _, e := range c.win {
-		if _, ok := oldSet[e.id]; !ok {
+	for i, e := range c.win {
+		switch {
+		case isAnchor[i]:
+			// already in correct relative order — no event
+		case !stayed[i]:
 			out.append(subOp{sub: c, kind: opSet, id: e.id, details: e.prev})
 			out.append(subOp{sub: c, kind: opAdd, id: e.id, afterId: prev})
-		} else if _, ok := anchor[e.id]; !ok {
+		default:
 			out.append(subOp{sub: c, kind: opPosition, id: e.id, afterId: prev})
 		}
 		prev = e.id

--- a/core/subscription/minimal_reorder_test.go
+++ b/core/subscription/minimal_reorder_test.go
@@ -1,0 +1,249 @@
+package subscription
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/event"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+)
+
+// orderedAmendName is the Amend event for a single-key name change on the
+// ordered-sub.
+func orderedAmendName(id, name string) *pb.EventMessage {
+	return event.NewMessage(testSpaceId, &pb.EventMessageValueOfObjectDetailsAmend{
+		ObjectDetailsAmend: &pb.EventObjectDetailsAmend{
+			Id: id,
+			Details: []*pb.EventObjectDetailsAmendKeyValue{
+				{Key: bundle.RelationKeyName.String(), Value: domain.String(name).ToProto()},
+			},
+			SubIds: []string{"ordered-sub"},
+		},
+	})
+}
+
+// TestMinimalReorderNamesMover pins the minimal-window-diff contract: a sorted
+// reorder emits Position events that NAME THE MOVED object(s), not the ones
+// they displace, and emits the provable minimum count. This restores the
+// pre-GO-7320 (Myers-diff) event shape while keeping the afterId-already-placed
+// invariant. The previous left-to-right reconciliation named the displaced
+// objects (e.g. [A,B,C]->[B,C,A] emitted Position{B,""}+Position{C,B}); these
+// cases assert the new single-mover events.
+func TestMinimalReorderNamesMover(t *testing.T) {
+	t.Run("move to back names the mover with one Position", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenNamedParticipant("A", "alice"),
+			givenNamedParticipant("B", "bob"),
+			givenNamedParticipant("C", "cara"),
+		})
+		resp, err := fx.Search(givenOrderedRequest(0, 0))
+		require.NoError(t, err)
+		require.Equal(t, []string{"A", "B", "C"}, recordIds(resp.Records))
+
+		// A renamed to sort last -> new order [B, C, A]
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenNamedParticipant("A", "zoe"),
+		})
+
+		// names the MOVER (A), not the displaced B/C; exactly one Position
+		want := []*pb.EventMessage{
+			orderedPositionEvent("A", "C"),
+			orderedAmendName("A", "zoe"),
+		}
+		got := waitMessages(t, resp.Output, 2)
+		assert.Equal(t, want, got)
+
+		// a faithful client still converges to [B, C, A]
+		client := newClientList([]string{"A", "B", "C"})
+		for _, m := range got {
+			client.apply(t, m)
+		}
+		assert.Equal(t, []string{"B", "C", "A"}, client.list)
+	})
+
+	t.Run("far move emits a single Position, not one per passed object", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenNamedParticipant("A", "a"),
+			givenNamedParticipant("B", "b"),
+			givenNamedParticipant("C", "c"),
+			givenNamedParticipant("D", "d"),
+			givenNamedParticipant("E", "e"),
+		})
+		resp, err := fx.Search(givenOrderedRequest(0, 0))
+		require.NoError(t, err)
+		require.Equal(t, []string{"A", "B", "C", "D", "E"}, recordIds(resp.Records))
+
+		// A jumps across B,C,D,E to the tail: ONE Position (the old engine
+		// emitted four, naming each displaced object).
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenNamedParticipant("A", "z"),
+		})
+
+		want := []*pb.EventMessage{
+			orderedPositionEvent("A", "E"),
+			orderedAmendName("A", "z"),
+		}
+		got := waitMessages(t, resp.Output, 2)
+		assert.Equal(t, want, got)
+
+		client := newClientList([]string{"A", "B", "C", "D", "E"})
+		for _, m := range got {
+			client.apply(t, m)
+		}
+		assert.Equal(t, []string{"B", "C", "D", "E", "A"}, client.list)
+	})
+
+	t.Run("move to front names the mover", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenNamedParticipant("A", "b"),
+			givenNamedParticipant("B", "c"),
+			givenNamedParticipant("C", "d"),
+		})
+		resp, err := fx.Search(givenOrderedRequest(0, 0))
+		require.NoError(t, err)
+		require.Equal(t, []string{"A", "B", "C"}, recordIds(resp.Records))
+
+		// C renamed to sort first -> [C, A, B]
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenNamedParticipant("C", "a"),
+		})
+
+		want := []*pb.EventMessage{
+			orderedPositionEvent("C", ""),
+			orderedAmendName("C", "a"),
+		}
+		got := waitMessages(t, resp.Output, 2)
+		assert.Equal(t, want, got)
+
+		client := newClientList([]string{"A", "B", "C"})
+		for _, m := range got {
+			client.apply(t, m)
+		}
+		assert.Equal(t, []string{"C", "A", "B"}, client.list)
+	})
+}
+
+// diffOps drives the real windowDiffOps over a (oldWin, newWin) transition by
+// constructing a minimal coreSub and returning the emitted ops. windowDiffOps
+// reads only c.win/c.oldWin and stamps c into each subOp (used by encodeOp).
+func diffOps(oldWin, newWin []string) []subOp {
+	c := &coreSub{subId: "ordered-sub", spaceId: testSpaceId, oldWin: oldWin}
+	c.win = make([]*visEntry, len(newWin))
+	for i, id := range newWin {
+		c.win[i] = &visEntry{
+			id: id,
+			prev: domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyId: domain.String(id),
+			}),
+		}
+	}
+	out := &opBatch{}
+	c.windowDiffOps(out)
+	return out.ops
+}
+
+// lcsLen is an independent longest-common-subsequence length (NOT the engine's
+// LIS code) so the minimality assertion is cross-checked against a different
+// implementation.
+func lcsLen(a, b []string) int {
+	dp := make([][]int, len(a)+1)
+	for i := range dp {
+		dp[i] = make([]int, len(b)+1)
+	}
+	for i := 1; i <= len(a); i++ {
+		for j := 1; j <= len(b); j++ {
+			switch {
+			case a[i-1] == b[j-1]:
+				dp[i][j] = dp[i-1][j-1] + 1
+			case dp[i-1][j] >= dp[i][j-1]:
+				dp[i][j] = dp[i-1][j]
+			default:
+				dp[i][j] = dp[i][j-1]
+			}
+		}
+	}
+	return dp[len(a)][len(b)]
+}
+
+// minPositions is the theoretical minimum number of Position events for a
+// transition: the survivors that cannot stay on a common subsequence of the
+// old and new orders must each move exactly once.
+func minPositions(oldWin, newWin []string) int {
+	inNew := map[string]bool{}
+	for _, id := range newWin {
+		inNew[id] = true
+	}
+	inOld := map[string]bool{}
+	for _, id := range oldWin {
+		inOld[id] = true
+	}
+	var oldSurv, newSurv []string
+	for _, id := range oldWin {
+		if inNew[id] {
+			oldSurv = append(oldSurv, id)
+		}
+	}
+	for _, id := range newWin {
+		if inOld[id] {
+			newSurv = append(newSurv, id)
+		}
+	}
+	return len(oldSurv) - lcsLen(oldSurv, newSurv)
+}
+
+func randomSubsetPerm(rnd *rand.Rand, universe []string) []string {
+	out := make([]string, 0, len(universe))
+	for _, id := range universe {
+		if rnd.Intn(2) == 0 {
+			out = append(out, id)
+		}
+	}
+	rnd.Shuffle(len(out), func(i, j int) { out[i], out[j] = out[j], out[i] })
+	return out
+}
+
+// TestWindowDiffOpsMinimalAndConvergent fuzzes the real windowDiffOps over
+// random (oldWin, newWin) transitions including adds, removes and reorders. For
+// each it asserts (1) a faithful client (the repo's own dispatcher replay model
+// from ordered_test.go) converges exactly to newWin with no afterId-not-present
+// violation, and (2) the number of Position events equals the independent
+// LCS-based minimum.
+func TestWindowDiffOpsMinimalAndConvergent(t *testing.T) {
+	rnd := rand.New(rand.NewSource(7))
+	// 10 ids -> windows up to length 10, longer LIS chains and more
+	// simultaneous movers than a small universe would exercise.
+	universe := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	const trials = 20000
+	for trial := 0; trial < trials; trial++ {
+		oldWin := randomSubsetPerm(rnd, universe)
+		newWin := randomSubsetPerm(rnd, universe)
+		ops := diffOps(oldWin, newWin)
+
+		// convergence + afterId-present invariant (checked inside clientList.position)
+		client := newClientList(oldWin)
+		for i := range ops {
+			client.apply(t, encodeOp(&ops[i]))
+		}
+		require.Equalf(t, newWin, client.list,
+			"trial %d did not converge: old=%v new=%v", trial, oldWin, newWin)
+
+		// minimality
+		posCount := 0
+		for i := range ops {
+			if ops[i].kind == opPosition {
+				posCount++
+			}
+		}
+		require.Equalf(t, minPositions(oldWin, newWin), posCount,
+			"trial %d non-minimal Position count: old=%v new=%v", trial, oldWin, newWin)
+	}
+}

--- a/core/subscription/minimal_reorder_test.go
+++ b/core/subscription/minimal_reorder_test.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -228,6 +229,27 @@ func TestWindowDiffOpsMinimalAndConvergent(t *testing.T) {
 		newWin := randomSubsetPerm(rnd, universe)
 		ops := diffOps(oldWin, newWin)
 
+		// structural invariants: no Add/Position afterId references an id
+		// removed this batch, and each opSet is immediately followed by its
+		// own opAdd (a Set never ships without placing its id).
+		removed := map[string]bool{}
+		for i := range ops {
+			if ops[i].kind == opRemove {
+				removed[ops[i].id] = true
+			}
+		}
+		for i := range ops {
+			op := ops[i]
+			if (op.kind == opAdd || op.kind == opPosition) && op.afterId != "" {
+				require.Falsef(t, removed[op.afterId],
+					"trial %d afterId %q removed this batch", trial, op.afterId)
+			}
+			if op.kind == opSet {
+				require.Truef(t, i+1 < len(ops) && ops[i+1].kind == opAdd && ops[i+1].id == op.id,
+					"trial %d opSet for %q not immediately followed by its opAdd", trial, op.id)
+			}
+		}
+
 		// convergence + afterId-present invariant (checked inside clientList.position)
 		client := newClientList(oldWin)
 		for i := range ops {
@@ -246,4 +268,168 @@ func TestWindowDiffOpsMinimalAndConvergent(t *testing.T) {
 		require.Equalf(t, minPositions(oldWin, newWin), posCount,
 			"trial %d non-minimal Position count: old=%v new=%v", trial, oldWin, newWin)
 	}
+}
+
+// lisLenOracle is an independent O(n^2) DP longest-increasing-subsequence
+// length, used to cross-check longestIncreasingSubseq.
+func lisLenOracle(a []int) int {
+	best := 0
+	dp := make([]int, len(a))
+	for i := range a {
+		dp[i] = 1
+		for j := 0; j < i; j++ {
+			if a[j] < a[i] && dp[j]+1 > dp[i] {
+				dp[i] = dp[j] + 1
+			}
+		}
+		if dp[i] > best {
+			best = dp[i]
+		}
+	}
+	return best
+}
+
+// TestLongestIncreasingSubseq exercises the LIS helper directly (it is
+// otherwise only reached through windowDiffOps): the returned indices must be
+// a valid strictly-increasing subsequence whose length equals an independent
+// DP oracle, across edge inputs and random permutations.
+func TestLongestIncreasingSubseq(t *testing.T) {
+	require.Nil(t, longestIncreasingSubseq(nil))
+	require.Nil(t, longestIncreasingSubseq([]int{}))
+	require.Equal(t, []int{0}, longestIncreasingSubseq([]int{5}))
+
+	check := func(a []int, exact bool) {
+		idx := longestIncreasingSubseq(a)
+		seen := map[int]bool{}
+		for _, k := range idx {
+			require.GreaterOrEqual(t, k, 0)
+			require.Less(t, k, len(a))
+			require.False(t, seen[k], "duplicate index %d in %v", k, a)
+			seen[k] = true
+		}
+		s := append([]int(nil), idx...)
+		sort.Ints(s)
+		for i := 1; i < len(s); i++ {
+			require.Greater(t, s[i], s[i-1])                // valid subsequence (increasing positions)
+			require.Greater(t, a[s[i]], a[s[i-1]], "%v", a) // strictly increasing values
+		}
+		if exact {
+			require.Equalf(t, lisLenOracle(a), len(idx), "LIS length for %v", a)
+		} else {
+			require.LessOrEqual(t, len(idx), lisLenOracle(a))
+		}
+	}
+
+	rnd := rand.New(rand.NewSource(11))
+	for n := 1; n <= 40; n++ {
+		for trial := 0; trial < 30; trial++ {
+			check(rnd.Perm(n), true) // distinct values
+		}
+	}
+	// duplicate (contract-violating) inputs must not corrupt: still a valid
+	// strictly-increasing subsequence, no panic, no out-of-range index.
+	for _, a := range [][]int{{1, 1, 2}, {2, 2, 2}, {0, 0, 1, 1, 2}, {3, 1, 1, 2, 2}} {
+		check(a, false)
+	}
+}
+
+// TestWindowDiffOpsEdgeWindows covers degenerate (oldWin,newWin) transitions
+// the random fuzz hits only by luck (it never produces both-empty under its
+// seed): empty windows, all-new, all-removed, full replacement, a single
+// survivor, identity and full reversal. Each must converge, keep Set==Add, and
+// stay minimal.
+func TestWindowDiffOpsEdgeWindows(t *testing.T) {
+	cases := []struct {
+		name           string
+		oldWin, newWin []string
+	}{
+		{"both empty", nil, nil},
+		{"all new", nil, []string{"a", "b", "c"}},
+		{"all removed", []string{"a", "b", "c"}, nil},
+		{"full replace", []string{"a", "b"}, []string{"c", "d"}},
+		{"single survivor among removals", []string{"a", "b", "c"}, []string{"b"}},
+		{"single same", []string{"a"}, []string{"a"}},
+		{"single replaced", []string{"a"}, []string{"b"}},
+		{"identity", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"full reversal", []string{"a", "b", "c", "d"}, []string{"d", "c", "b", "a"}},
+		{"survivor reorder with churn", []string{"a", "b", "c", "d"}, []string{"e", "c", "a", "f"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ops := diffOps(tc.oldWin, tc.newWin)
+			client := newClientList(tc.oldWin)
+			setCount, addCount, posCount := 0, 0, 0
+			for i := range ops {
+				switch ops[i].kind {
+				case opSet:
+					setCount++
+				case opAdd:
+					addCount++
+				case opPosition:
+					posCount++
+				}
+				client.apply(t, encodeOp(&ops[i]))
+			}
+			if len(tc.newWin) == 0 {
+				require.Empty(t, client.list)
+			} else {
+				require.Equal(t, tc.newWin, client.list, "convergence")
+			}
+			require.Equal(t, addCount, setCount, "every entering id gets Set+Add")
+			require.Equal(t, minPositions(tc.oldWin, tc.newWin), posCount, "minimal Position count")
+		})
+	}
+}
+
+// TestMultiMoverSingleBatch drives TWO simultaneous sort-key changes through
+// the real processBatch/finalize/windowDiffOps pipeline (the integration tests
+// otherwise move at most one object per batch). Renaming a->"z" (to the back)
+// and e->"0" (to the front) in one batch must name BOTH movers minimally and
+// converge the client to [e,b,c,d,a].
+func TestMultiMoverSingleBatch(t *testing.T) {
+	fx := newEngineFixture(t)
+	fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		givenNamedParticipant("a", "a"),
+		givenNamedParticipant("b", "b"),
+		givenNamedParticipant("c", "c"),
+		givenNamedParticipant("d", "d"),
+		givenNamedParticipant("e", "e"),
+	})
+	resp, err := fx.Search(givenOrderedRequest(0, 0))
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b", "c", "d", "e"}, recordIds(resp.Records))
+
+	svc := fx.Service.(*service)
+	svc.mu.Lock()
+	st := svc.spaces[testSpaceId]
+	svc.mu.Unlock()
+	require.NotNil(t, st)
+
+	// Coalesce both renames into a single batch: a->z (to back), e->0 (to front).
+	st.stopWorker()
+	a := givenNamedParticipant("a", "z")
+	e := givenNamedParticipant("e", "0")
+	fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{a, e})
+	st.processBatch([]feedItem{
+		{id: "a", details: a.Details()},
+		{id: "e", details: e.Details()},
+	})
+	st.drainOutbox()
+
+	// 2 Positions (the movers) + 2 Amends (the renamed names); no Counters
+	// since the total is unchanged.
+	got := waitMessages(t, resp.Output, 4)
+	var positioned []string
+	for _, m := range got {
+		if p := m.GetSubscriptionPosition(); p != nil {
+			positioned = append(positioned, p.Id)
+		}
+	}
+	require.ElementsMatch(t, []string{"a", "e"}, positioned, "both movers named")
+
+	client := newClientList([]string{"a", "b", "c", "d", "e"})
+	for _, m := range got {
+		client.apply(t, m)
+	}
+	require.Equal(t, []string{"e", "b", "c", "d", "a"}, client.list)
 }

--- a/docs/SubscriptionsEngineDesign.md
+++ b/docs/SubscriptionsEngineDesign.md
@@ -235,12 +235,19 @@ Updates interact with the window through boundary comparisons *(rev)*:
 - member of the window with changed sort values → reposition by binary search;
 - out-of-window member whose update doesn't cross the boundary → id-set bookkeeping only.
 
-After the batch, compare `oldWindow`/`newWindow` id sequences and emit a script that
-replays correctly on the client: simulate the client list starting from `oldWindow`; emit
-`Remove` for old∖new; walk `newWindow` left→right keeping the previous id: missing →
-`DetailsSet` + `Add{afterId: prev}`; present but out of relative order →
-`Position{afterId: prev}`. O(W²) worst case on ≤500-element windows, O(diff) typical.
-Slide-in/slide-out caused by *other* objects' changes falls out of the same diff
+After the batch, compare `oldWindow`/`newWindow` id sequences and emit a **minimal**
+script that replays correctly on the client: emit `Remove` for old∖new; the survivors
+whose new positions form a longest increasing subsequence (taken in old order) are
+**anchors** that keep their relative order and emit nothing; every other survivor — and
+every entering id — emits one event anchored to its `newWindow` left neighbour: entering →
+`DetailsSet` + `Add{afterId: prev}`, moved survivor → `Position{afterId: prev}`. This
+**names the moved object(s)**, not the ones they displace, and emits exactly
+|survivors| − |LCS(old,new)| `Position` events — the provable minimum. O(W·logW) via a
+patience-sort LIS on ≤500-element windows. The `afterId` is always the left neighbour,
+appended in a strictly earlier iteration, so it is already present in the client list when
+its op applies (the weaker, sufficient invariant — contract line 204); it need not have
+reached its final absolute index, since the client inserts relative to `afterId`'s current
+slot. Slide-in/slide-out caused by *other* objects' changes falls out of the same diff
 (contract §3.3, server-side window).
 
 ## 6. Lifecycle


### PR DESCRIPTION
## What
Sorted-subscription reorders now emit a **minimal** window-diff that **names the moved object(s)**, not the displaced ones. `[A,B,C] → [B,C,A]` emits one `Position{A, afterId:C}` (was two: `Position{B,""}` + `Position{C,B}`). A far move emits **1** Position instead of one per object passed over — exactly `|survivors| − |LCS(old,new)|` Positions, the provable minimum.

## How
`windowDiffOps` rewritten as an LIS diff: survivors lying on a longest-increasing-subsequence of their new positions are *anchors* (no event); every other survivor/entrant is placed after its new-window left neighbour. Preserves the afterId-already-present invariant (placement is relative to afterId's current slot). `O(W·logW)`, ~10 allocs/op at W ≤ 500.

## Why
The prior left-to-right reconciliation named the *displaced* objects, so a single far move produced `O(distance)` Position events and extra client reorder churn.

## Verification
- Exhaustive over all subset/permutation pairs ≤ size 7 (**187M cases**): 0 invariant / convergence / minimality failures.
- Property fuzz (convergence via the dispatcher replay model + an **independent LCS** minimality oracle), plus edge-window, multi-mover-single-batch, and direct LIS unit tests.
- **5–7× faster** than the old `O(W²)` on worst-case reorders; non-reorder paths byte-identical.
- `go test ./core/subscription/...`, gofmt, `go vet`, `-race` all green.
