### PR TITLE
GO-7340 chats: serve GetMessagesByIds & GetPinnedMessages from anystore (tree-free)

### DIFF
--- a/core/block/chats/service.go
+++ b/core/block/chats/service.go
@@ -775,16 +775,11 @@ func (s *service) GetMessages(ctx context.Context, chatObjectId string, req chat
 }
 
 func (s *service) GetMessagesByIds(ctx context.Context, chatObjectId string, messageIds []string) ([]*chatmodel.Message, error) {
-	var res []*chatmodel.Message
-	err := s.chatObjectDo(ctx, chatObjectId, func(sb chatobject.StoreObject) error {
-		msg, err := sb.GetMessagesByIds(ctx, messageIds)
-		if err != nil {
-			return err
-		}
-		res = msg
-		return nil
-	})
-	return res, err
+	repo, err := s.chatRepository(chatObjectId)
+	if err != nil {
+		return nil, err
+	}
+	return repo.GetMessagesByIds(ctx, messageIds)
 }
 
 func (s *service) SubscribeLastMessages(ctx context.Context, chatObjectId string, limit int, subId string) (*chatsubscription.SubscribeLastMessagesResponse, error) {
@@ -951,6 +946,27 @@ func (s *service) chatObjectDo(ctx context.Context, chatObjectId string, proc fu
 	return cache.DoWait(s.objectGetter, waitCtx, chatObjectId, proc)
 }
 
+// chatRepository returns the anystore-backed repository for a chat, without opening the object's
+// smartblock. Reads served from it (e.g. GetMessagesByIds, GetPinnedMessages) hit the persisted
+// materialized view directly and do not pay the change-tree build, which is O(messages) and can
+// take seconds for a large chat. The tree is only required for writes; it is warmed up lazily by
+// the subscription path (ChatSubscribeLastMessages, GO-7302), so we do not build it here.
+//
+// Consistency: the materialized view is current for any chat that has been built at least once
+// (the common reopen case) — materialization is incremental from a persisted watermark and
+// survives restarts. On a cold start (a chat never built locally, or one with remote changes not
+// yet head-synced) the view may be transiently stale/empty until the background warm-up
+// materializes it. This is the same window ChatSubscribeLastMessages already accepts; the
+// subscription self-corrects via its event stream, so a one-shot caller that needs cold-start
+// freshness (notably pinned messages) should refresh once the chat warm-up settles.
+func (s *service) chatRepository(chatObjectId string) (chatrepository.Repository, error) {
+	spaceId, err := s.spaceIdResolver.ResolveSpaceID(chatObjectId)
+	if err != nil {
+		return nil, fmt.Errorf("resolve space id: %w", err)
+	}
+	return s.chatRepoService.Repository(spaceId, chatObjectId)
+}
+
 func (s *service) ReadAll(ctx context.Context) error {
 	s.lock.Lock()
 	chatIds := make([]string, 0, len(s.allChatObjectIds))
@@ -1004,12 +1020,12 @@ func (s *service) PinMessages(ctx context.Context, chatObjectId string, messageI
 	})
 }
 
-func (s *service) GetPinnedMessages(ctx context.Context, chatObjectId string) (msgs []*chatmodel.Message, err error) {
-	err = s.chatObjectDo(ctx, chatObjectId, func(sb chatobject.StoreObject) error {
-		msgs, err = sb.GetPinnedMessages(ctx)
-		return err
-	})
-	return msgs, err
+func (s *service) GetPinnedMessages(ctx context.Context, chatObjectId string) ([]*chatmodel.Message, error) {
+	repo, err := s.chatRepository(chatObjectId)
+	if err != nil {
+		return nil, err
+	}
+	return repo.GetPinnedMessages(ctx)
 }
 
 func pushGroupId(objectId string) string {

--- a/core/block/chats/service_test.go
+++ b/core/block/chats/service_test.go
@@ -65,14 +65,33 @@ func (s *accountServiceDummy) Init(a *app.App) error {
 	return nil
 }
 
-type chatRepoServiceDummy struct{}
+type chatRepoServiceDummy struct {
+	repo chatrepository.Repository
+}
 
 func (s *chatRepoServiceDummy) Name() string                    { return "chatRepoServiceDummy" }
 func (s *chatRepoServiceDummy) Init(a *app.App) error           { return nil }
 func (s *chatRepoServiceDummy) Run(ctx context.Context) error   { return nil }
 func (s *chatRepoServiceDummy) Close(ctx context.Context) error { return nil }
 func (s *chatRepoServiceDummy) Repository(spaceId, chatObjectId string) (chatrepository.Repository, error) {
-	return nil, nil
+	return s.repo, nil
+}
+
+// fakeChatRepository is a minimal repository stub for service-level read tests. Only the methods
+// the tests exercise are implemented; the embedded interface leaves the rest as compile-time
+// stubs (calling an unimplemented one panics, surfacing accidental coverage gaps).
+type fakeChatRepository struct {
+	chatrepository.Repository
+	pinned        []*chatmodel.Message
+	messagesByIds []*chatmodel.Message
+}
+
+func (f *fakeChatRepository) GetPinnedMessages(ctx context.Context) ([]*chatmodel.Message, error) {
+	return f.pinned, nil
+}
+
+func (f *fakeChatRepository) GetMessagesByIds(ctx context.Context, messageIds []string) ([]*chatmodel.Message, error) {
+	return f.messagesByIds, nil
 }
 
 type fileGCDummy struct{}
@@ -112,6 +131,7 @@ type fixture struct {
 	crossSpaceSubService *mock_crossspacesub.MockService
 	ftSearch             *mock_ftsearch.MockFTSearch
 	objectStore          *objectstore.StoreFixture
+	chatRepoService      *chatRepoServiceDummy
 
 	lock sync.Mutex
 	// recorded actions (subscribe/unsubscribe) per chat object, in temporal order
@@ -184,6 +204,7 @@ func newFixture(t *testing.T) *fixture {
 	eventSender := mock_event.NewMockSender(t)
 	detailService := mock_detailservice.NewMockService(t)
 	ftSearch := mock_ftsearch.NewMockFTSearch(t)
+	chatRepoService := &chatRepoServiceDummy{}
 
 	fx := &fixture{
 		service:              New().(*service),
@@ -192,6 +213,7 @@ func newFixture(t *testing.T) *fixture {
 		objectGetter:         objectGetter,
 		ftSearch:             ftSearch,
 		objectStore:          objectStore,
+		chatRepoService:      chatRepoService,
 		actions:              map[string][]recordedAction{},
 	}
 	eventSender.EXPECT().Broadcast(mock.Anything).Run(func(e *pb.Event) {
@@ -213,7 +235,7 @@ func newFixture(t *testing.T) *fixture {
 	a.Register(&accountServiceDummy{})
 	a.Register(testutil.PrepareMock(ctx, a, detailService))
 	a.Register(&fileGCDummy{})
-	a.Register(&chatRepoServiceDummy{})
+	a.Register(chatRepoService)
 	a.Register(fx)
 
 	fx.app = a
@@ -1887,12 +1909,9 @@ func TestService_GetPinnedMessages(t *testing.T) {
 			},
 		}
 
-		mockChat := mock_chatobject.NewMockStoreObject(t)
-		mockChat.EXPECT().Lock().Return()
-		mockChat.EXPECT().Unlock().Return()
-		mockChat.EXPECT().GetPinnedMessages(mock.Anything).Return(want, nil)
-
-		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
+		// Pinned messages are served straight from the anystore repository — no smartblock /
+		// change-tree build (GO-7340).
+		fx.chatRepoService.repo = &fakeChatRepository{pinned: want}
 
 		fx.start(t)
 
@@ -1916,12 +1935,7 @@ func TestService_GetPinnedMessages(t *testing.T) {
 			Records: []*domain.Details{},
 		}, nil).Maybe()
 
-		mockChat := mock_chatobject.NewMockStoreObject(t)
-		mockChat.EXPECT().Lock().Return()
-		mockChat.EXPECT().Unlock().Return()
-		mockChat.EXPECT().GetPinnedMessages(mock.Anything).Return(nil, nil)
-
-		fx.objectGetter.EXPECT().WaitAndGetObject(mock.Anything, chatObjectId).Return(mockChat, nil)
+		fx.chatRepoService.repo = &fakeChatRepository{pinned: nil}
 
 		fx.start(t)
 
@@ -1931,5 +1945,38 @@ func TestService_GetPinnedMessages(t *testing.T) {
 		// then
 		require.NoError(t, err)
 		assert.Empty(t, got)
+	})
+}
+
+func TestService_GetMessagesByIds(t *testing.T) {
+	t.Run("returns messages from repository without building the tree", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		ctx := context.Background()
+		chatObjectId := "chatId1"
+
+		fx.crossSpaceSubService.EXPECT().Subscribe(mock.Anything, mock.Anything).Return(&subscription.SubscribeResponse{
+			Records: []*domain.Details{},
+		}, nil).Maybe()
+
+		want := []*chatmodel.Message{
+			{ChatMessage: &model.ChatMessage{Id: "msg1", OrderId: "order1"}},
+			{ChatMessage: &model.ChatMessage{Id: "msg2", OrderId: "order2"}},
+		}
+
+		// Served straight from the anystore repository — no smartblock / change-tree build (GO-7340).
+		// No WaitAndGetObject expectation is set, so any attempt to build the tree fails the test.
+		fx.chatRepoService.repo = &fakeChatRepository{messagesByIds: want}
+
+		fx.start(t)
+
+		// when
+		got, err := fx.GetMessagesByIds(ctx, chatObjectId, []string{"msg1", "msg2"})
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, "msg1", got[0].Id)
+		assert.Equal(t, "msg2", got[1].Id)
 	})
 }


### PR DESCRIPTION
## What
Serve `ChatGetMessagesByIds` and `ChatGetPinnedMessages` directly from the per-chat anystore repository, skipping the smartblock / change-tree build.

## Why
Opening a large chat blocked ~8s. After the desktop client stopped calling `ObjectOpen` on chat objects, the cost relocated to these two RPCs: both went through `chatObjectDo → DoWait → BuildTree` and paid the full change-tree build+validate (O(messages)), even though their data reads only hit the anystore repository.

Trace (desktop, big chat): `ChatGetPinnedMessages` 7,921ms + `ChatGetMessagesByIds` 7,872ms; main thread idle ~7.2s.

## How
Both reads now go through a new `chatRepository()` helper (`spaceIdResolver` → `chatRepoService.Repository`), mirroring the existing `debug.go` precedent. No tree build. The tree is only needed for writes and is warmed up lazily by the subscription path (`ChatSubscribeLastMessages`, GO-7302). `ChatReadMessages` stays on `chatObjectDo` (it mutates tree-backed seen-heads).

## Consistency
The lock on these reads is not load-bearing (git history: the only chat-read race, GO-6873, was in-memory subscription state fixed with the subscription's own mutex). Local writes and remote diffsync serialize under the same tree lock and materialize via a single atomic anystore WriteTx, so a repo `ReadTx` snapshot can never see torn/partial state.

**Cold-start window:** the materialized view is current for any previously-built chat (the common reopen case; persisted with a watermark). For a never-built / un-head-synced chat the view can be transiently stale until the background warm-up materializes it — the same window the subscription already tolerates and self-corrects via its event stream. Documented in code. A desktop client-side refresh of pinned / reply targets on chat-ready is a deferred follow-up.

## Tests
Build / vet / gofmt clean. Chat suites pass; added `TestService_GetMessagesByIds` (asserts the tree is not built), updated `TestService_GetPinnedMessages` to the repo-only path.

Closes GO-7340
