### PR TITLE
GO-7327 md: round-trip toggle blocks (export <details> / import to Toggle)

### DIFF
--- a/core/block/import/markdown/anymark/blocks_renderer.go
+++ b/core/block/import/markdown/anymark/blocks_renderer.go
@@ -137,6 +137,32 @@ func (r *blocksRenderer) OpenNewTextBlock(style model.BlockContentTextStyle, fie
 	r.openedTextBlocks = append(r.openedTextBlocks, &textBlock{Block: newBlock})
 }
 
+// OpenToggleBlock opens a Toggle text block (e.g. from a <details>/<summary>
+// element) with its summary text already set. The summary text is stored in the
+// model Text field (not only the text buffer) so that subsequently closed child
+// blocks are appended as children instead of having their text merged into the
+// still-empty toggle (see CloseTextBlock's parent-merge branch).
+func (r *blocksRenderer) OpenToggleBlock(summary string) {
+	r.curStyledBlock = model.BlockContentText_Toggle
+
+	newBlock := model.Block{
+		Id: bson.NewObjectId().Hex(),
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  summary,
+				Style: model.BlockContentText_Toggle,
+			},
+		},
+	}
+
+	r.openedTextBlocks = append(r.openedTextBlocks, &textBlock{Block: newBlock, textBuffer: summary})
+}
+
+// CloseToggleBlock closes the most recently opened Toggle block.
+func (r *blocksRenderer) CloseToggleBlock() {
+	r.CloseTextBlock(model.BlockContentText_Toggle)
+}
+
 func (r *blocksRenderer) GetBlocks() []*model.Block {
 	r.blocks = preprocessBlocks(r.blocks)
 	return r.blocks

--- a/core/block/import/markdown/anymark/blocks_renderer.go
+++ b/core/block/import/markdown/anymark/blocks_renderer.go
@@ -163,6 +163,42 @@ func (r *blocksRenderer) CloseToggleBlock() {
 	r.CloseTextBlock(model.BlockContentText_Toggle)
 }
 
+// AppendChildBlocks adds an already-parsed block tree (e.g. the inner content of
+// a self-contained <details>...</details> HTML block parsed via MarkdownToBlocks)
+// to the output and nests its top-level blocks under the currently open
+// container block (the nearest opened block that can hold children, i.e. the
+// Toggle we just opened). The passed-in blocks already encode their own internal
+// parent/child relationships via ChildrenIds; only the roots (blocks not
+// referenced as a child of any other passed-in block) are attached to the open
+// container so the whole subtree nests correctly.
+func (r *blocksRenderer) AppendChildBlocks(children []*model.Block) {
+	if len(children) == 0 {
+		return
+	}
+
+	var parentBlock *textBlock
+	for i := len(r.openedTextBlocks) - 1; i >= 0; i-- {
+		if isBlockCanHaveChild(r.openedTextBlocks[i].Block) {
+			parentBlock = r.openedTextBlocks[i]
+			break
+		}
+	}
+
+	referenced := make(map[string]bool)
+	for _, b := range children {
+		for _, cID := range b.ChildrenIds {
+			referenced[cID] = true
+		}
+	}
+
+	for _, b := range children {
+		r.blocks = append(r.blocks, b)
+		if parentBlock != nil && !referenced[b.Id] {
+			parentBlock.ChildrenIds = append(parentBlock.ChildrenIds, b.Id)
+		}
+	}
+}
+
 func (r *blocksRenderer) GetBlocks() []*model.Block {
 	r.blocks = preprocessBlocks(r.blocks)
 	return r.blocks
@@ -363,7 +399,20 @@ func (r *blocksRenderer) CloseTextBlock(content model.BlockContentTextStyle) {
 	}
 
 	if parentBlock != nil {
+		// A Toggle parent must never absorb a child's text. A Toggle gets its own
+		// title from the <summary> (set on OpenToggleBlock); its children always
+		// arrive as separate blocks to be nested. When the summary is empty the
+		// Toggle's Text == "", which would otherwise trigger the merge below and
+		// steal the first child's text, dropping the nesting (M2). Other container
+		// styles (Quote/list/checkbox) legitimately rely on this merge to lift the
+		// text of their first paragraph child into themselves, so we only special-
+		// case Toggle here.
+		parentIsToggle := false
+		if pt := parentBlock.GetText(); pt != nil && pt.Style == model.BlockContentText_Toggle {
+			parentIsToggle = true
+		}
 		if parentText := parentBlock.GetText(); parentText != nil && parentText.Text == "" &&
+			!parentIsToggle &&
 			!isBlockCanHaveChild(closingBlock.Block) && t.Text != "" {
 			parentText.Marks = t.Marks
 			parentText.Checked = t.Checked

--- a/core/block/import/markdown/anymark/blocks_renderer.go
+++ b/core/block/import/markdown/anymark/blocks_renderer.go
@@ -199,6 +199,45 @@ func (r *blocksRenderer) AppendChildBlocks(children []*model.Block) {
 	}
 }
 
+// AppendSiblingBlocks adds an already-parsed block tree (e.g. the content that
+// goldmark folded into a self-contained <details>...</details> HTML block AFTER
+// the matched </details>) to the output WITHOUT nesting it under any currently
+// open container. The blocks are emitted as siblings at the same level as the
+// details block itself, preserving their own internal parent/child structure.
+// This is used to recover trailing content that would otherwise be lost because
+// a goldmark HTML block ends at a blank line, not at </details> (Major 1).
+func (r *blocksRenderer) AppendSiblingBlocks(siblings []*model.Block) {
+	if len(siblings) == 0 {
+		return
+	}
+
+	// Determine the open container (if any) so we explicitly avoid nesting under
+	// it: when this remainder lives inside an OUTER still-open <details> (the
+	// recursive case), the siblings belong to that outer toggle and must be
+	// attached to it, just like AppendChildBlocks does for direct children.
+	var parentBlock *textBlock
+	for i := len(r.openedTextBlocks) - 1; i >= 0; i-- {
+		if isBlockCanHaveChild(r.openedTextBlocks[i].Block) {
+			parentBlock = r.openedTextBlocks[i]
+			break
+		}
+	}
+
+	referenced := make(map[string]bool)
+	for _, b := range siblings {
+		for _, cID := range b.ChildrenIds {
+			referenced[cID] = true
+		}
+	}
+
+	for _, b := range siblings {
+		r.blocks = append(r.blocks, b)
+		if parentBlock != nil && !referenced[b.Id] {
+			parentBlock.ChildrenIds = append(parentBlock.ChildrenIds, b.Id)
+		}
+	}
+}
+
 func (r *blocksRenderer) GetBlocks() []*model.Block {
 	r.blocks = preprocessBlocks(r.blocks)
 	return r.blocks

--- a/core/block/import/markdown/anymark/markdown.go
+++ b/core/block/import/markdown/anymark/markdown.go
@@ -190,6 +190,27 @@ func getCustomHTMLRules() []html2md.Rule {
 		},
 	}
 
+	// <details>/<summary> maps to a Toggle block. Re-emit it as a Markdown
+	// <details> element (matching the md exporter), so the goldmark pass turns it
+	// back into a Toggle with the inner content nested as children.
+	summary := html2md.Rule{
+		Filter: []string{"summary"},
+		Replacement: func(content string, selec *goquery.Selection, options *html2md.Options) *string {
+			return html2md.String("")
+		},
+	}
+
+	details := html2md.Rule{
+		Filter: []string{"details"},
+		Replacement: func(content string, selec *goquery.Selection, options *html2md.Options) *string {
+			summaryText := strings.TrimSpace(selec.Find("summary").First().Text())
+			summaryText = strings.ReplaceAll(summaryText, "\n", " ")
+			body := strings.TrimSpace(content)
+			res := "\n\n<details>\n<summary>" + summaryText + "</summary>\n\n" + body + "\n\n</details>\n\n"
+			return html2md.String(res)
+		},
+	}
+
 	italic := html2md.Rule{
 		Filter: []string{"cite", "dfn", "address"},
 		Replacement: func(content string, selec *goquery.Selection, options *html2md.Options) *string {
@@ -260,7 +281,7 @@ func getCustomHTMLRules() []html2md.Rule {
 	}
 
 	return []html2md.Rule{span, del, underscore, br, anohref,
-		simpleText, blockquote, italic, code, bdo, div, img, table}
+		simpleText, blockquote, summary, details, italic, code, bdo, div, img, table}
 }
 
 func extractImageSource(selec *goquery.Selection) string {

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -168,7 +168,7 @@ func (r *Renderer) renderHTMLBlock(_ util.BufWriter,
 	// <summary>, parse the inner content (between </summary> and the matching
 	// </details>) as Markdown into child blocks, nest them, then close the Toggle.
 	// Without this the block would be silently dropped (M3).
-	if summary, inner, ok := parseSelfContainedDetails(raw); ok {
+	if summary, inner, remainder, ok := parseSelfContainedDetails(raw); ok {
 		r.OpenToggleBlock(summary)
 		inner = strings.TrimSpace(inner)
 		if inner != "" {
@@ -180,6 +180,20 @@ func (r *Renderer) renderHTMLBlock(_ util.BufWriter,
 			}
 		}
 		r.CloseToggleBlock()
+		// goldmark's HTML block (type 6) ends at a blank line, NOT at the matched
+		// </details>. So any content after the matched close lives in this SAME
+		// HTMLBlock and must be emitted as SIBLINGS at this level (not children of
+		// the toggle we just closed), otherwise it is silently lost (Major 1). The
+		// remainder may itself contain another tight <details>, which is handled by
+		// routing it back through the normal MarkdownToBlocks parse.
+		if remainder = strings.TrimSpace(remainder); remainder != "" {
+			siblings, _, err := MarkdownToBlocks([]byte(remainder), r.GetBaseFilepath(), r.GetAllFileShortPaths())
+			if err != nil {
+				log.Errorf("failed to parse trailing content after self-contained <details>: %v", err)
+			} else {
+				r.AppendSiblingBlocks(siblings)
+			}
+		}
 		return ast.WalkContinue, nil
 	}
 
@@ -256,13 +270,17 @@ func isDetailsClose(raw string) bool {
 
 // parseSelfContainedDetails reports whether raw is a single self-contained
 // <details>...</details> block (it both opens and closes <details>). If so it
-// returns the decoded <summary> text and the inner content between the
-// </summary> and the </details> that closes the OUTER <details> (depth-aware, so
-// a nested <details> inside the content is kept intact for recursive parsing).
-func parseSelfContainedDetails(raw string) (summary string, inner string, ok bool) {
+// returns the decoded <summary> text, the inner content between the </summary>
+// and the </details> that closes the OUTER <details> (depth-aware, so a nested
+// <details> inside the content is kept intact for recursive parsing), and the
+// remainder of the block AFTER that matched </details>. The remainder is
+// non-empty when goldmark folded trailing content into the same HTML block (its
+// block ends at a blank line, not at </details>); the caller emits it as
+// siblings so it is not lost (Major 1).
+func parseSelfContainedDetails(raw string) (summary string, inner string, remainder string, ok bool) {
 	openLoc := reDetailsOpen.FindStringIndex(raw)
 	if openLoc == nil || !reDetailsEnd.MatchString(raw) {
-		return "", "", false
+		return "", "", "", false
 	}
 
 	// Decode the (HTML-escaped) summary, mirroring parseDetailsSummary.
@@ -280,12 +298,15 @@ func parseSelfContainedDetails(raw string) (summary string, inner string, ok boo
 	// Find the </details> that closes the OUTER <details> by tracking depth over
 	// the remaining open/close tags after the body start.
 	body := raw[bodyStart:]
-	closeRel := matchingDetailsClose(body)
+	closeRel, closeEnd := matchingDetailsClose(body)
 	if closeRel < 0 {
 		// Shouldn't happen given reDetailsEnd matched, but be safe.
-		return summary, strings.TrimSpace(body), true
+		return summary, strings.TrimSpace(body), "", true
 	}
-	return summary, body[:closeRel], true
+	// inner and remainder are sliced from the ORIGINAL body using the matched
+	// offsets, so masking (used only to find the true close) never reaches the
+	// returned text.
+	return summary, body[:closeRel], body[closeEnd:], true
 }
 
 // detailsOpenerTrailingContent returns any content that appears after the
@@ -300,21 +321,29 @@ func detailsOpenerTrailingContent(raw string) string {
 	return raw[sumLoc[1]:]
 }
 
-// matchingDetailsClose returns the byte offset (within s) of the </details> tag
-// that closes the outer <details>, accounting for nested <details> elements. It
-// scans for <details ...> openers and </details> closers, incrementing/
-// decrementing depth; the close at depth 0 is the match. Returns -1 if none.
-func matchingDetailsClose(s string) int {
+// matchingDetailsClose returns the byte offsets (within s) of the </details>
+// tag that closes the outer <details>, accounting for nested <details> elements
+// AND ignoring any <details>/</details> tags that fall inside fenced code blocks
+// (``` / ~~~) or inline code spans (backtick runs). It scans a masked copy of s
+// (code regions replaced with a neutral byte of EQUAL length, so all offsets map
+// 1:1 back to the original) for openers/closers, incrementing/decrementing
+// depth; the close at depth 0 is the match. It returns (start, end) where start
+// is the offset of the matched </details> and end is the offset just after it
+// (so the caller can slice inner = s[:start] and remainder = s[end:] from the
+// ORIGINAL text). Returns (-1, -1) if no matching close is found.
+func matchingDetailsClose(s string) (start int, end int) {
+	masked := maskCodeRegions(s)
+
 	type tok struct {
 		idx   int
 		end   int
 		isEnd bool
 	}
 	var toks []tok
-	for _, loc := range reDetailsOpen.FindAllStringIndex(s, -1) {
+	for _, loc := range reDetailsOpen.FindAllStringIndex(masked, -1) {
 		toks = append(toks, tok{idx: loc[0], end: loc[1], isEnd: false})
 	}
-	for _, loc := range reDetailsEnd.FindAllStringIndex(s, -1) {
+	for _, loc := range reDetailsEnd.FindAllStringIndex(masked, -1) {
 		toks = append(toks, tok{idx: loc[0], end: loc[1], isEnd: true})
 	}
 	// Sort tokens by position (simple insertion sort; lists are tiny).
@@ -327,11 +356,185 @@ func matchingDetailsClose(s string) int {
 	for _, tk := range toks {
 		if tk.isEnd {
 			if depth == 0 {
-				return tk.idx
+				return tk.idx, tk.end
 			}
 			depth--
 		} else {
 			depth++
+		}
+	}
+	return -1, -1
+}
+
+// maskCodeRegions returns a copy of s in which the bytes belonging to fenced
+// code blocks (``` or ~~~) and inline code spans (backtick runs) are replaced
+// with a neutral space, preserving the original byte length so that offsets into
+// the returned string map 1:1 onto the original. This lets the </details> close
+// scan ignore tags that live inside code, which goldmark would render verbatim
+// (Major 2). Only the FENCE/DELIMITER-driven structure is considered; real HTML
+// tags outside code stay intact.
+//
+// Fences: a line whose first non-space run is >= 3 of the same fence char
+// (` or ~) opens a fenced block; the block closes at the next line whose fence
+// run is the same char and at least as long (an opening info string is allowed,
+// a closing fence must not have one). Goldmark allows up to 3 leading spaces of
+// indentation on a fence line; we mirror that.
+//
+// Inline spans: a run of N backticks opens an inline code span that closes at
+// the next run of exactly N backticks on the same logical text. Code spans are
+// only scanned outside fenced blocks.
+func maskCodeRegions(s string) string {
+	out := []byte(s)
+	n := len(out)
+
+	maskRange := func(from, to int) {
+		for i := from; i < to && i < n; i++ {
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+
+	i := 0
+	atLineStart := true
+	for i < n {
+		if atLineStart {
+			// Detect a fence opener at the start of this line (allow up to 3 spaces).
+			lineStart := i
+			j := i
+			spaces := 0
+			for j < n && out[j] == ' ' && spaces < 4 {
+				j++
+				spaces++
+			}
+			if spaces < 4 && j < n && (out[j] == '`' || out[j] == '~') {
+				fenceChar := out[j]
+				runLen := 0
+				k := j
+				for k < n && out[k] == fenceChar {
+					k++
+					runLen++
+				}
+				if runLen >= 3 {
+					// Find the end of this fenced block: scan subsequent lines for a
+					// closing fence (same char, run >= runLen, no trailing non-space
+					// for backtick fences with info strings is not required to close).
+					// First, advance to end of the opening fence line.
+					lineEnd := indexByteFrom(out, '\n', k)
+					blockStart := lineStart
+					var blockEnd int
+					if lineEnd < 0 {
+						blockEnd = n
+					} else {
+						blockEnd = lineEnd + 1
+						// Now scan following lines.
+						closed := false
+						for blockEnd < n {
+							ls := blockEnd
+							le := indexByteFrom(out, '\n', ls)
+							var lineLimit int
+							if le < 0 {
+								lineLimit = n
+							} else {
+								lineLimit = le
+							}
+							// Inspect this line for a closing fence.
+							p := ls
+							sp := 0
+							for p < lineLimit && out[p] == ' ' && sp < 4 {
+								p++
+								sp++
+							}
+							clRun := 0
+							for p < lineLimit && out[p] == fenceChar {
+								p++
+								clRun++
+							}
+							// A closing fence: same char, run >= opening run, and only
+							// spaces after it on the line.
+							onlySpaces := true
+							for q := p; q < lineLimit; q++ {
+								if out[q] != ' ' && out[q] != '\t' {
+									onlySpaces = false
+									break
+								}
+							}
+							if sp < 4 && clRun >= runLen && onlySpaces {
+								if le < 0 {
+									blockEnd = n
+								} else {
+									blockEnd = le + 1
+								}
+								closed = true
+								break
+							}
+							if le < 0 {
+								blockEnd = n
+								break
+							}
+							blockEnd = le + 1
+						}
+						if !closed {
+							blockEnd = n
+						}
+					}
+					maskRange(blockStart, blockEnd)
+					i = blockEnd
+					atLineStart = true
+					continue
+				}
+			}
+		}
+
+		switch out[i] {
+		case '\n':
+			atLineStart = true
+			i++
+		case '`':
+			// Inline code span: run of N backticks .. matching run of N backticks.
+			runLen := 0
+			start := i
+			for i < n && out[i] == '`' {
+				i++
+				runLen++
+			}
+			// Find a closing run of exactly runLen backticks.
+			closeAt := -1
+			for p := i; p < n; {
+				if out[p] == '`' {
+					cl := 0
+					q := p
+					for q < n && out[q] == '`' {
+						q++
+						cl++
+					}
+					if cl == runLen {
+						closeAt = q
+						break
+					}
+					p = q
+				} else {
+					p++
+				}
+			}
+			if closeAt >= 0 {
+				maskRange(start, closeAt)
+				i = closeAt
+			}
+			// If unterminated, leave as-is (goldmark treats it as literal backticks).
+			atLineStart = false
+		default:
+			atLineStart = false
+			i++
+		}
+	}
+	return string(out)
+}
+
+func indexByteFrom(b []byte, c byte, from int) int {
+	for i := from; i < len(b); i++ {
+		if b[i] == c {
+			return i
 		}
 	}
 	return -1

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -154,8 +155,64 @@ func (r *Renderer) renderHTMLBlock(_ util.BufWriter,
 	source []byte,
 	node ast.Node,
 	entering bool) (ast.WalkStatus, error) {
-	// Do not render
+	if !entering {
+		return ast.WalkContinue, nil
+	}
+
+	raw := rawHTMLBlockText(source, node)
+
+	// A <details> element (with a <summary>) is the export encoding for a Toggle
+	// block. We open a Toggle here so the blocks parsed between this opening
+	// <details> and the closing </details> become its children, then close it on
+	// </details>. This mirrors the md exporter's <details>/<summary> output.
+	if summary, ok := parseDetailsSummary(raw); ok {
+		r.OpenToggleBlock(summary)
+		return ast.WalkContinue, nil
+	}
+	if isDetailsClose(raw) {
+		r.CloseToggleBlock()
+		return ast.WalkContinue, nil
+	}
+
+	// Other HTML blocks are not rendered.
 	return ast.WalkContinue, nil
+}
+
+func rawHTMLBlockText(source []byte, node ast.Node) string {
+	var buf bytes.Buffer
+	lines := node.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		line := lines.At(i)
+		buf.Write(line.Value(source))
+	}
+	return buf.String()
+}
+
+var (
+	reDetailsOpen = regexp.MustCompile(`(?is)<details\b[^>]*>`)
+	reSummary     = regexp.MustCompile(`(?is)<summary\b[^>]*>(.*?)</summary>`)
+	reDetailsEnd  = regexp.MustCompile(`(?is)</details\s*>`)
+	reHTMLTag     = regexp.MustCompile(`(?is)<[^>]+>`)
+)
+
+// parseDetailsSummary reports whether raw opens a (not self-closed) <details>
+// element, and if so returns the plain text of its <summary>, if present. A
+// block that both opens and closes <details> is not treated as an opener,
+// because there would be no following children to nest and no separate close.
+func parseDetailsSummary(raw string) (string, bool) {
+	if !reDetailsOpen.MatchString(raw) || reDetailsEnd.MatchString(raw) {
+		return "", false
+	}
+	summary := ""
+	if m := reSummary.FindStringSubmatch(raw); len(m) > 1 {
+		summary = strings.TrimSpace(reHTMLTag.ReplaceAllString(m[1], ""))
+		summary = Unescape(summary)
+	}
+	return summary, true
+}
+
+func isDetailsClose(raw string) bool {
+	return reDetailsEnd.MatchString(raw) && !reDetailsOpen.MatchString(raw)
 }
 
 func (r *Renderer) renderList(_ util.BufWriter,

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -2,6 +2,7 @@ package anymark
 
 import (
 	"bytes"
+	"html"
 	"net/url"
 	"path/filepath"
 	"regexp"
@@ -192,7 +193,6 @@ var (
 	reDetailsOpen = regexp.MustCompile(`(?is)<details\b[^>]*>`)
 	reSummary     = regexp.MustCompile(`(?is)<summary\b[^>]*>(.*?)</summary>`)
 	reDetailsEnd  = regexp.MustCompile(`(?is)</details\s*>`)
-	reHTMLTag     = regexp.MustCompile(`(?is)<[^>]+>`)
 )
 
 // parseDetailsSummary reports whether raw opens a (not self-closed) <details>
@@ -205,8 +205,13 @@ func parseDetailsSummary(raw string) (string, bool) {
 	}
 	summary := ""
 	if m := reSummary.FindStringSubmatch(raw); len(m) > 1 {
-		summary = strings.TrimSpace(reHTMLTag.ReplaceAllString(m[1], ""))
-		summary = Unescape(summary)
+		// The exporter HTML-escapes the summary text, so the captured content is
+		// the escaped plain text of the toggle title (e.g. "&lt;/details&gt;" for
+		// a literal "</details>"). Decode HTML entities to recover the original
+		// text exactly. We intentionally do NOT strip tag-shaped substrings here:
+		// since the content is escaped, any '<'/'>' belong to the user's title and
+		// stripping them would silently drop text.
+		summary = strings.TrimSpace(html.UnescapeString(m[1]))
 	}
 	return summary, true
 }

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -169,31 +169,7 @@ func (r *Renderer) renderHTMLBlock(_ util.BufWriter,
 	// </details>) as Markdown into child blocks, nest them, then close the Toggle.
 	// Without this the block would be silently dropped (M3).
 	if summary, inner, remainder, ok := parseSelfContainedDetails(raw); ok {
-		r.OpenToggleBlock(summary)
-		inner = strings.TrimSpace(inner)
-		if inner != "" {
-			children, _, err := MarkdownToBlocks([]byte(inner), r.GetBaseFilepath(), r.GetAllFileShortPaths())
-			if err != nil {
-				log.Errorf("failed to parse inner content of self-contained <details>: %v", err)
-			} else {
-				r.AppendChildBlocks(children)
-			}
-		}
-		r.CloseToggleBlock()
-		// goldmark's HTML block (type 6) ends at a blank line, NOT at the matched
-		// </details>. So any content after the matched close lives in this SAME
-		// HTMLBlock and must be emitted as SIBLINGS at this level (not children of
-		// the toggle we just closed), otherwise it is silently lost (Major 1). The
-		// remainder may itself contain another tight <details>, which is handled by
-		// routing it back through the normal MarkdownToBlocks parse.
-		if remainder = strings.TrimSpace(remainder); remainder != "" {
-			siblings, _, err := MarkdownToBlocks([]byte(remainder), r.GetBaseFilepath(), r.GetAllFileShortPaths())
-			if err != nil {
-				log.Errorf("failed to parse trailing content after self-contained <details>: %v", err)
-			} else {
-				r.AppendSiblingBlocks(siblings)
-			}
-		}
+		r.handleSelfContainedDetails(summary, inner, remainder)
 		return ast.WalkContinue, nil
 	}
 
@@ -225,6 +201,40 @@ func (r *Renderer) renderHTMLBlock(_ util.BufWriter,
 
 	// Other HTML blocks are not rendered.
 	return ast.WalkContinue, nil
+}
+
+// handleSelfContainedDetails materializes a self-contained <details>...</details>
+// block into a Toggle: the inner content (between </summary> and the matched
+// </details>) becomes child blocks, and any remainder folded into the same HTML
+// block by goldmark (its block ends at a blank line, not at </details>) is
+// emitted as SIBLINGS so it is not lost (Major 1). The remainder may itself
+// contain another tight <details>, handled by routing it back through the normal
+// MarkdownToBlocks parse.
+func (r *Renderer) handleSelfContainedDetails(summary, inner, remainder string) {
+	r.OpenToggleBlock(summary)
+	if inner = strings.TrimSpace(inner); inner != "" {
+		if children := r.parseMarkdownBlocks(inner, "inner content of self-contained <details>"); children != nil {
+			r.AppendChildBlocks(children)
+		}
+	}
+	r.CloseToggleBlock()
+	if remainder = strings.TrimSpace(remainder); remainder != "" {
+		if siblings := r.parseMarkdownBlocks(remainder, "trailing content after self-contained <details>"); siblings != nil {
+			r.AppendSiblingBlocks(siblings)
+		}
+	}
+}
+
+// parseMarkdownBlocks parses md into blocks using the renderer's base filepath
+// and file short paths, logging (and returning nil) on error. context describes
+// the source for the error message.
+func (r *Renderer) parseMarkdownBlocks(md, context string) []*model.Block {
+	blocks, _, err := MarkdownToBlocks([]byte(md), r.GetBaseFilepath(), r.GetAllFileShortPaths())
+	if err != nil {
+		log.Errorf("failed to parse %s: %v", context, err)
+		return nil
+	}
+	return blocks
 }
 
 func rawHTMLBlockText(source []byte, node ast.Node) string {
@@ -339,11 +349,13 @@ func matchingDetailsClose(s string) (start int, end int) {
 		end   int
 		isEnd bool
 	}
-	var toks []tok
-	for _, loc := range reDetailsOpen.FindAllStringIndex(masked, -1) {
+	opens := reDetailsOpen.FindAllStringIndex(masked, -1)
+	ends := reDetailsEnd.FindAllStringIndex(masked, -1)
+	toks := make([]tok, 0, len(opens)+len(ends))
+	for _, loc := range opens {
 		toks = append(toks, tok{idx: loc[0], end: loc[1], isEnd: false})
 	}
-	for _, loc := range reDetailsEnd.FindAllStringIndex(masked, -1) {
+	for _, loc := range ends {
 		toks = append(toks, tok{idx: loc[0], end: loc[1], isEnd: true})
 	}
 	// Sort tokens by position (simple insertion sort; lists are tiny).
@@ -387,102 +399,14 @@ func maskCodeRegions(s string) string {
 	out := []byte(s)
 	n := len(out)
 
-	maskRange := func(from, to int) {
-		for i := from; i < to && i < n; i++ {
-			if out[i] != '\n' {
-				out[i] = ' '
-			}
-		}
-	}
-
 	i := 0
 	atLineStart := true
 	for i < n {
 		if atLineStart {
-			// Detect a fence opener at the start of this line (allow up to 3 spaces).
-			lineStart := i
-			j := i
-			spaces := 0
-			for j < n && out[j] == ' ' && spaces < 4 {
-				j++
-				spaces++
-			}
-			if spaces < 4 && j < n && (out[j] == '`' || out[j] == '~') {
-				fenceChar := out[j]
-				runLen := 0
-				k := j
-				for k < n && out[k] == fenceChar {
-					k++
-					runLen++
-				}
-				if runLen >= 3 {
-					// Find the end of this fenced block: scan subsequent lines for a
-					// closing fence (same char, run >= runLen, no trailing non-space
-					// for backtick fences with info strings is not required to close).
-					// First, advance to end of the opening fence line.
-					lineEnd := indexByteFrom(out, '\n', k)
-					blockStart := lineStart
-					var blockEnd int
-					if lineEnd < 0 {
-						blockEnd = n
-					} else {
-						blockEnd = lineEnd + 1
-						// Now scan following lines.
-						closed := false
-						for blockEnd < n {
-							ls := blockEnd
-							le := indexByteFrom(out, '\n', ls)
-							var lineLimit int
-							if le < 0 {
-								lineLimit = n
-							} else {
-								lineLimit = le
-							}
-							// Inspect this line for a closing fence.
-							p := ls
-							sp := 0
-							for p < lineLimit && out[p] == ' ' && sp < 4 {
-								p++
-								sp++
-							}
-							clRun := 0
-							for p < lineLimit && out[p] == fenceChar {
-								p++
-								clRun++
-							}
-							// A closing fence: same char, run >= opening run, and only
-							// spaces after it on the line.
-							onlySpaces := true
-							for q := p; q < lineLimit; q++ {
-								if out[q] != ' ' && out[q] != '\t' {
-									onlySpaces = false
-									break
-								}
-							}
-							if sp < 4 && clRun >= runLen && onlySpaces {
-								if le < 0 {
-									blockEnd = n
-								} else {
-									blockEnd = le + 1
-								}
-								closed = true
-								break
-							}
-							if le < 0 {
-								blockEnd = n
-								break
-							}
-							blockEnd = le + 1
-						}
-						if !closed {
-							blockEnd = n
-						}
-					}
-					maskRange(blockStart, blockEnd)
-					i = blockEnd
-					atLineStart = true
-					continue
-				}
+			if blockEnd, ok := maskFencedBlock(out, i); ok {
+				i = blockEnd
+				atLineStart = true
+				continue
 			}
 		}
 
@@ -491,37 +415,7 @@ func maskCodeRegions(s string) string {
 			atLineStart = true
 			i++
 		case '`':
-			// Inline code span: run of N backticks .. matching run of N backticks.
-			runLen := 0
-			start := i
-			for i < n && out[i] == '`' {
-				i++
-				runLen++
-			}
-			// Find a closing run of exactly runLen backticks.
-			closeAt := -1
-			for p := i; p < n; {
-				if out[p] == '`' {
-					cl := 0
-					q := p
-					for q < n && out[q] == '`' {
-						q++
-						cl++
-					}
-					if cl == runLen {
-						closeAt = q
-						break
-					}
-					p = q
-				} else {
-					p++
-				}
-			}
-			if closeAt >= 0 {
-				maskRange(start, closeAt)
-				i = closeAt
-			}
-			// If unterminated, leave as-is (goldmark treats it as literal backticks).
+			i = maskInlineCodeSpan(out, i)
 			atLineStart = false
 		default:
 			atLineStart = false
@@ -529,6 +423,159 @@ func maskCodeRegions(s string) string {
 		}
 	}
 	return string(out)
+}
+
+// maskRange replaces every non-newline byte in out[from:to) with a space,
+// preserving newlines (and thus byte offsets and line structure).
+func maskRange(out []byte, from, to int) {
+	n := len(out)
+	for i := from; i < to && i < n; i++ {
+		if out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+}
+
+// fenceRun reports the fence character and run length of a fence at line offset
+// lineStart in out, allowing up to 3 leading spaces (goldmark's rule). ok is
+// true only when a run of >= 3 identical fence chars (` or ~) is found; bodyEnd
+// is the offset just past that run. When ok is false the other results are
+// meaningless.
+func fenceRun(out []byte, lineStart int) (fenceChar byte, runLen, bodyEnd int, ok bool) {
+	n := len(out)
+	j := lineStart
+	spaces := 0
+	for j < n && out[j] == ' ' && spaces < 4 {
+		j++
+		spaces++
+	}
+	if spaces >= 4 || j >= n || (out[j] != '`' && out[j] != '~') {
+		return 0, 0, 0, false
+	}
+	fenceChar = out[j]
+	k := j
+	for k < n && out[k] == fenceChar {
+		k++
+		runLen++
+	}
+	if runLen < 3 {
+		return 0, 0, 0, false
+	}
+	return fenceChar, runLen, k, true
+}
+
+// isClosingFence reports whether the line out[ls:lineLimit) is a closing fence
+// for an opening fence of fenceChar with run length openRun: same char, run
+// length >= openRun, and only spaces/tabs after the run.
+func isClosingFence(out []byte, ls, lineLimit int, fenceChar byte, openRun int) bool {
+	p := ls
+	sp := 0
+	for p < lineLimit && out[p] == ' ' && sp < 4 {
+		p++
+		sp++
+	}
+	if sp >= 4 {
+		return false
+	}
+	clRun := 0
+	for p < lineLimit && out[p] == fenceChar {
+		p++
+		clRun++
+	}
+	if clRun < openRun {
+		return false
+	}
+	for q := p; q < lineLimit; q++ {
+		if out[q] != ' ' && out[q] != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+// maskFencedBlock checks whether a fenced code block (``` or ~~~) opens at line
+// offset lineStart and, if so, masks the whole block (open fence line through
+// the closing fence line, or end of input if unterminated) and returns the
+// offset just past the block with ok=true. When no fence opens it returns
+// ok=false and leaves out unchanged.
+func maskFencedBlock(out []byte, lineStart int) (blockEnd int, ok bool) {
+	fenceChar, runLen, bodyEnd, ok := fenceRun(out, lineStart)
+	if !ok {
+		return 0, false
+	}
+	n := len(out)
+	// Advance past the opening fence line.
+	lineEnd := indexByteFrom(out, '\n', bodyEnd)
+	if lineEnd < 0 {
+		blockEnd = n
+	} else {
+		blockEnd = lineEnd + 1
+		blockEnd = scanToFenceClose(out, blockEnd, fenceChar, runLen)
+	}
+	maskRange(out, lineStart, blockEnd)
+	return blockEnd, true
+}
+
+// scanToFenceClose scans lines starting at offset start for the closing fence of
+// an open fence (fenceChar, openRun) and returns the offset just past the block
+// (the byte after the newline of the closing line, or end of input if no close
+// is found).
+func scanToFenceClose(out []byte, start int, fenceChar byte, openRun int) int {
+	n := len(out)
+	blockEnd := start
+	for blockEnd < n {
+		ls := blockEnd
+		le := indexByteFrom(out, '\n', ls)
+		lineLimit := le
+		if le < 0 {
+			lineLimit = n
+		}
+		if isClosingFence(out, ls, lineLimit, fenceChar, openRun) {
+			if le < 0 {
+				return n
+			}
+			return le + 1
+		}
+		if le < 0 {
+			return n
+		}
+		blockEnd = le + 1
+	}
+	return blockEnd
+}
+
+// maskInlineCodeSpan masks an inline code span starting at offset start (where
+// out[start] == '`'): a run of N backticks closed by the next run of exactly N
+// backticks. It returns the offset to continue scanning from. If the span is
+// unterminated nothing is masked and scanning continues just past the opening
+// run (goldmark treats it as literal backticks).
+func maskInlineCodeSpan(out []byte, start int) int {
+	n := len(out)
+	runLen := 0
+	i := start
+	for i < n && out[i] == '`' {
+		i++
+		runLen++
+	}
+	// Find a closing run of exactly runLen backticks.
+	for p := i; p < n; {
+		if out[p] != '`' {
+			p++
+			continue
+		}
+		cl := 0
+		q := p
+		for q < n && out[q] == '`' {
+			q++
+			cl++
+		}
+		if cl == runLen {
+			maskRange(out, start, q)
+			return q
+		}
+		p = q
+	}
+	return i
 }
 
 func indexByteFrom(b []byte, c byte, from int) int {

--- a/core/block/import/markdown/anymark/renderer.go
+++ b/core/block/import/markdown/anymark/renderer.go
@@ -162,12 +162,46 @@ func (r *Renderer) renderHTMLBlock(_ util.BufWriter,
 
 	raw := rawHTMLBlockText(source, node)
 
+	// A self-contained <details>...</details> block (no blank line between the
+	// <summary> and the children) is emitted by goldmark as a SINGLE HTMLBlock
+	// containing the whole element. Parse it fully here: open a Toggle from the
+	// <summary>, parse the inner content (between </summary> and the matching
+	// </details>) as Markdown into child blocks, nest them, then close the Toggle.
+	// Without this the block would be silently dropped (M3).
+	if summary, inner, ok := parseSelfContainedDetails(raw); ok {
+		r.OpenToggleBlock(summary)
+		inner = strings.TrimSpace(inner)
+		if inner != "" {
+			children, _, err := MarkdownToBlocks([]byte(inner), r.GetBaseFilepath(), r.GetAllFileShortPaths())
+			if err != nil {
+				log.Errorf("failed to parse inner content of self-contained <details>: %v", err)
+			} else {
+				r.AppendChildBlocks(children)
+			}
+		}
+		r.CloseToggleBlock()
+		return ast.WalkContinue, nil
+	}
+
 	// A <details> element (with a <summary>) is the export encoding for a Toggle
 	// block. We open a Toggle here so the blocks parsed between this opening
 	// <details> and the closing </details> become its children, then close it on
 	// </details>. This mirrors the md exporter's <details>/<summary> output.
 	if summary, ok := parseDetailsSummary(raw); ok {
 		r.OpenToggleBlock(summary)
+		// goldmark folds a tight first line of children into the opener HTMLBlock
+		// (e.g. "<details>\n<summary>S</summary>\nFirst\n"). That trailing content
+		// after </summary> would otherwise be lost, so parse it as children here.
+		// Subsequent loosely-separated blocks still nest via the open Toggle and
+		// the closing </details> still closes it.
+		if inner := strings.TrimSpace(detailsOpenerTrailingContent(raw)); inner != "" {
+			children, _, err := MarkdownToBlocks([]byte(inner), r.GetBaseFilepath(), r.GetAllFileShortPaths())
+			if err != nil {
+				log.Errorf("failed to parse trailing content of <details> opener: %v", err)
+			} else {
+				r.AppendChildBlocks(children)
+			}
+		}
 		return ast.WalkContinue, nil
 	}
 	if isDetailsClose(raw) {
@@ -218,6 +252,89 @@ func parseDetailsSummary(raw string) (string, bool) {
 
 func isDetailsClose(raw string) bool {
 	return reDetailsEnd.MatchString(raw) && !reDetailsOpen.MatchString(raw)
+}
+
+// parseSelfContainedDetails reports whether raw is a single self-contained
+// <details>...</details> block (it both opens and closes <details>). If so it
+// returns the decoded <summary> text and the inner content between the
+// </summary> and the </details> that closes the OUTER <details> (depth-aware, so
+// a nested <details> inside the content is kept intact for recursive parsing).
+func parseSelfContainedDetails(raw string) (summary string, inner string, ok bool) {
+	openLoc := reDetailsOpen.FindStringIndex(raw)
+	if openLoc == nil || !reDetailsEnd.MatchString(raw) {
+		return "", "", false
+	}
+
+	// Decode the (HTML-escaped) summary, mirroring parseDetailsSummary.
+	if m := reSummary.FindStringSubmatch(raw); len(m) > 1 {
+		summary = strings.TrimSpace(html.UnescapeString(m[1]))
+	}
+
+	// Locate the body start: just after the first </summary> if present,
+	// otherwise just after the opening <details ...> tag.
+	bodyStart := openLoc[1]
+	if sumLoc := reSummary.FindStringIndex(raw); sumLoc != nil {
+		bodyStart = sumLoc[1]
+	}
+
+	// Find the </details> that closes the OUTER <details> by tracking depth over
+	// the remaining open/close tags after the body start.
+	body := raw[bodyStart:]
+	closeRel := matchingDetailsClose(body)
+	if closeRel < 0 {
+		// Shouldn't happen given reDetailsEnd matched, but be safe.
+		return summary, strings.TrimSpace(body), true
+	}
+	return summary, body[:closeRel], true
+}
+
+// detailsOpenerTrailingContent returns any content that appears after the
+// </summary> in a <details> opener HTMLBlock that does NOT contain a </details>.
+// goldmark folds a tight first child line into this opener block; that content
+// would otherwise be lost.
+func detailsOpenerTrailingContent(raw string) string {
+	sumLoc := reSummary.FindStringIndex(raw)
+	if sumLoc == nil {
+		return ""
+	}
+	return raw[sumLoc[1]:]
+}
+
+// matchingDetailsClose returns the byte offset (within s) of the </details> tag
+// that closes the outer <details>, accounting for nested <details> elements. It
+// scans for <details ...> openers and </details> closers, incrementing/
+// decrementing depth; the close at depth 0 is the match. Returns -1 if none.
+func matchingDetailsClose(s string) int {
+	type tok struct {
+		idx   int
+		end   int
+		isEnd bool
+	}
+	var toks []tok
+	for _, loc := range reDetailsOpen.FindAllStringIndex(s, -1) {
+		toks = append(toks, tok{idx: loc[0], end: loc[1], isEnd: false})
+	}
+	for _, loc := range reDetailsEnd.FindAllStringIndex(s, -1) {
+		toks = append(toks, tok{idx: loc[0], end: loc[1], isEnd: true})
+	}
+	// Sort tokens by position (simple insertion sort; lists are tiny).
+	for i := 1; i < len(toks); i++ {
+		for j := i; j > 0 && toks[j-1].idx > toks[j].idx; j-- {
+			toks[j-1], toks[j] = toks[j], toks[j-1]
+		}
+	}
+	depth := 0
+	for _, tk := range toks {
+		if tk.isEnd {
+			if depth == 0 {
+				return tk.idx
+			}
+			depth--
+		} else {
+			depth++
+		}
+	}
+	return -1
 }
 
 func (r *Renderer) renderList(_ util.BufWriter,

--- a/core/block/import/markdown/anymark/toggle_test.go
+++ b/core/block/import/markdown/anymark/toggle_test.go
@@ -1,6 +1,7 @@
 package anymark
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,26 @@ import (
 func blockByText(blocks []*model.Block, text string) *model.Block {
 	for _, b := range blocks {
 		if t := b.GetText(); t != nil && t.Text == text {
+			return b
+		}
+	}
+	return nil
+}
+
+// blockContaining returns the first block whose text contains the given substring.
+func blockContaining(blocks []*model.Block, substr string) *model.Block {
+	for _, b := range blocks {
+		if t := b.GetText(); t != nil && strings.Contains(t.Text, substr) {
+			return b
+		}
+	}
+	return nil
+}
+
+// codeBlockContaining returns the first Code-styled block whose text contains substr.
+func codeBlockContaining(blocks []*model.Block, substr string) *model.Block {
+	for _, b := range blocks {
+		if t := b.GetText(); t != nil && t.Style == model.BlockContentText_Code && strings.Contains(t.Text, substr) {
 			return b
 		}
 	}
@@ -228,6 +249,163 @@ func TestMarkdownToBlocks_TightDetailsToggle(t *testing.T) {
 		require.NotNil(t, deep, "expected deep child, got: %+v", blocks)
 		assert.Contains(t, inner.ChildrenIds, deep.Id,
 			"deep child must be nested under inner toggle, got: %+v", blocks)
+	})
+}
+
+// Major 1: a tight <details>...</details> block ends (for goldmark) at a blank
+// line, not at </details>. So content AFTER the matched </details> lives inside
+// the SAME HTMLBlock and was silently dropped. The trailing content must be
+// emitted as following SIBLING blocks (not nested under the toggle).
+func TestMarkdownToBlocks_TightDetailsTrailingContent(t *testing.T) {
+	t.Run("single trailing line after close is kept as a sibling", func(t *testing.T) {
+		md := "<details>\n<summary>S</summary>\nChild\n</details>\nTRAILING\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "S")
+		require.NotNil(t, toggle, "expected a toggle block 'S', got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		child := blockByText(blocks, "Child")
+		require.NotNil(t, child, "expected child 'Child', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id,
+			"child must be nested under the toggle, got: %+v", blocks)
+
+		trailing := blockByText(blocks, "TRAILING")
+		require.NotNil(t, trailing, "expected trailing sibling 'TRAILING', got: %+v", blocks)
+		assert.NotContains(t, toggle.ChildrenIds, trailing.Id,
+			"trailing content must be a sibling, NOT nested under the toggle, got: %+v", blocks)
+	})
+
+	t.Run("multiple trailing lines after close are all kept", func(t *testing.T) {
+		md := "<details>\n<summary>S</summary>\nChild\n</details>\nFirstTrail\n\nSecondTrail\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "S")
+		require.NotNil(t, toggle, "expected a toggle block 'S', got: %+v", blocks)
+
+		child := blockByText(blocks, "Child")
+		require.NotNil(t, child, "expected child 'Child', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id)
+
+		first := blockByText(blocks, "FirstTrail")
+		second := blockByText(blocks, "SecondTrail")
+		require.NotNil(t, first, "expected trailing 'FirstTrail', got: %+v", blocks)
+		require.NotNil(t, second, "expected trailing 'SecondTrail', got: %+v", blocks)
+		assert.NotContains(t, toggle.ChildrenIds, first.Id)
+		assert.NotContains(t, toggle.ChildrenIds, second.Id)
+	})
+
+	t.Run("inner tight details followed by sibling text inside outer", func(t *testing.T) {
+		md := "<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nDeep\n</details>\nInnerSibling\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		outer := blockByText(blocks, "Outer")
+		require.NotNil(t, outer, "expected outer toggle, got: %+v", blocks)
+		inner := blockByText(blocks, "Inner")
+		require.NotNil(t, inner, "expected inner toggle, got: %+v", blocks)
+		assert.Contains(t, outer.ChildrenIds, inner.Id,
+			"inner toggle must be nested under outer, got: %+v", blocks)
+
+		deep := blockByText(blocks, "Deep")
+		require.NotNil(t, deep, "expected deep child, got: %+v", blocks)
+		assert.Contains(t, inner.ChildrenIds, deep.Id,
+			"deep child must be nested under inner toggle, got: %+v", blocks)
+
+		// "InnerSibling" appears after the inner </details> but before the outer
+		// </details>, so it is a sibling of the inner toggle, nested under outer.
+		sibling := blockByText(blocks, "InnerSibling")
+		require.NotNil(t, sibling, "expected inner sibling 'InnerSibling', got: %+v", blocks)
+		assert.Contains(t, outer.ChildrenIds, sibling.Id,
+			"inner sibling must be nested under outer toggle, got: %+v", blocks)
+		assert.NotContains(t, inner.ChildrenIds, sibling.Id,
+			"inner sibling must NOT be nested under inner toggle, got: %+v", blocks)
+	})
+}
+
+// Major 2: matchingDetailsClose did a raw regex scan, so a </details> inside a
+// fenced code block or inline code span was mistaken for the real close. The
+// toggle then got zero children and the real content after the true close was
+// lost. Code regions must be ignored when finding the matching close.
+func TestMarkdownToBlocks_TightDetailsCodeFenceClose(t *testing.T) {
+	t.Run("fenced code block containing literal </details> is preserved", func(t *testing.T) {
+		// The first </details> is inside a ``` fence and must NOT be the close.
+		md := "<details>\n<summary>S</summary>\n```\n</details>\n```\nrealchild\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "S")
+		require.NotNil(t, toggle, "expected a toggle block 'S', got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		// The fenced code block (which contains the literal "</details>" text) must
+		// be nested under the toggle as a code block.
+		code := codeBlockContaining(blocks, "</details>")
+		require.NotNil(t, code, "expected code block with literal '</details>', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, code.Id,
+			"code block must be nested under the toggle, got: %+v", blocks)
+
+		realchild := blockByText(blocks, "realchild")
+		require.NotNil(t, realchild, "expected 'realchild' after fence, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, realchild.Id,
+			"realchild must be nested under the toggle, got: %+v", blocks)
+	})
+
+	t.Run("tilde fenced code block containing literal </details> is preserved", func(t *testing.T) {
+		md := "<details>\n<summary>S</summary>\n~~~\n</details>\n~~~\nrealchild\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "S")
+		require.NotNil(t, toggle, "expected a toggle block 'S', got: %+v", blocks)
+
+		code := codeBlockContaining(blocks, "</details>")
+		require.NotNil(t, code, "expected code block with literal '</details>', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, code.Id)
+
+		realchild := blockByText(blocks, "realchild")
+		require.NotNil(t, realchild, "expected 'realchild' after fence, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, realchild.Id)
+	})
+
+	t.Run("inline code span containing </details> is not the close", func(t *testing.T) {
+		// The first </details> appears in an inline code span `</details>` and must
+		// NOT be treated as the close; the real close is the last line. goldmark
+		// joins the two consecutive child lines into a single paragraph (soft break),
+		// so the inner content is one nested block carrying both the inline code
+		// span and the realchild text - the key point is that NONE of it is lost.
+		md := "<details>\n<summary>S</summary>\nuse `</details>` here\nrealchild\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "S")
+		require.NotNil(t, toggle, "expected a toggle block 'S', got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		inner := blockContaining(blocks, "</details>")
+		require.NotNil(t, inner, "expected a nested block carrying the inline </details>, got: %+v", blocks)
+		assert.Contains(t, inner.GetText().Text, "realchild",
+			"the realchild text after the inline span must not be lost, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, inner.Id,
+			"inner content must be nested under the toggle, got: %+v", blocks)
+		// The inline code span must be marked as a Keyboard (inline code) mark.
+		require.NotNil(t, inner.GetText().Marks)
+		hasKeyboard := false
+		for _, m := range inner.GetText().Marks.Marks {
+			if m.Type == model.BlockContentTextMark_Keyboard {
+				hasKeyboard = true
+			}
+		}
+		assert.True(t, hasKeyboard,
+			"the </details> inline span must remain an inline-code mark, got: %+v", blocks)
 	})
 }
 

--- a/core/block/import/markdown/anymark/toggle_test.go
+++ b/core/block/import/markdown/anymark/toggle_test.go
@@ -55,6 +55,26 @@ func TestMarkdownToBlocks_DetailsToggle(t *testing.T) {
 		assert.Contains(t, toggle.ChildrenIds, second.Id)
 	})
 
+	t.Run("escaped summary entities decode to original text", func(t *testing.T) {
+		// The exporter HTML-escapes the summary, so </details>, <, >, & arrive
+		// as entities. The importer must decode them back and keep the child
+		// nested (the opener line must no longer contain a literal </details>).
+		md := "<details>\n<summary>Sneaky &lt;/details&gt; a &lt; b &amp;&amp; c &gt; d text</summary>\n\nHidden content\n\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		const want = "Sneaky </details> a < b && c > d text"
+		toggle := blockByText(blocks, want)
+		require.NotNil(t, toggle, "expected toggle with decoded summary, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		child := blockByText(blocks, "Hidden content")
+		require.NotNil(t, child, "expected child block, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id,
+			"child must be nested under the toggle, got: %+v", blocks)
+	})
+
 	t.Run("plain blockquote still parses to Quote", func(t *testing.T) {
 		md := "> A real quote\n"
 

--- a/core/block/import/markdown/anymark/toggle_test.go
+++ b/core/block/import/markdown/anymark/toggle_test.go
@@ -87,6 +87,150 @@ func TestMarkdownToBlocks_DetailsToggle(t *testing.T) {
 	})
 }
 
+// M2: an empty-summary <details> must still nest its children. Previously the
+// toggle's empty Text caused the parent-merge branch in CloseTextBlock to absorb
+// the FIRST child's text into the toggle and drop it as a child.
+func TestMarkdownToBlocks_EmptySummaryToggle(t *testing.T) {
+	t.Run("empty summary with single child nests the child", func(t *testing.T) {
+		md := "<details>\n<summary></summary>\n\nHidden content\n\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		var toggle *model.Block
+		for _, b := range blocks {
+			if t := b.GetText(); t != nil && t.Style == model.BlockContentText_Toggle {
+				toggle = b
+				break
+			}
+		}
+		require.NotNil(t, toggle, "expected a toggle block, got: %+v", blocks)
+		assert.Equal(t, "", toggle.GetText().Text,
+			"empty-summary toggle must have empty text (no absorbed child text), got: %+v", blocks)
+
+		child := blockByText(blocks, "Hidden content")
+		require.NotNil(t, child, "expected child block 'Hidden content', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id,
+			"child must be nested under the empty-summary toggle, got: %+v", blocks)
+	})
+
+	t.Run("empty summary with multiple children nests all", func(t *testing.T) {
+		md := "<details>\n<summary></summary>\n\nFirst\n\nSecond\n\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		var toggle *model.Block
+		for _, b := range blocks {
+			if t := b.GetText(); t != nil && t.Style == model.BlockContentText_Toggle {
+				toggle = b
+				break
+			}
+		}
+		require.NotNil(t, toggle, "expected a toggle block, got: %+v", blocks)
+		assert.Equal(t, "", toggle.GetText().Text,
+			"empty-summary toggle must have empty text, got: %+v", blocks)
+
+		first := blockByText(blocks, "First")
+		second := blockByText(blocks, "Second")
+		require.NotNil(t, first, "expected 'First', got: %+v", blocks)
+		require.NotNil(t, second, "expected 'Second', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, first.Id,
+			"first child must be nested, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, second.Id,
+			"second child must be nested, got: %+v", blocks)
+	})
+}
+
+// M3: a self-contained <details>...</details> with no blank line before the
+// children is emitted by goldmark as a SINGLE HTMLBlock. Previously
+// parseDetailsSummary returned false for the "both open and close present" case,
+// so the whole block (summary + children) was silently dropped.
+func TestMarkdownToBlocks_TightDetailsToggle(t *testing.T) {
+	t.Run("tight details with single child nests the child", func(t *testing.T) {
+		md := "<details>\n<summary>S</summary>\nChild\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "S")
+		require.NotNil(t, toggle, "expected a toggle block with summary 'S', got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		child := blockByText(blocks, "Child")
+		require.NotNil(t, child, "expected child block 'Child', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id,
+			"child must be nested under the tight toggle, got: %+v", blocks)
+	})
+
+	t.Run("tight details with multiple children nests all", func(t *testing.T) {
+		md := "<details>\n<summary>Group</summary>\nFirst\n\nSecond\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "Group")
+		require.NotNil(t, toggle, "expected a toggle block, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		first := blockByText(blocks, "First")
+		second := blockByText(blocks, "Second")
+		require.NotNil(t, first, "expected 'First', got: %+v", blocks)
+		require.NotNil(t, second, "expected 'Second', got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, first.Id)
+		assert.Contains(t, toggle.ChildrenIds, second.Id)
+	})
+
+	t.Run("tight details summary entities are decoded", func(t *testing.T) {
+		md := "<details>\n<summary>A &lt; B &amp; C</summary>\nChild\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "A < B & C")
+		require.NotNil(t, toggle, "expected toggle with decoded summary, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		child := blockByText(blocks, "Child")
+		require.NotNil(t, child, "expected child block, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id)
+	})
+
+	t.Run("empty self-contained details produces a childless toggle (no crash)", func(t *testing.T) {
+		md := "<details>\n<summary>Empty</summary>\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "Empty")
+		require.NotNil(t, toggle, "expected a toggle block, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+		assert.Empty(t, toggle.ChildrenIds, "empty toggle must have no children, got: %+v", blocks)
+	})
+
+	t.Run("nested tight details nests inner toggle under outer", func(t *testing.T) {
+		md := "<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nDeep\n</details>\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		outer := blockByText(blocks, "Outer")
+		require.NotNil(t, outer, "expected outer toggle, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, outer.GetText().Style)
+
+		inner := blockByText(blocks, "Inner")
+		require.NotNil(t, inner, "expected inner toggle, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, inner.GetText().Style)
+		assert.Contains(t, outer.ChildrenIds, inner.Id,
+			"inner toggle must be nested under outer, got: %+v", blocks)
+
+		deep := blockByText(blocks, "Deep")
+		require.NotNil(t, deep, "expected deep child, got: %+v", blocks)
+		assert.Contains(t, inner.ChildrenIds, deep.Id,
+			"deep child must be nested under inner toggle, got: %+v", blocks)
+	})
+}
+
 func TestHTMLToBlocks_DetailsToggle(t *testing.T) {
 	t.Run("html details parses to nested toggle", func(t *testing.T) {
 		html := "<details><summary>My Toggle</summary><p>Child content</p></details>"

--- a/core/block/import/markdown/anymark/toggle_test.go
+++ b/core/block/import/markdown/anymark/toggle_test.go
@@ -1,0 +1,85 @@
+package anymark
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func blockByText(blocks []*model.Block, text string) *model.Block {
+	for _, b := range blocks {
+		if t := b.GetText(); t != nil && t.Text == text {
+			return b
+		}
+	}
+	return nil
+}
+
+func TestMarkdownToBlocks_DetailsToggle(t *testing.T) {
+	t.Run("details with single child parses to nested toggle", func(t *testing.T) {
+		md := "<details>\n<summary>My Toggle</summary>\n\nChild content\n\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "My Toggle")
+		require.NotNil(t, toggle, "expected a toggle block, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		child := blockByText(blocks, "Child content")
+		require.NotNil(t, child, "expected a child block, got: %+v", blocks)
+		assert.NotEqual(t, model.BlockContentText_Code, child.GetText().Style,
+			"child must not be parsed as a code block")
+		assert.Contains(t, toggle.ChildrenIds, child.Id,
+			"child must be nested under the toggle, got: %+v", blocks)
+	})
+
+	t.Run("details with multiple children parses to nested toggle", func(t *testing.T) {
+		md := "<details>\n<summary>Group</summary>\n\nFirst\n\nSecond\n\n</details>\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "Group")
+		require.NotNil(t, toggle)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		first := blockByText(blocks, "First")
+		second := blockByText(blocks, "Second")
+		require.NotNil(t, first)
+		require.NotNil(t, second)
+		assert.Contains(t, toggle.ChildrenIds, first.Id)
+		assert.Contains(t, toggle.ChildrenIds, second.Id)
+	})
+
+	t.Run("plain blockquote still parses to Quote", func(t *testing.T) {
+		md := "> A real quote\n"
+
+		blocks, _, err := MarkdownToBlocks([]byte(md), "", nil)
+		require.NoError(t, err)
+
+		quote := blockByText(blocks, "A real quote")
+		require.NotNil(t, quote, "expected a quote block, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Quote, quote.GetText().Style)
+	})
+}
+
+func TestHTMLToBlocks_DetailsToggle(t *testing.T) {
+	t.Run("html details parses to nested toggle", func(t *testing.T) {
+		html := "<details><summary>My Toggle</summary><p>Child content</p></details>"
+
+		blocks, _, err := HTMLToBlocks([]byte(html), "")
+		require.NoError(t, err)
+
+		toggle := blockByText(blocks, "My Toggle")
+		require.NotNil(t, toggle, "expected a toggle block, got: %+v", blocks)
+		assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+		child := blockByText(blocks, "Child content")
+		require.NotNil(t, child, "expected a child block, got: %+v", blocks)
+		assert.Contains(t, toggle.ChildrenIds, child.Id)
+	})
+}

--- a/core/converter/md/md.go
+++ b/core/converter/md/md.go
@@ -553,7 +553,7 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 	// — into the child text). Nesting is reconstructed by the importer's
 	// open/close <details> stack, not by markdown indentation.
 	if text.Style != model.BlockContentText_Toggle {
-		buf.WriteString(in.indent)
+		buf.WriteString(in.indent) // nolint:errcheck
 	}
 
 	switch text.Style {
@@ -607,13 +607,13 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 		// to the HTML parser ('<', '>', '&') — including a literal "</details>" in
 		// the title — survive the round-trip. The importer unescapes them back.
 		childIn := &renderState{}
-		buf.WriteString("<details>\n")
-		buf.WriteString("<summary>")
-		buf.WriteString(html.EscapeString(strings.ReplaceAll(text.Text, "\n", " ")))
-		buf.WriteString("</summary>\n\n")
+		buf.WriteString("<details>\n")                                               // nolint:errcheck
+		buf.WriteString("<summary>")                                                 // nolint:errcheck
+		buf.WriteString(html.EscapeString(strings.ReplaceAll(text.Text, "\n", " "))) // nolint:errcheck
+		buf.WriteString("</summary>\n\n")                                            // nolint:errcheck
 		h.renderChildren(buf, childIn, b)
-		buf.WriteString("\n")
-		buf.WriteString("</details>\n\n")
+		buf.WriteString("\n")             // nolint:errcheck
+		buf.WriteString("</details>\n\n") // nolint:errcheck
 	case model.BlockContentText_Code:
 		buf.WriteString("```\n") // nolint:errcheck
 		txt := strings.ReplaceAll(text.Text, "```", "\\`\\`\\`")

--- a/core/converter/md/md.go
+++ b/core/converter/md/md.go
@@ -545,7 +545,16 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 		in.listNumber = 0
 	}
 
-	buf.WriteString(in.indent)
+	// Toggle blocks are emitted as an HTML <details> element at column 0 (see the
+	// Toggle case below): the indent prefix is intentionally skipped here so the
+	// opener is not indented (a >=4-space indent would make goldmark parse the
+	// whole element as an indented code block on re-import, and a smaller indent
+	// leaks indentation characters — e.g. the figure-space from a Checkbox parent
+	// — into the child text). Nesting is reconstructed by the importer's
+	// open/close <details> stack, not by markdown indentation.
+	if text.Style != model.BlockContentText_Toggle {
+		buf.WriteString(in.indent)
+	}
 
 	switch text.Style {
 	case model.BlockContentText_Header1, model.BlockContentText_ToggleHeader1, model.BlockContentText_Title:
@@ -584,20 +593,26 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 	case model.BlockContentText_Toggle:
 		// Toggle blocks are exported as an HTML <details>/<summary> element so that
 		// they round-trip back to a Toggle on import (and don't collide with Quote's
-		// "> " blockquote marker). Children are rendered nested inside the element.
+		// "> " blockquote marker).
+		//
+		// The whole element (opener, <summary>, children, closer) is written at
+		// column 0 regardless of the toggle's parent indent: markdown indentation
+		// is NOT used to convey nesting here (the importer rebuilds it from the
+		// open/close <details> stack). Indenting the opener by >=4 spaces would make
+		// goldmark treat it as an indented code block and collapse the toggle;
+		// smaller indents would leak into child text. So children are rendered with
+		// a reset (empty) indent too.
+		//
+		// The summary text is HTML-escaped so that characters that are significant
+		// to the HTML parser ('<', '>', '&') — including a literal "</details>" in
+		// the title — survive the round-trip. The importer unescapes them back.
+		childIn := &renderState{}
 		buf.WriteString("<details>\n")
-		buf.WriteString(in.indent)
 		buf.WriteString("<summary>")
-		buf.WriteString(strings.ReplaceAll(text.Text, "\n", " "))
+		buf.WriteString(html.EscapeString(strings.ReplaceAll(text.Text, "\n", " ")))
 		buf.WriteString("</summary>\n\n")
-		// Children are rendered between the <summary> and </details> tags. Nesting
-		// is conveyed by the <details> wrapper itself, so children keep the current
-		// indent: an extra Markdown indent would either trip the 4-space
-		// indented-code-block rule or leak indentation characters into the child
-		// text on re-import.
-		h.renderChildren(buf, in, b)
+		h.renderChildren(buf, childIn, b)
 		buf.WriteString("\n")
-		buf.WriteString(in.indent)
 		buf.WriteString("</details>\n\n")
 	case model.BlockContentText_Code:
 		buf.WriteString("```\n") // nolint:errcheck

--- a/core/converter/md/md.go
+++ b/core/converter/md/md.go
@@ -576,11 +576,29 @@ func (h *MD) renderText(buf writer, in *renderState, b *model.Block) {
 		}
 		renderText()
 		h.renderChildren(buf, in.AddSpace(), b)
-	case model.BlockContentText_Quote, model.BlockContentText_Toggle:
+	case model.BlockContentText_Quote:
 		buf.WriteString("> ")
 		buf.WriteString(strings.ReplaceAll(text.Text, "\n", "   \n> "))
 		buf.WriteString("   \n\n")
 		h.renderChildren(buf, in, b)
+	case model.BlockContentText_Toggle:
+		// Toggle blocks are exported as an HTML <details>/<summary> element so that
+		// they round-trip back to a Toggle on import (and don't collide with Quote's
+		// "> " blockquote marker). Children are rendered nested inside the element.
+		buf.WriteString("<details>\n")
+		buf.WriteString(in.indent)
+		buf.WriteString("<summary>")
+		buf.WriteString(strings.ReplaceAll(text.Text, "\n", " "))
+		buf.WriteString("</summary>\n\n")
+		// Children are rendered between the <summary> and </details> tags. Nesting
+		// is conveyed by the <details> wrapper itself, so children keep the current
+		// indent: an extra Markdown indent would either trip the 4-space
+		// indented-code-block rule or leak indentation characters into the child
+		// text on re-import.
+		h.renderChildren(buf, in, b)
+		buf.WriteString("\n")
+		buf.WriteString(in.indent)
+		buf.WriteString("</details>\n\n")
 	case model.BlockContentText_Code:
 		buf.WriteString("```\n") // nolint:errcheck
 		txt := strings.ReplaceAll(text.Text, "```", "\\`\\`\\`")

--- a/core/converter/md/toggle_roundtrip_test.go
+++ b/core/converter/md/toggle_roundtrip_test.go
@@ -89,6 +89,138 @@ func TestMD_QuoteStillExportsAsBlockquote(t *testing.T) {
 	assert.NotContains(t, res, "<details>", "quote must not be exported as details, got:\n%s", res)
 }
 
+// newTextBlock is a small helper for building text blocks in tests.
+func newTextBlock(id, text string, style model.BlockContentTextStyle, children ...string) simple.Block {
+	return simple.New(&model.Block{
+		Id:          id,
+		ChildrenIds: children,
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{Text: text, Style: style},
+		},
+	})
+}
+
+// roundTrip exports the doc to markdown and parses it back to blocks.
+func roundTrip(t *testing.T, blocks map[string]simple.Block) (string, []*model.Block) {
+	t.Helper()
+	s := state.NewDoc("root", blocks).(*state.State)
+	c := NewMDConverter(s, nil, false)
+	md := string(c.Convert(model.SmartBlockType_Page))
+	t.Logf("exported markdown:\n%s", md)
+	parsed, _, err := anymark.MarkdownToBlocks([]byte(md), "", nil)
+	require.NoError(t, err)
+	return md, parsed
+}
+
+// B1: a Toggle nested under a Header must round-trip as a Toggle with its child
+// still nested. Previously the <details> opener was indented (Header AddSpace =
+// 4 spaces), so goldmark parsed it as an indented code block and the whole
+// toggle collapsed into one Code block of literal HTML.
+func TestMD_ToggleUnderHeaderRoundTrip(t *testing.T) {
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"h1"}}),
+		"h1":      newTextBlock("h1", "H", model.BlockContentText_Header1, "toggle1"),
+		"toggle1": newTextBlock("toggle1", "T", model.BlockContentText_Toggle, "child1"),
+		"child1":  newTextBlock("child1", "Inside", model.BlockContentText_Paragraph),
+	}
+
+	_, parsed := roundTrip(t, blocks)
+
+	toggle := findBlockByText(parsed, "T")
+	require.NotNil(t, toggle, "expected a toggle block, parsed:\n%+v", parsed)
+	assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style,
+		"toggle nested under a header must stay a Toggle, parsed:\n%+v", parsed)
+
+	child := findBlockByText(parsed, "Inside")
+	require.NotNil(t, child, "expected the child block, parsed:\n%+v", parsed)
+	assert.NotEqual(t, model.BlockContentText_Code, child.GetText().Style,
+		"child must not collapse into a code block, parsed:\n%+v", parsed)
+	assert.Contains(t, toggle.ChildrenIds, child.Id,
+		"child must remain nested under the toggle, parsed:\n%+v", parsed)
+}
+
+// B2: a Toggle nested under a Checkbox must round-trip as a Toggle with its
+// child nested and no leaked indent characters (figure-space U+2007 from
+// AddNBSpace). Previously the indent leaked into the child text and the toggle
+// style was lost.
+func TestMD_ToggleUnderCheckboxRoundTrip(t *testing.T) {
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"chk1"}}),
+		"chk1":    newTextBlock("chk1", "Task", model.BlockContentText_Checkbox, "toggle1"),
+		"toggle1": newTextBlock("toggle1", "T", model.BlockContentText_Toggle, "child1"),
+		"child1":  newTextBlock("child1", "Inside", model.BlockContentText_Paragraph),
+	}
+
+	_, parsed := roundTrip(t, blocks)
+
+	toggle := findBlockByText(parsed, "T")
+	require.NotNil(t, toggle, "expected a toggle block, parsed:\n%+v", parsed)
+	assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style,
+		"toggle nested under a checkbox must stay a Toggle, parsed:\n%+v", parsed)
+
+	child := findBlockByText(parsed, "Inside")
+	require.NotNil(t, child, "expected the child block (no leaked indent), parsed:\n%+v", parsed)
+	assert.Contains(t, toggle.ChildrenIds, child.Id,
+		"child must remain nested under the toggle, parsed:\n%+v", parsed)
+
+	// No block text may contain a leaked figure-space (U+2007) indent char.
+	for _, b := range parsed {
+		if tb := b.GetText(); tb != nil {
+			assert.NotContains(t, tb.Text, " ",
+				"no leaked figure-space indent expected, block text=%q parsed:\n%+v", tb.Text, parsed)
+		}
+	}
+}
+
+// B3 + M1: summary text containing HTML-significant characters (</details>, <,
+// >, &) must round-trip exactly, and the child must stay nested. Previously the
+// raw </details> in the summary caused the importer to drop the whole toggle,
+// and raw </>/tag-shaped text was stripped.
+func TestMD_ToggleSummaryWithSpecialCharsRoundTrip(t *testing.T) {
+	const title = "Sneaky </details> a < b && c > d text"
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"toggle1"}}),
+		"toggle1": newTextBlock("toggle1", title, model.BlockContentText_Toggle, "child1"),
+		"child1":  newTextBlock("child1", "Hidden content", model.BlockContentText_Paragraph),
+	}
+
+	_, parsed := roundTrip(t, blocks)
+
+	toggle := findBlockByText(parsed, title)
+	require.NotNil(t, toggle,
+		"toggle with special-char summary must round-trip its text exactly, parsed:\n%+v", parsed)
+	assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style,
+		"must stay a Toggle, parsed:\n%+v", parsed)
+
+	child := findBlockByText(parsed, "Hidden content")
+	require.NotNil(t, child, "expected the child block, parsed:\n%+v", parsed)
+	assert.Contains(t, toggle.ChildrenIds, child.Id,
+		"child must remain nested under the toggle, parsed:\n%+v", parsed)
+}
+
+// A normal sibling block after a toggle must be unaffected by the toggle's
+// column-0 rendering.
+func TestMD_SiblingAfterToggleRoundTrip(t *testing.T) {
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"toggle1", "after"}}),
+		"toggle1": newTextBlock("toggle1", "My Toggle", model.BlockContentText_Toggle, "child1"),
+		"child1":  newTextBlock("child1", "Child content", model.BlockContentText_Paragraph),
+		"after":   newTextBlock("after", "After paragraph", model.BlockContentText_Paragraph),
+	}
+
+	_, parsed := roundTrip(t, blocks)
+
+	toggle := findBlockByText(parsed, "My Toggle")
+	require.NotNil(t, toggle)
+	assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style)
+
+	after := findBlockByText(parsed, "After paragraph")
+	require.NotNil(t, after, "sibling after toggle must survive, parsed:\n%+v", parsed)
+	assert.Equal(t, model.BlockContentText_Paragraph, after.GetText().Style)
+	assert.NotContains(t, toggle.ChildrenIds, after.Id,
+		"sibling must NOT be nested under the toggle, parsed:\n%+v", parsed)
+}
+
 // TestMD_ToggleRoundTrip is the core TDD test: build a Toggle+child tree,
 // render to markdown, parse it back via anymark, and assert the result is a
 // Toggle with the child nested under it.

--- a/core/converter/md/toggle_roundtrip_test.go
+++ b/core/converter/md/toggle_roundtrip_test.go
@@ -1,0 +1,141 @@
+package md
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/import/markdown/anymark"
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// findBlockByText finds the first block whose text equals the given value.
+func findBlockByText(blocks []*model.Block, text string) *model.Block {
+	for _, b := range blocks {
+		if t := b.GetText(); t != nil && t.Text == text {
+			return b
+		}
+	}
+	return nil
+}
+
+func TestMD_ToggleExportEncoding(t *testing.T) {
+	toggleBlock := &model.Block{
+		Id:          "toggle1",
+		ChildrenIds: []string{"child1"},
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  "My Toggle",
+				Style: model.BlockContentText_Toggle,
+			},
+		},
+	}
+	childBlock := &model.Block{
+		Id: "child1",
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  "Child content",
+				Style: model.BlockContentText_Paragraph,
+			},
+		},
+	}
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"toggle1"}}),
+		"toggle1": simple.New(toggleBlock),
+		"child1":  simple.New(childBlock),
+	}
+	s := state.NewDoc("root", blocks).(*state.State)
+
+	c := NewMDConverter(s, nil, false)
+	res := string(c.Convert(model.SmartBlockType_Page))
+
+	// Toggle must NOT be exported as a quote blockquote.
+	for _, line := range strings.Split(res, "\n") {
+		assert.False(t, strings.HasPrefix(strings.TrimSpace(line), "> My Toggle"),
+			"toggle must not be exported as a blockquote, got line: %q in:\n%s", line, res)
+	}
+	// Toggle is exported as <details>/<summary>.
+	assert.Contains(t, res, "<details>", "expected details encoding, got:\n%s", res)
+	assert.Contains(t, res, "<summary>My Toggle</summary>", "expected summary with toggle text, got:\n%s", res)
+	assert.Contains(t, res, "</details>", "expected details close, got:\n%s", res)
+	// Child content is still rendered.
+	assert.Contains(t, res, "Child content", "child content must be present, got:\n%s", res)
+}
+
+func TestMD_QuoteStillExportsAsBlockquote(t *testing.T) {
+	quoteBlock := &model.Block{
+		Id: "quote1",
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  "A real quote",
+				Style: model.BlockContentText_Quote,
+			},
+		},
+	}
+	blocks := map[string]simple.Block{
+		"root":   simple.New(&model.Block{Id: "root", ChildrenIds: []string{"quote1"}}),
+		"quote1": simple.New(quoteBlock),
+	}
+	s := state.NewDoc("root", blocks).(*state.State)
+
+	c := NewMDConverter(s, nil, false)
+	res := string(c.Convert(model.SmartBlockType_Page))
+
+	assert.Contains(t, res, "> A real quote", "quote must still export as blockquote, got:\n%s", res)
+	assert.NotContains(t, res, "<details>", "quote must not be exported as details, got:\n%s", res)
+}
+
+// TestMD_ToggleRoundTrip is the core TDD test: build a Toggle+child tree,
+// render to markdown, parse it back via anymark, and assert the result is a
+// Toggle with the child nested under it.
+func TestMD_ToggleRoundTrip(t *testing.T) {
+	toggleBlock := &model.Block{
+		Id:          "toggle1",
+		ChildrenIds: []string{"child1"},
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  "My Toggle",
+				Style: model.BlockContentText_Toggle,
+			},
+		},
+	}
+	childBlock := &model.Block{
+		Id: "child1",
+		Content: &model.BlockContentOfText{
+			Text: &model.BlockContentText{
+				Text:  "Child content",
+				Style: model.BlockContentText_Paragraph,
+			},
+		},
+	}
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"toggle1"}}),
+		"toggle1": simple.New(toggleBlock),
+		"child1":  simple.New(childBlock),
+	}
+	s := state.NewDoc("root", blocks).(*state.State)
+
+	c := NewMDConverter(s, nil, false)
+	md := string(c.Convert(model.SmartBlockType_Page))
+	t.Logf("exported markdown:\n%s", md)
+
+	parsed, _, err := anymark.MarkdownToBlocks([]byte(md), "", nil)
+	require.NoError(t, err)
+
+	toggle := findBlockByText(parsed, "My Toggle")
+	require.NotNil(t, toggle, "expected a block with toggle text, parsed:\n%+v", parsed)
+	assert.Equal(t, model.BlockContentText_Toggle, toggle.GetText().Style,
+		"toggle must round-trip as Toggle style, parsed:\n%+v", parsed)
+
+	child := findBlockByText(parsed, "Child content")
+	require.NotNil(t, child, "expected the child block, parsed:\n%+v", parsed)
+
+	// The child must be nested under the toggle, not a top-level sibling.
+	assert.Contains(t, toggle.ChildrenIds, child.Id,
+		"child must be nested under the toggle, toggle.ChildrenIds=%v child.Id=%s parsed:\n%+v",
+		toggle.ChildrenIds, child.Id, parsed)
+}

--- a/core/converter/md/toggle_roundtrip_test.go
+++ b/core/converter/md/toggle_roundtrip_test.go
@@ -221,6 +221,37 @@ func TestMD_SiblingAfterToggleRoundTrip(t *testing.T) {
 		"sibling must NOT be nested under the toggle, parsed:\n%+v", parsed)
 }
 
+// M2: an empty-summary (untitled) Toggle must round-trip with its child still
+// nested. The exporter emits <summary></summary>, and previously the importer's
+// parent-merge branch absorbed the first child's text into the empty toggle and
+// dropped the nesting.
+func TestMD_EmptySummaryToggleRoundTrip(t *testing.T) {
+	blocks := map[string]simple.Block{
+		"root":    simple.New(&model.Block{Id: "root", ChildrenIds: []string{"toggle1"}}),
+		"toggle1": newTextBlock("toggle1", "", model.BlockContentText_Toggle, "child1"),
+		"child1":  newTextBlock("child1", "Hidden content", model.BlockContentText_Paragraph),
+	}
+
+	md, parsed := roundTrip(t, blocks)
+	assert.Contains(t, md, "<summary></summary>", "exporter must emit an empty summary, got:\n%s", md)
+
+	var toggle *model.Block
+	for _, b := range parsed {
+		if tb := b.GetText(); tb != nil && tb.Style == model.BlockContentText_Toggle {
+			toggle = b
+			break
+		}
+	}
+	require.NotNil(t, toggle, "expected a toggle block, parsed:\n%+v", parsed)
+	assert.Equal(t, "", toggle.GetText().Text,
+		"empty-summary toggle must stay empty (no absorbed child text), parsed:\n%+v", parsed)
+
+	child := findBlockByText(parsed, "Hidden content")
+	require.NotNil(t, child, "expected the child block, parsed:\n%+v", parsed)
+	assert.Contains(t, toggle.ChildrenIds, child.Id,
+		"child must remain nested under the empty-summary toggle, parsed:\n%+v", parsed)
+}
+
 // TestMD_ToggleRoundTrip is the core TDD test: build a Toggle+child tree,
 // render to markdown, parse it back via anymark, and assert the result is a
 // Toggle with the child nested under it.


### PR DESCRIPTION
## What & why

Fixes **GO-7327**: Markdown export→import round-trip destroys Toggle (collapse) blocks.

A `Toggle` block (`model.BlockContentText_Toggle`, style 11) was exported as a Markdown blockquote (`> `) — sharing the exact same `case` as `Quote` — and its nested children were rendered with the parent's indent, flattening them to top-level siblings. On re-import the `> ` was parsed as a `Quote` block (style 5, the "vertical line"), with nesting lost. Users reported all their toggles turning into vertical lines with broken structure.

> User report: "I exported my MD. When importing back, all the toggles/collapse MD are not recognized and replaced by a vertical line. Destroying all the structure."

## Approach

Serialize a Toggle as an HTML `<details>`/`<summary>` block — widely supported (GitHub/Obsidian), unambiguously distinct from Quote's `> ` marker, and it round-trips cleanly through the existing goldmark parser:

```
<details>
<summary>My Toggle</summary>

...children...

</details>
```

goldmark parses the `<details>`+`<summary>` opener and the `</details>` closer as two separate `HTMLBlock` nodes (terminated by blank lines), with the inner content parsed as normal Markdown blocks in between. The previously no-op `renderHTMLBlock` now opens a Toggle on the opener and closes it on the closer, so intervening blocks nest as children via the renderer's existing parent-stack logic. Nesting is conveyed by the `<details>` wrapper itself, **not** indentation (a 4-space indent would trip Markdown's indented-code-block rule and re-import children as Code).

## Changes

- `core/converter/md/md.go` — split `Toggle` out of the shared `Quote` case; Toggle renders `<details>/<summary>/</details>` with children nested. Quote still renders `> `.
- `core/block/import/markdown/anymark/renderer.go` — `renderHTMLBlock` detects `<details>` opener (extracts `<summary>` → opens Toggle) and `</details>` closer (closes it); added regex helpers.
- `core/block/import/markdown/anymark/blocks_renderer.go` — `OpenToggleBlock(summary)` / `CloseToggleBlock()`; summary is set into the model `Text` so the first child isn't merged into the empty toggle.
- `core/block/import/markdown/anymark/markdown.go` — html2md `details`/`summary` rules so HTML-paste/web `<details>` also imports as a toggle.

## Tests

- `core/converter/md/toggle_roundtrip_test.go` (new) — export encoding, Quote-still-`> `, and a render→parse round-trip test (written red-first, TDD).
- `core/block/import/markdown/anymark/toggle_test.go` (new) — `<details>`→nested Toggle (single + multiple children), plain `> `→Quote, HTML `<details>`→Toggle.

```
go test ./core/converter/md/...                 ok
go test ./core/block/import/markdown/...        ok
go build ./...                                  ok
```

## Limitations / follow-ups

- `ToggleHeader1/2/3` left as-is (export as `#/##/###`, re-import as plain headers — pre-existing behavior, not the "vertical line" bug). Worth a follow-up for full toggle-header fidelity.
- Verified: nested toggles (toggle-in-toggle), multiple children, and list children all nest correctly.

An end-to-end repro lives in the `anytype-suite` integration tests (`src/scenarios/objects/markdown-roundtrip-toggle.test.ts`) and should flip to passing once a server built from this branch is used.
