### PR TITLE
GO-7343 Strip high-churn local keys from subscription events by default

### DIFF
--- a/core/block/editor/smartblock/dependencies_test.go
+++ b/core/block/editor/smartblock/dependencies_test.go
@@ -5,10 +5,13 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/session"
+	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -184,4 +187,142 @@ func TestDependenciesSubscription(t *testing.T) {
 		assert.Contains(t, fx.smartBlock.lastDepDetails, space2obj1)
 	})
 
+}
+
+func amendedKeys(t *testing.T, e *pb.Event) []string {
+	t.Helper()
+	var keys []string
+	for _, m := range e.Messages {
+		if a := m.GetObjectDetailsAmend(); a != nil {
+			for _, kv := range a.Details {
+				keys = append(keys, kv.Key)
+			}
+		}
+	}
+	return keys
+}
+
+func TestOnMetaChangeStripKeys(t *testing.T) {
+	setup := func(t *testing.T) (*fixture, *[]*pb.Event) {
+		mainObjId := "id"
+		fx := newFixture(mainObjId, t)
+		root := bb.Root(bb.ID(mainObjId), bb.Children())
+		fx.Doc = state.NewDoc(mainObjId, root.BuildMap()).NewState()
+
+		var events []*pb.Event
+		fx.RegisterSession(session.NewContext())
+		fx.eventSender.EXPECT().
+			SendToSession(mock.Anything, mock.Anything).
+			Run(func(_ string, e *pb.Event) { events = append(events, e) }).
+			Maybe()
+		return fx, &events
+	}
+
+	t.Run("dependent sync-only change emits no event", func(t *testing.T) {
+		fx, events := setup(t)
+		depId := "dep1"
+		fx.onMetaChange(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String(depId),
+			bundle.RelationKeyName:       domain.String("Dep"),
+			bundle.RelationKeySyncStatus: domain.Int64(1),
+		}))
+		*events = nil // discard first-sight Set
+
+		fx.onMetaChange(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String(depId),
+			bundle.RelationKeyName:       domain.String("Dep"),
+			bundle.RelationKeySyncStatus: domain.Int64(2),
+			bundle.RelationKeySyncDate:   domain.Int64(123456),
+		}))
+		assert.Empty(t, *events)
+	})
+
+	t.Run("dependent name change emits amend without sync keys", func(t *testing.T) {
+		fx, events := setup(t)
+		depId := "dep2"
+		fx.onMetaChange(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String(depId),
+			bundle.RelationKeyName:       domain.String("Old"),
+			bundle.RelationKeySyncStatus: domain.Int64(1),
+		}))
+		*events = nil
+
+		fx.onMetaChange(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String(depId),
+			bundle.RelationKeyName:       domain.String("New"),
+			bundle.RelationKeySyncStatus: domain.Int64(2),
+		}))
+		require.Len(t, *events, 1)
+		keys := amendedKeys(t, (*events)[0])
+		assert.Contains(t, keys, bundle.RelationKeyName.String())
+		assert.NotContains(t, keys, bundle.RelationKeySyncStatus.String())
+	})
+
+	t.Run("self sync change is still emitted", func(t *testing.T) {
+		fx, events := setup(t)
+		selfId := fx.Id() // == "id"
+		fx.onMetaChange(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String(selfId),
+			bundle.RelationKeySyncStatus: domain.Int64(1),
+		}))
+		*events = nil
+
+		fx.onMetaChange(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+			bundle.RelationKeyId:         domain.String(selfId),
+			bundle.RelationKeySyncStatus: domain.Int64(2),
+		}))
+		require.Len(t, *events, 1)
+		keys := amendedKeys(t, (*events)[0])
+		assert.Contains(t, keys, bundle.RelationKeySyncStatus.String())
+	})
+}
+
+func findViewDetails(t *testing.T, set []*model.ObjectViewDetailsSet, id string) *types.Struct {
+	t.Helper()
+	for _, d := range set {
+		if d.Id == id {
+			return d.Details
+		}
+	}
+	t.Fatalf("ObjectViewDetailsSet for %s not found", id)
+	return nil
+}
+
+func TestFetchMetaStripsDependentKeys(t *testing.T) {
+	mainObjId := "id"
+	fx := newFixture(mainObjId, t)
+
+	depId := "obj1"
+	fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:         domain.String(depId),
+			bundle.RelationKeySpaceId:    domain.String(testSpaceId),
+			bundle.RelationKeyName:       domain.String("Object 1"),
+			bundle.RelationKeySyncStatus: domain.Int64(1),
+			bundle.RelationKeySyncDate:   domain.Int64(999),
+		},
+	})
+	fx.spaceIdResolver.EXPECT().ResolveSpaceID(depId).Return(testSpaceId, nil)
+	fx.space.EXPECT().Id().Return(testSpaceId)
+
+	root := bb.Root(bb.ID(mainObjId), bb.Children(bb.Link(depId)))
+	fx.Doc = state.NewDoc(mainObjId, root.BuildMap()).NewState()
+	fx.Doc.(*state.State).SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+		bundle.RelationKeyId:         domain.String(mainObjId),
+		bundle.RelationKeySpaceId:    domain.String(testSpaceId),
+		bundle.RelationKeyName:       domain.String("Main object"),
+		bundle.RelationKeySyncStatus: domain.Int64(1),
+	}))
+
+	details, err := fx.fetchMeta()
+	require.NoError(t, err)
+	defer fx.closeRecordsSub()
+
+	dep := findViewDetails(t, details, depId)
+	assert.Contains(t, dep.Fields, bundle.RelationKeyName.String())
+	assert.NotContains(t, dep.Fields, bundle.RelationKeySyncStatus.String())
+	assert.NotContains(t, dep.Fields, bundle.RelationKeySyncDate.String())
+
+	self := findViewDetails(t, details, mainObjId)
+	assert.Contains(t, self.Fields, bundle.RelationKeySyncStatus.String())
 }

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -508,7 +508,7 @@ func (sb *smartBlock) fetchMeta() (details []*model.ObjectViewDetailsSet, err er
 	for _, rec := range records {
 		details = append(details, &model.ObjectViewDetailsSet{
 			Id:      rec.Details.GetString(bundle.RelationKeyId),
-			Details: rec.Details.ToProto(),
+			Details: rec.Details.CopyWithoutKeys(bundle.DefaultStrippedKeys...).ToProto(),
 		})
 	}
 	go sb.metaListener(recordsCh)
@@ -568,6 +568,12 @@ func (sb *smartBlock) onMetaChange(details *domain.Details) {
 		return
 	}
 	id := details.GetString(bundle.RelationKeyId)
+	if id != sb.Id() {
+		// dependents never carry strip-by-default keys (sync/usage churn);
+		// strip before diffing/storing so a later change to those keys produces
+		// an empty diff and no event for the client
+		details = details.CopyWithoutKeys(bundle.DefaultStrippedKeys...)
+	}
 	var msgs []*pb.EventMessage
 	if v, exists := sb.lastDepDetails[id]; exists {
 		diff, keysToUnset := domain.StructDiff(v, details)

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -506,9 +506,16 @@ func (sb *smartBlock) fetchMeta() (details []*model.ObjectViewDetailsSet, err er
 	})
 
 	for _, rec := range records {
+		recId := rec.Details.GetString(bundle.RelationKeyId)
+		recDetails := rec.Details
+		if recId != sb.Id() {
+			// strip dependents only; a self-reference (rare) keeps full details,
+			// matching the self entry added above and the onMetaChange self branch
+			recDetails = rec.Details.CopyWithoutKeys(bundle.DefaultStrippedKeys...)
+		}
 		details = append(details, &model.ObjectViewDetailsSet{
-			Id:      rec.Details.GetString(bundle.RelationKeyId),
-			Details: rec.Details.CopyWithoutKeys(bundle.DefaultStrippedKeys...).ToProto(),
+			Id:      recId,
+			Details: recDetails.ToProto(),
 		})
 	}
 	go sb.metaListener(recordsCh)

--- a/core/history/history.go
+++ b/core/history/history.go
@@ -303,9 +303,11 @@ func (h *history) buildDetails(s *state.State, spc clientspace.Space) (details [
 		}
 
 		for _, record := range records {
+			// dependents are name/icon chips in the version view; strip the
+			// high-churn strip-by-default keys, consistent with smartblock.fetchMeta
 			details = append(details, &model.ObjectViewDetailsSet{
 				Id:      record.Details.GetString(bundle.RelationKeyId),
-				Details: record.Details.ToProto(),
+				Details: record.Details.CopyWithoutKeys(bundle.DefaultStrippedKeys...).ToProto(),
 			})
 		}
 	}

--- a/core/history/history_test.go
+++ b/core/history/history_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/anyproto/anytype-heart/space/clientspace/mock_clientspace"
 	"github.com/anyproto/anytype-heart/space/mock_space"
 	"github.com/anyproto/anytype-heart/space/spacedomain"
+	bb "github.com/anyproto/anytype-heart/tests/blockbuilder"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 )
 
@@ -1160,6 +1161,68 @@ func TestHistory_Show(t *testing.T) {
 		assert.NotNil(t, view)
 		assert.NotNil(t, version)
 	})
+}
+
+func TestHistory_buildDetailsStripsDependents(t *testing.T) {
+	spaceID := "spaceID"
+	rootId := "root1"
+	depId := "dep1"
+
+	store := objectstore.NewStoreFixture(t)
+	store.AddObjects(t, spaceID, []objectstore.TestObject{{
+		bundle.RelationKeyId:         domain.String(depId),
+		bundle.RelationKeySpaceId:    domain.String(spaceID),
+		bundle.RelationKeyName:       domain.String("Dep"),
+		bundle.RelationKeySyncStatus: domain.Int64(1),
+		bundle.RelationKeySyncDate:   domain.Int64(999),
+	}})
+
+	resolver := mock_idresolver.NewMockResolver(t)
+	resolver.EXPECT().ResolveSpaceID(mock.Anything).Return(spaceID, nil).Maybe()
+	fetcher := mock_relationutils.NewMockRelationFormatFetcher(t)
+	fetcher.EXPECT().GetRelationFormatByKey(mock.Anything, mock.Anything).RunAndReturn(func(_ string, key domain.RelationKey) (model.RelationFormat, error) {
+		rel, err := bundle.GetRelation(key)
+		if err != nil {
+			return 0, err
+		}
+		return rel.Format, nil
+	}).Maybe()
+
+	space := mock_clientspace.NewMockSpace(t)
+	space.EXPECT().Id().Return(spaceID).Maybe()
+
+	h := &history{objectStore: store, resolver: resolver, formatFetcher: fetcher}
+
+	root := bb.Root(bb.ID(rootId), bb.Children(bb.Link(depId)))
+	st := state.NewDoc(rootId, root.BuildMap()).NewState()
+	st.SetDetails(domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+		bundle.RelationKeyId:         domain.String(rootId),
+		bundle.RelationKeySpaceId:    domain.String(spaceID),
+		bundle.RelationKeyName:       domain.String("Root"),
+		bundle.RelationKeySyncStatus: domain.Int64(1),
+	}))
+
+	details, err := h.buildDetails(st, space)
+	require.NoError(t, err)
+
+	dep := findHistoryViewDetails(t, details, depId)
+	assert.Contains(t, dep.Fields, bundle.RelationKeyName.String())
+	assert.NotContains(t, dep.Fields, bundle.RelationKeySyncStatus.String())
+	assert.NotContains(t, dep.Fields, bundle.RelationKeySyncDate.String())
+
+	rootView := findHistoryViewDetails(t, details, rootId)
+	assert.Contains(t, rootView.Fields, bundle.RelationKeySyncStatus.String())
+}
+
+func findHistoryViewDetails(t *testing.T, set []*model.ObjectViewDetailsSet, id string) *types.Struct {
+	t.Helper()
+	for _, d := range set {
+		if d.Id == id {
+			return d.Details
+		}
+	}
+	t.Fatalf("ObjectViewDetailsSet for %s not found", id)
+	return nil
 }
 
 type historyFixture struct {

--- a/core/subscription/deps.go
+++ b/core/subscription/deps.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/anyproto/anytype-heart/core/domain"
@@ -58,9 +59,14 @@ func newDepTracker(parent *coreSub, spec subSpec, idx spaceindex.Store) *depTrac
 		keySet[string(k)] = struct{}{}
 	}
 	child := &coreSub{
-		subId:            spec.subId + "/dep",
-		spaceId:          spec.spaceId,
-		keys:             spec.keys,
+		subId:   spec.subId + "/dep",
+		spaceId: spec.spaceId,
+		// dependent objects are rendered as name/icon chips; never stream the
+		// high-churn strip-by-default keys (sync/usage) for them, even if the
+		// parent lists those keys for its own rows. depKeys above are derived
+		// from spec.keys and are unaffected (stripped keys are never object/file
+		// format).
+		keys:             slices.DeleteFunc(slices.Clone(spec.keys), bundle.IsDefaultStrippedKey),
 		members:          make(map[string]struct{}),
 		vis:              make(map[string]*visEntry),
 		detailEventsOnly: true,

--- a/core/subscription/deps_test.go
+++ b/core/subscription/deps_test.go
@@ -104,6 +104,48 @@ func TestDependencies(t *testing.T) {
 		assert.Equal(t, bundle.RelationKeyName.String(), amend.Details[0].Key)
 	})
 
+	t.Run("strip-by-default keys are stripped from deps even when the parent requests them", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		alice := givenPerson("alice", "Alice")
+		alice[bundle.RelationKeySyncStatus] = domain.Int64(1)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenAssigneeRelation(),
+			alice,
+			givenTask("task1", "fix bug", "alice"),
+		})
+
+		// parent explicitly lists syncStatus for its own rows
+		req := givenDepRequest()
+		req.Keys = append(req.Keys, bundle.RelationKeySyncStatus.String())
+		resp, err := fx.Search(req)
+		require.NoError(t, err)
+
+		// the dependency snapshot for alice must NOT carry syncStatus
+		require.Len(t, resp.Dependencies, 1)
+		assert.Equal(t, "alice", resp.Dependencies[0].GetString(bundle.RelationKeyId))
+		_, hasSync := resp.Dependencies[0].TryGet(bundle.RelationKeySyncStatus)
+		assert.False(t, hasSync, "dep snapshot leaked syncStatus")
+
+		// a syncStatus-only change to the dependency emits nothing
+		aliceSync := givenPerson("alice", "Alice")
+		aliceSync[bundle.RelationKeySyncStatus] = domain.Int64(2)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{aliceSync})
+		assertNoMessages(t, resp.Output)
+
+		// a real (requested, non-stripped) change still arrives, without sync keys
+		aliceRenamed := givenPerson("alice", "Alice Renamed")
+		aliceRenamed[bundle.RelationKeySyncStatus] = domain.Int64(3)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{aliceRenamed})
+		msgs := waitMessages(t, resp.Output, 1)
+		require.Len(t, msgs, 1)
+		amend := msgs[0].GetObjectDetailsAmend()
+		require.NotNil(t, amend)
+		assert.Equal(t, "alice", amend.Id)
+		assert.Equal(t, []string{"dep-parent/dep"}, amend.SubIds)
+		require.Len(t, amend.Details, 1)
+		assert.Equal(t, bundle.RelationKeyName.String(), amend.Details[0].Key)
+	})
+
 	t.Run("changing a member's dep value swaps the tracked dependency", func(t *testing.T) {
 		fx := newEngineFixture(t)
 		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{

--- a/core/subscription/service_test.go
+++ b/core/subscription/service_test.go
@@ -556,3 +556,68 @@ func TestBroadcastSubscription(t *testing.T) {
 	}
 	assert.Equal(t, want, events[0].Messages)
 }
+
+func TestStrippedKeysInvariant(t *testing.T) {
+	syncFilter := []database.FilterRequest{{
+		RelationKey: bundle.RelationKeyResolvedLayout,
+		Condition:   model.BlockContentDataviewFilter_Equal,
+		Value:       domain.Int64(int64(model.ObjectType_participant)),
+	}}
+
+	t.Run("syncStatus not requested: change emits no event", func(t *testing.T) {
+		fx := newEngineFixture(t)
+
+		resp, err := fx.Search(SubscribeRequest{
+			SpaceId:           testSpaceId,
+			SubId:             "sub-no-sync",
+			Internal:          true,
+			NoDepSubscription: true,
+			Keys:              []string{bundle.RelationKeyId.String(), bundle.RelationKeyName.String()},
+			Filters:           syncFilter,
+		})
+		require.NoError(t, err)
+
+		obj := givenParticipant("p1")
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{obj})
+		waitMessages(t, resp.Output, 3) // drain Set, Add, Counters
+
+		obj[bundle.RelationKeySyncStatus] = domain.Int64(2)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{obj})
+
+		assertNoMessages(t, resp.Output)
+	})
+
+	t.Run("syncStatus requested: change emits amend", func(t *testing.T) {
+		fx := newEngineFixture(t)
+
+		resp, err := fx.Search(SubscribeRequest{
+			SpaceId:           testSpaceId,
+			SubId:             "sub-with-sync",
+			Internal:          true,
+			NoDepSubscription: true,
+			Keys:              []string{bundle.RelationKeyId.String(), bundle.RelationKeySyncStatus.String()},
+			Filters:           syncFilter,
+		})
+		require.NoError(t, err)
+
+		obj := givenParticipant("p1")
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{obj})
+		waitMessages(t, resp.Output, 3) // drain Set, Add, Counters
+
+		obj[bundle.RelationKeySyncStatus] = domain.Int64(2)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{obj})
+
+		want := []*pb.EventMessage{
+			event.NewMessage(testSpaceId, &pb.EventMessageValueOfObjectDetailsAmend{
+				ObjectDetailsAmend: &pb.EventObjectDetailsAmend{
+					Id: "p1",
+					Details: []*pb.EventObjectDetailsAmendKeyValue{
+						{Key: bundle.RelationKeySyncStatus.String(), Value: pbtypes.Int64(2)},
+					},
+					SubIds: []string{"sub-with-sync"},
+				},
+			}),
+		}
+		assert.Equal(t, want, waitMessages(t, resp.Output, 1))
+	})
+}

--- a/pkg/lib/bundle/strippedkeys.go
+++ b/pkg/lib/bundle/strippedkeys.go
@@ -1,0 +1,31 @@
+package bundle
+
+import "github.com/anyproto/anytype-heart/core/domain"
+
+// DefaultStrippedKeys are high-churn local relation keys excluded from
+// subscription events by default. They reach the client only when explicitly
+// requested via the subscription's keys field. Smartblock dependent
+// subscriptions (which have no keys field) never carry them; the open object
+// itself is exempt and keeps delivering them through LocalRelationsKeys.
+var DefaultStrippedKeys = []domain.RelationKey{
+	RelationKeySyncStatus,
+	RelationKeySyncError,
+	RelationKeySyncDate,
+	RelationKeyLastUsedDate,
+	RelationKeyLastOpenedDate,
+}
+
+var defaultStrippedKeysSet = func() map[domain.RelationKey]struct{} {
+	m := make(map[domain.RelationKey]struct{}, len(DefaultStrippedKeys))
+	for _, k := range DefaultStrippedKeys {
+		m[k] = struct{}{}
+	}
+	return m
+}()
+
+// IsDefaultStrippedKey reports whether a key is stripped from subscription
+// events unless explicitly requested via the keys field.
+func IsDefaultStrippedKey(k domain.RelationKey) bool {
+	_, ok := defaultStrippedKeysSet[k]
+	return ok
+}

--- a/pkg/lib/bundle/strippedkeys_test.go
+++ b/pkg/lib/bundle/strippedkeys_test.go
@@ -1,0 +1,20 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultStrippedKeys(t *testing.T) {
+	assert.Len(t, DefaultStrippedKeys, 5)
+
+	assert.True(t, IsDefaultStrippedKey(RelationKeySyncStatus))
+	assert.True(t, IsDefaultStrippedKey(RelationKeySyncError))
+	assert.True(t, IsDefaultStrippedKey(RelationKeySyncDate))
+	assert.True(t, IsDefaultStrippedKey(RelationKeyLastUsedDate))
+	assert.True(t, IsDefaultStrippedKey(RelationKeyLastOpenedDate))
+
+	assert.False(t, IsDefaultStrippedKey(RelationKeyName))
+	assert.False(t, IsDefaultStrippedKey(RelationKeyId))
+}


### PR DESCRIPTION
GO-7343: https://linear.app/anytype/issue/GO-7343

## Problem
`syncStatus`/`syncDate`/`syncError` are rewritten on every sync tick. For each open editor the smartblock subscribes to all dependent objects, and any subscription with a relation column has a hidden `/dep` child for referenced objects — so every sync tick fired an `ObjectDetailsAmend` to the client for dependents whose sync status is never rendered. Pure event spam × open editors × dependents.

## Change
A subscription emits a default-stripped key only when the client explicitly lists it in `keys`. **Dependents are always stripped; primary rows and the open object never are.**

Strip set (`bundle.DefaultStrippedKeys`): `syncStatus, syncError, syncDate, lastUsedDate, lastOpenedDate` — all in `LocalRelationsKeys`, so the open object keeps them via the existing self-path.

Touched paths:
- smartblock `onMetaChange` + `fetchMeta` — strip dependents (`id != sb.Id()`).
- engine `/dep` child (`deps.go`) — was inheriting the parent's full keys; now stripped.
- version history `buildDetails` — strip dependents.
- `core/subscription` already emitted only requested keys — locked with tests.

`lastModifiedDate`/`lastModifiedBy` are **derived**, intentionally not stripped (user-facing "Updated", churns per-edit not per-sync-tick).

## Verification
- 5-lens adversarial review: Go side safe, diffs correct on every path, no spurious `Unset`, strip set correct.
- Client audit (ts/swift/kotlin): **safe to ship** — all draw sync indicators from a dedicated space-level sync channel, not per-object `syncStatus` on dependents. Dataview columns are safe (clients request displayed-relation keys; rows are primary).
- One low-severity follow-up: anytype-ts file-block "syncing from another device" spinner reads `syncStatus` from ObjectShow deps (no `keys` param) → tracked separately.

## Tests
bundle membership; smartblock (dep sync-only ⇒ no event, dep name ⇒ amend w/o sync keys, self sync ⇒ still emitted, fetchMeta strip); subscription invariant + `/dep` strip; history `buildDetails`. All touched packages green; `go vet`/`gofmt` clean.
