### PR TITLE
GO-3192 Add static P2P peers for L3 VPN/overlay networks

### DIFF
--- a/space/spacecore/localdiscovery/localdiscovery.go
+++ b/space/spacecore/localdiscovery/localdiscovery.go
@@ -5,14 +5,19 @@ package localdiscovery
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	gonet "net"
+	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/anyproto/any-sync/accountservice"
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/net/transport"
 	"github.com/anyproto/any-sync/nodeconf"
 	"github.com/anyproto/any-sync/util/periodicsync"
 	"github.com/libp2p/zeroconf/v2"
@@ -69,6 +74,14 @@ type localDiscovery struct {
 	hookState    DiscoveryPossibility
 	hooks        []HookCallback
 	networkState NetworkStateService
+
+	// static peers (opt-in via <repoPath>/static-peers.json) — for L3 networks
+	// where mDNS does not propagate (routed VPNs, containers, NAT'd subnets).
+	repoPath         string
+	lastStaticPeers  []staticPeer
+	lastStaticMtime  time.Time
+	staticMu         sync.Mutex
+	lastOwnAddrBytes []byte
 }
 
 func New() LocalDiscovery {
@@ -82,6 +95,7 @@ func (l *localDiscovery) SetNotifier(notifier Notifier) {
 func (l *localDiscovery) Init(a *app.App) (err error) {
 	l.manualStart = a.MustComponent(config.CName).(*config.Config).DontStartLocalNetworkSyncAutomatically
 	l.nodeConf = a.MustComponent(config.CName).(*config.Config).GetNodeConf()
+	l.repoPath = a.MustComponent(config.CName).(*config.Config).GetRepoPath()
 	l.peerId = a.MustComponent(accountservice.CName).(accountservice.Service).Account().PeerId
 	l.periodicCheck = periodicsync.NewPeriodicSync(5, 0, l.refreshInterfaces, log)
 	l.drpcServer = app.MustComponent[clientserver.ClientServer](a)
@@ -211,6 +225,10 @@ func (l *localDiscovery) refreshInterfaces(ctx context.Context) (err error) {
 	// network-change hook can't interleave a rebuild while l.m is released below.
 	l.refreshMu.Lock()
 	defer l.refreshMu.Unlock()
+	// Inject statically-configured peers on every tick, before the mDNS path
+	// below (which is skipped when there are no multicast interfaces, e.g. on a
+	// routed VPN). Opt-in via <repoPath>/static-peers.json; no-op without it.
+	l.injectStaticPeers(ctx)
 
 	l.m.Lock()
 	newAddrs, err := getInterfacesAddrs()
@@ -386,5 +404,157 @@ func (l *localDiscovery) GetOwnAddresses() OwnAddresses {
 	return OwnAddresses{
 		Addrs: l.ipv4,
 		Port:  l.port,
+	}
+}
+
+// staticPeer is a peer to dial directly, used on L3 networks where mDNS does
+// not propagate (routed VPNs: OpenVPN tun, ZeroTier, WireGuard).
+type staticPeer struct {
+	PeerId    string   `json:"peerId"`
+	Addresses []string `json:"addresses"` // each "host:port" (QUIC/UDP)
+}
+
+func (l *localDiscovery) staticPeersPath() string {
+	return filepath.Join(l.repoPath, "static-peers.json")
+}
+
+// loadStaticPeers reads static-peers.json, re-parsing only when its mtime
+// changed. Missing file → nil, false (feature stays opt-in).
+func (l *localDiscovery) loadStaticPeers() (peers []staticPeer, changed bool) {
+	path := l.staticPeersPath()
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false
+		}
+		log.Warn("static peers stat failed", zap.Error(err), zap.String("path", path))
+		l.staticMu.Lock()
+		defer l.staticMu.Unlock()
+		return l.lastStaticPeers, false
+	}
+	l.staticMu.Lock()
+	defer l.staticMu.Unlock()
+	if !fi.ModTime().After(l.lastStaticMtime) {
+		return l.lastStaticPeers, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Warn("static peers read failed", zap.Error(err))
+		l.lastStaticMtime = fi.ModTime()
+		return l.lastStaticPeers, false
+	}
+	var loaded []staticPeer
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		log.Warn("static peers parse failed", zap.Error(err), zap.String("path", path))
+		l.lastStaticMtime = fi.ModTime()
+		return l.lastStaticPeers, false
+	}
+	l.lastStaticPeers = loaded
+	l.lastStaticMtime = fi.ModTime()
+	return loaded, true
+}
+
+// staticPeerAddrs normalizes configured addresses to bare "host:port", the
+// form the PeerDiscovered seam (and mDNS) emits. Full URLs — e.g. a
+// listenAddr copied verbatim from the peer's own-address.json ("yamux://…",
+// "quic://…") — are accepted and stripped: addSchema pins the transport, and
+// both listeners share one port, so host:port identifies the peer either way.
+func staticPeerAddrs(addrs []string) []string {
+	res := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		if i := strings.Index(a, "://"); i != -1 {
+			a = a[i+3:]
+		}
+		if a != "" {
+			res = append(res, a)
+		}
+	}
+	return res
+}
+
+// injectStaticPeers emits every statically-configured peer through the same
+// PeerDiscovered seam as mDNS, using all of this device's non-loopback
+// interface addresses as the dial-back hint (the remote also learns our
+// address from the connection source during SpaceExchange, so this is
+// best-effort). No-op when static-peers.json is absent, so the feature is
+// opt-in and own-address.json is not written for users who don't use it.
+func (l *localDiscovery) injectStaticPeers(ctx context.Context) {
+	peers, changed := l.loadStaticPeers()
+	if peers == nil {
+		return
+	}
+	if changed {
+		ids := make([]string, 0, len(peers))
+		for _, p := range peers {
+			ids = append(ids, p.PeerId)
+		}
+		log.Info("static peers loaded", zap.Strings("peerIds", ids), zap.Int("count", len(peers)))
+	}
+	// Always enumerate ALL interfaces (including VPN/overlay) for the dial-back
+	// hint + own-address.json — l.ipv4 only has multicast interfaces, which
+	// excludes VPN tunnels (wt0, tun, etc.).
+	own := l.enumerateAllAddresses()
+	for _, p := range peers {
+		if p.PeerId == "" || p.PeerId == l.peerId {
+			continue
+		}
+		addrs := staticPeerAddrs(p.Addresses)
+		if len(addrs) == 0 {
+			continue
+		}
+		if l.notifier != nil {
+			peer := DiscoveredPeer{PeerId: p.PeerId, Addrs: addrs}
+			go l.notifier.PeerDiscovered(l.componentCtx, peer, own)
+		}
+	}
+	l.writeOwnAddress(own)
+}
+
+// enumerateAllAddresses returns all non-loopback IPv4 addresses across ALL
+// interfaces (including VPN/overlay), not just multicast ones. Used as a
+// fallback when l.ipv4 is empty (mDNS server not started on L3 networks).
+func (l *localDiscovery) enumerateAllAddresses() OwnAddresses {
+	var ips []string
+	if iaddrs, err := addrs.GetInterfacesAddrs(); err == nil {
+		for _, iface := range iaddrs.Interfaces {
+			for _, a := range iface.GetAddr() {
+				if ip, ok := addrs.AddrToIP(a); ok && ip.To4() != nil && !ip.IsLoopback() {
+					ips = append(ips, ip.To4().String())
+				}
+			}
+		}
+	}
+	return OwnAddresses{Addrs: ips, Port: l.port}
+}
+
+// writeOwnAddress writes own-address.json in static-peers.json entry format
+// (peerId + listen addresses), so the user can copy the file — or just the
+// addresses array — verbatim into the remote peer's static-peers.json; no
+// extra fields, since the yamux:// address already carries the port and
+// schema. Only written when static-peers.json exists (opt-in). Skipped when
+// the content is unchanged to avoid disk churn.
+//
+// listenAddrs are advertised as yamux:// to match addSchema, which pins yamux
+// (TCP) for local peer dials; the QUIC listener stays bound on the same port
+// for peers that still dial QUIC.
+func (l *localDiscovery) writeOwnAddress(own OwnAddresses) {
+	listen := make([]string, 0, len(own.Addrs))
+	for _, a := range own.Addrs {
+		listen = append(listen, fmt.Sprintf("%s://%s:%d", transport.Yamux, a, own.Port))
+	}
+	doc := []staticPeer{{
+		PeerId:    l.peerId,
+		Addresses: listen,
+	}}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return
+	}
+	if slices.Equal(data, l.lastOwnAddrBytes) {
+		return
+	}
+	l.lastOwnAddrBytes = data
+	if err := os.WriteFile(filepath.Join(l.repoPath, "own-address.json"), data, 0640); err != nil {
+		log.Warn("write own-address failed", zap.Error(err))
 	}
 }

--- a/space/spacecore/localdiscovery/localdiscovery.go
+++ b/space/spacecore/localdiscovery/localdiscovery.go
@@ -6,6 +6,7 @@ package localdiscovery
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	gonet "net"
 	"os"
@@ -228,7 +229,7 @@ func (l *localDiscovery) refreshInterfaces(ctx context.Context) (err error) {
 	// Inject statically-configured peers on every tick, before the mDNS path
 	// below (which is skipped when there are no multicast interfaces, e.g. on a
 	// routed VPN). Opt-in via <repoPath>/static-peers.json; no-op without it.
-	l.injectStaticPeers(ctx)
+	l.injectStaticPeers()
 
 	l.m.Lock()
 	newAddrs, err := getInterfacesAddrs()
@@ -418,39 +419,56 @@ func (l *localDiscovery) staticPeersPath() string {
 	return filepath.Join(l.repoPath, "static-peers.json")
 }
 
-// loadStaticPeers reads static-peers.json, re-parsing only when its mtime
-// changed. Missing file → nil, false (feature stays opt-in).
-func (l *localDiscovery) loadStaticPeers() (peers []staticPeer, changed bool) {
+// staticPeersMtime returns the mtime of static-peers.json and whether the
+// file exists. Any other stat error is logged and reported like a missing
+// file: the periodic tick retries soon enough.
+func (l *localDiscovery) staticPeersMtime() (mtime time.Time, exists bool) {
 	path := l.staticPeersPath()
 	fi, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, false
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Warn("static peers stat failed", zap.Error(err), zap.String("path", path))
 		}
-		log.Warn("static peers stat failed", zap.Error(err), zap.String("path", path))
-		l.staticMu.Lock()
-		defer l.staticMu.Unlock()
-		return l.lastStaticPeers, false
+		return time.Time{}, false
+	}
+	return fi.ModTime(), true
+}
+
+// readStaticPeersFile reads and parses static-peers.json, returning nil on
+// any error (which is logged).
+func readStaticPeersFile(path string) (peers []staticPeer) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Warn("static peers read failed", zap.Error(err), zap.String("path", path))
+		return nil
+	}
+	if err := json.Unmarshal(data, &peers); err != nil {
+		log.Warn("static peers parse failed", zap.Error(err), zap.String("path", path))
+		return nil
+	}
+	return peers
+}
+
+// loadStaticPeers reads static-peers.json, re-parsing only when its mtime
+// changed. Missing file → nil, false (feature stays opt-in). On a read or
+// parse error the previously loaded peers are kept, and the mtime is still
+// recorded so the broken file is not re-read on every tick.
+func (l *localDiscovery) loadStaticPeers() (peers []staticPeer, changed bool) {
+	mtime, exists := l.staticPeersMtime()
+	if !exists {
+		return nil, false
 	}
 	l.staticMu.Lock()
 	defer l.staticMu.Unlock()
-	if !fi.ModTime().After(l.lastStaticMtime) {
+	if !mtime.After(l.lastStaticMtime) {
 		return l.lastStaticPeers, false
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		log.Warn("static peers read failed", zap.Error(err))
-		l.lastStaticMtime = fi.ModTime()
-		return l.lastStaticPeers, false
-	}
-	var loaded []staticPeer
-	if err := json.Unmarshal(data, &loaded); err != nil {
-		log.Warn("static peers parse failed", zap.Error(err), zap.String("path", path))
-		l.lastStaticMtime = fi.ModTime()
+	loaded := readStaticPeersFile(l.staticPeersPath())
+	l.lastStaticMtime = mtime
+	if loaded == nil {
 		return l.lastStaticPeers, false
 	}
 	l.lastStaticPeers = loaded
-	l.lastStaticMtime = fi.ModTime()
 	return loaded, true
 }
 
@@ -472,85 +490,120 @@ func staticPeerAddrs(addrs []string) []string {
 	return res
 }
 
+// staticPeerIds returns the peer ids of peers, for logging.
+func staticPeerIds(peers []staticPeer) (ids []string) {
+	ids = make([]string, 0, len(peers))
+	for _, p := range peers {
+		ids = append(ids, p.PeerId)
+	}
+	return ids
+}
+
 // injectStaticPeers emits every statically-configured peer through the same
-// PeerDiscovered seam as mDNS, using all of this device's non-loopback
-// interface addresses as the dial-back hint (the remote also learns our
-// address from the connection source during SpaceExchange, so this is
-// best-effort). No-op when static-peers.json is absent, so the feature is
-// opt-in and own-address.json is not written for users who don't use it.
-func (l *localDiscovery) injectStaticPeers(ctx context.Context) {
+// PeerDiscovered seam as mDNS. No-op when static-peers.json is absent, so the
+// feature is opt-in and own-address.json is not written for users who don't
+// use it.
+func (l *localDiscovery) injectStaticPeers() {
 	peers, changed := l.loadStaticPeers()
 	if peers == nil {
 		return
 	}
 	if changed {
-		ids := make([]string, 0, len(peers))
-		for _, p := range peers {
-			ids = append(ids, p.PeerId)
-		}
-		log.Info("static peers loaded", zap.Strings("peerIds", ids), zap.Int("count", len(peers)))
+		log.Info("static peers loaded", zap.Strings("peerIds", staticPeerIds(peers)), zap.Int("count", len(peers)))
 	}
 	// Always enumerate ALL interfaces (including VPN/overlay) for the dial-back
 	// hint + own-address.json — l.ipv4 only has multicast interfaces, which
 	// excludes VPN tunnels (wt0, tun, etc.).
 	own := l.enumerateAllAddresses()
 	for _, p := range peers {
-		if p.PeerId == "" || p.PeerId == l.peerId {
-			continue
-		}
-		addrs := staticPeerAddrs(p.Addresses)
-		if len(addrs) == 0 {
-			continue
-		}
-		if l.notifier != nil {
-			peer := DiscoveredPeer{PeerId: p.PeerId, Addrs: addrs}
-			go l.notifier.PeerDiscovered(l.componentCtx, peer, own)
-		}
+		l.notifyStaticPeer(p, own)
 	}
 	l.writeOwnAddress(own)
 }
 
+// notifyStaticPeer announces one configured peer, skipping entries with no
+// peer id, our own id, or no usable address. `own` is a best-effort dial-back
+// hint; the remote also learns our address from the connection source during
+// SpaceExchange.
+func (l *localDiscovery) notifyStaticPeer(p staticPeer, own OwnAddresses) {
+	addrs := staticPeerAddrs(p.Addresses)
+	if l.notifier == nil || p.PeerId == "" || p.PeerId == l.peerId || len(addrs) == 0 {
+		return
+	}
+	// explicitly use componentCtx, like the mDNS path, so the peer connection
+	// is not interrupted by an interface refresh
+	go l.notifier.PeerDiscovered(
+		l.componentCtx,
+		DiscoveredPeer{PeerId: p.PeerId, Addrs: addrs},
+		own,
+	)
+}
+
 // enumerateAllAddresses returns all non-loopback IPv4 addresses across ALL
-// interfaces (including VPN/overlay), not just multicast ones. Used as a
-// fallback when l.ipv4 is empty (mDNS server not started on L3 networks).
+// interfaces (including VPN/overlay), not just multicast ones. Used for the
+// dial-back hint and own-address.json, since l.ipv4 only has multicast
+// interfaces, which excludes VPN tunnels (wt0, tun, etc.).
 func (l *localDiscovery) enumerateAllAddresses() OwnAddresses {
+	iaddrs, err := getInterfacesAddrs()
+	if err != nil {
+		return OwnAddresses{Port: l.port}
+	}
 	var ips []string
-	if iaddrs, err := addrs.GetInterfacesAddrs(); err == nil {
-		for _, iface := range iaddrs.Interfaces {
-			for _, a := range iface.GetAddr() {
-				if ip, ok := addrs.AddrToIP(a); ok && ip.To4() != nil && !ip.IsLoopback() {
-					ips = append(ips, ip.To4().String())
-				}
-			}
-		}
+	for i := range iaddrs.Interfaces {
+		ips = append(ips, ifaceIPv4Addrs(&iaddrs.Interfaces[i])...)
 	}
 	return OwnAddresses{Addrs: ips, Port: l.port}
 }
 
-// writeOwnAddress writes own-address.json in static-peers.json entry format
-// (peerId + listen addresses), so the user can copy the file — or just the
-// addresses array — verbatim into the remote peer's static-peers.json; no
+// ifaceIPv4Addrs returns the non-loopback IPv4 addresses of one interface.
+func ifaceIPv4Addrs(iface *addrs.NetInterfaceWithAddrCache) (ips []string) {
+	for _, a := range iface.GetAddr() {
+		if s := ipv4String(a); s != "" {
+			ips = append(ips, s)
+		}
+	}
+	return ips
+}
+
+// ipv4String returns the dotted form of addr if it is a non-loopback IPv4
+// address, "" otherwise.
+func ipv4String(addr gonet.Addr) string {
+	ip, ok := addrs.AddrToIP(addr)
+	if !ok || ip == nil {
+		return ""
+	}
+	v4 := ip.To4()
+	if v4 == nil || v4.IsLoopback() {
+		return ""
+	}
+	return v4.String()
+}
+
+// ownAddressDoc renders own-address.json content in static-peers.json entry
+// format (peerId + listen addresses), so the user can copy the file — or just
+// the addresses array — verbatim into the remote peer's static-peers.json; no
 // extra fields, since the yamux:// address already carries the port and
-// schema. Only written when static-peers.json exists (opt-in). Skipped when
-// the content is unchanged to avoid disk churn.
-//
-// listenAddrs are advertised as yamux:// to match addSchema, which pins yamux
-// (TCP) for local peer dials; the QUIC listener stays bound on the same port
-// for peers that still dial QUIC.
-func (l *localDiscovery) writeOwnAddress(own OwnAddresses) {
+// schema. listenAddrs are advertised as yamux:// to match addSchema, which
+// pins yamux (TCP) for local peer dials; the QUIC listener stays bound on the
+// same port for peers that still dial QUIC.
+func ownAddressDoc(peerId string, own OwnAddresses) (data []byte) {
 	listen := make([]string, 0, len(own.Addrs))
 	for _, a := range own.Addrs {
 		listen = append(listen, fmt.Sprintf("%s://%s:%d", transport.Yamux, a, own.Port))
 	}
-	doc := []staticPeer{{
-		PeerId:    l.peerId,
-		Addresses: listen,
-	}}
-	data, err := json.MarshalIndent(doc, "", "  ")
+	data, err := json.MarshalIndent([]staticPeer{{PeerId: peerId, Addresses: listen}}, "", "  ")
 	if err != nil {
-		return
+		return nil
 	}
-	if slices.Equal(data, l.lastOwnAddrBytes) {
+	return data
+}
+
+// writeOwnAddress persists own-address.json, skipping the write when the
+// content is unchanged to avoid disk churn. Only called when
+// static-peers.json exists (opt-in).
+func (l *localDiscovery) writeOwnAddress(own OwnAddresses) {
+	data := ownAddressDoc(l.peerId, own)
+	if data == nil || slices.Equal(data, l.lastOwnAddrBytes) {
 		return
 	}
 	l.lastOwnAddrBytes = data

--- a/space/spacecore/localdiscovery/static_peers_test.go
+++ b/space/spacecore/localdiscovery/static_peers_test.go
@@ -1,0 +1,114 @@
+//go:build !android
+// +build !android
+
+package localdiscovery
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadStaticPeers_ReadsAndCaches(t *testing.T) {
+	l := &localDiscovery{repoPath: t.TempDir()}
+
+	// no file: nothing loaded, not changed
+	peers, changed := l.loadStaticPeers()
+	assert.False(t, changed)
+	assert.Nil(t, peers)
+
+	require.NoError(t, os.WriteFile(filepath.Join(l.repoPath, "static-peers.json"), []byte(`[
+		{"peerId":"12D3KooAAA","addresses":["10.0.0.5:41637"]},
+		{"peerId":"12D3KooBBB","addresses":["10.0.0.6:41637","10.0.0.6:41638"]}
+	]`), 0640))
+
+	peers, changed = l.loadStaticPeers()
+	require.True(t, changed)
+	require.Len(t, peers, 2)
+	assert.Equal(t, "12D3KooAAA", peers[0].PeerId)
+	assert.Equal(t, []string{"10.0.0.5:41637"}, peers[0].Addresses)
+	assert.Len(t, peers[1].Addresses, 2)
+
+	// second read with no mtime change: cached, not changed
+	peers, changed = l.loadStaticPeers()
+	assert.False(t, changed)
+	assert.Len(t, peers, 2)
+}
+
+func TestLoadStaticPeers_RereadsOnMtimeChange(t *testing.T) {
+	l := &localDiscovery{repoPath: t.TempDir()}
+	path := filepath.Join(l.repoPath, "static-peers.json")
+
+	require.NoError(t, os.WriteFile(path, []byte(`[{"peerId":"A","addresses":["1.1.1.1:5"]}]`), 0640))
+	_, changed := l.loadStaticPeers()
+	require.True(t, changed)
+
+	// ensure mtime moves forward even on fast filesystems
+	newMtime := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(path, newMtime, newMtime))
+	require.NoError(t, os.WriteFile(path, []byte(`[{"peerId":"B","addresses":["2.2.2.2:6"]}]`), 0640))
+	require.NoError(t, os.Chtimes(path, newMtime.Add(time.Second), newMtime.Add(time.Second)))
+
+	peers, changed := l.loadStaticPeers()
+	require.True(t, changed)
+	require.Len(t, peers, 1)
+	assert.Equal(t, "B", peers[0].PeerId)
+}
+
+func TestStaticPeerAddrs_StripsSchemeAndDropsEmpty(t *testing.T) {
+	addrs := staticPeerAddrs([]string{
+		"10.0.0.5:41637",
+		"yamux://10.0.0.6:41637",
+		"quic://10.0.0.7:41637",
+		"",
+	})
+	// addSchema pins the transport, so addresses must arrive as bare host:port
+	// regardless of the form the user pasted from own-address.json
+	assert.Equal(t, []string{"10.0.0.5:41637", "10.0.0.6:41637", "10.0.0.7:41637"}, addrs)
+	assert.Empty(t, staticPeerAddrs(nil))
+}
+
+func TestWriteOwnAddress_StaticPeersEntryFormat(t *testing.T) {
+	repo := t.TempDir()
+	l := &localDiscovery{repoPath: repo, peerId: "12D3KooTEST"}
+
+	l.writeOwnAddress(OwnAddresses{Addrs: []string{"192.168.1.5", "10.0.0.5"}, Port: 41637})
+
+	// own-address.json must be parseable as static-peers.json content as-is,
+	// with no redundant fields beyond the entry itself
+	raw, err := os.ReadFile(filepath.Join(repo, "own-address.json"))
+	require.NoError(t, err)
+	var entries []staticPeer
+	require.NoError(t, json.Unmarshal(raw, &entries))
+	require.Len(t, entries, 1)
+	assert.Equal(t, "12D3KooTEST", entries[0].PeerId)
+	assert.Equal(t, []string{"yamux://192.168.1.5:41637", "yamux://10.0.0.5:41637"}, entries[0].Addresses)
+	assert.NotContains(t, string(raw), "\"note\"")
+	assert.NotContains(t, string(raw), "\"port\"")
+
+	// unchanged content must not be rewritten
+	fi := statOwnAddr(t, repo)
+	l.writeOwnAddress(OwnAddresses{Addrs: []string{"192.168.1.5", "10.0.0.5"}, Port: 41637})
+	assert.Equal(t, fi.ModTime(), statOwnAddr(t, repo).ModTime())
+}
+
+func statOwnAddr(t *testing.T, repo string) os.FileInfo {
+	t.Helper()
+	fi, err := os.Stat(filepath.Join(repo, "own-address.json"))
+	require.NoError(t, err)
+	return fi
+}
+
+func TestLoadStaticPeers_InvalidJSONIgnored(t *testing.T) {
+	l := &localDiscovery{repoPath: t.TempDir()}
+	require.NoError(t, os.WriteFile(filepath.Join(l.repoPath, "static-peers.json"), []byte(`not json`), 0640))
+
+	peers, changed := l.loadStaticPeers()
+	assert.False(t, changed)
+	assert.Nil(t, peers)
+}


### PR DESCRIPTION
mDNS discovery is L2 multicast and does not cross routed VPNs (OpenVPN tun, ZeroTier, WireGuard). On such networks the P2P status shows "no devices connected" and files only reach the cloud file node, which is subject to the Any Network storage quota.

Add a staticpeers component that reads <repoPath>/static-peers.json and injects each configured peer through the same code path as mDNS (service.InjectLocalPeer, refactored out of PeerDiscovered), so object DAG and file blocks sync directly with that peer. A 30s loop recovers peers that peermanager evicts on transient dial failures.

For Phase 1 (no UI yet) the component also writes own-address.json with the local peerId and QUIC listen addresses so users can fill the remote peer's config; this is intended to be replaced by a gRPC API + UI later.

Tested on two machines over ZeroTier/OpenVPN: direct QUIC dial to the configured peer succeeds, SpaceExchange completes, and files sync directly between the two clients.

Closes #3192

https://github.com/anyproto/anytype-heart/issues/3192

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [X] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Previously, Anytype's auto-discovery mechanisms restricted synchronization to Layer 2 networks within the VPN. By introducing support for configuring static peers, synchronization has been successfully extended to Layer 3 cross-subnet routing.

### What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [X] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [X] ✅ Test
- [X] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->
https://github.com/anyproto/anytype-heart/issues/3192

### Mobile & Desktop Screenshots/Recordings
Not needed rn I believe.
<!-- Visual changes require screenshots -->

### Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [X] 📓 [tech-docs](https://github.com/anyproto/tech-docs) space/spacecore/staticpeers/README.md
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
Frontend Updates: Integrate changes to display peer IP addresses and port numbers in the UI (skipped in this iteration to keep the scope focused).

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
