### PR TITLE
GO-7316 Fix chat fulltext backfill: _all merge precedence, FT rebuild, discussions

### DIFF
--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -493,7 +493,9 @@ func (i *indexer) reindexDiscussions(ctx context.Context, space clientspace.Spac
 }
 
 func (i *indexer) reindexChatMessagesFulltext(ctx context.Context, space clientspace.Space) error {
-	ids, err := i.getIdsForTypes(space, coresb.SmartBlockTypeChatDerivedObject)
+	// Both chatDerived (space chats) and discussion (object chats) use the chat
+	// editor and store messages identically, so both must be backfilled.
+	ids, err := i.getIdsForTypes(space, coresb.SmartBlockTypeChatDerivedObject, coresb.SmartBlockTypeDiscussionObject)
 	if err != nil {
 		return err
 	}

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -52,9 +52,13 @@ const (
 
 	ForceReindexDeletedObjectsCounter int32 = 1
 
-	ForceReindexParticipantsCounter  int32 = 1
-	ForceReindexChatsCounter         int32 = 7
-	ForceReindexChatsFulltextCounter int32 = 1
+	ForceReindexParticipantsCounter int32 = 1
+	ForceReindexChatsCounter        int32 = 7
+	// Bumped to 2: the initial chat-message fulltext backfill (counter 1) could
+	// silently index only a recent suffix of each chat — an incoming "_all"
+	// reindex entry lost to a pending real order id in the queue merge (fixed in
+	// AddChatMessageToIndexQueue). Re-run the now-correct backfill once.
+	ForceReindexChatsFulltextCounter int32 = 2
 	ForceReindexDiscussionsCounter   int32 = 1
 
 	// ForceFTRecheckCounter triggers a lightweight FT consistency check

--- a/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
+++ b/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
@@ -68,10 +68,36 @@ func TestFtAllOrderId_QueueMergePrecedence(t *testing.T) {
 		s := NewStoreFixture(t)
 		chatId := domain.FullID{ObjectID: "chatLowerWins", SpaceID: "space1"}
 
-		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "order5"))
-		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "order2"))
+		// real order ids start with '!' (0x21); keep the lower one (covers more)
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "!bbb"))
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "!aaa"))
 
-		assert.Equal(t, "order2", queuedOrderId(t, s, chatId),
+		assert.Equal(t, "!aaa", queuedOrderId(t, s, chatId),
 			"the lower real order id covers more messages and must be kept")
+	})
+
+	t.Run("incoming _all preserves a pending deletion list", func(t *testing.T) {
+		// the fix routes an incoming _all through the overwrite path; the merge
+		// must still carry over a pending deletion list so queued message deletes
+		// are not silently dropped by a full-history backfill.
+		s := NewStoreFixture(t)
+		chatId := domain.FullID{ObjectID: "chatDelKept", SpaceID: "space1"}
+
+		require.NoError(t, s.AddChatMessageDeleteToIndexQueue(ctx, chatId, "deletedMsg1"))
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, FtAllOrderId))
+
+		ids, err := s.ListIdsFromFullTextQueue([]string{chatId.SpaceID}, 10)
+		require.NoError(t, err)
+		var got *domain.FullTextQueuedObject
+		for i := range ids {
+			if ids[i].ObjectId == chatId.ObjectID {
+				got = &ids[i]
+				break
+			}
+		}
+		require.NotNil(t, got, "chat should be queued")
+		assert.Equal(t, FtAllOrderId, got.MsgOrderId, "_all must win")
+		assert.Contains(t, got.DeletedMsgIds, "deletedMsg1",
+			"pending message deletion must survive the _all overwrite")
 	})
 }

--- a/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
+++ b/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
@@ -1,0 +1,77 @@
+package objectstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+)
+
+// TestFtAllOrderId_QueueMergePrecedence guards the chat-fulltext backfill fix
+// from GO-7316.
+//
+// reindexChatMessagesFulltext enqueues every chat with FtAllOrderId ("_all") to
+// reindex the FULL message history. Real order ids start with '!' (0x21) and
+// "_all" starts with '_' (0x5F), so every real order id sorts BEFORE "_all".
+// The original merge kept the existing order id whenever `currentOrderId <
+// orderId`, so an incoming "_all" lost to any pending real order id (a live
+// message the backed-up queue hadn't processed yet) — and only messages from
+// that order id forward got indexed, never the full history.
+//
+// Observed in real data: a chat with 299 messages had only its most-recent 32
+// (everything >= one real order id "!%wK") indexed; the older 267 were invisible
+// to chat search.
+func TestFtAllOrderId_QueueMergePrecedence(t *testing.T) {
+	ctx := context.Background()
+
+	queuedOrderId := func(t *testing.T, s *StoreFixture, chatId domain.FullID) string {
+		t.Helper()
+		ids, err := s.ListIdsFromFullTextQueue([]string{chatId.SpaceID}, 10)
+		require.NoError(t, err)
+		for i := range ids {
+			if ids[i].ObjectId == chatId.ObjectID {
+				return ids[i].MsgOrderId
+			}
+		}
+		t.Fatalf("chat %s not queued", chatId.ObjectID)
+		return ""
+	}
+
+	t.Run("incoming _all overrides a pending real order id", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		chatId := domain.FullID{ObjectID: "chatAllWins", SpaceID: "space1"}
+
+		// a live message enqueued a real order id (still pending in a backed-up queue)
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "!%wK"))
+		// the reindex backfill asks to index the WHOLE history
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, FtAllOrderId))
+
+		assert.Equal(t, FtAllOrderId, queuedOrderId(t, s, chatId),
+			"_all backfill must win over a pending real order id, else chat history is never fully indexed")
+	})
+
+	t.Run("a real order id does not downgrade a pending _all", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		chatId := domain.FullID{ObjectID: "chatAllKept", SpaceID: "space1"}
+
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, FtAllOrderId))
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "!%wK"))
+
+		assert.Equal(t, FtAllOrderId, queuedOrderId(t, s, chatId),
+			"a real order id must not shrink a pending full-history reindex")
+	})
+
+	t.Run("smaller real order id still wins over a larger one", func(t *testing.T) {
+		s := NewStoreFixture(t)
+		chatId := domain.FullID{ObjectID: "chatLowerWins", SpaceID: "space1"}
+
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "order5"))
+		require.NoError(t, s.AddChatMessageToIndexQueue(ctx, chatId, "order2"))
+
+		assert.Equal(t, "order2", queuedOrderId(t, s, chatId),
+			"the lower real order id covers more messages and must be kept")
+	})
+}

--- a/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
+++ b/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
@@ -123,6 +123,11 @@ func TestEnqueueAllForFulltextIndexing_TagsChatsWithAllOrder(t *testing.T) {
 			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_chatDerived)),
 		},
 		{
+			bundle.RelationKeyId:             domain.String("discussionObj"),
+			bundle.RelationKeySpaceId:        domain.String(spaceId),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_discussion)),
+		},
+		{
 			bundle.RelationKeyId:             domain.String("regularObj"),
 			bundle.RelationKeySpaceId:        domain.String(spaceId),
 			bundle.RelationKeyName:           domain.String("a note"),
@@ -139,10 +144,13 @@ func TestEnqueueAllForFulltextIndexing_TagsChatsWithAllOrder(t *testing.T) {
 		got[ids[i].ObjectId] = ids[i].MsgOrderId
 	}
 
-	chatOrd, chatQueued := got["chatObj"]
-	require.True(t, chatQueued, "chat object must be enqueued by the rebuild")
-	assert.Equal(t, FtAllOrderId, chatOrd,
-		"chat object must be tagged _all so the rebuild reindexes its messages")
+	// both chatDerived and discussion objects hold messages → must be tagged _all
+	for _, chatId := range []string{"chatObj", "discussionObj"} {
+		ord, queued := got[chatId]
+		require.True(t, queued, "%s must be enqueued by the rebuild", chatId)
+		assert.Equal(t, FtAllOrderId, ord,
+			"%s must be tagged _all so the rebuild reindexes its messages", chatId)
+	}
 
 	regularOrd, regularQueued := got["regularObj"]
 	require.True(t, regularQueued, "regular object must be enqueued by the rebuild")

--- a/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
+++ b/pkg/lib/localstore/objectstore/ftqueue_allorder_repro_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
 // TestFtAllOrderId_QueueMergePrecedence guards the chat-fulltext backfill fix
@@ -100,4 +102,49 @@ func TestFtAllOrderId_QueueMergePrecedence(t *testing.T) {
 		assert.Contains(t, got.DeletedMsgIds, "deletedMsg1",
 			"pending message deletion must survive the _all overwrite")
 	})
+}
+
+// TestEnqueueAllForFulltextIndexing_TagsChatsWithAllOrder guards the sibling fix
+// from GO-7316. A full FT-index rebuild (docCount==0) re-enqueues every object
+// via EnqueueAllForFulltextIndexing. Chat objects keep their searchable text in
+// messages, so they must be enqueued with FtAllOrderId — otherwise the consume
+// path indexes only the chat object's relations/blocks and chat search stays
+// empty after the rebuild (and the per-space checksum gate stops
+// reindexChatMessagesFulltext from re-running).
+func TestEnqueueAllForFulltextIndexing_TagsChatsWithAllOrder(t *testing.T) {
+	s := NewStoreFixture(t)
+	ctx := context.Background()
+	const spaceId = "spaceFtRebuild"
+
+	s.AddObjects(t, spaceId, []TestObject{
+		{
+			bundle.RelationKeyId:             domain.String("chatObj"),
+			bundle.RelationKeySpaceId:        domain.String(spaceId),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_chatDerived)),
+		},
+		{
+			bundle.RelationKeyId:             domain.String("regularObj"),
+			bundle.RelationKeySpaceId:        domain.String(spaceId),
+			bundle.RelationKeyName:           domain.String("a note"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+		},
+	})
+
+	require.NoError(t, s.EnqueueAllForFulltextIndexing(ctx))
+
+	ids, err := s.ListIdsFromFullTextQueue([]string{spaceId}, 100)
+	require.NoError(t, err)
+	got := make(map[string]string, len(ids))
+	for i := range ids {
+		got[ids[i].ObjectId] = ids[i].MsgOrderId
+	}
+
+	chatOrd, chatQueued := got["chatObj"]
+	require.True(t, chatQueued, "chat object must be enqueued by the rebuild")
+	assert.Equal(t, FtAllOrderId, chatOrd,
+		"chat object must be tagged _all so the rebuild reindexes its messages")
+
+	regularOrd, regularQueued := got["regularObj"]
+	require.True(t, regularQueued, "regular object must be enqueued by the rebuild")
+	assert.Empty(t, regularOrd, "a non-chat object must not get a message order id")
 }

--- a/pkg/lib/localstore/objectstore/indexer_store.go
+++ b/pkg/lib/localstore/objectstore/indexer_store.go
@@ -228,7 +228,14 @@ func (s *dsObjectStore) AddChatMessageToIndexQueue(ctx context.Context, chatId d
 		}
 
 		currentOrderId := v.GetString(ftOrderIdKey)
-		if currentOrderId != "" && (currentOrderId < orderId || currentOrderId == FtAllOrderId) {
+		// An incoming FtAllOrderId ("_all") means "reindex the whole history" and
+		// must always win: it covers a strictly wider range than any real order
+		// id. We can't lean on string comparison for that — "_all" (0x5F '_')
+		// sorts AFTER every real order id (which start with 0x21 '!'), so
+		// `currentOrderId < orderId` would wrongly keep a pending real order id
+		// and the full-history backfill would silently index only messages from
+		// that order id forward (GO-7316).
+		if orderId != FtAllOrderId && currentOrderId != "" && (currentOrderId < orderId || currentOrderId == FtAllOrderId) {
 			// we take messages with orderId equal and more than saved in the queue;
 			// still bump the generation so an in-flight mark-as-indexed is voided
 			v.Set(ftGenKey, genVal)

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -814,8 +814,11 @@ func (s *dsObjectStore) EnqueueAllForFulltextIndexing(ctx context.Context) error
 			// relations/blocks. Tag them with FtAllOrderId so a full FT rebuild
 			// reindexes the whole message history via prepareChatSearchDocs;
 			// otherwise the consume path treats them as a regular object and chat
-			// search stays empty after the index is rebuilt (GO-7316).
-			if model.ObjectTypeLayout(doc.GetInt(bundle.RelationKeyResolvedLayout.String())) == model.ObjectType_chatDerived {
+			// search stays empty after the index is rebuilt (GO-7316). Both
+			// chatDerived (space chats) and discussion (object chats) use the chat
+			// editor and store messages the same way, so both must be tagged.
+			switch model.ObjectTypeLayout(doc.GetInt(bundle.RelationKeyResolvedLayout.String())) {
+			case model.ObjectType_chatDerived, model.ObjectType_discussion:
 				obj.Set(ftOrderIdKey, arena.NewString(FtAllOrderId))
 			}
 			err := s.fulltextQueue.UpsertOne(txn.Context(), obj)

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -810,6 +810,14 @@ func (s *dsObjectStore) EnqueueAllForFulltextIndexing(ctx context.Context) error
 			obj.Set(spaceIdKey, arena.NewString(spaceId))
 			obj.Set(ftSequenceKey, arena.NewBinary(emptyBuffer))
 			obj.Set(ftGenKey, arena.NewNumberFloat64(float64(gen)))
+			// Chat objects keep their searchable text in messages, not in object
+			// relations/blocks. Tag them with FtAllOrderId so a full FT rebuild
+			// reindexes the whole message history via prepareChatSearchDocs;
+			// otherwise the consume path treats them as a regular object and chat
+			// search stays empty after the index is rebuilt (GO-7316).
+			if model.ObjectTypeLayout(doc.GetInt(bundle.RelationKeyResolvedLayout.String())) == model.ObjectType_chatDerived {
+				obj.Set(ftOrderIdKey, arena.NewString(FtAllOrderId))
+			}
 			err := s.fulltextQueue.UpsertOne(txn.Context(), obj)
 			if err != nil {
 				if loggedErrors < maxErrorsToLog {


### PR DESCRIPTION
## Summary

Chat full-text search returned **no results for messages that exist** (e.g. searching "notion" in a chat that clearly contains "notion import"). Root cause: the chat-message full-text **backfill never completed** — only a recent suffix of each chat was indexed.

Diagnosed against real client data: a chat with **299 messages had only 32 indexed** (exactly the most-recent contiguous tail), and the searched message was present in the CRDT store but absent from the tantivy index.

## Root cause

`reindexChatMessagesFulltext` enqueues each chat with `FtAllOrderId` (`"_all"`) to reindex the full history. But `AddChatMessageToIndexQueue`'s queue merge kept the existing order id whenever `currentOrderId < orderId`. Real order ids start with `!` (0x21) and `"_all"` starts with `_` (0x5F), so **every real order id sorts before `"_all"`** — an incoming `_all` lost to any pending real order id (a live message the backed-up queue hadn't drained yet), and only messages from that order id forward were indexed.

## Changes

1. **Queue merge fix** (`indexer_store.go`): an incoming `_all` always wins (`orderId != FtAllOrderId &&` guard). `_all` covers a strictly wider range than any real order id.
2. **Re-run the backfill** (`reindex.go`): bump `ForceReindexChatsFulltextCounter` 1 → 2 so already-affected clients re-run the now-correct backfill once (their stored checksum is `1`).
3. **FT-rebuild path** (`service.go`): `EnqueueAllForFulltextIndexing` (the `docCount==0` rebuild) previously enqueued chats **without** an order id, so a full FT-index rebuild indexed only relations/blocks, never messages — and the checksum gate stopped the backfill from recovering them. Now chat objects are tagged with `FtAllOrderId`.
4. **Discussion coverage**: discussion chats (`SmartBlockTypeDiscussionObject` / layout `discussion`) use the same chat editor and store messages identically, but both the backfill and the rebuild only handled `chatDerived`. Both paths now cover discussions too.

Regression tests cover: `_all` precedence (both merge directions + lower-real-wins), deletion-list preservation across the `_all` overwrite, and that the rebuild tags both chatDerived and discussion objects with `_all`.

## Review

Reviewed with a 3-lens adversarial pass (correctness / blast-radius / concurrency), two rounds. No defect or race found in the change itself; the merge fix, gen-protocol, single-writer serialization, and rebuild self-healing were all verified. The discussion gap (item 4) was surfaced and fixed during the review.

## Notes / follow-ups (not addressed here)

- **One-time reindex cost**: the counter bump (#2) triggers a fleet-wide full chat reindex on upgrade. It's idempotent (upsert by doc id, no deletes), but it does materialize each chat's message history.
- **Memory bound depends on #3081 (GO-6758)**: the `_all` consume path (`prepareChatSearchDocs`) currently materializes a chat's full history. #3081 batches the fetch and should land alongside this so the fleet-wide reindex stays memory-safe. (Left a note on #3081 about the remaining docs-accumulation.)
- **Checksum robustness (pre-existing)**: `saveLatestChecksums` runs unconditionally, so a *transient* enqueue failure during the backfill marks it done with no retry. Shared by all reindex steps; out of scope here, worth a follow-up to gate the save on success.

## Test plan

- [x] `go test ./pkg/lib/localstore/objectstore/` (incl. new `TestFtAllOrderId_QueueMergePrecedence`, `TestEnqueueAllForFulltextIndexing_TagsChatsWithAllOrder`)
- [x] `go test ./core/indexer/`
- [x] Verified end-to-end against real client data (299-msg chat): post-fix backfill indexes the full history.
