### PR TITLE
GO-7334 crossspacesub: coalesce + grace-delay client-facing broadcasts

### DIFF
--- a/core/subscription/crossspacesub/clock.go
+++ b/core/subscription/crossspacesub/clock.go
@@ -1,0 +1,16 @@
+package crossspacesub
+
+import "time"
+
+// clock is the timing seam so the broadcast run loop is deterministic in tests.
+// Production uses realClock; tests inject a fake whose after() channel they fire
+// manually. It is a struct field (never a package var) to stay -race clean.
+type clock interface {
+	now() time.Time
+	after(d time.Duration) <-chan time.Time
+}
+
+type realClock struct{}
+
+func (realClock) now() time.Time                         { return time.Now() }
+func (realClock) after(d time.Duration) <-chan time.Time { return time.After(d) }

--- a/core/subscription/crossspacesub/coalescer.go
+++ b/core/subscription/crossspacesub/coalescer.go
@@ -35,6 +35,9 @@ type coalescer struct {
 }
 
 func newCoalescer(createdAt time.Time, grace, window time.Duration, maxFlush int) *coalescer {
+	if maxFlush <= 0 {
+		maxFlush = maxFlushSize // guard: a non-positive cap would spin the chunk loop
+	}
 	return &coalescer{createdAt: createdAt, grace: grace, window: window, maxFlush: maxFlush}
 }
 
@@ -98,7 +101,11 @@ func (c *coalescer) nextDeadline() time.Time { return c.deadline }
 // coalesceCounters drops every SubscriptionCounters message except the last and
 // appends that survivor at the tail. After patchEvent each counters message
 // carries the cross-space subId and an absolute aggregate total, so only the
-// latest matters; its position relative to adds/removes is irrelevant.
+// latest matters; its position relative to adds/removes is irrelevant. With ≤1
+// counters message it returns the input unchanged (no relocation). It runs per
+// emitted chunk, so a flush split across multiple Broadcasts can carry one
+// counters message per chunk — each self-consistent, last-wins across the
+// ordered Broadcasts.
 func coalesceCounters(msgs []*pb.EventMessage) []*pb.EventMessage {
 	last := -1
 	count := 0

--- a/core/subscription/crossspacesub/coalescer.go
+++ b/core/subscription/crossspacesub/coalescer.go
@@ -1,0 +1,129 @@
+package crossspacesub
+
+import (
+	"time"
+
+	"github.com/anyproto/anytype-heart/pb"
+)
+
+const (
+	// defaultInitialGrace is how long the first broadcast for a new subId is
+	// held after the subscription was created, to let the client apply the
+	// subscribe response before live events land.
+	defaultInitialGrace = 200 * time.Millisecond
+	// defaultWindow is the steady-state coalescing window measured from the
+	// first buffered message of a flush.
+	defaultWindow = 50 * time.Millisecond
+	// maxFlushSize is the hard upper bound on messages per Broadcast.
+	maxFlushSize = 500
+)
+
+// coalescer is the pure, synchronous buffering policy for the client-facing
+// cross-space broadcast path. It owns the coalescing window, the once-per-sub
+// initial grace, the per-Broadcast size cap, and counters last-wins. It holds
+// no goroutine and no real clock: callers pass `now` so it is fully
+// deterministic and unit-testable. The run loop (crossspacesub.go) drives it.
+type coalescer struct {
+	createdAt time.Time
+	grace     time.Duration
+	window    time.Duration
+	maxFlush  int
+
+	firstDone bool
+	buf       []*pb.EventMessage
+	deadline  time.Time // zero when buf is empty
+}
+
+func newCoalescer(createdAt time.Time, grace, window time.Duration, maxFlush int) *coalescer {
+	return &coalescer{createdAt: createdAt, grace: grace, window: window, maxFlush: maxFlush}
+}
+
+// push appends already-patched messages. It arms the flush deadline when the
+// buffer transitions from empty to non-empty: the first flush is held until
+// max(createdAt+grace, now+window); later flushes use now+window.
+func (c *coalescer) push(now time.Time, msgs []*pb.EventMessage) {
+	if len(msgs) == 0 {
+		return
+	}
+	if len(c.buf) == 0 {
+		if !c.firstDone {
+			c.deadline = laterOf(c.createdAt.Add(c.grace), now.Add(c.window))
+		} else {
+			c.deadline = now.Add(c.window)
+		}
+	}
+	c.buf = append(c.buf, msgs...)
+}
+
+// ready returns the batches to broadcast now, each already counters-coalesced
+// and never larger than maxFlush. Rules:
+//   - first-flush grace: while !firstDone and now < deadline, hold everything
+//     (even a buffer over the size cap — the grace must not be pre-empted);
+//   - size cap: once grace is satisfied (or on a later flush), emit full
+//     maxFlush-sized chunks whenever the buffer is over the cap;
+//   - window: a sub-cap remainder is emitted only once the deadline passes.
+//
+// A sub-cap remainder left after size-triggered chunking keeps its existing
+// (future) deadline, so it still flushes on time.
+func (c *coalescer) ready(now time.Time) [][]*pb.EventMessage {
+	if len(c.buf) == 0 {
+		c.deadline = time.Time{}
+		return nil
+	}
+	if !c.firstDone && now.Before(c.deadline) {
+		return nil // first-flush grace not met: hold
+	}
+	timeUp := !now.Before(c.deadline)
+
+	var out [][]*pb.EventMessage
+	for len(c.buf) >= c.maxFlush {
+		out = append(out, coalesceCounters(c.buf[:c.maxFlush:c.maxFlush]))
+		c.buf = c.buf[c.maxFlush:]
+		c.firstDone = true
+	}
+	if timeUp && len(c.buf) > 0 {
+		out = append(out, coalesceCounters(c.buf))
+		c.buf = nil
+		c.firstDone = true
+	}
+	if len(c.buf) == 0 {
+		c.deadline = time.Time{}
+	}
+	return out
+}
+
+// nextDeadline is when the run loop should wake to flush; zero when idle.
+func (c *coalescer) nextDeadline() time.Time { return c.deadline }
+
+// coalesceCounters drops every SubscriptionCounters message except the last and
+// appends that survivor at the tail. After patchEvent each counters message
+// carries the cross-space subId and an absolute aggregate total, so only the
+// latest matters; its position relative to adds/removes is irrelevant.
+func coalesceCounters(msgs []*pb.EventMessage) []*pb.EventMessage {
+	last := -1
+	count := 0
+	for i, m := range msgs {
+		if m.GetSubscriptionCounters() != nil {
+			last = i
+			count++
+		}
+	}
+	if count <= 1 {
+		return msgs
+	}
+	out := make([]*pb.EventMessage, 0, len(msgs)-count+1)
+	for _, m := range msgs {
+		if m.GetSubscriptionCounters() != nil {
+			continue // skip all counters here; append the survivor at the tail below
+		}
+		out = append(out, m)
+	}
+	return append(out, msgs[last])
+}
+
+func laterOf(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}

--- a/core/subscription/crossspacesub/coalescer_test.go
+++ b/core/subscription/crossspacesub/coalescer_test.go
@@ -76,7 +76,18 @@ func TestCoalescer(t *testing.T) {
 		assert.Nil(t, c.ready(t0), "must hold during grace")
 		assert.Nil(t, c.ready(t0.Add(grace-time.Millisecond)), "still within grace")
 		out := c.ready(t0.Add(grace))
+		require.Len(t, out, 1, "single broadcast batch")
 		assert.Equal(t, 3, flatLen(out), "flush at grace deadline")
+	})
+
+	t.Run("late first event flushes after only window, not grace", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		late := t0.Add(grace + time.Second) // first event arrives well after grace
+		c.push(late, adds(2))
+		assert.Nil(t, c.ready(late), "held only for the window from the first message")
+		out := c.ready(late.Add(window))
+		require.Len(t, out, 1)
+		assert.Equal(t, 2, flatLen(out))
 	})
 
 	t.Run("large first wave still held for grace (M1 regression)", func(t *testing.T) {
@@ -96,6 +107,7 @@ func TestCoalescer(t *testing.T) {
 		c2.push(t0.Add(window/2), adds(3)) // second wave inside the window
 		assert.Nil(t, c2.ready(t0.Add(window/2)))
 		out := c2.ready(t0.Add(window))
+		require.Len(t, out, 1, "both waves coalesced into a single broadcast batch")
 		assert.Equal(t, 5, flatLen(out), "both waves in one flush")
 	})
 

--- a/core/subscription/crossspacesub/coalescer_test.go
+++ b/core/subscription/crossspacesub/coalescer_test.go
@@ -1,0 +1,120 @@
+package crossspacesub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/event"
+	"github.com/anyproto/anytype-heart/pb"
+)
+
+func addMsg(id string) *pb.EventMessage {
+	return event.NewMessage("s", &pb.EventMessageValueOfSubscriptionAdd{
+		SubscriptionAdd: &pb.EventObjectSubscriptionAdd{Id: id, SubId: "cs"},
+	})
+}
+
+func countersMsg(total int64) *pb.EventMessage {
+	return event.NewMessage("s", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{Total: total, SubId: "cs"},
+	})
+}
+
+func countersTotals(msgs []*pb.EventMessage) []int64 {
+	var out []int64
+	for _, m := range msgs {
+		if c := m.GetSubscriptionCounters(); c != nil {
+			out = append(out, c.Total)
+		}
+	}
+	return out
+}
+
+func TestCoalesceCounters(t *testing.T) {
+	t.Run("keeps only the last counters, at the tail", func(t *testing.T) {
+		in := []*pb.EventMessage{countersMsg(1), addMsg("a"), countersMsg(2), addMsg("b"), countersMsg(3)}
+		out := coalesceCounters(in)
+		// 2 adds + exactly 1 counters
+		require.Len(t, out, 3)
+		assert.Equal(t, []int64{3}, countersTotals(out))
+		assert.Nil(t, out[len(out)-1].GetSubscriptionAdd(), "counters must be last")
+		assert.NotNil(t, out[len(out)-1].GetSubscriptionCounters())
+	})
+	t.Run("no counters: unchanged", func(t *testing.T) {
+		in := []*pb.EventMessage{addMsg("a"), addMsg("b")}
+		assert.Equal(t, in, coalesceCounters(in))
+	})
+}
+
+func adds(n int) []*pb.EventMessage {
+	out := make([]*pb.EventMessage, n)
+	for i := range out {
+		out[i] = addMsg("x")
+	}
+	return out
+}
+
+func flatLen(batches [][]*pb.EventMessage) int {
+	n := 0
+	for _, b := range batches {
+		n += len(b)
+	}
+	return n
+}
+
+func TestCoalescer(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	grace := 200 * time.Millisecond
+	window := 50 * time.Millisecond
+
+	t.Run("first flush held until createdAt+grace", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		c.push(t0, adds(3))
+		assert.Nil(t, c.ready(t0), "must hold during grace")
+		assert.Nil(t, c.ready(t0.Add(grace-time.Millisecond)), "still within grace")
+		out := c.ready(t0.Add(grace))
+		assert.Equal(t, 3, flatLen(out), "flush at grace deadline")
+	})
+
+	t.Run("large first wave still held for grace (M1 regression)", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		c.push(t0, adds(maxFlushSize+50)) // > cap
+		assert.Nil(t, c.ready(t0.Add(grace-time.Millisecond)), "size cap must not pre-empt grace")
+		out := c.ready(t0.Add(grace))
+		require.Len(t, out, 2)
+		assert.Len(t, out[0], maxFlushSize)
+		assert.Len(t, out[1], 50)
+	})
+
+	t.Run("window coalesces waves that arrive close together", func(t *testing.T) {
+		c2 := newCoalescer(t0, 0, window, maxFlushSize)
+		c2.push(t0, adds(2))
+		assert.Nil(t, c2.ready(t0), "within window")
+		c2.push(t0.Add(window/2), adds(3)) // second wave inside the window
+		assert.Nil(t, c2.ready(t0.Add(window/2)))
+		out := c2.ready(t0.Add(window))
+		assert.Equal(t, 5, flatLen(out), "both waves in one flush")
+	})
+
+	t.Run("size cap chunks to a hard bound; sub-cap remainder waits for window", func(t *testing.T) {
+		c := newCoalescer(t0, 0, window, maxFlushSize)
+		c.firstDone = true // later flush: no grace
+		c.push(t0, adds(maxFlushSize+120))
+		out := c.ready(t0) // not timeUp, but over cap -> one full chunk only
+		require.Len(t, out, 1)
+		assert.Len(t, out[0], maxFlushSize)
+		assert.Nil(t, c.ready(t0), "remainder (120) waits for window")
+		out = c.ready(t0.Add(window))
+		require.Len(t, out, 1)
+		assert.Len(t, out[0], 120)
+	})
+
+	t.Run("empty buffer: no batches, zero deadline", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		assert.Nil(t, c.ready(t0))
+		assert.True(t, c.nextDeadline().IsZero())
+	})
+}

--- a/core/subscription/crossspacesub/crossspacesub.go
+++ b/core/subscription/crossspacesub/crossspacesub.go
@@ -56,6 +56,11 @@ type crossSpaceSubscription struct {
 	pendingSpaceIds map[string]struct{}
 	// internal sub id (bson id) => total count
 	totalCounts map[string]int64
+	// internal sub ids whose counters may still be aggregated. A per-space sub
+	// is added when finalized and removed when its space is removed/rolled
+	// back, so a counter still queued for a removed space cannot resurrect its
+	// total (GO-7337).
+	activeInternalSubs map[string]struct{}
 }
 
 func newCrossSpaceSubscription(subId string, request subscriptionservice.SubscribeRequest, eventSender event.Sender, subscriptionService subscriptionservice.Service, loadedSpaceIds []string, pendingSpaceIds []string, predicate Predicate, clk clock, grace, window time.Duration) (*crossSpaceSubscription, *subscriptionservice.SubscribeResponse, error) {
@@ -72,6 +77,7 @@ func newCrossSpaceSubscription(subId string, request subscriptionservice.Subscri
 		inflightSpaceIds:      make(map[string]uint64),
 		pendingSpaceIds:       make(map[string]struct{}, len(pendingSpaceIds)),
 		totalCounts:           map[string]int64{},
+		activeInternalSubs:    map[string]struct{}{},
 		queue:                 mb.New[*pb.EventMessage](0),
 		clk:                   clk,
 		initialGrace:          grace,
@@ -106,6 +112,7 @@ func newCrossSpaceSubscription(subId string, request subscriptionservice.Subscri
 
 			s.lock.Lock()
 			s.perSpaceSubscriptions[spaceId] = resp.SubId
+			s.activeInternalSubs[resp.SubId] = struct{}{}
 			aggregatedResp.Records = append(aggregatedResp.Records, resp.Records...)
 			aggregatedResp.Dependencies = append(aggregatedResp.Dependencies, resp.Dependencies...)
 			aggregatedResp.Counters.Total += resp.Counters.Total
@@ -359,6 +366,7 @@ func (s *crossSpaceSubscription) completeReservation(spaceId string, token uint6
 		return nil
 	}
 	s.perSpaceSubscriptions[spaceId] = resp.SubId
+	s.activeInternalSubs[resp.SubId] = struct{}{}
 	s.lock.Unlock()
 	return nil
 }
@@ -448,6 +456,9 @@ func (s *crossSpaceSubscription) removeSpace(spaceId string) error {
 			}
 		}
 
+		// mark inactive before draining its total so any counter for this
+		// internal sub still queued ahead is ignored when patched (GO-7337)
+		delete(s.activeInternalSubs, subId)
 		total := s.removeTotalCount(subId)
 		err = s.queue.Add(s.ctx, event.NewMessage(spaceId, &pb.EventMessageValueOfSubscriptionCounters{
 			SubscriptionCounters: &pb.EventObjectSubscriptionCounters{
@@ -474,6 +485,11 @@ func (s *crossSpaceSubscription) updateTotalCount(internalSubId string, perSpace
 	if internalSubId == s.subId {
 		// a synthesized counters event (space removal/rollback) — already
 		// aggregated, nothing per-space to record
+		return s.getTotalCount()
+	}
+	if _, active := s.activeInternalSubs[internalSubId]; !active {
+		// counter for a removed/rolled-back per-space sub: ignore so a stale
+		// queued counter cannot resurrect the removed space's total (GO-7337)
 		return s.getTotalCount()
 	}
 	s.totalCounts[internalSubId] = perSpaceTotal

--- a/core/subscription/crossspacesub/crossspacesub.go
+++ b/core/subscription/crossspacesub/crossspacesub.go
@@ -37,6 +37,13 @@ type crossSpaceSubscription struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	queue     *mb.MB[*pb.EventMessage]
+	// started is closed when the run goroutine begins; done is closed when it
+	// exits. close() waits on done (only if started) so a replaced/unsubscribed
+	// subscription stops broadcasting before its successor starts — no stale
+	// tail under the same subId. close() always cancels ctx first, so a run that
+	// begins after the started check exits without broadcasting anyway.
+	started chan struct{}
+	done    chan struct{}
 
 	clk          clock
 	createdAt    time.Time
@@ -79,6 +86,8 @@ func newCrossSpaceSubscription(subId string, request subscriptionservice.Subscri
 		totalCounts:           map[string]int64{},
 		activeInternalSubs:    map[string]struct{}{},
 		queue:                 mb.New[*pb.EventMessage](0),
+		started:               make(chan struct{}),
+		done:                  make(chan struct{}),
 		clk:                   clk,
 		initialGrace:          grace,
 		window:                window,
@@ -141,13 +150,18 @@ func (s *crossSpaceSubscription) run(internalQueue *mb.MB[*pb.EventMessage]) {
 // runNested forwards each patched message to the parent queue (unchanged
 // behavior for nested cross-space subscriptions).
 func (s *crossSpaceSubscription) runNested(internalQueue *mb.MB[*pb.EventMessage]) {
+	close(s.started)
+	defer close(s.done)
 	for {
 		msgs, err := s.queue.Wait(s.ctx)
-		if errors.Is(err, context.Canceled) {
-			return
-		}
 		if err != nil {
-			log.Error("wait messages", zap.Error(err), zap.String("subId", s.subId))
+			// exit on any error; only close/cancel are reachable here (close()
+			// cancels ctx before closing the queue), but returning avoids a
+			// tight error-logging spin if Wait ever yields a sticky error.
+			if !errors.Is(err, context.Canceled) {
+				log.Error("wait messages", zap.Error(err), zap.String("subId", s.subId))
+			}
+			return
 		}
 		for _, msg := range msgs {
 			s.patchEvent(msg)
@@ -162,6 +176,8 @@ func (s *crossSpaceSubscription) runNested(internalQueue *mb.MB[*pb.EventMessage
 // first emission for the initial grace. A drainer goroutine converts the
 // blocking queue into a channel so the loop can select message-vs-timer.
 func (s *crossSpaceSubscription) runBroadcast() {
+	close(s.started)
+	defer close(s.done)
 	msgCh := make(chan []*pb.EventMessage)
 	go s.drain(msgCh)
 
@@ -173,10 +189,20 @@ func (s *crossSpaceSubscription) runBroadcast() {
 			s.eventSender.Broadcast(&pb.Event{Messages: batch})
 		}
 	}
+	// Re-arm the flush timer only when the deadline actually changes (it changes
+	// at most once per flush cycle: empty->armed on the first buffered message,
+	// armed->cleared when the buffer drains). Re-creating it every loop
+	// iteration would orphan a timer per message during a burst.
+	var timerC <-chan time.Time
+	var armed time.Time
 	for {
-		var timerC <-chan time.Time
-		if d := c.nextDeadline(); !d.IsZero() {
-			timerC = s.clk.after(d.Sub(s.clk.now()))
+		if d := c.nextDeadline(); !d.Equal(armed) {
+			armed = d
+			if d.IsZero() {
+				timerC = nil
+			} else {
+				timerC = s.clk.after(d.Sub(s.clk.now()))
+			}
 		}
 		select {
 		case <-s.ctx.Done():
@@ -248,9 +274,43 @@ func (s *crossSpaceSubscription) patchEvent(msg *pb.EventMessage) {
 	matcher.Match(msg)
 }
 
+// close tears the subscription down: it stops the run goroutine (and waits for
+// it, so no stale tail is broadcast under this subId), closes the queue, and
+// unsubscribes every finalized per-space subscription from the underlying
+// engine. The per-space subs use a caller-provided queue, so closing the queue
+// alone does NOT release them — only UnsubscribeAndReturnIds does; without this
+// they would leak (slots, pinned objects, per-change CPU) on every
+// Unsubscribe/resubscribe. Callers hold the service lock; UnsubscribeAndReturnIds
+// takes only the engine lock (service-lock -> engine-lock is the established
+// order via onSpaceIndexOpened), so this is deadlock-free.
 func (s *crossSpaceSubscription) close() error {
 	s.ctxCancel()
-	return s.queue.Close()
+	// Join the run goroutine only if it actually started, so close() works on a
+	// subscription whose run() was never launched (e.g. unit tests, or an error
+	// before `go run`). ctx is already canceled, so a run beginning after this
+	// check exits without broadcasting.
+	select {
+	case <-s.started:
+		<-s.done
+	default:
+	}
+	err := s.queue.Close()
+
+	s.lock.Lock()
+	perSpace := s.perSpaceSubscriptions
+	s.perSpaceSubscriptions = map[string]string{}
+	s.activeInternalSubs = map[string]struct{}{}
+	s.inflightSpaceIds = map[string]uint64{}
+	s.pendingSpaceIds = map[string]struct{}{}
+	s.lock.Unlock()
+
+	for spaceId, internalSubId := range perSpace {
+		if _, uerr := s.subscriptionService.UnsubscribeAndReturnIds(spaceId, internalSubId); uerr != nil {
+			log.Error("close: unsubscribe per-space subscription",
+				zap.String("subId", s.subId), zap.String("spaceId", spaceId), zap.Error(uerr))
+		}
+	}
+	return err
 }
 
 func (s *crossSpaceSubscription) AddSpace(spaceId string) error {
@@ -370,6 +430,16 @@ func (s *crossSpaceSubscription) completeReservation(spaceId string, token uint6
 	s.perSpaceSubscriptions[spaceId] = resp.SubId
 	s.activeInternalSubs[resp.SubId] = struct{}{}
 	s.lock.Unlock()
+	// Record the per-space total synchronously, mirroring the loaded-space path
+	// in newCrossSpaceSubscription. The async-init snapshot's counter is
+	// delivered later through the queue, and the GO-7337 active-sub gate would
+	// drop it if it were patched before activeInternalSubs was set above —
+	// leaving the aggregate permanently undercounted. updateTotalCount is
+	// idempotent (absolute, last-wins), so a later async counter just rewrites
+	// the same value.
+	if resp.Counters != nil {
+		s.updateTotalCount(resp.SubId, resp.Counters.Total)
+	}
 	return nil
 }
 
@@ -379,7 +449,10 @@ func (s *crossSpaceSubscription) completeReservation(spaceId string, token uint6
 // had already delivered through its async-init events — without them the
 // client keeps ghost records of a removed space — plus a zeroing counters
 // event. After close() the queue is gone and the client unsubscribed, so
-// failing to enqueue is fine.
+// failing to enqueue is fine. A rolled-back sub is never added to
+// activeInternalSubs (completeReservation only marks it active on the finalize
+// path), so any async-init counter still queued for it is ignored by the
+// updateTotalCount gate — no resurrection (GO-7337).
 func (s *crossSpaceSubscription) rollbackSubscription(spaceId string, subId string) {
 	ids, err := s.subscriptionService.UnsubscribeAndReturnIds(spaceId, subId)
 	if err != nil {
@@ -429,7 +502,9 @@ func (s *crossSpaceSubscription) RemoveSpace(spaceId string) {
 	defer s.lock.Unlock()
 	delete(s.pendingSpaceIds, spaceId)
 	err := s.removeSpace(spaceId)
-	if err != nil {
+	if err != nil && !errors.Is(err, mb.ErrClosed) && !errors.Is(err, context.Canceled) {
+		// ErrClosed/Canceled just mean a concurrent close() is tearing the
+		// queue down; the bookkeeping is already updated, so don't log noise.
 		log.Error("remove space", zap.Error(err), zap.String("subId", s.subId), zap.String("spaceId", spaceId))
 	}
 }
@@ -445,6 +520,14 @@ func (s *crossSpaceSubscription) removeSpace(spaceId string) error {
 		if err != nil {
 			return err
 		}
+		// Mutate all in-memory bookkeeping together, before enqueueing events, so
+		// a later queue.Add failure (teardown: ErrClosed/Canceled) cannot leave
+		// perSpaceSubscriptions present while activeInternalSubs/totalCounts are
+		// gone. Marking the internal sub inactive also makes any counter for it
+		// still queued ahead be ignored when patched (GO-7337).
+		delete(s.perSpaceSubscriptions, spaceId)
+		delete(s.activeInternalSubs, subId)
+		total := s.removeTotalCount(subId)
 		for _, id := range ids {
 			err = s.queue.Add(s.ctx, event.NewMessage(spaceId, &pb.EventMessageValueOfSubscriptionRemove{
 				SubscriptionRemove: &pb.EventObjectSubscriptionRemove{
@@ -457,11 +540,6 @@ func (s *crossSpaceSubscription) removeSpace(spaceId string) error {
 				return fmt.Errorf("send remove event to queue: %w", err)
 			}
 		}
-
-		// mark inactive before draining its total so any counter for this
-		// internal sub still queued ahead is ignored when patched (GO-7337)
-		delete(s.activeInternalSubs, subId)
-		total := s.removeTotalCount(subId)
 		err = s.queue.Add(s.ctx, event.NewMessage(spaceId, &pb.EventMessageValueOfSubscriptionCounters{
 			SubscriptionCounters: &pb.EventObjectSubscriptionCounters{
 				// the cross-space subId: keyed by the internal id, patchEvent's
@@ -475,7 +553,6 @@ func (s *crossSpaceSubscription) removeSpace(spaceId string) error {
 		if err != nil {
 			return fmt.Errorf("send counters event to queue: %w", err)
 		}
-		delete(s.perSpaceSubscriptions, spaceId)
 	}
 	return nil
 }

--- a/core/subscription/crossspacesub/crossspacesub.go
+++ b/core/subscription/crossspacesub/crossspacesub.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/cheggaaa/mb/v3"
 	"go.uber.org/zap"
@@ -37,6 +38,11 @@ type crossSpaceSubscription struct {
 	ctxCancel context.CancelFunc
 	queue     *mb.MB[*pb.EventMessage]
 
+	clk          clock
+	createdAt    time.Time
+	initialGrace time.Duration
+	window       time.Duration
+
 	lock sync.Mutex
 	// spaceId => subId (only finalized, real subscriptions)
 	perSpaceSubscriptions map[string]string
@@ -52,7 +58,7 @@ type crossSpaceSubscription struct {
 	totalCounts map[string]int64
 }
 
-func newCrossSpaceSubscription(subId string, request subscriptionservice.SubscribeRequest, eventSender event.Sender, subscriptionService subscriptionservice.Service, loadedSpaceIds []string, pendingSpaceIds []string, predicate Predicate) (*crossSpaceSubscription, *subscriptionservice.SubscribeResponse, error) {
+func newCrossSpaceSubscription(subId string, request subscriptionservice.SubscribeRequest, eventSender event.Sender, subscriptionService subscriptionservice.Service, loadedSpaceIds []string, pendingSpaceIds []string, predicate Predicate, clk clock, grace, window time.Duration) (*crossSpaceSubscription, *subscriptionservice.SubscribeResponse, error) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	s := &crossSpaceSubscription{
 		ctx:                   ctx,
@@ -67,6 +73,9 @@ func newCrossSpaceSubscription(subId string, request subscriptionservice.Subscri
 		pendingSpaceIds:       make(map[string]struct{}, len(pendingSpaceIds)),
 		totalCounts:           map[string]int64{},
 		queue:                 mb.New[*pb.EventMessage](0),
+		clk:                   clk,
+		initialGrace:          grace,
+		window:                window,
 	}
 	for _, spaceId := range pendingSpaceIds {
 		s.pendingSpaceIds[spaceId] = struct{}{}
@@ -107,10 +116,24 @@ func newCrossSpaceSubscription(subId string, request subscriptionservice.Subscri
 	}
 	wg.Wait()
 
+	// anchor the grace as late as the server can — close to when the response
+	// is sent — so the initial-grace budget is not eaten by the synchronous
+	// loaded-space subscribes above.
+	s.createdAt = s.clk.now()
 	return s, aggregatedResp, resErr
 }
 
 func (s *crossSpaceSubscription) run(internalQueue *mb.MB[*pb.EventMessage]) {
+	if internalQueue != nil {
+		s.runNested(internalQueue)
+		return
+	}
+	s.runBroadcast()
+}
+
+// runNested forwards each patched message to the parent queue (unchanged
+// behavior for nested cross-space subscriptions).
+func (s *crossSpaceSubscription) runNested(internalQueue *mb.MB[*pb.EventMessage]) {
 	for {
 		msgs, err := s.queue.Wait(s.ctx)
 		if errors.Is(err, context.Canceled) {
@@ -121,18 +144,63 @@ func (s *crossSpaceSubscription) run(internalQueue *mb.MB[*pb.EventMessage]) {
 		}
 		for _, msg := range msgs {
 			s.patchEvent(msg)
-			if internalQueue != nil {
-				err = internalQueue.Add(s.ctx, msg)
-				if err != nil {
-					log.Error("add to internal queue", zap.Error(err), zap.String("subId", s.subId))
-				}
+			if aerr := internalQueue.Add(s.ctx, msg); aerr != nil {
+				log.Error("add to internal queue", zap.Error(aerr), zap.String("subId", s.subId))
 			}
 		}
+	}
+}
 
-		if internalQueue == nil {
-			s.eventSender.Broadcast(&pb.Event{
-				Messages: msgs,
-			})
+// runBroadcast coalesces patched messages and broadcasts them, holding the
+// first emission for the initial grace. A drainer goroutine converts the
+// blocking queue into a channel so the loop can select message-vs-timer.
+func (s *crossSpaceSubscription) runBroadcast() {
+	msgCh := make(chan []*pb.EventMessage)
+	go s.drain(msgCh)
+
+	c := newCoalescer(s.createdAt, s.initialGrace, s.window, maxFlushSize)
+	flush := func() {
+		for _, batch := range c.ready(s.clk.now()) {
+			s.eventSender.Broadcast(&pb.Event{Messages: batch})
+		}
+	}
+	for {
+		var timerC <-chan time.Time
+		if d := c.nextDeadline(); !d.IsZero() {
+			timerC = s.clk.after(d.Sub(s.clk.now()))
+		}
+		select {
+		case <-s.ctx.Done():
+			return
+		case msgs, ok := <-msgCh:
+			if !ok {
+				return
+			}
+			for _, m := range msgs {
+				s.patchEvent(m)
+			}
+			c.push(s.clk.now(), msgs)
+			flush()
+		case <-timerC:
+			flush()
+		}
+	}
+}
+
+// drain reads bounded batches from the queue and hands them to runBroadcast,
+// stopping when the queue closes or the subscription is cancelled.
+func (s *crossSpaceSubscription) drain(out chan<- []*pb.EventMessage) {
+	defer close(out)
+	cond := s.queue.NewCond().WithMax(maxFlushSize)
+	for {
+		msgs, err := s.queue.WaitCond(s.ctx, cond)
+		if err != nil {
+			return
+		}
+		select {
+		case out <- msgs:
+		case <-s.ctx.Done():
+			return
 		}
 	}
 }

--- a/core/subscription/crossspacesub/crossspacesub.go
+++ b/core/subscription/crossspacesub/crossspacesub.go
@@ -168,6 +168,8 @@ func (s *crossSpaceSubscription) runBroadcast() {
 	c := newCoalescer(s.createdAt, s.initialGrace, s.window, maxFlushSize)
 	flush := func() {
 		for _, batch := range c.ready(s.clk.now()) {
+			log.Debug("crossspacesub broadcast flush",
+				zap.String("subId", s.subId), zap.Int("messages", len(batch)))
 			s.eventSender.Broadcast(&pb.Event{Messages: batch})
 		}
 	}
@@ -195,7 +197,7 @@ func (s *crossSpaceSubscription) runBroadcast() {
 }
 
 // drain reads bounded batches from the queue and hands them to runBroadcast,
-// stopping when the queue closes or the subscription is cancelled.
+// stopping when the queue closes or the subscription is canceled.
 func (s *crossSpaceSubscription) drain(out chan<- []*pb.EventMessage) {
 	defer close(out)
 	cond := s.queue.NewCond().WithMax(maxFlushSize)

--- a/core/subscription/crossspacesub/crossspacesub.go
+++ b/core/subscription/crossspacesub/crossspacesub.go
@@ -183,6 +183,9 @@ func (s *crossSpaceSubscription) runBroadcast() {
 
 	c := newCoalescer(s.createdAt, s.initialGrace, s.window, maxFlushSize)
 	flush := func() {
+		if s.ctx.Err() != nil {
+			return // closed: don't broadcast a stale tail (close() also joins us)
+		}
 		for _, batch := range c.ready(s.clk.now()) {
 			log.Debug("crossspacesub broadcast flush",
 				zap.String("subId", s.subId), zap.Int("messages", len(batch)))
@@ -280,9 +283,11 @@ func (s *crossSpaceSubscription) patchEvent(msg *pb.EventMessage) {
 // engine. The per-space subs use a caller-provided queue, so closing the queue
 // alone does NOT release them — only UnsubscribeAndReturnIds does; without this
 // they would leak (slots, pinned objects, per-change CPU) on every
-// Unsubscribe/resubscribe. Callers hold the service lock; UnsubscribeAndReturnIds
-// takes only the engine lock (service-lock -> engine-lock is the established
-// order via onSpaceIndexOpened), so this is deadlock-free.
+// Unsubscribe/resubscribe. Callers hold the service lock; the unsubscribe loop
+// runs with the per-sub lock released and only reaches the engine lock, which
+// never calls back into this service (no onSpaceIndexOpened off the unsubscribe
+// path). The service-lock -> engine-lock order is the one the monitor already
+// establishes, so this is deadlock-free.
 func (s *crossSpaceSubscription) close() error {
 	s.ctxCancel()
 	// Join the run goroutine only if it actually started, so close() works on a
@@ -429,17 +434,24 @@ func (s *crossSpaceSubscription) completeReservation(spaceId string, token uint6
 	}
 	s.perSpaceSubscriptions[spaceId] = resp.SubId
 	s.activeInternalSubs[resp.SubId] = struct{}{}
-	s.lock.Unlock()
-	// Record the per-space total synchronously, mirroring the loaded-space path
-	// in newCrossSpaceSubscription. The async-init snapshot's counter is
-	// delivered later through the queue, and the GO-7337 active-sub gate would
-	// drop it if it were patched before activeInternalSubs was set above —
-	// leaving the aggregate permanently undercounted. updateTotalCount is
-	// idempotent (absolute, last-wins), so a later async counter just rewrites
-	// the same value.
+	// Record the install-time total under the SAME lock as the active-set, so the
+	// two are atomic. The async-init snapshot's counter is delivered later
+	// through the queue; the GO-7337 active-sub gate would drop it if it were
+	// patched before activeInternalSubs was set, leaving the aggregate
+	// undercounted. Recording it here (a raw absolute write, not updateTotalCount
+	// which re-locks) fixes that. It must be inside the critical section: a live
+	// counter the run goroutine processes is then strictly ordered after this
+	// (and correctly overwrites it with the fresher absolute value) or before it
+	// (gated out as not-yet-active). Writing after the unlock would let this
+	// stale install-time value clobber a fresher live counter.
+	// Residual (negligible): a live counter processed in the tiny window before
+	// the active-set above is dropped, so only the install-time total is
+	// restored — a transient undercount for a just-promoted space that then goes
+	// quiet; the next counter for it corrects it.
 	if resp.Counters != nil {
-		s.updateTotalCount(resp.SubId, resp.Counters.Total)
+		s.totalCounts[resp.SubId] = resp.Counters.Total
 	}
+	s.lock.Unlock()
 	return nil
 }
 

--- a/core/subscription/crossspacesub/crossspacesub_test.go
+++ b/core/subscription/crossspacesub/crossspacesub_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anyproto/anytype-heart/core/event/mock_event"
 	subscriptionservice "github.com/anyproto/anytype-heart/core/subscription"
 	"github.com/anyproto/anytype-heart/core/subscription/mock_subscription"
 	"github.com/anyproto/anytype-heart/pb"
@@ -32,6 +33,7 @@ func newBareCrossSpaceSub(t *testing.T, ms subscriptionservice.Service, pending 
 		pendingSpaceIds:       map[string]struct{}{},
 		totalCounts:           map[string]int64{},
 		queue:                 mb.New[*pb.EventMessage](0),
+		clk:                   realClock{},
 	}
 	for _, p := range pending {
 		s.pendingSpaceIds[p] = struct{}{}
@@ -374,4 +376,89 @@ func TestPromotePending_decisionAndClaimAreAtomic(t *testing.T) {
 
 	assert.False(t, gapObserved.Load(),
 		"promote was observable in limbo (not pending, not reserved, not subscribed): a RemoveSpace in that window cannot cancel it and the space gets resurrected")
+}
+
+func TestRunBroadcast_graceDelaysFirstFlush(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	fc := newFakeClock()
+	s.clk = fc
+	s.initialGrace = 200 * time.Millisecond
+	s.window = 50 * time.Millisecond
+	s.createdAt = fc.now()
+
+	var mu sync.Mutex
+	var broadcasts int
+	sender := mock_event.NewMockSender(t)
+	sender.EXPECT().Broadcast(mock.Anything).Run(func(*pb.Event) {
+		mu.Lock()
+		broadcasts++
+		mu.Unlock()
+	}).Maybe()
+	s.eventSender = sender
+
+	go s.runBroadcast()
+
+	require.NoError(t, s.queue.Add(context.Background(), addMsg("a")))
+	// run loop must arm the grace timer before we advance the clock
+	require.Eventually(t, func() bool { return fc.numWaiters() >= 1 }, time.Second, time.Millisecond)
+	mu.Lock()
+	assert.Equal(t, 0, broadcasts, "no broadcast before grace deadline")
+	mu.Unlock()
+
+	fc.advance(200 * time.Millisecond)
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return broadcasts == 1 },
+		time.Second, time.Millisecond, "exactly one broadcast after grace")
+}
+
+type fakeClock struct {
+	mu      sync.Mutex
+	t       time.Time
+	waiters []fakeWaiter
+}
+
+type fakeWaiter struct {
+	at time.Time
+	ch chan time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1000, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) after(d time.Duration) <-chan time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	if d <= 0 {
+		ch <- c.t
+		return ch
+	}
+	c.waiters = append(c.waiters, fakeWaiter{at: c.t.Add(d), ch: ch})
+	return ch
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+	kept := c.waiters[:0]
+	for _, w := range c.waiters {
+		if !w.at.After(c.t) {
+			w.ch <- c.t
+		} else {
+			kept = append(kept, w)
+		}
+	}
+	c.waiters = kept
+}
+
+func (c *fakeClock) numWaiters() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.waiters)
 }

--- a/core/subscription/crossspacesub/crossspacesub_test.go
+++ b/core/subscription/crossspacesub/crossspacesub_test.go
@@ -620,8 +620,9 @@ func TestClose_unsubscribesPerSpaceSubsAndClosesQueue(t *testing.T) {
 		"close must close the queue")
 }
 
-// close() during the initial grace stops the run loop and drops the buffer
-// without broadcasting. GO-7334.
+// A ctx-cancel (close) during the initial grace drops the buffered events
+// without broadcasting. (The broadcaster join itself is covered by
+// TestRunBroadcast_closeWaitsForInflightBroadcast.) GO-7334.
 func TestRunBroadcast_closeMidWindowDropsBuffer(t *testing.T) {
 	ms := mock_subscription.NewMockService(t)
 	s := newBareCrossSpaceSub(t, ms)
@@ -640,4 +641,107 @@ func TestRunBroadcast_closeMidWindowDropsBuffer(t *testing.T) {
 		"grace timer armed (message buffered, not yet flushed)")
 
 	require.NoError(t, s.close()) // joins the run loop; buffer dropped, nothing broadcast
+}
+
+// close() must wait for an in-flight Broadcast to finish (join) so the old
+// generation cannot emit a tail under the subId after its successor starts.
+// GO-7336.
+func TestRunBroadcast_closeWaitsForInflightBroadcast(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	fc := newFakeClock()
+	s.clk = fc
+	s.initialGrace = 0
+	s.window = 50 * time.Millisecond
+	s.createdAt = fc.now()
+
+	enterBroadcast := make(chan struct{})
+	releaseBroadcast := make(chan struct{})
+	var broadcasts int32
+	sender := mock_event.NewMockSender(t)
+	sender.EXPECT().Broadcast(mock.Anything).Run(func(*pb.Event) {
+		if atomic.AddInt32(&broadcasts, 1) == 1 {
+			close(enterBroadcast)
+			<-releaseBroadcast
+		}
+	}).Maybe()
+	s.eventSender = sender
+	go s.run(nil)
+
+	require.NoError(t, s.queue.Add(context.Background(), addMsg("a")))
+	require.Eventually(t, func() bool { return fc.numWaiters() >= 1 }, time.Second, time.Millisecond)
+	fc.advance(50 * time.Millisecond) // fire the window timer -> flush -> Broadcast blocks
+	<-enterBroadcast                  // the Broadcast is now in flight, blocked
+
+	closed := make(chan struct{})
+	go func() { _ = s.close(); close(closed) }()
+
+	select {
+	case <-closed:
+		t.Fatal("close() returned before the in-flight Broadcast completed (join missing)")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseBroadcast)
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("close() did not return after the Broadcast completed")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&broadcasts), "exactly one broadcast; none after close")
+}
+
+// The flush timer must re-arm for a second wave after the buffer drained on the
+// first — guards the deadline-change re-arm logic across cycles. GO-7334.
+func TestRunBroadcast_reArmsTimerAcrossFlushCycles(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	fc := newFakeClock()
+	s.clk = fc
+	s.initialGrace = 0
+	s.window = 50 * time.Millisecond
+	s.createdAt = fc.now()
+
+	var mu sync.Mutex
+	var batches int
+	sender := mock_event.NewMockSender(t)
+	sender.EXPECT().Broadcast(mock.Anything).Run(func(*pb.Event) {
+		mu.Lock()
+		batches++
+		mu.Unlock()
+	}).Maybe()
+	s.eventSender = sender
+	go s.run(nil)
+
+	flushWave := func(id string, want int) {
+		require.NoError(t, s.queue.Add(context.Background(), addMsg(id)))
+		require.Eventually(t, func() bool { return fc.numWaiters() >= 1 }, time.Second, time.Millisecond)
+		fc.advance(50 * time.Millisecond)
+		require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return batches == want },
+			time.Second, time.Millisecond)
+	}
+	flushWave("a", 1)
+	flushWave("b", 2) // second wave only broadcasts if the timer re-armed after cycle 1
+}
+
+// The synchronous install-time total record plus a later async snapshot counter
+// for the same internal sub must not double-count (absolute, last-wins).
+func TestPromotePending_syncTotalIdempotentWithAsyncCounter(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms, "space1")
+	ms.EXPECT().Search(mock.Anything).Return(&subscriptionservice.SubscribeResponse{
+		SubId:    "sub-A",
+		Counters: &pb.EventObjectSubscriptionCounters{Total: 5},
+	}, nil)
+	require.NoError(t, s.PromotePending("space1"))
+
+	// the async snapshot counter for the same sub is patched afterwards
+	counter := event.NewMessage("space1", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{SubId: "sub-A", Total: 5},
+	})
+	s.patchEvent(counter)
+
+	s.lock.Lock()
+	total := s.getTotalCount()
+	s.lock.Unlock()
+	assert.Equal(t, int64(5), total, "sync record + async counter must not double-count")
 }

--- a/core/subscription/crossspacesub/crossspacesub_test.go
+++ b/core/subscription/crossspacesub/crossspacesub_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anyproto/anytype-heart/core/event"
 	"github.com/anyproto/anytype-heart/core/event/mock_event"
 	subscriptionservice "github.com/anyproto/anytype-heart/core/subscription"
 	"github.com/anyproto/anytype-heart/core/subscription/mock_subscription"
@@ -32,6 +33,7 @@ func newBareCrossSpaceSub(t *testing.T, ms subscriptionservice.Service, pending 
 		inflightSpaceIds:      map[string]uint64{},
 		pendingSpaceIds:       map[string]struct{}{},
 		totalCounts:           map[string]int64{},
+		activeInternalSubs:    map[string]struct{}{},
 		queue:                 mb.New[*pb.EventMessage](0),
 		clk:                   realClock{},
 	}
@@ -461,4 +463,39 @@ func (c *fakeClock) numWaiters() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.waiters)
+}
+
+func countersValue(m *pb.EventMessage) (int64, bool) {
+	if c := m.GetSubscriptionCounters(); c != nil {
+		return c.Total, true
+	}
+	return 0, false
+}
+
+// A per-space counter still queued when its space is removed must not resurrect
+// the removed space's total. GO-7337.
+func TestPatchEvent_removedSpaceCounterDoesNotResurrectTotal(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	s.perSpaceSubscriptions["space1"] = "sub-A"
+	s.activeInternalSubs["sub-A"] = struct{}{}
+	ms.EXPECT().UnsubscribeAndReturnIds("space1", "sub-A").Return([]string{"obj1", "obj2"}, nil)
+
+	// 1) per-space A's initial counter is still queued (unpatched)
+	queuedCounter := event.NewMessage("space1", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{SubId: "sub-A", Total: 2},
+	})
+
+	// 2) space removed: marks sub-A inactive and zeroes its total
+	s.RemoveSpace("space1")
+
+	// 3) the stale queued counter is now patched
+	s.patchEvent(queuedCounter)
+
+	total, ok := countersValue(queuedCounter)
+	require.True(t, ok)
+	assert.Equal(t, int64(0), total, "removed space's queued counter must not re-add its total")
+	s.lock.Lock()
+	assert.Equal(t, int64(0), s.getTotalCount())
+	s.lock.Unlock()
 }

--- a/core/subscription/crossspacesub/crossspacesub_test.go
+++ b/core/subscription/crossspacesub/crossspacesub_test.go
@@ -35,6 +35,8 @@ func newBareCrossSpaceSub(t *testing.T, ms subscriptionservice.Service, pending 
 		totalCounts:           map[string]int64{},
 		activeInternalSubs:    map[string]struct{}{},
 		queue:                 mb.New[*pb.EventMessage](0),
+		started:               make(chan struct{}),
+		done:                  make(chan struct{}),
 		clk:                   realClock{},
 	}
 	for _, p := range pending {
@@ -479,6 +481,7 @@ func TestPatchEvent_removedSpaceCounterDoesNotResurrectTotal(t *testing.T) {
 	s := newBareCrossSpaceSub(t, ms)
 	s.perSpaceSubscriptions["space1"] = "sub-A"
 	s.activeInternalSubs["sub-A"] = struct{}{}
+	s.totalCounts["sub-A"] = 2 // sub-A already contributed its total
 	ms.EXPECT().UnsubscribeAndReturnIds("space1", "sub-A").Return([]string{"obj1", "obj2"}, nil)
 
 	// 1) per-space A's initial counter is still queued (unpatched)
@@ -498,4 +501,143 @@ func TestPatchEvent_removedSpaceCounterDoesNotResurrectTotal(t *testing.T) {
 	s.lock.Lock()
 	assert.Equal(t, int64(0), s.getTotalCount())
 	s.lock.Unlock()
+}
+
+// completeReservation (AddSpace/PromotePending) must record the per-space total
+// synchronously; otherwise the GO-7337 active-sub gate can drop the async-init
+// counter and undercount the aggregate. GO-7337 regression guard.
+func TestPromotePending_recordsTotalSynchronously(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms, "space1")
+	ms.EXPECT().Search(mock.Anything).RunAndReturn(
+		func(subscriptionservice.SubscribeRequest) (*subscriptionservice.SubscribeResponse, error) {
+			return &subscriptionservice.SubscribeResponse{
+				SubId:    "sub-A",
+				Counters: &pb.EventObjectSubscriptionCounters{Total: 5},
+			}, nil
+		})
+
+	require.NoError(t, s.PromotePending("space1"))
+
+	s.lock.Lock()
+	total := s.getTotalCount()
+	s.lock.Unlock()
+	assert.Equal(t, int64(5), total,
+		"per-space total must be recorded synchronously, not left to the racy async counter")
+}
+
+// A rolled-back per-space sub's stray async counter must be ignored (it was
+// never marked active). GO-7337.
+func TestPatchEvent_rolledBackSubCounterIgnored(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	// sub-X was created then rolled back: present nowhere in activeInternalSubs.
+	counter := event.NewMessage("space1", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{SubId: "sub-X", Total: 7},
+	})
+	s.patchEvent(counter)
+	total, ok := countersValue(counter)
+	require.True(t, ok)
+	assert.Equal(t, int64(0), total, "counter for a non-active internal sub must be ignored")
+}
+
+// After remove+re-add of a space, the new internal sub's counter is aggregated
+// while the old (removed) sub's stale counter is ignored. GO-7337.
+func TestPatchEvent_reAddAfterRemove(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	s.perSpaceSubscriptions["space1"] = "sub-A"
+	s.activeInternalSubs["sub-A"] = struct{}{}
+	s.totalCounts["sub-A"] = 2
+	ms.EXPECT().UnsubscribeAndReturnIds("space1", "sub-A").Return(nil, nil)
+
+	s.RemoveSpace("space1")
+	// re-add under a fresh internal id
+	s.lock.Lock()
+	s.perSpaceSubscriptions["space1"] = "sub-B"
+	s.activeInternalSubs["sub-B"] = struct{}{}
+	s.lock.Unlock()
+
+	// stale counter for the removed sub-A is ignored; sub-B's is counted
+	stale := event.NewMessage("space1", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{SubId: "sub-A", Total: 2},
+	})
+	fresh := event.NewMessage("space1", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{SubId: "sub-B", Total: 3},
+	})
+	s.patchEvent(stale)
+	s.patchEvent(fresh)
+
+	s.lock.Lock()
+	total := s.getTotalCount()
+	s.lock.Unlock()
+	assert.Equal(t, int64(3), total, "only the live sub-B contributes; stale sub-A is ignored")
+}
+
+// The nested path (internalQueue != nil) forwards each patched message to the
+// parent queue and never broadcasts.
+func TestRunNested_forwardsPatchedMessages(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	parent := mb.New[*pb.EventMessage](0)
+	go s.run(parent) // nested path
+
+	require.NoError(t, s.queue.Add(context.Background(), addMsg("obj1")))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	msgs, err := parent.NewCond().WithMin(1).Wait(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	add := msgs[0].GetSubscriptionAdd()
+	require.NotNil(t, add)
+	assert.Equal(t, "cs", add.SubId, "subId rewritten to the cross-space subId")
+	assert.Equal(t, "obj1", add.Id)
+}
+
+// close() releases finalized per-space subscriptions from the engine (closing
+// the queue alone does not) and closes the queue. GO-7336.
+func TestClose_unsubscribesPerSpaceSubsAndClosesQueue(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	s.perSpaceSubscriptions["space1"] = "sub-A"
+	s.activeInternalSubs["sub-A"] = struct{}{}
+
+	sender := mock_event.NewMockSender(t) // no Broadcast expected
+	s.eventSender = sender
+	go s.run(nil) // broadcast path; no events -> no Broadcast
+
+	var unsubbed []string
+	ms.EXPECT().UnsubscribeAndReturnIds("space1", "sub-A").RunAndReturn(
+		func(_ string, id string) ([]string, error) {
+			unsubbed = append(unsubbed, id)
+			return nil, nil
+		})
+
+	require.NoError(t, s.close())
+	assert.Equal(t, []string{"sub-A"}, unsubbed, "close must unsubscribe per-space subs")
+	assert.ErrorIs(t, s.queue.Add(context.Background(), addMsg("x")), mb.ErrClosed,
+		"close must close the queue")
+}
+
+// close() during the initial grace stops the run loop and drops the buffer
+// without broadcasting. GO-7334.
+func TestRunBroadcast_closeMidWindowDropsBuffer(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	fc := newFakeClock()
+	s.clk = fc
+	s.initialGrace = 200 * time.Millisecond
+	s.window = 50 * time.Millisecond
+	s.createdAt = fc.now()
+
+	sender := mock_event.NewMockSender(t) // no Broadcast expected: buffer is dropped
+	s.eventSender = sender
+	go s.run(nil)
+
+	require.NoError(t, s.queue.Add(context.Background(), addMsg("a")))
+	require.Eventually(t, func() bool { return fc.numWaiters() >= 1 }, time.Second, time.Millisecond,
+		"grace timer armed (message buffered, not yet flushed)")
+
+	require.NoError(t, s.close()) // joins the run loop; buffer dropped, nothing broadcast
 }

--- a/core/subscription/crossspacesub/service.go
+++ b/core/subscription/crossspacesub/service.go
@@ -177,6 +177,17 @@ func (s *service) Subscribe(req subscriptionservice.SubscribeRequest, spaceViewP
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	// Resubscribe with an existing subId replaces the previous subscription:
+	// close it first so its run loop, queue, and per-space subscriptions are
+	// released. Otherwise the old instance keeps broadcasting under the same
+	// subId (leak + duplicate events). close() does not take s.lock. (GO-7336)
+	if existing, ok := s.subscriptions[req.SubId]; ok {
+		if cerr := existing.close(); cerr != nil {
+			log.Error("close existing subscription on resubscribe",
+				zap.String("subId", req.SubId), zap.Error(cerr))
+		}
+		delete(s.subscriptions, req.SubId)
+	}
 	var loadedIds, pendingIds []string
 	for spaceViewId, details := range s.spaceViewDetails {
 		if spaceViewPredicate(details) {

--- a/core/subscription/crossspacesub/service.go
+++ b/core/subscription/crossspacesub/service.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/globalsign/mgo/bson"
@@ -62,6 +63,10 @@ type service struct {
 	componentCtx       context.Context
 	componentCtxCancel context.CancelFunc
 
+	initialGrace time.Duration
+	window       time.Duration
+	clk          clock
+
 	lock             sync.Mutex
 	spaceViewsSubId  string
 	spaceViewDetails map[string]*domain.Details
@@ -87,6 +92,9 @@ func (s *service) Init(a *app.App) error {
 	s.spaceViewTargetIds = map[string]string{}
 	s.spaceViewDetails = map[string]*domain.Details{}
 	s.openedSpaceIds = map[string]struct{}{}
+	s.initialGrace = defaultInitialGrace
+	s.window = defaultWindow
+	s.clk = realClock{}
 
 	return nil
 }
@@ -183,7 +191,7 @@ func (s *service) Subscribe(req subscriptionservice.SubscribeRequest, spaceViewP
 			}
 		}
 	}
-	spaceSub, resp, err := newCrossSpaceSubscription(req.SubId, req, s.eventSender, s.subscriptionService, loadedIds, pendingIds, spaceViewPredicate)
+	spaceSub, resp, err := newCrossSpaceSubscription(req.SubId, req, s.eventSender, s.subscriptionService, loadedIds, pendingIds, spaceViewPredicate, s.clk, s.initialGrace, s.window)
 	if err != nil {
 		return nil, fmt.Errorf("new cross space subscription: %w", err)
 	}

--- a/core/subscription/crossspacesub/service.go
+++ b/core/subscription/crossspacesub/service.go
@@ -177,17 +177,6 @@ func (s *service) Subscribe(req subscriptionservice.SubscribeRequest, spaceViewP
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	// Resubscribe with an existing subId replaces the previous subscription:
-	// close it first so its run loop, queue, and per-space subscriptions are
-	// released. Otherwise the old instance keeps broadcasting under the same
-	// subId (leak + duplicate events). close() does not take s.lock. (GO-7336)
-	if existing, ok := s.subscriptions[req.SubId]; ok {
-		if cerr := existing.close(); cerr != nil {
-			log.Error("close existing subscription on resubscribe",
-				zap.String("subId", req.SubId), zap.Error(cerr))
-		}
-		delete(s.subscriptions, req.SubId)
-	}
 	var loadedIds, pendingIds []string
 	for spaceViewId, details := range s.spaceViewDetails {
 		if spaceViewPredicate(details) {
@@ -205,6 +194,19 @@ func (s *service) Subscribe(req subscriptionservice.SubscribeRequest, spaceViewP
 	spaceSub, resp, err := newCrossSpaceSubscription(req.SubId, req, s.eventSender, s.subscriptionService, loadedIds, pendingIds, spaceViewPredicate, s.clk, s.initialGrace, s.window)
 	if err != nil {
 		return nil, fmt.Errorf("new cross space subscription: %w", err)
+	}
+	// Resubscribe with an existing subId replaces the previous subscription. The
+	// new sub is built first (above) so a build failure leaves the existing one
+	// intact; only on success do we close the old one. close() stops its run
+	// loop, closes its queue, and unsubscribes its per-space subs — and it joins
+	// the run goroutine, so the old generation cannot broadcast a stale tail
+	// under this subId after the new snapshot. close() does not take s.lock.
+	// (GO-7336)
+	if existing, ok := s.subscriptions[req.SubId]; ok {
+		if cerr := existing.close(); cerr != nil {
+			log.Error("close existing subscription on resubscribe",
+				zap.String("subId", req.SubId), zap.Error(cerr))
+		}
 	}
 	s.subscriptions[req.SubId] = spaceSub
 	go spaceSub.run(req.InternalQueue)

--- a/core/subscription/crossspacesub/service_test.go
+++ b/core/subscription/crossspacesub/service_test.go
@@ -1124,3 +1124,45 @@ func TestSubscribe_resubscribeReplacesOldSub(t *testing.T) {
 	assert.ErrorIs(t, oldSub.queue.Add(context.Background(), addMsg("x")), mb.ErrClosed,
 		"old sub queue must be closed on resubscribe")
 }
+
+// End-to-end: coalescing/grace is actually wired through service.Subscribe (clk,
+// window, createdAt). With a non-zero window and an injected clock, a promoted
+// space's events are held until the clock advances, then broadcast in one go.
+func TestService_coalescesThroughRealSubscribe(t *testing.T) {
+	fx := newFixture(t)
+	fc := newFakeClock()
+	fx.service.clk = fc
+	fx.service.initialGrace = 0
+	fx.service.window = 50 * time.Millisecond
+
+	fx.objectStore.AddObjects(t, techSpaceId, []objectstore.TestObject{
+		givenSpaceViewObject("spaceView1", "space1", model.SpaceStatus_SpaceActive, model.SpaceStatus_Ok),
+	})
+	resp, err := fx.Subscribe(givenRequest(), NoOpPredicate())
+	require.NoError(t, err)
+
+	obj := objectstore.TestObject{
+		bundle.RelationKeyId:             domain.String("participant1"),
+		bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_participant)),
+	}
+	fx.objectStore.AddObjects(t, "space1", []objectstore.TestObject{obj})
+
+	// the events reach the coalescer and arm the window timer, but are NOT
+	// broadcast until the clock advances past the window.
+	require.Eventually(t, func() bool { return fc.numWaiters() >= 1 }, 2*time.Second, time.Millisecond)
+	assert.Equal(t, 0, fx.eventQueue.Len(), "events held by the coalescing window, not yet broadcast")
+
+	fc.advance(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	msgs, err := fx.eventQueue.NewCond().WithMin(3).Wait(ctx)
+	require.NoError(t, err)
+	found := false
+	for _, m := range msgs {
+		if a := m.GetSubscriptionAdd(); a != nil && a.Id == "participant1" && a.SubId == resp.SubId {
+			found = true
+		}
+	}
+	assert.True(t, found, "participant1 add broadcast under the cross-space subId after the window")
+}

--- a/core/subscription/crossspacesub/service_test.go
+++ b/core/subscription/crossspacesub/service_test.go
@@ -1086,3 +1086,39 @@ func givenSpaceViewObjectWithCreator(id string, targetSpaceId string, spaceStatu
 		bundle.RelationKeyCreator:            domain.String(creator),
 	}
 }
+
+func TestSubscribe_resubscribeReplacesOldSub(t *testing.T) {
+	fx := newFixture(t)
+
+	fx.objectStore.AddObjects(t, techSpaceId, []objectstore.TestObject{
+		givenSpaceViewObject("spaceView1", "space1", model.SpaceStatus_SpaceActive, model.SpaceStatus_Ok),
+	})
+
+	req := givenRequest()
+	req.SubId = "fixed-sub-id"
+	_, err := fx.Subscribe(req, NoOpPredicate())
+	require.NoError(t, err)
+
+	fx.service.lock.Lock()
+	oldSub := fx.service.subscriptions[req.SubId]
+	fx.service.lock.Unlock()
+	require.NotNil(t, oldSub)
+	require.NoError(t, oldSub.ctx.Err(), "old sub must be live before resubscribe")
+
+	// resubscribe with the SAME subId
+	_, err = fx.Subscribe(req, NoOpPredicate())
+	require.NoError(t, err)
+
+	fx.service.lock.Lock()
+	newSub := fx.service.subscriptions[req.SubId]
+	n := len(fx.service.subscriptions)
+	fx.service.lock.Unlock()
+
+	require.NotNil(t, newSub)
+	assert.NotSame(t, oldSub, newSub, "resubscribe must create a fresh sub instance")
+	assert.Equal(t, 1, n, "exactly one sub registered for the subId")
+	// the previous sub must be closed (ctx cancelled) so its run loop, queue,
+	// and per-space subscriptions are released instead of leaking and
+	// double-broadcasting under the same subId.
+	assert.Error(t, oldSub.ctx.Err(), "old sub must be closed on resubscribe")
+}

--- a/core/subscription/crossspacesub/service_test.go
+++ b/core/subscription/crossspacesub/service_test.go
@@ -1117,8 +1117,10 @@ func TestSubscribe_resubscribeReplacesOldSub(t *testing.T) {
 	require.NotNil(t, newSub)
 	assert.NotSame(t, oldSub, newSub, "resubscribe must create a fresh sub instance")
 	assert.Equal(t, 1, n, "exactly one sub registered for the subId")
-	// the previous sub must be closed (ctx cancelled) so its run loop, queue,
-	// and per-space subscriptions are released instead of leaking and
+	// the previous sub must be fully closed so its run loop, queue, and
+	// per-space subscriptions are released instead of leaking and
 	// double-broadcasting under the same subId.
-	assert.Error(t, oldSub.ctx.Err(), "old sub must be closed on resubscribe")
+	assert.Error(t, oldSub.ctx.Err(), "old sub ctx must be canceled on resubscribe")
+	assert.ErrorIs(t, oldSub.queue.Add(context.Background(), addMsg("x")), mb.ErrClosed,
+		"old sub queue must be closed on resubscribe")
 }

--- a/core/subscription/crossspacesub/service_test.go
+++ b/core/subscription/crossspacesub/service_test.go
@@ -73,6 +73,12 @@ func newFixture(t *testing.T) *fixture {
 	err := a.Start(ctx)
 	require.NoError(t, err)
 
+	// Neutralize coalescing timing so existing exact-sequence assertions are
+	// unaffected and fast: with grace=0/window=0 each wave flushes immediately.
+	svc := s.(*service)
+	svc.initialGrace = 0
+	svc.window = 0
+
 	t.Cleanup(func() {
 		closeCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
@@ -81,7 +87,7 @@ func newFixture(t *testing.T) *fixture {
 	})
 
 	return &fixture{
-		service:      s.(*service),
+		service:      svc,
 		objectStore:  objectStore,
 		spaceService: spaceService,
 		eventQueue:   eventQueue,

--- a/docs/superpowers/plans/2026-06-25-crossspace-broadcast-coalescing.md
+++ b/docs/superpowers/plans/2026-06-25-crossspace-broadcast-coalescing.md
@@ -1,0 +1,960 @@
+# Cross-Space Broadcast Coalescing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Coalesce and grace-delay the event broadcasts of the client-facing cross-space subscription (`ObjectCrossSpaceSearchSubscribe`) to shrink the subscribe-response/event race window and the startup redraw storm, and fix two adjacent pre-existing bugs.
+
+**Architecture:** Separate the buffering *policy* from the delivery *mechanism*. A pure, synchronous `coalescer` (timestamps passed in, no goroutines, no real time) owns the window/grace/size-cap/counters-last-wins logic and is exhaustively unit-tested. A thin run-loop (a drainer goroutine feeding a `select` over the message channel and an injected-clock timer) drives the coalescer and calls `eventSender.Broadcast`. Only the `internalQueue == nil` (broadcast) path is changed; the nested-forward path is untouched.
+
+**Tech Stack:** Go; `github.com/cheggaaa/mb/v3` (message buffer queue); `github.com/anyproto/anytype-heart/pb` (event protos); testify (`assert`/`require`/`mock`); existing `mock_event.MockSender` and `mock_subscription.MockService`.
+
+## Global Constraints
+
+- Commit message prefix: `GO-7334` for coalescing work; `GO-7336` for the resubscribe-leak fix; `GO-7337` for the counter-resurrection fix. Format: `GO-NNNN Short description`.
+- Wrap every non-trivial error with context: `fmt.Errorf("operation: %w", err)`. Never return a bare `err` — wrap it. Do not change a bare `return` to `return err`; change it to `return fmt.Errorf("context: %w", err)`.
+- All work targets the `develop` branch (branch off `develop`).
+- The full `crossspacesub` and `core/subscription` suites must pass under `-race`.
+- Scope is `core/subscription/crossspacesub` only. Do not touch the regular subscription engine, the event sender, or the wire protocol.
+- Package consts (in `core/subscription/crossspacesub`): `defaultInitialGrace = 200 * time.Millisecond`, `defaultWindow = 50 * time.Millisecond`, `maxFlushSize = 500`.
+
+---
+
+## File Structure
+
+- **Create** `core/subscription/crossspacesub/coalescer.go` — pure policy: `coalescer` type (`push`/`ready`/`nextDeadline`), `coalesceCounters`, `laterOf`.
+- **Create** `core/subscription/crossspacesub/coalescer_test.go` — exhaustive pure unit tests.
+- **Create** `core/subscription/crossspacesub/clock.go` — `clock` interface + `realClock`.
+- **Modify** `core/subscription/crossspacesub/crossspacesub.go` — add timing/clock fields to `crossSpaceSubscription`; rewrite the broadcast branch of `run`; add `drain`; counter-resurrection fix in `updateTotalCount`/finalize/`removeSpace` (Task 4).
+- **Modify** `core/subscription/crossspacesub/service.go` — add `initialGrace`/`window`/`clk` to `service`, default them in `Init`, pass to `newCrossSpaceSubscription`; resubscribe-replace in `Subscribe` (Task 3).
+- **Modify** `core/subscription/crossspacesub/crossspacesub_test.go` — update `newBareCrossSpaceSub` for new fields; add Task 4 unit test; add a fake clock helper.
+- **Modify** `core/subscription/crossspacesub/service_test.go` — set `initialGrace=0`/`window=0` in `newFixture`; add Task 2 wiring tests and Task 3 resubscribe test.
+
+---
+
+## Task 1: Pure coalescer policy
+
+**Files:**
+- Create: `core/subscription/crossspacesub/coalescer.go`
+- Test: `core/subscription/crossspacesub/coalescer_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type coalescer struct { ... }` with constructor `newCoalescer(createdAt time.Time, grace, window time.Duration, maxFlush int) *coalescer`
+  - `func (c *coalescer) push(now time.Time, msgs []*pb.EventMessage)`
+  - `func (c *coalescer) ready(now time.Time) [][]*pb.EventMessage`
+  - `func (c *coalescer) nextDeadline() time.Time` (zero value when buffer empty)
+  - `func coalesceCounters(msgs []*pb.EventMessage) []*pb.EventMessage`
+  - `func laterOf(a, b time.Time) time.Time`
+- Consumes: `*pb.EventMessage`, `pb.EventMessageValueOfSubscriptionCounters` from `github.com/anyproto/anytype-heart/pb`.
+
+- [ ] **Step 1: Write the failing test for `coalesceCounters`**
+
+Create `core/subscription/crossspacesub/coalescer_test.go`:
+
+```go
+package crossspacesub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/event"
+	"github.com/anyproto/anytype-heart/pb"
+)
+
+func addMsg(id string) *pb.EventMessage {
+	return event.NewMessage("s", &pb.EventMessageValueOfSubscriptionAdd{
+		SubscriptionAdd: &pb.EventObjectSubscriptionAdd{Id: id, SubId: "cs"},
+	})
+}
+
+func countersMsg(total int64) *pb.EventMessage {
+	return event.NewMessage("s", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{Total: total, SubId: "cs"},
+	})
+}
+
+func countersTotals(msgs []*pb.EventMessage) []int64 {
+	var out []int64
+	for _, m := range msgs {
+		if c := m.GetSubscriptionCounters(); c != nil {
+			out = append(out, c.Total)
+		}
+	}
+	return out
+}
+
+func TestCoalesceCounters(t *testing.T) {
+	t.Run("keeps only the last counters, at the tail", func(t *testing.T) {
+		in := []*pb.EventMessage{countersMsg(1), addMsg("a"), countersMsg(2), addMsg("b"), countersMsg(3)}
+		out := coalesceCounters(in)
+		// 2 adds + exactly 1 counters
+		require.Len(t, out, 3)
+		assert.Equal(t, []int64{3}, countersTotals(out))
+		assert.Nil(t, out[len(out)-1].GetSubscriptionAdd(), "counters must be last")
+		assert.NotNil(t, out[len(out)-1].GetSubscriptionCounters())
+	})
+	t.Run("no counters: unchanged", func(t *testing.T) {
+		in := []*pb.EventMessage{addMsg("a"), addMsg("b")}
+		assert.Equal(t, in, coalesceCounters(in))
+	})
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestCoalesceCounters -v`
+Expected: FAIL — `undefined: coalesceCounters`.
+
+- [ ] **Step 3: Implement `coalescer.go`**
+
+Create `core/subscription/crossspacesub/coalescer.go`:
+
+```go
+package crossspacesub
+
+import (
+	"time"
+
+	"github.com/anyproto/anytype-heart/pb"
+)
+
+// coalescer is the pure, synchronous buffering policy for the client-facing
+// cross-space broadcast path. It owns the coalescing window, the once-per-sub
+// initial grace, the per-Broadcast size cap, and counters last-wins. It holds
+// no goroutine and no real clock: callers pass `now` so it is fully
+// deterministic and unit-testable. The run loop (crossspacesub.go) drives it.
+type coalescer struct {
+	createdAt time.Time
+	grace     time.Duration
+	window    time.Duration
+	maxFlush  int
+
+	firstDone bool
+	buf       []*pb.EventMessage
+	deadline  time.Time // zero when buf is empty
+}
+
+func newCoalescer(createdAt time.Time, grace, window time.Duration, maxFlush int) *coalescer {
+	return &coalescer{createdAt: createdAt, grace: grace, window: window, maxFlush: maxFlush}
+}
+
+// push appends already-patched messages. It arms the flush deadline when the
+// buffer transitions from empty to non-empty: the first flush is held until
+// max(createdAt+grace, now+window); later flushes use now+window.
+func (c *coalescer) push(now time.Time, msgs []*pb.EventMessage) {
+	if len(msgs) == 0 {
+		return
+	}
+	if len(c.buf) == 0 {
+		if !c.firstDone {
+			c.deadline = laterOf(c.createdAt.Add(c.grace), now.Add(c.window))
+		} else {
+			c.deadline = now.Add(c.window)
+		}
+	}
+	c.buf = append(c.buf, msgs...)
+}
+
+// ready returns the batches to broadcast now, each already counters-coalesced
+// and never larger than maxFlush. Rules:
+//   - first-flush grace: while !firstDone and now < deadline, hold everything
+//     (even a buffer over the size cap — the grace must not be pre-empted);
+//   - size cap: once grace is satisfied (or on a later flush), emit full
+//     maxFlush-sized chunks whenever the buffer is over the cap;
+//   - window: a sub-cap remainder is emitted only once the deadline passes.
+//
+// A sub-cap remainder left after size-triggered chunking keeps its existing
+// (future) deadline, so it still flushes on time.
+func (c *coalescer) ready(now time.Time) [][]*pb.EventMessage {
+	if len(c.buf) == 0 {
+		c.deadline = time.Time{}
+		return nil
+	}
+	if !c.firstDone && now.Before(c.deadline) {
+		return nil // first-flush grace not met: hold
+	}
+	timeUp := !now.Before(c.deadline)
+
+	var out [][]*pb.EventMessage
+	for len(c.buf) >= c.maxFlush {
+		out = append(out, coalesceCounters(c.buf[:c.maxFlush:c.maxFlush]))
+		c.buf = c.buf[c.maxFlush:]
+		c.firstDone = true
+	}
+	if timeUp && len(c.buf) > 0 {
+		out = append(out, coalesceCounters(c.buf))
+		c.buf = nil
+		c.firstDone = true
+	}
+	if len(c.buf) == 0 {
+		c.deadline = time.Time{}
+	}
+	return out
+}
+
+// nextDeadline is when the run loop should wake to flush; zero when idle.
+func (c *coalescer) nextDeadline() time.Time { return c.deadline }
+
+// coalesceCounters drops every SubscriptionCounters message except the last and
+// appends that survivor at the tail. After patchEvent each counters message
+// carries the cross-space subId and an absolute aggregate total, so only the
+// latest matters; its position relative to adds/removes is irrelevant.
+func coalesceCounters(msgs []*pb.EventMessage) []*pb.EventMessage {
+	last := -1
+	count := 0
+	for i, m := range msgs {
+		if m.GetSubscriptionCounters() != nil {
+			last = i
+			count++
+		}
+	}
+	if count <= 1 {
+		return msgs
+	}
+	out := make([]*pb.EventMessage, 0, len(msgs)-count+1)
+	for i, m := range msgs {
+		if m.GetSubscriptionCounters() != nil && i != last {
+			continue
+		}
+		if i == last {
+			continue // append survivor at the tail below
+		}
+		out = append(out, m)
+	}
+	return append(out, msgs[last])
+}
+
+func laterOf(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+```
+
+- [ ] **Step 4: Run `TestCoalesceCounters` to verify it passes**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestCoalesceCounters -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the policy tests (grace, size cap, window)**
+
+Append to `coalescer_test.go`:
+
+```go
+func adds(n int) []*pb.EventMessage {
+	out := make([]*pb.EventMessage, n)
+	for i := range out {
+		out[i] = addMsg("x")
+	}
+	return out
+}
+
+func flatLen(batches [][]*pb.EventMessage) int {
+	n := 0
+	for _, b := range batches {
+		n += len(b)
+	}
+	return n
+}
+
+func TestCoalescer(t *testing.T) {
+	t0 := time.Unix(1000, 0)
+	grace := 200 * time.Millisecond
+	window := 50 * time.Millisecond
+
+	t.Run("first flush held until createdAt+grace", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		c.push(t0, adds(3))
+		assert.Nil(t, c.ready(t0), "must hold during grace")
+		assert.Nil(t, c.ready(t0.Add(grace-time.Millisecond)), "still within grace")
+		out := c.ready(t0.Add(grace))
+		assert.Equal(t, 3, flatLen(out), "flush at grace deadline")
+	})
+
+	t.Run("large first wave still held for grace (M1 regression)", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		c.push(t0, adds(maxFlushSize+50)) // > cap
+		assert.Nil(t, c.ready(t0.Add(grace-time.Millisecond)), "size cap must not pre-empt grace")
+		out := c.ready(t0.Add(grace))
+		require.Len(t, out, 2)
+		assert.Len(t, out[0], maxFlushSize)
+		assert.Len(t, out[1], 50)
+	})
+
+	t.Run("window coalesces waves that arrive close together", func(t *testing.T) {
+		c := newCoalescer(t0, 0, window, maxFlushSize) // grace 0: exercise steady-state window
+		c.push(t0, adds(2))
+		assert.Equal(t, 2, flatLen(c.ready(t0)), "grace 0 -> deadline = now+window; now==deadline? no")
+		// With grace 0 the first push deadline = now+window (future), so nothing yet:
+		c2 := newCoalescer(t0, 0, window, maxFlushSize)
+		c2.push(t0, adds(2))
+		assert.Nil(t, c2.ready(t0), "within window")
+		c2.push(t0.Add(window/2), adds(3)) // second wave inside the window
+		assert.Nil(t, c2.ready(t0.Add(window/2)))
+		out := c2.ready(t0.Add(window))
+		assert.Equal(t, 5, flatLen(out), "both waves in one flush")
+	})
+
+	t.Run("size cap chunks to a hard bound; sub-cap remainder waits for window", func(t *testing.T) {
+		c := newCoalescer(t0, 0, window, maxFlushSize)
+		c.firstDone = true // later flush: no grace
+		c.push(t0, adds(maxFlushSize+120))
+		out := c.ready(t0) // not timeUp, but over cap -> one full chunk only
+		require.Len(t, out, 1)
+		assert.Len(t, out[0], maxFlushSize)
+		assert.Nil(t, c.ready(t0), "remainder (120) waits for window")
+		out = c.ready(t0.Add(window))
+		require.Len(t, out, 1)
+		assert.Len(t, out[0], 120)
+	})
+
+	t.Run("empty buffer: no batches, zero deadline", func(t *testing.T) {
+		c := newCoalescer(t0, grace, window, maxFlushSize)
+		assert.Nil(t, c.ready(t0))
+		assert.True(t, c.nextDeadline().IsZero())
+	})
+}
+```
+
+- [ ] **Step 6: Run the full coalescer suite**
+
+Run: `go test ./core/subscription/crossspacesub/ -run 'TestCoalesce|TestCoalescer' -v`
+Expected: PASS (all subtests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/subscription/crossspacesub/coalescer.go core/subscription/crossspacesub/coalescer_test.go
+git commit -m "GO-7334 crossspacesub: add pure coalescer policy (window/grace/size-cap/counters)"
+```
+
+---
+
+## Task 2: Clock seam + wire the coalescer into `run`
+
+**Files:**
+- Create: `core/subscription/crossspacesub/clock.go`
+- Modify: `core/subscription/crossspacesub/crossspacesub.go` (struct fields, `run`, new `drain`)
+- Modify: `core/subscription/crossspacesub/service.go` (service fields/defaults, `newCrossSpaceSubscription` signature + call site)
+- Modify: `core/subscription/crossspacesub/crossspacesub_test.go` (`newBareCrossSpaceSub` fields, fake clock helper)
+- Modify: `core/subscription/crossspacesub/service_test.go` (zero timing in `newFixture`, wiring tests)
+
+**Interfaces:**
+- Consumes: `coalescer` from Task 1.
+- Produces:
+  - `type clock interface { now() time.Time; after(d time.Duration) <-chan time.Time }`
+  - `realClock` implementing it.
+  - `crossSpaceSubscription` gains fields `createdAt time.Time`, `initialGrace, window time.Duration`, `clk clock`.
+  - `newCrossSpaceSubscription(subId string, request subscriptionservice.SubscribeRequest, eventSender event.Sender, subscriptionService subscriptionservice.Service, loadedSpaceIds []string, pendingSpaceIds []string, predicate Predicate, clk clock, grace, window time.Duration)` (extended signature).
+  - `service` gains `initialGrace, window time.Duration`, `clk clock`.
+
+- [ ] **Step 1: Create the clock seam**
+
+Create `core/subscription/crossspacesub/clock.go`:
+
+```go
+package crossspacesub
+
+import "time"
+
+// clock is the timing seam so the broadcast run loop is deterministic in tests.
+// Production uses realClock; tests inject a fake whose after() channel they fire
+// manually. It is a struct field (never a package var) to stay -race clean.
+type clock interface {
+	now() time.Time
+	after(d time.Duration) <-chan time.Time
+}
+
+type realClock struct{}
+
+func (realClock) now() time.Time                         { return time.Now() }
+func (realClock) after(d time.Duration) <-chan time.Time { return time.After(d) }
+```
+
+- [ ] **Step 2: Add timing consts and struct fields**
+
+In `core/subscription/crossspacesub/crossspacesub.go`, add `"time"` to imports, add consts near the top, and the fields to `crossSpaceSubscription`:
+
+```go
+const (
+	defaultInitialGrace = 200 * time.Millisecond
+	defaultWindow       = 50 * time.Millisecond
+	maxFlushSize        = 500
+)
+```
+
+Add to the `crossSpaceSubscription` struct (after `queue`):
+
+```go
+	clk          clock
+	createdAt    time.Time
+	initialGrace time.Duration
+	window       time.Duration
+```
+
+- [ ] **Step 3: Extend `newCrossSpaceSubscription` to accept and stamp timing**
+
+In `crossspacesub.go`, change the signature and set the fields. Add to the struct literal in `newCrossSpaceSubscription`: `clk: clk, initialGrace: grace, window: window,`. Stamp `createdAt` as late as possible — immediately before the final `return`:
+
+```go
+func newCrossSpaceSubscription(subId string, request subscriptionservice.SubscribeRequest, eventSender event.Sender, subscriptionService subscriptionservice.Service, loadedSpaceIds []string, pendingSpaceIds []string, predicate Predicate, clk clock, grace, window time.Duration) (*crossSpaceSubscription, *subscriptionservice.SubscribeResponse, error) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	s := &crossSpaceSubscription{
+		ctx:                   ctx,
+		ctxCancel:             ctxCancel,
+		subId:                 subId,
+		request:               request,
+		eventSender:           eventSender,
+		spacePredicate:        predicate,
+		subscriptionService:   subscriptionService,
+		perSpaceSubscriptions: make(map[string]string),
+		inflightSpaceIds:      make(map[string]uint64),
+		pendingSpaceIds:       make(map[string]struct{}, len(pendingSpaceIds)),
+		totalCounts:           map[string]int64{},
+		queue:                 mb.New[*pb.EventMessage](0),
+		clk:                   clk,
+		initialGrace:          grace,
+		window:                window,
+	}
+	// ... existing body unchanged through wg.Wait() ...
+
+	s.createdAt = s.clk.now() // anchor grace as late as the server can (≈ response send)
+	return s, aggregatedResp, resErr
+}
+```
+
+- [ ] **Step 4: Rewrite the broadcast branch of `run`; add `drain`**
+
+In `crossspacesub.go`, replace `run` with the version below. The nested (`internalQueue != nil`) path keeps the existing per-message forward loop; the broadcast path uses the drainer + select + coalescer.
+
+```go
+func (s *crossSpaceSubscription) run(internalQueue *mb.MB[*pb.EventMessage]) {
+	if internalQueue != nil {
+		s.runNested(internalQueue)
+		return
+	}
+	s.runBroadcast()
+}
+
+// runNested forwards each patched message to the parent queue (unchanged behavior).
+func (s *crossSpaceSubscription) runNested(internalQueue *mb.MB[*pb.EventMessage]) {
+	for {
+		msgs, err := s.queue.Wait(s.ctx)
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		if err != nil {
+			log.Error("wait messages", zap.Error(err), zap.String("subId", s.subId))
+		}
+		for _, msg := range msgs {
+			s.patchEvent(msg)
+			if aerr := internalQueue.Add(s.ctx, msg); aerr != nil {
+				log.Error("add to internal queue", zap.Error(aerr), zap.String("subId", s.subId))
+			}
+		}
+	}
+}
+
+// runBroadcast coalesces patched messages and broadcasts them, holding the
+// first emission for the initial grace. A drainer goroutine converts the
+// blocking queue into a channel so the loop can select message-vs-timer.
+func (s *crossSpaceSubscription) runBroadcast() {
+	msgCh := make(chan []*pb.EventMessage)
+	go s.drain(msgCh)
+
+	c := newCoalescer(s.createdAt, s.initialGrace, s.window, maxFlushSize)
+	flush := func() {
+		for _, batch := range c.ready(s.clk.now()) {
+			s.eventSender.Broadcast(&pb.Event{Messages: batch})
+		}
+	}
+	for {
+		var timerC <-chan time.Time
+		if d := c.nextDeadline(); !d.IsZero() {
+			timerC = s.clk.after(d.Sub(s.clk.now()))
+		}
+		select {
+		case <-s.ctx.Done():
+			return
+		case msgs, ok := <-msgCh:
+			if !ok {
+				return
+			}
+			for _, m := range msgs {
+				s.patchEvent(m)
+			}
+			c.push(s.clk.now(), msgs)
+			flush()
+		case <-timerC:
+			flush()
+		}
+	}
+}
+
+// drain reads bounded batches from the queue and hands them to runBroadcast,
+// stopping when the queue closes or the subscription is cancelled.
+func (s *crossSpaceSubscription) drain(out chan<- []*pb.EventMessage) {
+	defer close(out)
+	cond := s.queue.NewCond().WithMax(maxFlushSize)
+	for {
+		msgs, err := s.queue.WaitCond(s.ctx, cond)
+		if err != nil {
+			return
+		}
+		select {
+		case out <- msgs:
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}
+```
+
+(Remove the old single `run` body. `patchEvent` is now called in `runBroadcast`/`runNested`; keep `patchEvent`/`patchAll` semantics — patching still happens on the single run-loop goroutine, before `push`.)
+
+- [ ] **Step 5: Add service fields, defaults, and pass-through**
+
+In `core/subscription/crossspacesub/service.go`: add `"time"` to imports; add fields to `service`:
+
+```go
+	initialGrace time.Duration
+	window       time.Duration
+	clk          clock
+```
+
+In `Init`, set defaults:
+
+```go
+	s.initialGrace = defaultInitialGrace
+	s.window = defaultWindow
+	s.clk = realClock{}
+```
+
+In `Subscribe`, pass them to the constructor:
+
+```go
+	spaceSub, resp, err := newCrossSpaceSubscription(req.SubId, req, s.eventSender, s.subscriptionService, loadedIds, pendingIds, spaceViewPredicate, s.clk, s.initialGrace, s.window)
+```
+
+- [ ] **Step 6: Update `newBareCrossSpaceSub` and add a fake clock helper**
+
+In `crossspacesub_test.go`, set the new fields in `newBareCrossSpaceSub` struct literal: `clk: realClock{}, initialGrace: 0, window: 0,`. Add a fake clock at the end of the file:
+
+```go
+type fakeClock struct {
+	mu      sync.Mutex
+	t       time.Time
+	waiters []fakeWaiter
+}
+
+type fakeWaiter struct {
+	at time.Time
+	ch chan time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{t: time.Unix(1000, 0)} }
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) after(d time.Duration) <-chan time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	if d <= 0 {
+		ch <- c.t
+		return ch
+	}
+	c.waiters = append(c.waiters, fakeWaiter{at: c.t.Add(d), ch: ch})
+	return ch
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+	kept := c.waiters[:0]
+	for _, w := range c.waiters {
+		if !w.at.After(c.t) {
+			w.ch <- c.t
+		} else {
+			kept = append(kept, w)
+		}
+	}
+	c.waiters = kept
+}
+
+func (c *fakeClock) numWaiters() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.waiters)
+}
+```
+
+- [ ] **Step 7: Zero the timing in the integration fixture**
+
+In `service_test.go` `newFixture`, after `a.Start` succeeds and before `return`, neutralize timing so existing exact-sequence tests are unaffected and fast:
+
+```go
+	svc := s.(*service)
+	svc.initialGrace = 0
+	svc.window = 0
+```
+
+(Use `svc` in the returned `service:` field.)
+
+- [ ] **Step 8: Run the existing integration suite to verify no regressions**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestSubscribe -race -v`
+Expected: PASS — coalescing with grace=0/window=0 flushes each wave immediately, so the asserted message sequences are unchanged.
+
+- [ ] **Step 9: Add a wiring test (grace actually delays via the injected clock)**
+
+Add to `crossspacesub_test.go`:
+
+```go
+func TestRunBroadcast_graceDelaysFirstFlush(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	fc := newFakeClock()
+	s.clk = fc
+	s.initialGrace = 200 * time.Millisecond
+	s.window = 50 * time.Millisecond
+	s.createdAt = fc.now()
+
+	var mu sync.Mutex
+	var broadcasts int
+	sender := mock_event.NewMockSender(t)
+	sender.EXPECT().Broadcast(mock.Anything).Run(func(*pb.Event) {
+		mu.Lock()
+		broadcasts++
+		mu.Unlock()
+	}).Maybe()
+	s.eventSender = sender
+
+	go s.runBroadcast()
+
+	require.NoError(t, s.queue.Add(context.Background(), addMsg("a")))
+	// run loop must arm the grace timer before we advance the clock
+	require.Eventually(t, func() bool { return fc.numWaiters() >= 1 }, time.Second, time.Millisecond)
+	mu.Lock()
+	assert.Equal(t, 0, broadcasts, "no broadcast before grace deadline")
+	mu.Unlock()
+
+	fc.advance(200 * time.Millisecond)
+	require.Eventually(t, func() bool { mu.Lock(); defer mu.Unlock(); return broadcasts == 1 },
+		time.Second, time.Millisecond, "exactly one broadcast after grace")
+}
+```
+
+(`s.eventSender` is set directly; ensure the field is assignable — it is exported within the package.)
+
+- [ ] **Step 10: Run the wiring test**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestRunBroadcast_graceDelaysFirstFlush -race -v`
+Expected: PASS.
+
+- [ ] **Step 11: Run the whole package under -race**
+
+Run: `go test ./core/subscription/crossspacesub/ -race`
+Expected: PASS.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add core/subscription/crossspacesub/clock.go core/subscription/crossspacesub/crossspacesub.go core/subscription/crossspacesub/service.go core/subscription/crossspacesub/crossspacesub_test.go core/subscription/crossspacesub/service_test.go
+git commit -m "GO-7334 crossspacesub: coalesce + grace-delay broadcasts on the client-facing path"
+```
+
+---
+
+## Task 3: Resubscribe replace (GO-7336)
+
+**Files:**
+- Modify: `core/subscription/crossspacesub/service.go` (`Subscribe`)
+- Test: `core/subscription/crossspacesub/service_test.go`
+
+**Interfaces:**
+- Consumes: existing `service.subscriptions`, `crossSpaceSubscription.close()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `service_test.go`:
+
+```go
+func TestSubscribe_resubscribeReplacesOldSub(t *testing.T) {
+	fx := newFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	fx.objectStore.AddObjects(t, techSpaceId, []objectstore.TestObject{
+		givenSpaceViewObject("spaceView1", "space1", model.SpaceStatus_SpaceActive, model.SpaceStatus_Ok),
+	})
+
+	req := givenRequest()
+	req.SubId = "fixed-sub-id"
+	_, err := fx.Subscribe(req, NoOpPredicate())
+	require.NoError(t, err)
+	// resubscribe with the SAME subId
+	_, err = fx.Subscribe(req, NoOpPredicate())
+	require.NoError(t, err)
+
+	// exactly one live subscription is registered for that subId
+	fx.service.lock.Lock()
+	_, ok := fx.service.subscriptions[req.SubId]
+	n := len(fx.service.subscriptions)
+	fx.service.lock.Unlock()
+	assert.True(t, ok)
+	assert.Equal(t, 1, n, "resubscribe must not leave two subs for one subId")
+
+	// a single object change is broadcast once, not twice (no orphaned old loop)
+	obj := objectstore.TestObject{
+		bundle.RelationKeyId:             domain.String("participant1"),
+		bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_participant)),
+	}
+	fx.objectStore.AddObjects(t, "space1", []objectstore.TestObject{obj})
+
+	msgs, err := fx.eventQueue.NewCond().WithMin(3).Wait(ctx)
+	require.NoError(t, err)
+	adds := 0
+	for _, m := range msgs {
+		if m.GetSubscriptionAdd() != nil && m.GetSubscriptionAdd().Id == "participant1" {
+			adds++
+		}
+	}
+	assert.Equal(t, 1, adds, "object added exactly once (old sub did not also broadcast)")
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestSubscribe_resubscribeReplacesOldSub -race -v`
+Expected: FAIL — two subs registered and/or the add is broadcast twice.
+
+- [ ] **Step 3: Implement the replace in `Subscribe`**
+
+In `service.go` `Subscribe`, after `req.SubId` is finalized and `s.lock` is held (it already is via `defer`), but **before** building the new sub, close any existing one:
+
+```go
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if existing, ok := s.subscriptions[req.SubId]; ok {
+		if cerr := existing.close(); cerr != nil {
+			log.Error("close existing subscription on resubscribe",
+				zap.String("subId", req.SubId), zap.Error(cerr))
+		}
+		delete(s.subscriptions, req.SubId)
+	}
+	var loadedIds, pendingIds []string
+	// ... existing body ...
+```
+
+(`crossSpaceSubscription.close()` cancels its ctx and closes its queue; it does not take `s.lock`, so closing under `s.lock` is safe. The old `run`/`drain` goroutines exit; the old per-space subscriptions are released by the cancelled context path. Place this block right after `s.lock.Lock()` / `defer s.lock.Unlock()` at `service.go:170-171`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestSubscribe_resubscribeReplacesOldSub -race -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/subscription/crossspacesub/service.go core/subscription/crossspacesub/service_test.go
+git commit -m "GO-7336 crossspacesub: close existing sub on resubscribe with same subId (fix leak)"
+```
+
+---
+
+## Task 4: Counter resurrection fix (GO-7337)
+
+**Files:**
+- Modify: `core/subscription/crossspacesub/crossspacesub.go` (`updateTotalCount`, finalize sites, `removeSpace`)
+- Test: `core/subscription/crossspacesub/crossspacesub_test.go`
+
+**Interfaces:**
+- Produces: `crossSpaceSubscription` gains `activeInternalSubs map[string]struct{}` (the set of internal per-space subIds whose totals may be counted).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `crossspacesub_test.go`:
+
+```go
+func countersValue(m *pb.EventMessage) (int64, bool) {
+	if c := m.GetSubscriptionCounters(); c != nil {
+		return c.Total, true
+	}
+	return 0, false
+}
+
+// A per-space counter still queued when its space is removed must not resurrect
+// the removed space's total. GO-7337.
+func TestPatchEvent_removedSpaceCounterDoesNotResurrectTotal(t *testing.T) {
+	ms := mock_subscription.NewMockService(t)
+	s := newBareCrossSpaceSub(t, ms)
+	s.perSpaceSubscriptions["space1"] = "sub-A"
+	s.activeInternalSubs["sub-A"] = struct{}{}
+	ms.EXPECT().UnsubscribeAndReturnIds("space1", "sub-A").Return([]string{"obj1", "obj2"}, nil)
+
+	// 1) per-space A's initial counter is still queued (unpatched)
+	queuedCounter := event.NewMessage("space1", &pb.EventMessageValueOfSubscriptionCounters{
+		SubscriptionCounters: &pb.EventObjectSubscriptionCounters{SubId: "sub-A", Total: 2},
+	})
+
+	// 2) space removed: marks sub-A inactive and zeroes its total
+	s.RemoveSpace("space1")
+
+	// 3) the stale queued counter is now patched
+	s.patchEvent(queuedCounter)
+
+	total, ok := countersValue(queuedCounter)
+	require.True(t, ok)
+	assert.Equal(t, int64(0), total, "removed space's queued counter must not re-add its total")
+	s.lock.Lock()
+	assert.Equal(t, int64(0), s.getTotalCount())
+	s.lock.Unlock()
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestPatchEvent_removedSpaceCounterDoesNotResurrectTotal -v`
+Expected: FAIL — total is `2` (resurrected), and/or `activeInternalSubs` is undefined.
+
+- [ ] **Step 3: Add the `activeInternalSubs` set and gate `updateTotalCount`**
+
+In `crossspacesub.go`:
+
+Add the field to the struct: `activeInternalSubs map[string]struct{}`. Initialize it in both `newCrossSpaceSubscription` (`activeInternalSubs: map[string]struct{}{},`) and `newBareCrossSpaceSub` in the test helper (`activeInternalSubs: map[string]struct{}{},`).
+
+Mark internal subs active where finalized:
+- In `newCrossSpaceSubscription`, where loaded spaces finalize (`s.perSpaceSubscriptions[spaceId] = resp.SubId`), add `s.activeInternalSubs[resp.SubId] = struct{}{}` under the same `s.lock`.
+- In `completeReservation`, where `s.perSpaceSubscriptions[spaceId] = resp.SubId` (the `ours && !closed` branch), add `s.activeInternalSubs[resp.SubId] = struct{}{}`.
+
+Gate aggregation in `updateTotalCount`:
+
+```go
+func (s *crossSpaceSubscription) updateTotalCount(internalSubId string, perSpaceTotal int64) int64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if internalSubId == s.subId {
+		// synthesized counters event (space removal/rollback): already aggregated
+		return s.getTotalCount()
+	}
+	if _, active := s.activeInternalSubs[internalSubId]; !active {
+		// counter for a removed/rolled-back per-space sub: ignore so a stale
+		// queued counter cannot resurrect the removed space's total (GO-7337)
+		return s.getTotalCount()
+	}
+	s.totalCounts[internalSubId] = perSpaceTotal
+	return s.getTotalCount()
+}
+```
+
+- [ ] **Step 4: Mark inactive on removal**
+
+In `removeSpace`, where the sub is removed, delete from the active set so later queued counters are ignored. After `subId, ok := s.perSpaceSubscriptions[spaceId]` and inside the `if ok {` block (alongside `total := s.removeTotalCount(subId)`):
+
+```go
+		delete(s.activeInternalSubs, subId)
+		total := s.removeTotalCount(subId)
+```
+
+Also handle rollback symmetry: in `rollbackSubscription` the sub was never added to `perSpaceSubscriptions`, so it was never marked active — `updateTotalCount` already ignores its counters. No change needed there; add a one-line comment noting it.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `go test ./core/subscription/crossspacesub/ -run TestPatchEvent_removedSpaceCounterDoesNotResurrectTotal -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the whole package under -race**
+
+Run: `go test ./core/subscription/crossspacesub/ -race`
+Expected: PASS (existing counter/total tests still green; the active-set gate does not change live-space totals).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add core/subscription/crossspacesub/crossspacesub.go core/subscription/crossspacesub/crossspacesub_test.go
+git commit -m "GO-7337 crossspacesub: ignore counters for removed per-space subs (fix wrong total)"
+```
+
+---
+
+## Task 5: Observability + full verification
+
+**Files:**
+- Modify: `core/subscription/crossspacesub/crossspacesub.go` (debug log in `runBroadcast` flush)
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Add a debug log of coalescing effect**
+
+In `runBroadcast`, change the `flush` closure to log batch sizes at debug level (cheap visibility into the redraw win; no new metrics dependency):
+
+```go
+	flush := func() {
+		for _, batch := range c.ready(s.clk.now()) {
+			log.Debug("crossspacesub broadcast flush",
+				zap.String("subId", s.subId), zap.Int("messages", len(batch)))
+			s.eventSender.Broadcast(&pb.Event{Messages: batch})
+		}
+	}
+```
+
+- [ ] **Step 2: Build and vet the package**
+
+Run: `go build ./core/subscription/... && go vet ./core/subscription/crossspacesub/`
+Expected: no output (success).
+
+- [ ] **Step 3: Run the full subscription suite under -race**
+
+Run: `go test ./core/subscription/... -race`
+Expected: PASS.
+
+- [ ] **Step 4: Lint the changed files**
+
+Run: `golangci-lint run core/subscription/crossspacesub/...`
+Expected: no findings (errcheck/funlen/nestif/prealloc clean — match the existing package style).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/subscription/crossspacesub/crossspacesub.go
+git commit -m "GO-7334 crossspacesub: debug log coalesced broadcast batch sizes"
+```
+
+---
+
+## Post-implementation (not code tasks)
+
+- The three **Open questions** in the spec remain: confirm `ObjectCrossSpaceSearchSubscribe` is startup-hot and how wide; measure promote-wave spacing to validate/tune `defaultWindow`; calibrate `defaultInitialGrace` against client response-apply latency. Capture findings on GO-7334 before tuning the consts.
+- Spec reference: `docs/superpowers/specs/2026-06-25-crossspace-broadcast-coalescing-design.md`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Design §0 timing seam → Task 2 (clock.go, fake clock). ✓
+- Design §1 window/grace/size-cap (M1, M3) → Task 1 (`push`/`ready`, grace-before-cap, hard chunk bound) + Task 2 (`createdAt` stamped late). ✓
+- Design §2 `flushBroadcast` counters last-wins → Task 1 (`coalesceCounters`) + Task 2 (flush). ✓
+- Design §3 resubscribe replace (GO-7336) → Task 3. ✓
+- Design §4 counter resurrection (GO-7337) → Task 4. ✓
+- Design §5 config consts → Task 2 (consts) + `newFixture` zeroing. ✓
+- Design §6 observability → Task 5. ✓
+- Error handling (drop-on-close single policy) → Task 2 (`runBroadcast`/`drain` return on `ctx.Done`/queue close, buffer dropped). ✓
+- Nested path unchanged → Task 2 (`runNested`). ✓
+- Testing section items → covered across Task 1 (policy), Task 2 (grace via fake clock, no-regression), Task 3 (resubscribe), Task 4 (counter). ✓
+
+**Placeholder scan:** No TBD/TODO; every code and test step shows complete code and exact run commands with expected output. ✓
+
+**Type consistency:** `clock.now()/after()` used identically in `realClock`, `fakeClock`, and `runBroadcast`. `coalescer` constructor/method names (`newCoalescer`, `push`, `ready`, `nextDeadline`, `coalesceCounters`, `laterOf`) match between Task 1 definition and Task 2 use. `newCrossSpaceSubscription` extended signature matches its `service.Subscribe` call site. `activeInternalSubs` defined (Task 4) and initialized in both constructors. `maxFlushSize`/`defaultInitialGrace`/`defaultWindow` consts used consistently. ✓

--- a/docs/superpowers/specs/2026-06-25-crossspace-broadcast-coalescing-design.md
+++ b/docs/superpowers/specs/2026-06-25-crossspace-broadcast-coalescing-design.md
@@ -1,0 +1,457 @@
+# Coalesced + grace-delayed broadcast for cross-space subscriptions
+
+Date: 2026-06-25
+Status: Implemented (branch go-7334-crossspace-broadcast-coalescing) — revised after a
+3-reviewer design pass and a 10-reviewer post-implementation pass (see Post-implementation
+review notes at the end)
+Issue: GO-7334
+Related (pre-existing bugs folded into implementation, also tracked separately):
+GO-7336 (resubscribe leak), GO-7337 (counter resurrection)
+
+## Problem
+
+The lazy cross-space subscription work (GO-7288, `801cbbc3e` and follow-ups) made
+`crossspacesub.Subscribe` lazy: on subscribe, only spaces whose objectstore is already open
+are subscribed synchronously and their records are returned in the **RPC response**; spaces
+whose store is not open yet are recorded as pending. As the background warm-up opens each
+store, `service.onSpaceIndexOpened → PromotePending` fires an `asyncInit=true` per-space
+subscribe whose records flow **as events** through `crossSpaceSubscription.run →
+eventSender.Broadcast` (`core/subscription/crossspacesub/crossspacesub.go:113-138`).
+
+### Scope: only the client-facing cross-space subscription broadcasts
+
+This matters and was initially mis-stated. A cross-space subscription only calls
+`eventSender.Broadcast` when `internalQueue == nil` (`crossspacesub.go:132-136`). The six
+in-process consumers (`pushnotification`, `acl/participantsub`, `filedownloader`, the four
+`api/service/cache.go` caches, `block/chats`) all pass an `InternalQueue` and take the
+**nested** path — they consume the per-space stream in-process via
+`objectsubscription.NewFromQueue` and never broadcast, so they produce **zero client
+redraws**. The **only** broadcasting (client-facing) cross-space subscription is
+`ObjectCrossSpaceSearchSubscribe` (`core/object.go:247-273`, no `InternalQueue`). This
+design therefore affects exactly that one RPC. The other six benefit only indirectly, if at
+all, via their own downstream client events — which is out of scope here.
+
+### 1. Subscribe-response vs. event race (the main issue)
+
+The Subscribe response and the live events travel on **two independent delivery paths with
+no ordering guarantee between them**:
+
+- the response is the synchronous return value of the `ObjectCrossSpaceSearchSubscribe` RPC;
+- events arrive on the long-lived `ListenSessionEvents` stream (`eventSender.Broadcast`).
+
+The client *does* know the subId (it generates and sends it in the request — confirmed:
+`pb/protos/service/service.proto` `ObjectCrossSpaceSearchSubscribe`, and `docs/Subscriptions.md`
+notes the client ignores the response's subId and uses its own). So this is **not** an
+"unknown subId" problem. The problem is that the client processes the *response* (which
+carries the initial record set) in one place, and receives *events* for the same subId in
+another, and **nothing sequences the two**. An event that the client handles before it has
+finished applying the response's initial set corrupts or drops against a not-yet-populated
+subscription.
+
+The lazy change widened this window substantially: there is now almost always a burst of
+promote events emitted immediately after `Subscribe` returns (one wave per space that opens
+during warm-up), so the race fires with high probability on a busy startup rather than
+rarely.
+
+The authoritative fix is client-side (buffer events for a subId until its response has been
+applied, then drain). That is real, awkward work and is deferred. Since this design adds a
+server-side buffer for batching anyway, holding the *first* emission briefly is a cheap,
+effective mitigation from the same buffer — there is no reason to fire an event microseconds
+after the response.
+
+### 2. Event storm / redraw avalanche on startup
+
+A single `ObjectCrossSpaceSearchSubscribe` spanning N spaces receives one promote wave per
+space as stores open during warm-up. Each wave is its own `Broadcast` today, and the client
+redraws per delivered payload, so a wide cross-space search produces a redraw burst right
+when the app is busiest. (`run` already coalesces a *single* wave's `Add×K + Counters` into
+one `Broadcast` via one `s.queue.Wait`; the new coalescing additionally merges waves that
+arrive close together — see "Open questions" on how much that buys, given warm-up spreads
+opens over seconds.)
+
+### Aggravating finding (out of scope, see Follow-ups)
+
+`GrpcSender.sendEvent` spawns a `go func()` **per event** to call `server.Server.Send`
+(`core/event/event_grpc.go:68-82`), and `Broadcast` fans out to every session. Separate
+`Broadcast` calls are therefore not ordered with respect to each other on the wire, and
+concurrent `Send` on a single gRPC stream is technically unsafe. Emitting fewer, larger
+`Broadcast` calls reduces how often this bites, but the real fix (serialize sends per
+session) is a separate change.
+
+## Goals
+
+- Collapse temporally-adjacent promote waves of `ObjectCrossSpaceSearchSubscribe` into fewer
+  `Broadcast` calls, reducing client redraws on startup.
+- Reduce the probability of the response-vs-event race by delaying the first emission for a
+  new subId until the client has had time to apply the response — from the same buffer.
+- Keep the change isolated to the cross-space broadcast path (`internalQueue == nil`); no
+  change to the regular subscription engine, the event sender, or the wire protocol.
+- Bounded added latency and bounded `pb.Event` payload size.
+- Make the timing fully test-injectable (no real-time sleeps in tests).
+
+## Non-goals
+
+- **A deterministic fix for the race.** This is a server-side *mitigation*. The authoritative
+  fix is the client-side event buffer (Follow-up 1). This design only shrinks the window and
+  the redraw count for the one broadcasting consumer.
+- **General subscription coalescing.** Scope is `ObjectCrossSpaceSearchSubscribe` only. The
+  same two-path race exists for regular `ObjectSearchSubscribe` and is **not** addressed here
+  — it remains exposed and is another reason the client-side fix is the real solution.
+- **Op-aware coalescing** (Add+Remove cancellation, Amend/Set merging). During warm-up the
+  storm is overwhelmingly pure `Add`s, so concatenation captures nearly all the benefit. Only
+  counters are merged (last-wins). Deeper merging is a possible future refinement.
+- **Serializing `GrpcSender` per-session sends** (the aggravating finding above).
+
+## Background: where events are emitted today
+
+`crossSpaceSubscription.run` (`crossspacesub.go:113-138`) consumes the internal queue
+`s.queue` that all per-space subscriptions feed into:
+
+```go
+func (s *crossSpaceSubscription) run(internalQueue *mb.MB[*pb.EventMessage]) {
+    for {
+        msgs, err := s.queue.Wait(s.ctx)
+        // ... ctx.Canceled -> return; other err -> log ...
+        for _, msg := range msgs {
+            s.patchEvent(msg)                 // rewrite per-space subId -> s.subId
+            if internalQueue != nil {
+                internalQueue.Add(s.ctx, msg) // nested sub: forward per-message, no broadcast
+            }
+        }
+        if internalQueue == nil {
+            s.eventSender.Broadcast(&pb.Event{Messages: msgs}) // client-facing path
+        }
+    }
+}
+```
+
+- `s.queue` is `mb.MB[*pb.EventMessage]` (cheggaaa/mb v3.0.2; `go.mod:23`).
+- `patchEvent` (`crossspacesub.go:140-172`) rewrites every message's per-space internal subId
+  to the unified `s.subId`, and routes counters through `updateTotalCount` so each emitted
+  `SubscriptionCounters` carries the aggregate absolute total for `s.subId`.
+- The broadcast path is taken **only when `internalQueue == nil`**. The nested path
+  (`internalQueue != nil`) must remain per-message and is untouched by this change.
+- All events for the subscription funnel through `s.queue → run` (verified: the only
+  `Broadcast` in the package is `crossspacesub.go:133`; `removeSpace` and
+  `rollbackSubscription` only `s.queue.Add`). So coalescing in `run` covers every event path.
+
+### Relevant `mb` v3 semantics (verified against v3.0.2 source)
+
+- `MB.WaitCond(ctx, cond)` returns immediately with whatever is buffered (subject to `cond`),
+  else blocks until messages arrive, the queue closes, or `ctx` is done.
+- A standard `context.WithDeadline`/`WithTimeout` child works: on deadline `WaitCond` returns
+  `(nil, context.DeadlineExceeded)` and **leaves buffered messages intact** — `releaseWaiter`
+  (mb.go:259-265) prepends any delivered-but-unconsumed message back to `buf`, preserving
+  FIFO. No event loss across the deadline.
+- `NewCond().WithMax(n)` caps the messages a single `Wait` returns. `WaitCond` is a value type
+  and `WithMax`/`WithMin` return copies, so a `cond` value is safe to reuse and re-derive
+  across iterations. Default `Min<1` is promoted to 1, so a `Wait` with messages buffered
+  returns them immediately.
+- **Do not** use `mb.CtxWithTimeLimit`: when its timer fires on an empty buffer it resets the
+  condition's `Min` to 1 and re-arms, so after one idle tick it stops coalescing. A
+  self-managed deadline avoids this.
+
+## Design
+
+### 0. Timing seam (so tests are deterministic) — addresses review M5
+
+`time.Until` and `context.WithTimeout` use the real wall clock; a fake `now()` alone controls
+nothing. So the subscription takes an injected timing seam, set at construction, **stored as a
+field (never a package var** — a package var would be read by the `run` goroutine while a test
+writes it, a `-race` failure):
+
+```go
+type clock interface {
+    now() time.Time
+    // after returns a channel that fires once `d` has elapsed; tests drive it manually.
+    after(d time.Duration) <-chan time.Time
+}
+```
+
+The real implementation wraps `time.Now` / `time.After`. Tests inject a manual clock and a
+fake `event.Sender` (the capturing `mock_event.MockSender` already used in
+`crossspacesub` tests). `initialGrace` and `window` are **fields** on the subscription
+(defaulted from the package consts, overridable in tests to ~0) rather than direct constant
+reads, so existing exact-sequence tests are not slowed by 200ms or merged unexpectedly.
+
+The coalescing loop blocks on `s.queue` for the first message, then selects between more
+queue messages and the injected timer — instead of `context.WithTimeout` per iteration
+(review m2) — so the deadline fires through the same injectable seam:
+
+```go
+firstFlush := true
+for {
+    first, err := s.queue.WaitOne(s.ctx)   // block for the first msg of a wave
+    if err != nil {                         // ErrClosed / ctx.Canceled
+        return                              // drop any (none here) and stop — see error handling
+    }
+    buf := s.patchAll([]*pb.EventMessage{first})
+
+    var deadline time.Time
+    if firstFlush {
+        deadline = laterOf(s.createdAt.Add(s.initialGrace), s.clk.now().Add(s.window))
+    } else {
+        deadline = s.clk.now().Add(s.window)
+    }
+    timer := s.clk.after(deadline.Sub(s.clk.now()))
+
+    for {
+        graceUnmet := firstFlush && s.clk.now().Before(deadline)
+        full := len(buf) >= maxFlushSize
+        if full && !graceUnmet {
+            break // size cap (grace satisfied, or a non-first flush)
+        }
+        if full { // buffer full but first-flush grace not yet met: hold, drain nothing
+            select {
+            case <-timer:        // grace elapsed -> flush this maxFlushSize batch
+            case <-s.ctx.Done(): // sub closed -> drop and stop
+                return
+            }
+            break
+        }
+        // WithMax(room) keeps buf <= maxFlushSize -> hard per-Broadcast bound (review m1)
+        cond := s.queue.NewCond().WithMax(maxFlushSize - len(buf))
+        more, werr := s.queue.WaitCond(ctxWithTimer(s.ctx, timer), cond)
+        buf = append(buf, s.patchAll(more)...)
+        if werr != nil {                    // timer fired or sub closed
+            if s.ctx.Err() != nil {         // sub closed mid-window: drop and stop
+                return
+            }
+            break                           // deadline reached: flush
+        }
+    }
+
+    s.flushBroadcast(buf)
+    firstFlush = false
+}
+```
+
+`ctxWithTimer` is a tiny helper that yields a context cancelled either by `s.ctx` or by the
+injected `timer` firing (so `WaitCond` returns `DeadlineExceeded`-equivalent through the seam).
+`patchAll` applies the existing `patchEvent` to each message (subId rewrite + counter
+aggregation happen exactly as today, before buffering). The nested `internalQueue != nil`
+branch keeps the existing per-message forward loop verbatim — coalescing applies only to the
+`internalQueue == nil` broadcast path (review #9).
+
+### 1. Window and grace semantics — addresses review M1, M3
+
+- **Steady-state window.** Each flush coalesces at most `window` of arrivals measured from the
+  first buffered message, so promote waves that land close together merge. A delivered event
+  waits at most `window`.
+- **Size cap is a hard bound and never pre-empts the first grace.** `WithMax(maxFlushSize -
+  len(buf))` clamps each `Wait` so `buf` never exceeds `maxFlushSize` (fixes the ~2× payload
+  bound, review m1). On the **first** flush the size cap is suppressed until the grace deadline
+  passes, so a large first wave (≥`maxFlushSize`) is still held for the grace and cannot fire
+  ungraced (fixes review M1 — the original draft flushed the first 500 immediately and
+  consumed `firstFlush`, defeating the mitigation in exactly the heavy case).
+- **Initial grace (race mitigation).** The first flush is held until
+  `max(createdAt + initialGrace, firstMsg + window)`, applied once per subscription.
+- **Grace anchor (review M3).** `createdAt` is stamped as **late as the server can** — right
+  before `Subscribe` returns the response / when `run` starts — not in
+  `newCrossSpaceSubscription` (which precedes the synchronous loaded-space subscribes, the RPC
+  marshal, the wire hop, and client deserialize). The server still cannot observe when the
+  client actually applied the response, so `initialGrace` is a heuristic; its value must be
+  calibrated against measured response-apply latency under startup load (see Open questions).
+
+### 2. `flushBroadcast` — coalescing depth
+
+```go
+func (s *crossSpaceSubscription) flushBroadcast(buf []*pb.EventMessage) {
+    if len(buf) == 0 { return }
+    msgs := coalesceCounters(buf) // keep only the last SubscriptionCounters, at the tail
+    s.eventSender.Broadcast(&pb.Event{Messages: msgs})
+}
+```
+
+- **Concatenation in arrival order** for all kinds except counters (FIFO preserved; review
+  confirmed ordering is safe and `patchEvent`'s in-place mutation does not alias another
+  subscriber — each message is a fresh allocation routed to a single destination).
+- **Counters last-wins.** After `patchEvent`, every `SubscriptionCounters` carries `s.subId`
+  and an absolute aggregate total, so intermediate counters in a flush are redundant; keep
+  only the last, appended at the tail.
+  - Caveat (review M8, transient): when a flush is cut by the size cap after trailing `Add`s
+    whose follow-on counter lands in the next flush, the kept counter can momentarily predate
+    those adds. Self-corrects on the next flush; acceptable.
+  - **Correctness depends on the GO-7337 fix** (below). Without it, counters last-wins can
+    surface a *permanently* wrong total — not a coalescing artifact (the bug is at patch time,
+    which batching does not change), but this design must not claim counter safety until
+    GO-7337 lands. The two are folded into the same implementation.
+
+### 3. Folded fix — resubscribe replace (GO-7336, review M7)
+
+`service.Subscribe` currently does `s.subscriptions[req.SubId] = spaceSub` with no lookup, so
+a resubscribe with an existing subId orphans the previous `crossSpaceSubscription`: its `run`
+goroutine keeps broadcasting under the same subId, its `s.queue` is never closed, and its
+per-space subs are never unsubscribed (leak). Resubscribe is a supported flow and is exactly
+when the race/grace recurs.
+
+Fix: in `Subscribe`, if `req.SubId` already exists, `close()` and remove the existing sub
+before creating the new one (mirroring the engine's replace-on-resubscribe). Done under
+`s.lock`; `crossSpaceSubscription.close()` does not acquire `s.lock`, so no deadlock. The new
+sub gets a fresh `createdAt`, so the grace correctly re-applies to the new generation.
+
+### 4. Folded fix — counter resurrection (GO-7337, review M2)
+
+A removed space's *queued* per-space counter, patched after `removeSpace` already ran, calls
+`updateTotalCount` (`crossspacesub.go:411`) and **re-inserts** the removed internal subId's
+total that `removeTotalCount` (`:383`) just deleted. Interleaving: space A emits
+`Add A1, Add A2, Counters(subId_A, 2)` into `s.queue`; `RemoveSpace(A)` enqueues `Remove A1,
+Remove A2, Counters(s.subId, 0)`; `run` patches in queue order, re-inserting `subId_A=2`, so
+the surviving last-wins counter reads **2 against 0 records**. Permanent wrong count.
+
+Fix: aggregation must ignore counters for internal subIds that are no longer active. Track the
+set of active internal subIds (or gate on `perSpaceSubscriptions` membership); `removeSpace`
+marks the internal subId inactive so its later queued counters are dropped in `patchEvent`.
+Implementation must handle the ordering subtlety where queued `Add`s for a just-removed space
+are still ahead in the queue (they are already covered by the `Remove` ids
+`UnsubscribeAndReturnIds` returns); this fix carries its own tests.
+
+### 5. Configuration
+
+Package-level defaults, copied into per-sub fields at construction (so tests can override):
+
+```go
+const (
+    defaultInitialGrace = 200 * time.Millisecond // first-flush hold after createdAt
+    defaultWindow       = 50 * time.Millisecond  // steady-state coalescing window (tune; see Open questions)
+    maxFlushSize        = 500                     // hard cap on messages per Broadcast
+)
+```
+
+Consistent with the package's no-per-request-tuning stance (`service.go:147-168` rejects
+limit/sorts/pagination/etc.); not runtime-tunable, so a bad value ships in the binary —
+hence the calibration note.
+
+### 6. Observability — addresses review m4
+
+Add debug-level counters: flushes emitted, messages per flush (avg/max), and grace-delayed
+first-flush count, so the redraw-reduction win can be confirmed in production. `mb.Stats()`
+(`mb.go:404`) is available for the queue side.
+
+## Data flow
+
+```
+ObjectCrossSpaceSearchSubscribe(req)
+   └─ loaded-space records ──▶ RPC response (synchronous)
+   └─ createdAt = now()  (stamped just before response returns)
+   └─ go run()  (broadcast path, internalQueue == nil)
+         queue.WaitOne(ctx)                  ── blocks for the first promote/live event
+         ── first wave ──▶ buf; deadline = max(createdAt+grace, firstMsg+window)
+         WaitCond(timer, WithMax(cap-len)) loop  ── coalesce until deadline; size cap honored only after grace
+         flushBroadcast(buf)                 ── one Broadcast (counters last-wins)
+         ── repeat with window-only deadline ──
+
+warm-up opens stores over seconds (bounded concurrency)
+   └─ onSpaceIndexOpened → PromotePending → asyncInit per-space subscribe
+         records ──▶ s.queue ──▶ coalesced into the flushes above
+```
+
+## Error handling
+
+- `s.queue.WaitOne(s.ctx)` returning `ErrClosed`/`context.Canceled` (Unsubscribe/Close): `run`
+  returns; buffer dropped. **Drop-on-close is the single consistent policy** for both the
+  outer and inner cancel paths (fixes review M3 flush-vs-drop contradiction — the client has
+  unsubscribed, so broadcasting is pointless).
+- Inner `WaitCond` timer firing: window elapsed, flush and continue.
+- Inner `WaitCond` error while `s.ctx` is done: drop and return.
+- Preserve a log for any unexpected (non-`ErrClosed`/non-`Canceled`) error to keep today's
+  diagnostic (review m7).
+- `RemoveSpace`/rollback synthetic Remove + Counters flow through `s.queue` and are batched
+  normally; counter correctness relies on the GO-7337 fix.
+
+## Testing
+
+Manual clock + capturing fake `event.Sender`; no real-time sleeps.
+
+- **Storm coalescing:** several promote waves within `window` → a single `Broadcast`,
+  arrival order preserved.
+- **Initial grace, small wave:** events enqueued right after subscribe → no `Broadcast`
+  before `createdAt + initialGrace`; first `Broadcast` carries all grace-window events.
+- **Initial grace, large wave (review M1 regression):** ≥`maxFlushSize` enqueued immediately
+  → still no `Broadcast` before the grace deadline (size cap suppressed during first grace).
+- **Late first event:** first event after `createdAt + initialGrace` → flush after only
+  `window`.
+- **Hard size cap (review m1):** `buf` never exceeds `maxFlushSize` in a single `Broadcast`.
+- **Counters last-wins:** a flush with multiple counters emits exactly one (latest total) at
+  the tail.
+- **Counter resurrection (GO-7337):** space added then removed across a window → final
+  counter matches record count (regression test).
+- **Resubscribe (GO-7336):** resubscribe with an existing subId closes the old sub (old
+  `run` exits, old per-space subs unsubscribed, no leak) before the new one starts.
+- **Close mid-window:** `close()` during an active window stops `run` without panic and drops
+  the buffer.
+- **Nested path unchanged:** `internalQueue != nil` still forwards per-message; nothing
+  broadcast.
+- Existing `crossspacesub` and subscription suites green under `-race` (per-sub grace/window
+  set to ~0 so exact-sequence tests are unaffected).
+
+## Open questions (measure before/with implementation)
+
+1. **Is `ObjectCrossSpaceSearchSubscribe` startup-hot, and how wide?** The benefit is real
+   only if the client opens broadcasting cross-space searches during the warm-up storm, over
+   many spaces. Confirm volume.
+2. **Promote arrival spacing.** Warm-up spreads opens over seconds (bounded concurrency ~4,
+   ~78 spaces per the startup profile). If waves land >`window` apart, the new cross-wave
+   coalescing buys little beyond what `run` already does per wave — `window` may need to be
+   250–500 ms, or the storm-reduction gain is marginal (the race mitigation still stands).
+3. **`initialGrace` calibration.** Measure client response-apply latency under startup load;
+   200 ms is a starting guess, not a measured value.
+
+## Follow-ups (tracked, out of scope here)
+
+1. Client-side deterministic fix: buffer events for a subId until its response is applied,
+   then drain. The authoritative fix; this server mitigation is interim.
+2. Serialize `GrpcSender` per-session sends (remove the per-event `go func`) to fix the
+   event-ordering / concurrent-`Send` hazard.
+3. Optional op-aware coalescing (Add+Remove cancellation, Amend/Set merge) if profiling shows
+   redundant churn beyond counters after this ships.
+4. The same two-path race for regular `ObjectSearchSubscribe` is unaddressed; the client-side
+   buffer (1) covers it generally.
+
+## Post-implementation review notes (2026-06-25)
+
+After implementation, a 10-agent adversarial review ran over the branch diff. The policy,
+ordering, hard per-Broadcast bound, lifecycle (no leak/deadlock), single-goroutine patching,
+and nested-path equivalence were all confirmed correct. Two real defects and several
+robustness/clarity items were found and fixed; a few are documented as accepted tradeoffs.
+
+### Defects found and fixed
+- **Undercount (GO-7337 follow-up).** The `activeInternalSubs` gate dropped the async-init
+  counter on the AddSpace/PromotePending path, because the internal subId was marked active
+  *after* `subscribe()` returns while the snapshot counter is delivered asynchronously. Fix:
+  `completeReservation` records the per-space total synchronously (idempotent, last-wins),
+  mirroring the loaded-space path.
+- **`close()` per-space leak (GO-7336 follow-up).** `close()` only cancelled ctx + closed the
+  queue; the per-space subs use a caller-provided queue, so they were never released by the
+  engine (slots, pinned objects, per-change CPU) — a pre-existing leak now hit on every
+  resubscribe. Fix: `close()` joins the run goroutine (via `started`/`done`, so no stale tail
+  broadcasts under the reused subId) and calls `UnsubscribeAndReturnIds` for each finalized
+  per-space sub. `Subscribe` builds the new sub before closing the old one, so a failed rebuild
+  no longer destroys the existing subscription.
+
+### Clarifications to this spec
+- **Size cap is a per-Broadcast hard bound, not a buffer bound.** §1/§2's "buf never exceeds
+  maxFlushSize" is imprecise: during the initial grace the buffer deliberately holds everything
+  (grace must not be pre-empted), so `coalescer.buf` may exceed `maxFlushSize`; what is bounded
+  is each emitted `pb.Event` (≤ `maxFlushSize`), enforced by chunking in `ready()`.
+- **Counters last-wins is per emitted chunk.** A flush split across multiple Broadcasts carries
+  at most one counters message per chunk; each is self-consistent and the latest total wins
+  across the ordered Broadcasts.
+- **Observability (§6) is intentionally minimal:** a per-flush `log.Debug` of batch size, not
+  the aggregate counters originally sketched.
+
+### Accepted tradeoffs (not changed)
+- **Transient buffer retention during grace.** A broad cold-start search can hold a multi-MB
+  burst for up to `initialGrace` before the first flush. Not capped on purpose: capping during
+  grace would re-expose the response-vs-event race for those records (which would ship to the
+  client anyway). The spike is freed at the grace flush.
+- **GrpcSender chunking.** A >`maxFlushSize` flush is emitted as N sequential `Broadcast`s,
+  each a separate (unordered) `Send` on the stream — amplifying the pre-existing per-event
+  `go func` hazard. Bounded and self-correcting because cross-space results are unsorted and
+  the counter converges. The real fix (serialize per-session sends) remains Follow-up 2.
+
+### Open question still outstanding
+- **Window value (`defaultWindow=50ms`).** Warm-up opens spaces seconds apart, so cross-wave
+  coalescing — and thus redraw reduction — is marginal at 50ms; the load-bearing wins are the
+  grace (race mitigation) and the bounded payload. Measure promote-wave spacing and client
+  redraw counts before raising the window or claiming a redraw reduction.


### PR DESCRIPTION
## Problem

Lazy cross-space subscriptions (GO-7288) emit promote events on the `ListenSessionEvents` stream right after `ObjectCrossSpaceSearchSubscribe` returns. The Subscribe **response** and the **events** travel on two independent paths with no ordering guarantee, so the client can process an event for a subId before it has applied that subId's response — a high-probability race on a busy startup. Each space opening is also its own `Broadcast`, producing a redraw burst.

This is a **server-side mitigation** (the authoritative fix is a client-side event buffer): since we add a server-side buffer for batching anyway, we also briefly hold the first emission so the client can apply the response first. Scope is the only broadcasting consumer, `ObjectCrossSpaceSearchSubscribe`; the six `InternalQueue` consumers are unaffected.

## What changed

- **Pure `coalescer` policy** (`coalescer.go`) — window-from-first-message batching, once-per-sub initial grace, hard per-`Broadcast` size cap, counters last-wins. Fully unit-tested, no concurrency.
- **`runBroadcast`** — a drainer goroutine + `select` over the message channel and an injected-clock timer drives the coalescer; the timer re-arms only when the deadline changes. The nested (`InternalQueue`) path is unchanged.
- **Timing seam** (`clock.go`) — injectable clock so tests are deterministic (no real sleeps); `initialGrace=200ms`, `window=50ms`, `maxFlushSize=500`.

### Folded-in pre-existing bug fixes
- **GO-7336** — `Subscribe` with an existing subId now replaces the old subscription: `close()` joins the run goroutine (no stale tail under the reused subId) and unsubscribes the old per-space subs from the engine (closing the caller-provided queue alone never released them — a leak on every Unsubscribe/resubscribe). The new sub is built before the old is closed, so a failed rebuild can't destroy the existing subscription.
- **GO-7337** — a removed space's still-queued counter no longer resurrects its total; the per-space total is recorded atomically with the active-set so a fresher live counter is never clobbered.

## Testing

Full package green under `-race` (0 failures/races), `--new-from-rev=develop` lint clean, `go build ./core/...` clean. New coverage: coalescer policy, grace/window via fake clock, broadcaster join, timer re-arm across cycles, counter resurrection/idempotency, resubscribe replace, and end-to-end coalescing through `service.Subscribe`.

## Follow-ups (out of scope)
1. Client-side event buffer (the authoritative race fix).
2. Serialize `GrpcSender` per-session sends (the per-event `go func` ordering hazard).
3. Measure promote-wave spacing before tuning `window` / claiming redraw reduction.

Related: GO-7336, GO-7337.
