### PR TITLE
GO-7342 acl: evict network-fetched ACL after Leave; guard getter map

### DIFF
--- a/core/acl/aclgetter.go
+++ b/core/acl/aclgetter.go
@@ -3,6 +3,7 @@ package acl
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/anyproto/any-sync/commonspace/acl/aclclient"
 	"github.com/anyproto/any-sync/commonspace/object/accountdata"
@@ -13,6 +14,7 @@ import (
 )
 
 type aclGetter struct {
+	mu          sync.Mutex // guards currentAcls (Leave runs without aclClientLock and may run concurrently)
 	currentAcls map[string]list.AclList
 	aclClient   aclclient.AclJoiningClient
 	keys        *accountdata.AccountKeys
@@ -29,24 +31,35 @@ func newAclGetter(aclClient aclclient.AclJoiningClient, keys *accountdata.Accoun
 }
 
 func (g *aclGetter) RemoveAcl(ctx context.Context, spaceId string) error {
+	g.mu.Lock()
 	delete(g.currentAcls, spaceId)
+	g.mu.Unlock()
 	return nil
 }
 
 func (g *aclGetter) GetOrRefreshAcl(ctx context.Context, spaceId string) (aclList list.AclList, err error) {
+	g.mu.Lock()
 	aclList, ok := g.currentAcls[spaceId]
-	if !ok {
-		aclList, err = g.getAcl(ctx, spaceId)
-		if err != nil {
-			return nil, err
-		}
-		g.currentAcls[spaceId] = aclList
-	} else {
+	g.mu.Unlock()
+	if ok {
 		if err := g.refresh(ctx, spaceId, aclList); err != nil {
 			return nil, err
 		}
+		return aclList, nil
 	}
-	return aclList, nil
+	// fetch outside the lock (network call), then publish, double-checking another goroutine didn't win.
+	fetched, err := g.getAcl(ctx, spaceId)
+	if err != nil {
+		return nil, err
+	}
+	g.mu.Lock()
+	if existing, ok := g.currentAcls[spaceId]; ok {
+		fetched = existing
+	} else {
+		g.currentAcls[spaceId] = fetched
+	}
+	g.mu.Unlock()
+	return fetched, nil
 }
 
 func (g *aclGetter) getAcl(ctx context.Context, spaceId string) (l list.AclList, err error) {

--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -434,6 +434,11 @@ func (a *aclService) Leave(ctx context.Context, spaceId string) (err error) {
 	if err != nil {
 		return convertedOrAclRequestError(err)
 	}
+	// We've left the space, so drop the network-fetched ACL copy the getter cached for
+	// this operation; otherwise it lingers in currentAcls for the rest of the session.
+	if removeErr := a.getter.RemoveAcl(ctx, spaceId); removeErr != nil {
+		log.Warn("remove acl from getter cache after leave", zap.Error(removeErr), zap.String("spaceId", spaceId))
+	}
 	return nil
 }
 

--- a/core/acl/aclservice_test.go
+++ b/core/acl/aclservice_test.go
@@ -774,6 +774,28 @@ func TestService_Leave(t *testing.T) {
 		err = fx.Leave(ctx, spaceId)
 		require.NoError(t, err)
 	})
+	t.Run("leave evicts acl from getter cache", func(t *testing.T) {
+		fx := newFixture(t)
+		defer fx.finish(t)
+		spaceId := "spaceId"
+
+		keys, err := accountdata.NewRandom()
+		require.NoError(t, err)
+		aclList, err := list.NewInMemoryDerivedAcl(spaceId, keys)
+		require.NoError(t, err)
+		records, err := aclList.RecordsAfter(ctx, "")
+		require.NoError(t, err)
+
+		fx.mockJoiningClient.EXPECT().AclGetRecords(ctx, spaceId, "").Return(records, nil)
+		fx.mockJoiningClient.EXPECT().RequestSelfRemove(ctx, spaceId, gomock.Any()).Return(nil)
+
+		err = fx.Leave(ctx, spaceId)
+		require.NoError(t, err)
+
+		// the network-fetched acl must not linger in the getter cache after leaving
+		_, cached := fx.getter.currentAcls[spaceId]
+		require.False(t, cached, "acl should be evicted from getter cache after leave")
+	})
 	t.Run("leave fail if acl getter error is known", func(t *testing.T) {
 		errs := []error{
 			space.ErrSpaceStorageMissig,
@@ -1168,4 +1190,37 @@ func TestService_ChangePermissions_AdminRejectedByValidator(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrAclRequestFailed)
 	require.ErrorIs(t, err, list.ErrInsufficientPermissions)
+}
+
+// TestAclGetter_ConcurrentNoRace guards the aclGetter map: Leave runs without aclClientLock, so concurrent
+// Leaves write currentAcls concurrently via GetOrRefreshAcl/RemoveAcl. Without the getter mutex this is a
+// fatal `concurrent map writes`; the mutex makes it safe. The getter is built directly (no app.Start) to
+// isolate the map fix from an unrelated pre-existing race in aclService.Run's background loop. Run under -race.
+func TestAclGetter_ConcurrentNoRace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	keys, err := accountdata.NewRandom()
+	require.NoError(t, err)
+	aclList, err := list.NewInMemoryDerivedAcl("spaceId", keys)
+	require.NoError(t, err)
+	records, err := aclList.RecordsAfter(ctx, "")
+	require.NoError(t, err)
+
+	mockClient := mock_aclclient.NewMockAclJoiningClient(ctrl)
+	mockClient.EXPECT().AclGetRecords(gomock.Any(), gomock.Any(), gomock.Any()).Return(records, nil).AnyTimes()
+	mockNodeConf := mock_nodeconf.NewMockService(ctrl)
+	mockNodeConf.EXPECT().Configuration().Return(nodeconf.Configuration{NetworkId: ""}).AnyTimes()
+
+	g := newAclGetter(mockClient, keys, mockNodeConf)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			sp := fmt.Sprintf("space-%d", n)
+			_, _ = g.GetOrRefreshAcl(ctx, sp)
+			_ = g.RemoveAcl(ctx, sp)
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem
`aclGetter.RemoveAcl` was dead code, so the ACL fetched for each `Leave` lingered in `currentAcls` for the rest of the session. Also, `Leave` runs without `aclClientLock`, so concurrent leaves race the `currentAcls` map (a fatal `concurrent map writes`).

## Change
- Wire `RemoveAcl` into `Leave()` after a successful self-remove, dropping the network-fetched ACL.
- Guard `currentAcls` with a `sync.Mutex` in `aclGetter` (the network fetch happens outside the lock).

Part of the ACL-memory work (GO-7342); independent of the any-sync keep-only-ours change.

## Tests
`go test -race ./core/acl/...` passes; new `TestService_Leave/leave_evicts_acl_from_getter_cache` and `TestAclGetter_ConcurrentNoRace`.

Issue: GO-7342
