### PR TITLE
GO-7341 chat: reuse in-memory sync tree for diff managers (4 scans → 1)

### DIFF
--- a/core/block/source/sourceimpl/store.go
+++ b/core/block/source/sourceimpl/store.go
@@ -168,7 +168,7 @@ func unmarshalSeenHeads(raw []byte) ([]string, error) {
 // sync tree holds the COMPLETE DAG (true for chats: BuildTree loads every change); a
 // future lazy/partial tree mode would need to revisit this.
 func (s *store) buildReusedDiffManager(seenHeads []string, onRemove func(removed []string)) (*objecttree.DiffManager, error) {
-	liveTree := s.treeSource.Tree()
+	liveTree := s.Tree()
 	// Reuse is equivalent to BuildHistoryTree only while the in-memory tree still spans the
 	// whole snapshotRoot..heads range. Creating a non-genesis snapshot resets the in-memory
 	// tree to [latest snapshot..heads] (objectTree clears ot.tree on IsSnapshot), after which

--- a/core/block/source/sourceimpl/store.go
+++ b/core/block/source/sourceimpl/store.go
@@ -12,7 +12,6 @@ import (
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree"
 	"github.com/anyproto/any-sync/commonspace/object/tree/synctree/updatelistener"
-	"github.com/anyproto/any-sync/commonspace/objecttreebuilder"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 
@@ -141,28 +140,54 @@ func unmarshalSeenHeads(raw []byte) ([]string, error) {
 	return seenHeads, nil
 }
 
+// buildReusedDiffManager creates a DiffManager that reuses the already-in-memory sync
+// tree instead of re-reading the entire change log from storage.
+//
+// Previously every diff manager built its own history tree via
+// space.TreeBuilder().BuildHistoryTree(...), i.e. a full GetAfterOrder scan of the whole
+// "changes" collection. A chat registers three diff managers (messages, mentions,
+// reactions), so opening it scanned the log 1 (sync build) + 3 (diff managers) = 4 times.
+//
+// NewChangeDiffer only iterates the tree (IterateRoot) to copy each change's
+// Id+PreviousIds into its own graph; it neither mutates nor retains the tree. For a chat
+// (single root snapshot) the live DAG (root..heads) is exactly what BuildHistoryTree
+// produced, because seenHeads are always ancestors-or-equal of the current tree heads.
+// So reusing the in-memory sync tree is equivalent and drops the 3 redundant scans (4->1).
+//
+// No lock is taken here ON PURPOSE: the object-tree mutex is non-reentrant and is already
+// held by every caller of InitDiffManager — factory.InitObject takes it (SetLocker(ot) +
+// Lock) around Init -> ReadStoreDoc -> initDiffManagers on open, and cache.DoWait takes it
+// (sb.Lock) on the mark-unread path. Locking again would self-deadlock.
+//
+// Safe against ocache eviction/GC: (1) the held lock blocks eviction during the build
+// (GC closes via smartBlock.TryClose -> TryLock, which fails while locked; Close() also
+// re-acquires the lock); (2) after the build the DiffManager keeps its OWN copied graph
+// and holds no reference to the tree, so later eviction/GC of the tree is harmless, and
+// ongoing updates pass a fresh tree via updateInDiffManagers. This assumes the in-memory
+// sync tree holds the COMPLETE DAG (true for chats: BuildTree loads every change); a
+// future lazy/partial tree mode would need to revisit this.
+func (s *store) buildReusedDiffManager(seenHeads []string, onRemove func(removed []string)) (*objecttree.DiffManager, error) {
+	liveTree := s.treeSource.Tree()
+	curTreeHeads := liveTree.Heads()
+	buildTree := func(heads []string) (objecttree.ReadableObjectTree, error) {
+		return liveTree, nil
+	}
+	return objecttree.NewDiffManager(seenHeads, curTreeHeads, buildTree, onRemove)
+}
+
 func (s *store) InitDiffManager(ctx context.Context, name string, seenHeads []string) (err error) {
 	manager, ok := s.diffManagers[name]
 	if !ok {
 		return nil
 	}
 
-	curTreeHeads := s.treeSource.Tree().Heads()
-
-	buildTree := func(heads []string) (objecttree.ReadableObjectTree, error) {
-		return s.space.TreeBuilder().BuildHistoryTree(ctx, s.Id(), objecttreebuilder.HistoryTreeOpts{
-			Heads:          heads,
-			Include:        true,
-			BuildEmptyData: true,
-		})
-	}
 	onRemove := func(removed []string) {
 		if manager.onRemove != nil {
 			manager.onRemove(removed)
 		}
 	}
 
-	manager.diffManager, err = objecttree.NewDiffManager(seenHeads, curTreeHeads, buildTree, onRemove)
+	manager.diffManager, err = s.buildReusedDiffManager(seenHeads, onRemove)
 	if err != nil {
 		return fmt.Errorf("init diff manager: %w", err)
 	}

--- a/core/block/source/sourceimpl/store.go
+++ b/core/block/source/sourceimpl/store.go
@@ -149,10 +149,11 @@ func unmarshalSeenHeads(raw []byte) ([]string, error) {
 // reactions), so opening it scanned the log 1 (sync build) + 3 (diff managers) = 4 times.
 //
 // NewChangeDiffer only iterates the tree (IterateRoot) to copy each change's
-// Id+PreviousIds into its own graph; it neither mutates nor retains the tree. For a chat
-// (single root snapshot) the live DAG (root..heads) is exactly what BuildHistoryTree
-// produced, because seenHeads are always ancestors-or-equal of the current tree heads.
-// So reusing the in-memory sync tree is equivalent and drops the 3 redundant scans (4->1).
+// Id+PreviousIds into its own graph; it does not mutate the tree and keeps no reference to
+// it (only the immutable PreviousIds slices, which are never modified after a change is
+// created). For a chat the live DAG (root..heads) is exactly what BuildHistoryTree produced,
+// because seenHeads are always ancestors-or-equal of the current tree heads. So reusing the
+// in-memory sync tree is equivalent and drops the 3 redundant scans (4->1).
 //
 // No lock is taken here ON PURPOSE: the object-tree mutex is non-reentrant and is already
 // held by every caller of InitDiffManager — factory.InitObject takes it (SetLocker(ot) +
@@ -168,8 +169,29 @@ func unmarshalSeenHeads(raw []byte) ([]string, error) {
 // future lazy/partial tree mode would need to revisit this.
 func (s *store) buildReusedDiffManager(seenHeads []string, onRemove func(removed []string)) (*objecttree.DiffManager, error) {
 	liveTree := s.treeSource.Tree()
+	// Reuse is equivalent to BuildHistoryTree only while the in-memory tree still spans the
+	// whole snapshotRoot..heads range. Creating a non-genesis snapshot resets the in-memory
+	// tree to [latest snapshot..heads] (objectTree clears ot.tree on IsSnapshot), after which
+	// a seenHead before that snapshot would be misclassified and unread counts would drift.
+	// Chats never create snapshots, so the genesis root (SnapshotCounter == 1) is the only
+	// snapshot. Trip loudly if that ever changes instead of silently miscounting.
+	root := liveTree.Root()
+	if root == nil || root.SnapshotCounter > 1 {
+		cnt := -1
+		if root != nil {
+			cnt = root.SnapshotCounter
+		}
+		return nil, fmt.Errorf("reuse diff manager: tree is not genesis-rooted (root snapshot counter %d); restore BuildHistoryTree for snapshotted objects", cnt)
+	}
+	// The object-tree mutex is non-reentrant and MUST already be held by the caller (see the
+	// doc above). Trip loudly on a future lock-free caller instead of silently racing the
+	// shared iteration flags: TryLock fails when this goroutine already holds the lock.
+	if liveTree.TryLock() {
+		liveTree.Unlock()
+		log.With("objectId", s.Id()).Error("buildReusedDiffManager called without the object-tree lock held")
+	}
 	curTreeHeads := liveTree.Heads()
-	buildTree := func(heads []string) (objecttree.ReadableObjectTree, error) {
+	buildTree := func(_ []string) (objecttree.ReadableObjectTree, error) {
 		return liveTree, nil
 	}
 	return objecttree.NewDiffManager(seenHeads, curTreeHeads, buildTree, onRemove)

--- a/core/block/source/sourceimpl/store_open_cost_test.go
+++ b/core/block/source/sourceimpl/store_open_cost_test.go
@@ -1,0 +1,246 @@
+package sourceimpl
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-sync/commonspace/object/acl/list"
+	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Ground-truth tests for the cost of opening a big chat (a CRDT "store" object),
+// measured as the number of times the full change log is read from storage.
+//
+// A chat has NO snapshots, so building its in-memory tree reads the entire change
+// log from SQLite. The chat registers THREE diff managers (messages, mentions,
+// reactions; see chatobject.go). Historically each diff manager built its OWN
+// history tree from storage (store.InitDiffManager -> objecttree.NewDiffManager ->
+// BuildHistoryTree), so an open read the whole log 1 (sync build) + 3 (diff
+// managers) = 4 times.
+//
+// The fix (store.buildReusedDiffManager) makes the diff managers reuse the
+// already-in-memory sync tree instead of re-reading storage: NewChangeDiffer only
+// iterates the tree (IterateRoot) and copies each change's Id+PreviousIds into its
+// own graph, so no storage scan is needed. That drops 4 scans -> 1.
+//
+// TestChatOpen_DiffManagersReuseSyncTree proves the production seam does 0 storage
+// scans (and contrasts it with the old per-manager-build cost on the same tree).
+
+// chatDiffManagerCount is the number of diff managers a chat registers
+// (messages, mentions, reactions). See chatobject.go.
+const chatDiffManagerCount = 3
+
+// openScanCounters counts reads against the tree "changes" collection.
+type openScanCounters struct {
+	findCalls atomic.Int64 // number of range queries (== number of full-log scans)
+	rowsRead  atomic.Int64 // number of change rows iterated across all scans
+}
+
+func (c *openScanCounters) reset() {
+	c.findCalls.Store(0)
+	c.rowsRead.Store(0)
+}
+
+// --- counting anystore wrappers (embed the interface, override only what we need) ---
+
+type countingDB struct {
+	anystore.DB
+	c *openScanCounters
+}
+
+func (d countingDB) Collection(ctx context.Context, name string) (anystore.Collection, error) {
+	coll, err := d.DB.Collection(ctx, name)
+	return d.wrap(coll, name), err
+}
+
+func (d countingDB) OpenCollection(ctx context.Context, name string) (anystore.Collection, error) {
+	coll, err := d.DB.OpenCollection(ctx, name)
+	return d.wrap(coll, name), err
+}
+
+func (d countingDB) CreateCollection(ctx context.Context, name string) (anystore.Collection, error) {
+	coll, err := d.DB.CreateCollection(ctx, name)
+	return d.wrap(coll, name), err
+}
+
+func (d countingDB) wrap(coll anystore.Collection, name string) anystore.Collection {
+	if coll == nil || name != objecttree.CollName {
+		return coll
+	}
+	return countingColl{Collection: coll, c: d.c}
+}
+
+type countingColl struct {
+	anystore.Collection
+	c *openScanCounters
+}
+
+func (cc countingColl) Find(filter any) anystore.Query {
+	cc.c.findCalls.Add(1)
+	return countingQuery{Query: cc.Collection.Find(filter), c: cc.c}
+}
+
+type countingQuery struct {
+	anystore.Query
+	c *openScanCounters
+}
+
+func (q countingQuery) Sort(s ...any) anystore.Query {
+	return countingQuery{Query: q.Query.Sort(s...), c: q.c}
+}
+func (q countingQuery) Limit(l uint) anystore.Query {
+	return countingQuery{Query: q.Query.Limit(l), c: q.c}
+}
+func (q countingQuery) Offset(o uint) anystore.Query {
+	return countingQuery{Query: q.Query.Offset(o), c: q.c}
+}
+func (q countingQuery) IndexHint(h ...anystore.IndexHint) anystore.Query {
+	return countingQuery{Query: q.Query.IndexHint(h...), c: q.c}
+}
+func (q countingQuery) Iter(ctx context.Context) (anystore.Iterator, error) {
+	it, err := q.Query.Iter(ctx)
+	if err != nil {
+		return it, err
+	}
+	return countingIter{Iterator: it, c: q.c}, nil
+}
+
+type countingIter struct {
+	anystore.Iterator
+	c *openScanCounters
+}
+
+func (i countingIter) Next() bool {
+	ok := i.Iterator.Next()
+	if ok {
+		i.c.rowsRead.Add(1)
+	}
+	return ok
+}
+
+// setupCountingChatTree builds a real anystore-backed object tree with numChanges
+// changes in a linear chain (mirroring a chat with numChanges messages), returns the
+// storage, acl, heads and a counter wired into the "changes" collection.
+func setupCountingChatTree(t *testing.T, numChanges int) (objecttree.Storage, list.AclList, []string, *openScanCounters) {
+	counters := &openScanCounters{}
+	aclList, _ := prepareAclList(t)
+
+	creator := objecttree.NewMockChangeCreator(func() anystore.DB {
+		db, err := anystore.Open(ctx, filepath.Join(t.TempDir(), "changes.db"), nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+		return countingDB{DB: db, c: counters}
+	})
+
+	storage := creator.CreateNewTreeStorage(t, "0", aclList.Head().Id, false)
+	tree, err := objecttree.BuildTestableTree(storage, aclList)
+	require.NoError(t, err)
+	tree.SetFlusher(objecttree.MarkNewChangeFlusher())
+
+	raws := make([]*treechangeproto.RawTreeChangeWithId, 0, numChanges)
+	prev := "0"
+	for i := 1; i <= numChanges; i++ {
+		id := strconv.Itoa(i)
+		raws = append(raws, creator.CreateRaw(id, aclList.Head().Id, "0", false, prev))
+		prev = id
+	}
+	_, err = tree.AddRawChanges(ctx, objecttree.RawChangesPayload{
+		NewHeads:   []string{prev},
+		RawChanges: raws,
+	})
+	require.NoError(t, err)
+
+	return storage, aclList, []string{prev}, counters
+}
+
+// TestChatOpen_DiffManagersReuseSyncTree is the before/after ground truth for the fix.
+// It builds the sync tree once, then measures the storage scans of (a) the OLD path
+// (one history-tree build per diff manager) and (b) the NEW path (production
+// store.buildReusedDiffManager, which reuses the in-memory sync tree). The NEW path
+// must do ZERO storage scans, dropping a chat open from 4 full-log scans to 1.
+func TestChatOpen_DiffManagersReuseSyncTree(t *testing.T) {
+	const numChanges = 300
+	storage, aclList, _, counters := setupCountingChatTree(t, numChanges)
+	logLen := int64(numChanges + 1) // + root
+
+	// The one mandatory build: the in-memory sync tree (this is the "tree build").
+	counters.reset()
+	syncTree, err := objecttree.BuildTestableTree(storage, aclList)
+	require.NoError(t, err)
+	syncScans := counters.findCalls.Load()
+
+	// OLD path: each diff manager re-read the whole log from storage.
+	counters.reset()
+	for i := 0; i < chatDiffManagerCount; i++ {
+		_, err := objecttree.BuildEmptyDataTestableTree(storage, aclList)
+		require.NoError(t, err)
+	}
+	oldDiffScans, oldDiffRows := counters.findCalls.Load(), counters.rowsRead.Load()
+
+	// NEW path: the production seam reuses the already-in-memory sync tree.
+	s := &store{treeSource: &treeSource{ObjectTree: syncTree}}
+	counters.reset()
+	for i := 0; i < chatDiffManagerCount; i++ {
+		dm, err := s.buildReusedDiffManager(nil, func([]string) {})
+		require.NoError(t, err)
+		require.NotNil(t, dm)
+	}
+	newDiffScans, newDiffRows := counters.findCalls.Load(), counters.rowsRead.Load()
+
+	t.Logf("change log length: %d", logLen)
+	t.Logf("sync build:        scans=%d", syncScans)
+	t.Logf("OLD diff init:     scans=%d rows=%d  -> total open = %d scans (1 sync + %d diff)", oldDiffScans, oldDiffRows, syncScans+oldDiffScans, chatDiffManagerCount)
+	t.Logf("NEW diff init:     scans=%d rows=%d  -> total open = %d scans (1 sync + 0 diff)", newDiffScans, newDiffRows, syncScans+newDiffScans)
+
+	// Sanity: the sync build reads the log exactly once.
+	assert.Equal(t, int64(1), syncScans, "sync tree build should scan the log once")
+	// The cost we are removing: 3 redundant full-log scans.
+	assert.Equal(t, int64(chatDiffManagerCount), oldDiffScans, "old path scanned the log once per diff manager")
+	// The fix: diff managers reuse the in-memory sync tree -> no storage scan.
+	assert.Equal(t, int64(0), newDiffScans, "reusing the in-memory sync tree must do NO storage scan")
+	assert.Equal(t, int64(0), newDiffRows, "no rows read from storage when reusing the in-memory tree")
+	// Net: a chat open goes from 4 full-log scans to 1.
+	assert.Equal(t, int64(1), syncScans+newDiffScans, "a chat open should scan the full log once after the fix")
+}
+
+// TestChatOpen_ScalingCost reports wall-clock + scans as the chat grows, confirming
+// the open scans the log exactly once at every size.
+// Run: go test ./core/block/source/sourceimpl/ -run TestChatOpen_ScalingCost -v
+func TestChatOpen_ScalingCost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scaling cost test skipped in -short mode")
+	}
+	for _, numChanges := range []int{200, 1000, 5000} {
+		t.Run(strconv.Itoa(numChanges)+"_changes", func(t *testing.T) {
+			storage, aclList, _, counters := setupCountingChatTree(t, numChanges)
+			logLen := int64(numChanges + 1)
+
+			counters.reset() // ignore the storage writes/reads done during setup
+			start := time.Now()
+			syncTree, err := objecttree.BuildTestableTree(storage, aclList)
+			require.NoError(t, err)
+			s := &store{treeSource: &treeSource{ObjectTree: syncTree}}
+			for i := 0; i < chatDiffManagerCount; i++ {
+				_, err := s.buildReusedDiffManager(nil, func([]string) {})
+				require.NoError(t, err)
+			}
+			elapsed := time.Since(start)
+
+			totalScans := counters.findCalls.Load()
+			totalRows := counters.rowsRead.Load()
+			t.Logf("n=%-5d open=%-12v rows_read=%d (%.1fx log) scans=%d (%.1f us/change)",
+				numChanges, elapsed, totalRows, float64(totalRows)/float64(logLen), totalScans,
+				float64(elapsed.Microseconds())/float64(logLen))
+
+			assert.Equal(t, int64(1), totalScans, "open should scan the full log exactly once at any size")
+		})
+	}
+}

--- a/core/block/source/sourceimpl/store_open_cost_test.go
+++ b/core/block/source/sourceimpl/store_open_cost_test.go
@@ -185,14 +185,20 @@ func TestChatOpen_DiffManagersReuseSyncTree(t *testing.T) {
 	}
 	oldDiffScans, oldDiffRows := counters.findCalls.Load(), counters.rowsRead.Load()
 
-	// NEW path: the production seam reuses the already-in-memory sync tree.
+	// NEW path: the production seam reuses the already-in-memory sync tree. Hold the
+	// object-tree lock as the real callers do (factory.InitObject / cache.DoWait).
 	s := &store{treeSource: &treeSource{ObjectTree: syncTree}}
 	counters.reset()
+	syncTree.Lock()
 	for i := 0; i < chatDiffManagerCount; i++ {
 		dm, err := s.buildReusedDiffManager(nil, func([]string) {})
 		require.NoError(t, err)
 		require.NotNil(t, dm)
+		// Proves the live tree was actually consumed (root + numChanges) — i.e. a genuine
+		// reuse, not a no-op that merely happens to do no storage I/O.
+		require.Len(t, dm.GetIds(), numChanges+1)
 	}
+	syncTree.Unlock()
 	newDiffScans, newDiffRows := counters.findCalls.Load(), counters.rowsRead.Load()
 
 	t.Logf("change log length: %d", logLen)
@@ -228,10 +234,12 @@ func TestChatOpen_ScalingCost(t *testing.T) {
 			syncTree, err := objecttree.BuildTestableTree(storage, aclList)
 			require.NoError(t, err)
 			s := &store{treeSource: &treeSource{ObjectTree: syncTree}}
+			syncTree.Lock()
 			for i := 0; i < chatDiffManagerCount; i++ {
 				_, err := s.buildReusedDiffManager(nil, func([]string) {})
 				require.NoError(t, err)
 			}
+			syncTree.Unlock()
 			elapsed := time.Since(start)
 
 			totalScans := counters.findCalls.Load()
@@ -243,4 +251,47 @@ func TestChatOpen_ScalingCost(t *testing.T) {
 			assert.Equal(t, int64(1), totalScans, "open should scan the full log exactly once at any size")
 		})
 	}
+}
+
+// TestChatOpen_ReusedDiffManager_CorrectDiff is the behavioral guard: it proves the diff
+// manager built from the reused in-memory tree computes the SAME ancestor-based diff that a
+// storage-built history tree would (the real correctness risk of the change), not just that
+// it does no storage I/O. Linear chain 0(root)<-1<-...<-n, current head = n.
+func TestChatOpen_ReusedDiffManager_CorrectDiff(t *testing.T) {
+	const n = 50
+	storage, aclList, _, _ := setupCountingChatTree(t, n)
+	syncTree, err := objecttree.BuildTestableTree(storage, aclList)
+	require.NoError(t, err)
+	s := &store{treeSource: &treeSource{ObjectTree: syncTree}}
+
+	// build a diff manager over the reused tree, apply seenHeads via Init(), return the
+	// full id set the differ ingested and the ids it reported as removed (seen).
+	build := func(seenHeads []string) (ids, removed []string) {
+		syncTree.Lock() // callers hold the object-tree lock in production
+		defer syncTree.Unlock()
+		dm, err := s.buildReusedDiffManager(seenHeads, func(r []string) { removed = append(removed, r...) })
+		require.NoError(t, err)
+		require.NotNil(t, dm)
+		ids = dm.GetIds()
+		dm.Init()
+		return
+	}
+
+	t.Run("reuses the full DAG", func(t *testing.T) {
+		ids, _ := build(nil)
+		assert.Len(t, ids, n+1, "differ should ingest root + all changes from the live tree")
+	})
+	t.Run("nil seenHeads removes nothing", func(t *testing.T) {
+		_, removed := build(nil)
+		assert.Empty(t, removed)
+	})
+	t.Run("ancestor seenHead removes exactly its prefix", func(t *testing.T) {
+		_, removed := build([]string{"5"})
+		// ancestors-or-equal of "5" in a linear chain == root "0".."5"
+		assert.ElementsMatch(t, []string{"0", "1", "2", "3", "4", "5"}, removed)
+	})
+	t.Run("unknown seenHead is handled gracefully", func(t *testing.T) {
+		_, removed := build([]string{"does-not-exist"})
+		assert.Empty(t, removed, "stale/unknown seenHead routes to notFound, not a panic or bad removal")
+	})
 }


### PR DESCRIPTION
Opening a big chat read the full change log from SQLite 4×: the sync tree build + one `BuildHistoryTree` per diff manager (messages, mentions, reactions). Each was a full `GetAfterOrder` scan — I/O-bound, worsened by memory pressure.

Fix: diff managers reuse the already-in-memory sync tree (`buildReusedDiffManager`) instead of re-reading storage. `NewChangeDiffer` only iterates the tree and copies Id+PreviousIds — no mutate, no retain. **4 scans → 1.** No new lock (callers already hold the non-reentrant object-tree mutex; locking would deadlock).

Guards: errors if the tree is ever snapshotted (`root.SnapshotCounter > 1`); logs if called without the tree lock.

Tests (`store_open_cost_test.go`): scan-count proof (diff init 3→0, total 4→1), scaling, and behavioral diff-equivalence. Passes under `-race`; chatobject/chats/sourceimpl green.

Note: counts diff-manager + sync-build scans; the store-apply pass is incremental on warm reopen, full only on cold first open (follow-up: feed it from the in-memory tree too).