### PR TITLE
GO-7356 Replay-scoped parent index for tree building + concurrent-replace safety fixes

### DIFF
--- a/core/block/editor/clipboard/clipboard_test.go
+++ b/core/block/editor/clipboard/clipboard_test.go
@@ -2526,3 +2526,99 @@ func TestPasteEmptyFileBlock(t *testing.T) {
 		assert.Empty(t, uploadArr)
 	})
 }
+
+func TestClipboard_PasteIntoEmptyBlockForksId(t *testing.T) {
+	newTextModel := func(text string) *model.Block {
+		return &model.Block{Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: text}}}
+	}
+	newPage := func(t *testing.T) *smarttest.SmartTest {
+		return createPage(t, []*model.Block{
+			{Id: "a", Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: "existing"}}},
+			{Id: "empty", Content: &model.BlockContentOfText{Text: &model.BlockContentText{}}},
+		})
+	}
+
+	t.Run("single text block into empty block gets a fresh id", func(t *testing.T) {
+		// given
+		sb := newPage(t)
+		cb := newFixture(t, sb)
+
+		// when
+		blockIds, _, caret, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    "empty",
+			SelectedTextRange: &model.Range{},
+			AnySlot:           []*model.Block{newTextModel("pasted")},
+		}, "")
+
+		// then
+		require.NoError(t, err)
+		assert.Nil(t, sb.Pick("empty"), "the peer-known empty block id must be replaced")
+		require.Len(t, blockIds, 1)
+		forked := sb.Pick(blockIds[0])
+		require.NotNil(t, forked)
+		assert.Equal(t, "pasted", forked.Model().GetText().Text)
+		assert.EqualValues(t, -1, caret, "caret must be reported via blockIds, not a position in the replaced block")
+		checkBlockText(t, sb, []string{"existing", "pasted"})
+	})
+
+	t.Run("multi block paste into empty block forks the first line", func(t *testing.T) {
+		// given
+		sb := newPage(t)
+		cb := newFixture(t, sb)
+
+		// when
+		blockIds, _, _, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    "empty",
+			SelectedTextRange: &model.Range{},
+			AnySlot:           []*model.Block{newTextModel("first"), newTextModel("second")},
+		}, "")
+
+		// then
+		require.NoError(t, err)
+		assert.Nil(t, sb.Pick("empty"))
+		require.Len(t, blockIds, 2)
+		assert.Equal(t, "first", sb.Pick(blockIds[0]).Model().GetText().Text)
+		checkBlockText(t, sb, []string{"existing", "first", "second"})
+	})
+
+	t.Run("paste into non-empty block keeps its id", func(t *testing.T) {
+		// given
+		sb := newPage(t)
+		cb := newFixture(t, sb)
+
+		// when: caret at the end of "existing"
+		_, _, caret, _, err := cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    "a",
+			SelectedTextRange: &model.Range{From: 8, To: 8},
+			AnySlot:           []*model.Block{newTextModel("-tail")},
+		}, "")
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, sb.Pick("a"))
+		assert.Equal(t, "existing-tail", sb.Pick("a").Model().GetText().Text)
+		assert.EqualValues(t, 13, caret)
+	})
+
+	t.Run("empty title keeps its id", func(t *testing.T) {
+		// given
+		sb := smarttest.New("text")
+		s := sb.NewState()
+		template.InitTemplate(s, template.WithTitle)
+		_, _, err := state.ApplyState("", s, false)
+		require.NoError(t, err)
+		cb := newFixture(t, sb)
+
+		// when
+		_, _, _, _, err = cb.Paste(nil, &pb.RpcBlockPasteRequest{
+			FocusedBlockId:    template.TitleBlockId,
+			SelectedTextRange: &model.Range{},
+			AnySlot:           []*model.Block{newTextModel("t")},
+		}, "")
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, sb.Pick(template.TitleBlockId))
+		assert.Equal(t, "t", sb.Pick(template.TitleBlockId).Model().GetText().Text)
+	})
+}

--- a/core/block/editor/clipboard/paste.go
+++ b/core/block/editor/clipboard/paste.go
@@ -3,6 +3,7 @@ package clipboard
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/samber/lo"
@@ -32,6 +33,10 @@ type pasteCtrl struct {
 	caretPos  int32
 	uploadArr []pb.RpcBlockUploadRequest
 	blockIds  []string
+
+	// formerly-empty focused block that got paste content written in place;
+	// forked to a fresh id at the end of Exec (see forkFilledEmptyBlock)
+	filledEmptyBlockId string
 }
 
 type pasteMode struct {
@@ -75,9 +80,38 @@ func (p *pasteCtrl) Exec(req *pb.RpcBlockPasteRequest) (err error) {
 	if p.mode.removeSelection {
 		p.removeSelection()
 	}
+	if err = p.forkFilledEmptyBlock(); err != nil {
+		return
+	}
 	p.normalize()
 	p.processFiles()
 	return
+}
+
+// forkFilledEmptyBlock re-creates a formerly-empty block that paste filled in
+// place under a fresh id. An empty block is a shared LWW register: its id is
+// known to all peers, so concurrent first-writes into it clobber each other.
+// A fresh id turns the concurrent case into two independent creates — both
+// texts survive the merge. The new id is prepended to blockIds so the client
+// re-targets focus from the replaced block.
+func (p *pasteCtrl) forkFilledEmptyBlock() (err error) {
+	if p.filledEmptyBlockId == "" {
+		return nil
+	}
+	old := p.s.Pick(p.filledEmptyBlockId)
+	if old == nil {
+		return nil
+	}
+	m := old.Copy().Model()
+	m.Id = ""
+	forked := simple.New(m)
+	p.s.Add(forked)
+	if err = p.s.InsertTo(p.filledEmptyBlockId, model.Block_Top, forked.Model().Id); err != nil {
+		return fmt.Errorf("insert forked block: %w", err)
+	}
+	p.s.Unlink(p.filledEmptyBlockId)
+	p.blockIds = append([]string{forked.Model().Id}, p.blockIds...)
+	return nil
 }
 
 // configure determines the paste mode based on the request parameters:
@@ -274,6 +308,9 @@ func (p *pasteCtrl) singleRange() (err error) {
 			// block"; the single-block toggle case is handled by intoBlock mode.
 			selText.SetText(firstPasteText.GetText(), firstPasteText.Model().GetText().Marks)
 			p.ps.Unlink(firstPasteText.Model().Id)
+			// an empty block's id is shared with peers — fork it (never a
+			// required block here: those returned earlier)
+			p.filledEmptyBlockId = targetId
 		}
 	}
 	return
@@ -292,8 +329,16 @@ func (p *pasteCtrl) intoBlock() (err error) {
 	if firstSelText == nil || firstPasteText == nil {
 		return
 	}
+	wasEmpty := firstSelText.GetText() == "" && !state.IsRequiredBlockId(firstSelText.Model().Id)
 	p.caretPos, err = firstSelText.RangeTextPaste(p.selRange.From, p.selRange.To, firstPasteText.Model(), p.mode.intoBlockCopyStyle)
 	p.ps.Unlink(firstPasteText.Model().Id)
+	if err == nil && wasEmpty {
+		// an empty block's id is shared with peers — fork it. The caret is
+		// reported through blockIds instead of a position in the (replaced)
+		// focused block.
+		p.filledEmptyBlockId = firstSelText.Model().Id
+		p.caretPos = -1
+	}
 	return
 }
 

--- a/core/block/editor/state/change.go
+++ b/core/block/editor/state/change.go
@@ -350,7 +350,7 @@ func (s *State) changeBlockCreate(bc *pb.ChangeBlockCreate) (err error) {
 		b := simple.New(m)
 		if m.Id != s.rootId {
 			bIds = append(bIds, b.Model().Id)
-			s.Unlink(m.Id)
+			s.unlinkForReplay(m.Id)
 		}
 		s.Set(b)
 		if dv := b.Model().GetDataview(); dv != nil {
@@ -569,7 +569,11 @@ func (s *State) fillChanges(msgs []simple.EventMessage) {
 	}
 	var cb = &changeBuilder{changes: s.changes}
 	if len(structMsgs) > 0 {
-		s.fillStructureChanges(cb, structMsgs)
+		deleted := make(map[string]struct{}, len(delIds))
+		for _, id := range delIds {
+			deleted[id] = struct{}{}
+		}
+		s.fillStructureChanges(cb, structMsgs, deleted)
 	}
 	if len(delIds) > 0 {
 		cb.AddChange(&pb.ChangeContent{
@@ -643,13 +647,13 @@ func (s *State) filterLocalAndDerivedRelationsByKey(relationKeys []string) []str
 	return relKeysWithoutLocal
 }
 
-func (s *State) fillStructureChanges(cb *changeBuilder, msgs []*pb.EventBlockSetChildrenIds) {
+func (s *State) fillStructureChanges(cb *changeBuilder, msgs []*pb.EventBlockSetChildrenIds, deleted map[string]struct{}) {
 	for _, msg := range msgs {
-		s.makeStructureChanges(cb, msg)
+		s.makeStructureChanges(cb, msg, deleted)
 	}
 }
 
-func (s *State) makeStructureChanges(cb *changeBuilder, msg *pb.EventBlockSetChildrenIds) (ch []*pb.ChangeContent) {
+func (s *State) makeStructureChanges(cb *changeBuilder, msg *pb.EventBlockSetChildrenIds, deleted map[string]struct{}) (ch []*pb.ChangeContent) {
 	if slice.FindPos(s.changesStructureIgnoreIds, msg.Id) != -1 {
 		return
 	}
@@ -667,12 +671,24 @@ func (s *State) makeStructureChanges(cb *changeBuilder, msg *pb.EventBlockSetChi
 	)
 	var makeTarget = func(pos int) {
 		if pos == 0 {
+			// anchor on the first previous sibling not deleted in this change:
+			// a concurrent change may carry the same deletion (e.g. two users
+			// replacing the same empty block), and a create or move targeting
+			// an already-deleted id is silently dropped on replay
+			for _, prevId := range ds.a {
+				if _, isDeleted := deleted[prevId]; !isDeleted {
+					targetId = prevId
+					targetPos = model.Block_Top
+					return
+				}
+			}
+			targetId = msg.Id
 			if len(ds.a) == 0 {
-				targetId = msg.Id
 				targetPos = model.Block_Inner
 			} else {
-				targetId = ds.a[0]
-				targetPos = model.Block_Top
+				// all previous siblings are deleted in this change: anchor on
+				// the parent so the target survives any concurrent replay
+				targetPos = model.Block_InnerFirst
 			}
 		} else {
 			targetId = ds.b[pos-1]

--- a/core/block/editor/state/change_test.go
+++ b/core/block/editor/state/change_test.go
@@ -211,6 +211,60 @@ func TestState_ChangesCreate_StoreSlice(t *testing.T) {
 	}
 }
 
+func TestState_ChangesCreate_ConcurrentReplaceFirstBlock(t *testing.T) {
+	newTextModel := func(id, txt string) *model.Block {
+		return &model.Block{
+			Id:      id,
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: txt}},
+		}
+	}
+	mkDoc := func() Doc {
+		return NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"e"}}),
+			"e":    simple.New(newTextModel("e", "")),
+		})
+	}
+	replace := func(t *testing.T, d Doc, newId, text string) []*pb.ChangeContent {
+		s := d.NewState()
+		s.Add(simple.New(newTextModel(newId, text)))
+		require.NoError(t, s.InsertTo("e", model.Block_Replace, newId))
+		_, _, err := ApplyState("", s, true)
+		require.NoError(t, err)
+		return d.(*State).GetChanges()
+	}
+
+	// given: two users concurrently replace the same first (empty) block
+	chA := replace(t, mkDoc(), "a1", "foo")
+	chB := replace(t, mkDoc(), "b1", "bar")
+
+	// then: no create may anchor on the replaced block — the concurrent change
+	// removes it, and a create targeting a missing id is dropped on replay
+	for _, chs := range [][]*pb.ChangeContent{chA, chB} {
+		for _, ch := range chs {
+			if create := ch.GetBlockCreate(); create != nil {
+				assert.NotEqual(t, "e", create.TargetId)
+			}
+		}
+	}
+
+	// and: replaying both changes in either order keeps both users' blocks
+	for name, order := range map[string][2][]*pb.ChangeContent{
+		"a then b": {chA, chB},
+		"b then a": {chB, chA},
+	} {
+		t.Run(name, func(t *testing.T) {
+			peer := mkDoc()
+			ps := peer.NewState()
+			ps.ApplyChangeIgnoreErr(order[0]...)
+			ps.ApplyChangeIgnoreErr(order[1]...)
+			_, _, err := ApplyState("", ps, true)
+			require.NoError(t, err)
+			assert.ElementsMatch(t, []string{"a1", "b1"}, peer.(*State).Pick("root").Model().ChildrenIds)
+			assert.Nil(t, peer.(*State).Pick("e"))
+		})
+	}
+}
+
 func TestState_ChangesCreate_MoveAdd_Wrap(t *testing.T) {
 	d := NewDoc("root", map[string]simple.Block{
 		"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"a", "b"}}),

--- a/core/block/editor/state/normalize.go
+++ b/core/block/editor/state/normalize.go
@@ -20,6 +20,9 @@ var (
 )
 
 func (s *State) Normalize(withLayouts bool) (err error) {
+	// normalization mutates children lists in ways no index hook can observe
+	// (in-place slice edits before setChildrenIds); never run it indexed
+	s.DisableParentIndex()
 	s.removeDuplicates()
 	s.normalizeDetails()
 	return s.normalize(withLayouts)
@@ -371,6 +374,7 @@ func isBlockEmpty(b simple.Block) bool {
 }
 
 func CleanupLayouts(s *State) (removedCount int) {
+	s.DisableParentIndex()
 	var cleanup func(id string) []string
 	cleanup = func(id string) (result []string) {
 		b := s.Get(id)

--- a/core/block/editor/state/parentindex.go
+++ b/core/block/editor/state/parentindex.go
@@ -1,0 +1,310 @@
+package state
+
+import (
+	"os"
+
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/util/slice"
+)
+
+// parentIndexDebug enables shadow verification: every index consultation also
+// runs the old whole-tree scan, the SCAN answer is used (replay behavior stays
+// bit-for-bit pre-index), and disagreements are logged. Meant for sweeping a
+// real account: rebuild every object with this on and grep the logs.
+var parentIndexDebug = os.Getenv("ANYTYPE_PARENT_INDEX_DEBUG") == "1"
+
+// parentIndex is a childId→parentId map that lets PickParentOf and UnlinkAll
+// skip whole-tree Iterate walks during change replay. Replay cost is dominated
+// by those walks (one per structural op → O(n²) for a flat document), see
+// BenchmarkTreeBuild.
+//
+// The index is ONLY safe on a single-layer (parentless) state whose structure
+// mutations all flow through Add/Set/InsertTo/Unlink/UnlinkAll — i.e. the
+// change-replay loop in BuildState. It must never be enabled on editing states
+// (layered, discardable, full of ChildrenIds writes that bypass the helpers)
+// and must be disabled before normalization runs (divBalance and
+// removeDuplicates pre-mutate slices in ways no hook can observe).
+//
+// Correctness model: the index is a verified cache, never an authority.
+//   - A hit is returned only when the mapped parent is alive and its
+//     ChildrenIds actually contains the child.
+//   - A child asserted under two different parents (the concurrent-move merge
+//     window that normalize.removeDuplicates exists for) is flagged ambiguous
+//     forever: resolution order between duplicate parents is defined by tree
+//     traversal order, which a map cannot reproduce, so ambiguous ids always
+//     take the Iterate fallback.
+//   - Any miss falls back to the same Iterate the code used before.
+type parentIndex struct {
+	parents   map[string]string
+	ambiguous map[string]struct{}
+
+	// shadow-verification counters (parentIndexDebug mode)
+	debugLookups    int
+	debugMismatches int
+	debugFallbacks  int
+}
+
+// lookupStatus distinguishes the strength of a lookup answer: a miss that
+// positively claims "nothing references this id" (safe to skip a scan) versus
+// a miss that only means "cannot verify, use traversal".
+type lookupStatus int
+
+const (
+	lookupHit lookupStatus = iota
+	// lookupNoParent: no entry and the id is not ambiguous. Because every
+	// children insertion during replay asserts (or flags ambiguity), and
+	// entries are only deleted when their target verifiably dropped the
+	// child, this is a positive "no parent reference anywhere" claim.
+	lookupNoParent
+	// lookupUnverifiable: ambiguity (own or on an ancestor) or a failed chain
+	// verification — the caller must fall back to tree traversal.
+	lookupUnverifiable
+)
+
+// EnableParentIndex builds the index for the current state view and turns on
+// the PickParentOf/UnlinkAll fast paths. No-op on layered states: their
+// copy-on-write lifecycle (discard on error, cross-layer Pick aliasing) makes
+// any index unsound.
+func (s *State) EnableParentIndex() {
+	if s.parent != nil {
+		return
+	}
+	idx := &parentIndex{
+		parents:   make(map[string]string, len(s.blocks)),
+		ambiguous: make(map[string]struct{}),
+	}
+	_ = s.Iterate(func(b simple.Block) bool {
+		pid := b.Model().Id
+		for _, cid := range b.Model().ChildrenIds {
+			idx.assert(cid, pid)
+		}
+		return true
+	})
+	s.parentIdx = idx
+}
+
+func (s *State) DisableParentIndex() {
+	if idx := s.parentIdx; idx != nil && parentIndexDebug && idx.debugLookups > 0 {
+		if idx.debugMismatches > 0 {
+			log.With("objectID", s.rootId).Errorf(
+				"parentIndex shadow check: %d mismatches in %d lookups (%d fallbacks)",
+				idx.debugMismatches, idx.debugLookups, idx.debugFallbacks)
+		} else {
+			log.With("objectID", s.rootId).Debugf(
+				"parentIndex shadow check: clean, %d lookups (%d fallbacks)",
+				idx.debugLookups, idx.debugFallbacks)
+		}
+	}
+	s.parentIdx = nil
+}
+
+func (idx *parentIndex) assert(childId, parentId string) {
+	if existing, ok := idx.parents[childId]; ok {
+		if existing != parentId {
+			idx.ambiguous[childId] = struct{}{}
+		}
+		return
+	}
+	idx.parents[childId] = parentId
+}
+
+func (idx *parentIndex) remove(childId, parentId string) {
+	if _, amb := idx.ambiguous[childId]; amb {
+		return
+	}
+	if idx.parents[childId] == parentId {
+		delete(idx.parents, childId)
+	}
+}
+
+// assertParentIds records parentId as the parent of every id. Called by the
+// children-mutation helpers with only the ADDED ids, so maintenance stays
+// O(inserted), not O(children list).
+func (s *State) assertParentIds(parentId string, ids ...string) {
+	if s.parentIdx == nil {
+		return
+	}
+	for _, id := range ids {
+		s.parentIdx.assert(id, parentId)
+	}
+}
+
+// unlinkForReplay removes id from its reachable parent's children, used by
+// changeBlockCreate for the re-create-acts-as-move semantics. Unlike Unlink it
+// must also handle DANGLING references (a parent listing id in ChildrenIds
+// before the block itself exists — e.g. a root create carrying children):
+// asserts are driven by parents' children lists, so dangling ids are indexed
+// too. The scan may only be skipped on a positive lookupNoParent claim; an
+// UNVERIFIABLE answer (e.g. an ambiguous ancestor in the chain) means the id
+// may well be reachable and must take the full scan.
+func (s *State) unlinkForReplay(id string) {
+	if s.parentIdx == nil {
+		s.Unlink(id)
+		return
+	}
+	if parentIndexDebug {
+		if p, ok := s.lookupParentShadow(id); ok {
+			if parent := s.Get(p.Model().Id); parent != nil {
+				s.removeChildren(parent.Model(), id)
+			}
+		}
+		return
+	}
+	p, status := s.lookupParentFast(id)
+	switch status {
+	case lookupHit:
+		if parent := s.Get(p.Model().Id); parent != nil {
+			s.removeChildren(parent.Model(), id)
+		}
+	case lookupNoParent:
+		// nothing references id — same no-op outcome as the scan
+	default:
+		s.Unlink(id)
+	}
+}
+
+// maxParentChainDepth caps the ancestor-chain verification walk; it only
+// exists to terminate on corrupt states with children cycles. Real documents
+// are nowhere near this deep.
+const maxParentChainDepth = 2048
+
+// lookupParent resolves id's parent through the index. found=false means the
+// caller must fall back to tree traversal (index disabled, no entry, ambiguous
+// entry, or an entry that failed verification). In shadow-verification mode it
+// additionally computes the traversal answer, logs any disagreement, and
+// returns the traversal answer so replay behavior is exactly pre-index.
+func (s *State) lookupParent(id string) (parent simple.Block, found bool) {
+	if s.parentIdx == nil {
+		return nil, false
+	}
+	if parentIndexDebug {
+		return s.lookupParentShadow(id)
+	}
+	p, status := s.lookupParentFast(id)
+	return p, status == lookupHit
+}
+
+// lookupParentShadow compares the fast answer against a FULL traversal that
+// collects every parent containing id (no early exit), which also exposes
+// unflagged duplicate-parent situations the ambiguity machinery should have
+// caught. The traversal answer wins.
+func (s *State) lookupParentShadow(id string) (parent simple.Block, found bool) {
+	idx := s.parentIdx
+	idx.debugLookups++
+
+	fast, status := s.lookupParentFast(id)
+
+	var all []simple.Block
+	_ = s.Iterate(func(b simple.Block) bool {
+		if slice.FindPos(b.Model().ChildrenIds, id) != -1 {
+			all = append(all, b)
+		}
+		return true
+	})
+	var slow simple.Block
+	if len(all) > 0 {
+		slow = all[0]
+	}
+
+	if _, amb := idx.ambiguous[id]; !amb {
+		var kind string
+		switch {
+		case len(all) > 1:
+			kind = "duplicate parents not flagged ambiguous"
+		case status == lookupUnverifiable:
+			// expected fallback (e.g. ambiguous ancestor in the chain) — the
+			// production code takes the traversal path here, so it costs
+			// speed, never correctness
+			idx.debugFallbacks++
+		case status == lookupNoParent && slow != nil:
+			kind = "index claims no reachable parent"
+		case status == lookupHit && slow == nil:
+			kind = "index returns parent for unreachable block"
+		case status == lookupHit && slow != nil && fast.Model().Id != slow.Model().Id:
+			kind = "index returns wrong parent"
+		}
+		if kind != "" {
+			idx.debugMismatches++
+			fastId, slowId := "<nil>", "<nil>"
+			if fast != nil {
+				fastId = fast.Model().Id
+			}
+			if slow != nil {
+				slowId = slow.Model().Id
+			}
+			allIds := make([]string, 0, len(all))
+			for _, b := range all {
+				allIds = append(allIds, b.Model().Id)
+			}
+			log.With("objectID", s.rootId).With("changeID", s.changeId).
+				Errorf("parentIndex shadow mismatch (%s): child=%s index=%s traversal=%s allParents=%v",
+					kind, id, fastId, slowId, allIds)
+		}
+	}
+
+	if slow == nil {
+		return nil, false
+	}
+	return slow, true
+}
+
+// lookupParentFast is the production lookup.
+//
+// Verification must prove REACHABILITY, not just map-aliveness: the semantics
+// being cached (Iterate) walk from the root, while a block that was unlinked
+// but not CleanupBlock-ed (e.g. a move whose wire target no longer exists —
+// the insert fails, the detached subtree stays alive in the map) still passes
+// alive+contains checks. So a hit requires the whole ancestor chain, resolved
+// through the index and verified hop by hop, to terminate at the root.
+//
+// A positive lookupNoParent is returned only for a non-ambiguous id with no
+// entry at all; every failure along the chain is merely lookupUnverifiable.
+func (s *State) lookupParentFast(id string) (parent simple.Block, status lookupStatus) {
+	idx := s.parentIdx
+	if idx == nil {
+		return nil, lookupUnverifiable
+	}
+	if _, amb := idx.ambiguous[id]; amb {
+		return nil, lookupUnverifiable
+	}
+	if _, ok := idx.parents[id]; !ok {
+		return nil, lookupNoParent
+	}
+	rootId := s.RootId()
+	var direct simple.Block
+	cur := id
+	for depth := 0; depth < maxParentChainDepth; depth++ {
+		if _, amb := idx.ambiguous[cur]; amb {
+			// an ambiguous ancestor makes the chain unverifiable, it says
+			// nothing about whether id itself has a parent
+			return nil, lookupUnverifiable
+		}
+		pid, ok := idx.parents[cur]
+		if !ok {
+			if cur == id {
+				return nil, lookupNoParent
+			}
+			return nil, lookupUnverifiable
+		}
+		p := s.Pick(pid)
+		if p == nil {
+			// parent was deleted (e.g. CleanupBlock) — entry is stale
+			delete(idx.parents, cur)
+			return nil, lookupUnverifiable
+		}
+		if slice.FindPos(p.Model().ChildrenIds, cur) == -1 {
+			// child was dropped without a removeChildren call (e.g. a
+			// wholesale children swap via Set) — entry is stale
+			delete(idx.parents, cur)
+			return nil, lookupUnverifiable
+		}
+		if direct == nil {
+			direct = p
+		}
+		if pid == rootId {
+			return direct, lookupHit
+		}
+		cur = pid
+	}
+	return nil, lookupUnverifiable
+}

--- a/core/block/editor/state/parentindex_guard_test.go
+++ b/core/block/editor/state/parentindex_guard_test.go
@@ -1,0 +1,79 @@
+package state
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestParentIndex_DirectChildrenWriteWhitelist guards the parent index's core
+// invariant: every code path that inserts an id into a ChildrenIds list while
+// the index can be active (the BuildState replay window) must either go
+// through the asserting helpers (Add/Set/prepend/append/insertChildrenIds),
+// update the index itself, or run with the index disabled.
+//
+// If this test fails you added a direct ChildrenIds write to the state
+// package. Either route it through the helpers, or — if the direct write is
+// genuinely needed — make it index-safe (assert inserted ids / remove dropped
+// ids / DisableParentIndex) and add the line to the whitelist below. Getting
+// this wrong breaks unlinkForReplay's "no entry ⇒ no parent reference" claim
+// and can silently duplicate blocks on change replay (see parentindex.go).
+func TestParentIndex_DirectChildrenWriteWhitelist(t *testing.T) {
+	whitelist := map[string][]string{
+		// changeBuilder mutates a wire-bound copy, never a state block
+		"change.go": {
+			"m.ChildrenIds = nil",
+		},
+		// normalization runs with the index force-disabled (see Normalize)
+		"normalize.go": {
+			"d1.ChildrenIds = append(d1.ChildrenIds, d2.ChildrenIds...)",
+		},
+		"position.go": {
+			// the chokepoint itself
+			"parent.ChildrenIds = childrenIds",
+			// updates the index
+			"parent.ChildrenIds = slice.RemoveMut(parent.ChildrenIds, childrenId)",
+			// wrapToRow slot write: hands the entry over and asserts
+			"parent.Model().ChildrenIds[pos] = row.Model().Id",
+		},
+		// UnlinkAll fallback scan: leaves stale entries on purpose — they are
+		// rejected by lookup verification (verified-cache model)
+		"state.go": {
+			"pm.ChildrenIds = slice.RemoveMut(pm.ChildrenIds, id)",
+		},
+	}
+
+	writeRe := regexp.MustCompile(`ChildrenIds(\[[^\]]*\])?\s*=[^=]`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "//") || !writeRe.MatchString(trimmed) {
+				continue
+			}
+			var allowed bool
+			for _, w := range whitelist[name] {
+				if strings.Contains(trimmed, w) {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				t.Errorf("%s:%d: direct ChildrenIds write outside the parent-index whitelist: %s", name, i+1, trimmed)
+			}
+		}
+	}
+}

--- a/core/block/editor/state/parentindex_test.go
+++ b/core/block/editor/state/parentindex_test.go
@@ -1,0 +1,393 @@
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func piTextModel(id string) *model.Block {
+	return &model.Block{Id: id, Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: "t-" + id}}}
+}
+
+func piCreate(targetId string, pos model.BlockPosition, blocks ...*model.Block) *pb.ChangeContent {
+	return &pb.ChangeContent{Value: &pb.ChangeContentValueOfBlockCreate{BlockCreate: &pb.ChangeBlockCreate{
+		TargetId: targetId, Position: pos, Blocks: blocks,
+	}}}
+}
+
+func piMove(targetId string, pos model.BlockPosition, ids ...string) *pb.ChangeContent {
+	return &pb.ChangeContent{Value: &pb.ChangeContentValueOfBlockMove{BlockMove: &pb.ChangeBlockMove{
+		TargetId: targetId, Position: pos, Ids: ids,
+	}}}
+}
+
+func piRemove(ids ...string) *pb.ChangeContent {
+	return &pb.ChangeContent{Value: &pb.ChangeContentValueOfBlockRemove{BlockRemove: &pb.ChangeBlockRemove{Ids: ids}}}
+}
+
+// adversarialReplay exercises every replay path that mutates structure,
+// including the cases the index must survive: duplicate parents (a created
+// block also declared as another block's child), orphaned subtrees (parent
+// removed, children swept only at the final apply), re-creation of an existing
+// id with a different children list (wholesale swap → stale index entries),
+// and side-moves (wrapToRow writes a child slot in place, bypassing helpers).
+func adversarialReplay() [][]*pb.ChangeContent {
+	return [][]*pb.ChangeContent{
+		// flat creates
+		{piCreate("root", model.Block_Inner, piTextModel("c1"))},
+		{piCreate("c1", model.Block_Bottom, piTextModel("c2"))},
+		{piCreate("c2", model.Block_Bottom, piTextModel("c3"))},
+		{piCreate("c3", model.Block_Bottom, piTextModel("c4"))},
+		{piCreate("c4", model.Block_Bottom, piTextModel("c5"))},
+		// duplicate parent: p1 declares c2 as child while c2 stays under root
+		{piCreate("c5", model.Block_Bottom, &model.Block{
+			Id:          "p1",
+			ChildrenIds: []string{"c2"},
+			Content:     &model.BlockContentOfText{Text: &model.BlockContentText{Text: "p1"}},
+		})},
+		// move into the duplicate-parented container
+		{piMove("p1", model.Block_Inner, "c3")},
+		// remove a middle block
+		{piRemove("c4")},
+		// re-create an existing id with a different children list (wholesale swap)
+		{piCreate("root", model.Block_Inner, &model.Block{
+			Id:          "c5",
+			ChildrenIds: []string{"c1"},
+			Content:     &model.BlockContentOfText{Text: &model.BlockContentText{Text: "c5-recreated"}},
+		})},
+		// side move → moveFromSide/wrapToRow (in-place child slot write)
+		{piCreate("root", model.Block_Inner, piTextModel("s1"))},
+		{piCreate("s1", model.Block_Bottom, piTextModel("s2"))},
+		{piMove("s1", model.Block_Left, "s2")},
+		// side-move a container that already has children (real-account shape,
+		// found by the shadow sweep): wrapToRow re-parents it into a fresh
+		// column — must not poison the subtree's chain with ambiguity, and
+		// later ops below its children must stay consistent
+		{piCreate("root", model.Block_Inner, piTextModel("w1"))},
+		{piCreate("w1", model.Block_Inner, piTextModel("w2"))},
+		{piCreate("root", model.Block_Inner, piTextModel("w3"))},
+		{piMove("w1", model.Block_Right, "w3")},
+		{piCreate("w2", model.Block_Bottom, piTextModel("w4"))},
+		{piRemove("w4")},
+		{piCreate("w2", model.Block_Bottom, piTextModel("w5"))},
+		// remove a subtree root: children become orphans until the final sweep
+		{piRemove("p1")},
+		// move something after the orphaning
+		{piMove("c5", model.Block_Bottom, "s2")},
+		// remove and re-add under a different parent
+		{piMove("c1", model.Block_Inner, "c2")},
+		// detached-but-alive subtree: a move whose target no longer exists
+		// unlinks the subtree but the insert fails (swallowed), leaving it
+		// alive in the map yet unreachable. Ops targeting blocks inside it
+		// must follow traversal semantics (dropped), not map-aliveness.
+		{piCreate("root", model.Block_Inner, piTextModel("dB"))},
+		{piCreate("root", model.Block_Inner, piTextModel("dP"))},
+		{piCreate("root", model.Block_Inner, piTextModel("dX"))},
+		{piMove("dP", model.Block_Inner, "dB")},
+		{piMove("missing-target", model.Block_Bottom, "dP")},
+		{piMove("dB", model.Block_Bottom, "dX")},
+		{piMove("root", model.Block_Inner, "dP")},
+	}
+}
+
+func collectIds(changeSets [][]*pb.ChangeContent) []string {
+	seen := map[string]struct{}{}
+	var ids []string
+	add := func(id string) {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	for _, cs := range changeSets {
+		for _, ch := range cs {
+			if c := ch.GetBlockCreate(); c != nil {
+				add(c.TargetId)
+				for _, b := range c.Blocks {
+					add(b.Id)
+					for _, cid := range b.ChildrenIds {
+						add(cid)
+					}
+				}
+			}
+			if m := ch.GetBlockMove(); m != nil {
+				add(m.TargetId)
+				for _, id := range m.Ids {
+					add(id)
+				}
+			}
+			if r := ch.GetBlockRemove(); r != nil {
+				for _, id := range r.Ids {
+					add(id)
+				}
+			}
+		}
+	}
+	return ids
+}
+
+// TestParentIndex_ReplayEquivalence replays the same adversarial change
+// sequence with and without the index in lockstep, comparing PickParentOf for
+// every known id after every change, and the full final structure.
+func TestParentIndex_ReplayEquivalence(t *testing.T) {
+	changeSets := adversarialReplay()
+	ids := collectIds(changeSets)
+
+	newDoc := func() *State {
+		return NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root"}),
+		}).(*State)
+	}
+	plain := newDoc()
+	indexed := newDoc()
+	indexed.EnableParentIndex()
+
+	parentOf := func(s *State, id string) string {
+		if p := s.PickParentOf(id); p != nil {
+			return p.Model().Id
+		}
+		return ""
+	}
+
+	// each replica must get its own deep copy: changeBlockCreate wraps the
+	// change's *model.Block by reference, so sharing change objects between
+	// replicas would alias every created block's ChildrenIds and structurally
+	// mask divergence
+	cloneChangeSet := func(cs []*pb.ChangeContent) []*pb.ChangeContent {
+		data, err := (&pb.Change{Content: cs}).Marshal()
+		require.NoError(t, err)
+		var ch pb.Change
+		require.NoError(t, ch.Unmarshal(data))
+		return ch.Content
+	}
+
+	for i, cs := range changeSets {
+		plain.ApplyChangeIgnoreErr(cloneChangeSet(cs)...)
+		indexed.ApplyChangeIgnoreErr(cloneChangeSet(cs)...)
+		for _, id := range ids {
+			require.Equal(t, parentOf(plain, id), parentOf(indexed, id),
+				"parent of %q diverged after change #%d", id, i)
+		}
+	}
+
+	finish := func(s *State) *State {
+		s.DisableParentIndex()
+		_, _, err := ApplyStateFastOne("", s)
+		require.NoError(t, err)
+		require.NoError(t, s.Normalize(false))
+		_, _, err = ApplyState("", s, false)
+		require.NoError(t, err)
+		return s
+	}
+	assert.Equal(t, finish(plain).String(), finish(indexed).String())
+}
+
+func TestParentIndex_LayeredStateIsNotIndexed(t *testing.T) {
+	d := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root"}),
+	}).(*State)
+	child := d.NewState()
+	child.EnableParentIndex()
+	assert.Nil(t, child.parentIdx, "index must never activate on a layered state")
+
+	d.EnableParentIndex()
+	require.NotNil(t, d.parentIdx)
+	assert.Nil(t, d.NewState().parentIdx, "index must not propagate to child states")
+	assert.Nil(t, d.Copy().parentIdx, "index must not propagate to copies")
+}
+
+func TestParentIndex_AmbiguousAndStaleFallBack(t *testing.T) {
+	// given: c under root, then also declared child of p (duplicate)
+	d := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"c"}}),
+		"c":    simple.New(piTextModel("c")),
+	}).(*State)
+	d.EnableParentIndex()
+
+	d.ApplyChangeIgnoreErr(piCreate("c", model.Block_Bottom, &model.Block{
+		Id:          "p",
+		ChildrenIds: []string{"c"},
+		Content:     &model.BlockContentOfText{Text: &model.BlockContentText{}},
+	}))
+
+	// then: ambiguous id resolves via traversal (root wins — first in order)
+	require.Contains(t, d.parentIdx.ambiguous, "c")
+	require.NotNil(t, d.PickParentOf("c"))
+	assert.Equal(t, "root", d.PickParentOf("c").Model().Id)
+
+	// and: a stale entry (parent deleted behind the index's back) self-heals
+	d2 := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"x"}}),
+		"x":    simple.New(&model.Block{Id: "x", ChildrenIds: []string{"y"}}),
+		"y":    simple.New(piTextModel("y")),
+	}).(*State)
+	d2.EnableParentIndex()
+	d2.ApplyChangeIgnoreErr(piRemove("x")) // y orphaned; its entry points at deleted x
+	assert.Nil(t, d2.PickParentOf("y"), "orphan must resolve to no parent, same as traversal")
+	_, found := d2.lookupParent("y")
+	assert.False(t, found)
+}
+
+func TestParentIndex_UnlinkAllMixedHitsAndMisses(t *testing.T) {
+	blocks := map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"a", "b", "c"}}),
+		"a":    simple.New(piTextModel("a")),
+		"b":    simple.New(piTextModel("b")),
+		"c":    simple.New(piTextModel("c")),
+	}
+	d := NewDoc("root", blocks).(*State)
+	d.EnableParentIndex()
+
+	// "ghost" has no parent anywhere → index miss → scan path
+	d.UnlinkAll([]string{"a", "ghost", "c"})
+	assert.Equal(t, []string{"b"}, d.Pick("root").Model().ChildrenIds)
+}
+
+func TestParentIndex_ShadowMode(t *testing.T) {
+	prev := parentIndexDebug
+	parentIndexDebug = true
+	defer func() { parentIndexDebug = prev }()
+
+	t.Run("clean replay reports zero mismatches", func(t *testing.T) {
+		// given
+		d := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root"}),
+		}).(*State)
+		d.EnableParentIndex()
+
+		// when: the full adversarial sequence runs under shadow verification
+		for _, cs := range adversarialReplay() {
+			d.ApplyChangeIgnoreErr(cs...)
+		}
+
+		// then
+		assert.Positive(t, d.parentIdx.debugLookups)
+		assert.Zero(t, d.parentIdx.debugMismatches)
+	})
+
+	t.Run("unflagged duplicate parents are detected and traversal answer wins", func(t *testing.T) {
+		// given: "a" listed under both root and b, but not flagged ambiguous
+		d := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"a", "b"}}),
+			"a":    simple.New(piTextModel("a")),
+			"b":    simple.New(&model.Block{Id: "b", ChildrenIds: []string{"a"}, Content: piTextModel("b").Content}),
+		}).(*State)
+		d.EnableParentIndex()
+		// the bootstrap flags "a" ambiguous — simulate the machinery missing it
+		delete(d.parentIdx.ambiguous, "a")
+		d.parentIdx.parents["a"] = "b"
+
+		// when
+		p := d.PickParentOf("a")
+
+		// then: traversal answer returned, mismatch counted
+		require.NotNil(t, p)
+		assert.Equal(t, "root", p.Model().Id)
+		assert.Equal(t, 1, d.parentIdx.debugMismatches)
+	})
+
+	t.Run("unverifiable chain counts as fallback, not mismatch", func(t *testing.T) {
+		// given: an ambiguous ancestor between the child and the root
+		d := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"mid"}}),
+			"mid":  simple.New(&model.Block{Id: "mid", ChildrenIds: []string{"leaf"}, Content: piTextModel("mid").Content}),
+			"leaf": simple.New(piTextModel("leaf")),
+		}).(*State)
+		d.EnableParentIndex()
+		d.parentIdx.ambiguous["mid"] = struct{}{}
+
+		// when
+		p := d.PickParentOf("leaf")
+
+		// then
+		require.NotNil(t, p)
+		assert.Equal(t, "mid", p.Model().Id)
+		assert.Zero(t, d.parentIdx.debugMismatches)
+		assert.Equal(t, 1, d.parentIdx.debugFallbacks)
+	})
+
+	t.Run("index claiming no parent is detected", func(t *testing.T) {
+		// given
+		d := NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"a"}}),
+			"a":    simple.New(piTextModel("a")),
+		}).(*State)
+		d.EnableParentIndex()
+		// simulate a missed assert
+		delete(d.parentIdx.parents, "a")
+
+		// when
+		p := d.PickParentOf("a")
+
+		// then
+		require.NotNil(t, p)
+		assert.Equal(t, "root", p.Model().Id)
+		assert.Equal(t, 1, d.parentIdx.debugMismatches)
+	})
+}
+
+func TestParentIndex_UnlinkForReplayUnderAmbiguousAncestor(t *testing.T) {
+	// given: root → mid → leaf, with mid flagged ambiguous — the leaf's chain
+	// is unverifiable, but the leaf IS reachable
+	d := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root", ChildrenIds: []string{"mid"}}),
+		"mid":  simple.New(&model.Block{Id: "mid", ChildrenIds: []string{"leaf"}, Content: piTextModel("mid").Content}),
+		"leaf": simple.New(piTextModel("leaf")),
+	}).(*State)
+	d.EnableParentIndex()
+	d.parentIdx.ambiguous["mid"] = struct{}{}
+
+	// when: a re-create of "leaf" replays (create acts as move)
+	d.ApplyChangeIgnoreErr(piCreate("root", model.Block_Inner, piTextModel("leaf")))
+
+	// then: the old occurrence must be unlinked (unverifiable → full scan),
+	// not left duplicated under mid
+	assert.Empty(t, d.Pick("mid").Model().ChildrenIds)
+	assert.Equal(t, []string{"mid", "leaf"}, d.Pick("root").Model().ChildrenIds)
+}
+
+func TestParentIndex_SideMoveDoesNotPoisonAmbiguity(t *testing.T) {
+	// given: the real-account shape found by the shadow sweep — a container
+	// with children gets side-moved (wrapToRow re-parents it into a column)
+	d := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root"}),
+	}).(*State)
+	d.EnableParentIndex()
+	d.ApplyChangeIgnoreErr(piCreate("root", model.Block_Inner, piTextModel("w1")))
+	d.ApplyChangeIgnoreErr(piCreate("w1", model.Block_Inner, piTextModel("w2")))
+	d.ApplyChangeIgnoreErr(piCreate("root", model.Block_Inner, piTextModel("w3")))
+
+	// when
+	d.ApplyChangeIgnoreErr(piMove("w1", model.Block_Right, "w3"))
+
+	// then: the re-parented container is not flagged ambiguous, and lookups
+	// under it still resolve through the index
+	assert.NotContains(t, d.parentIdx.ambiguous, "w1")
+	p, status := d.lookupParentFast("w2")
+	require.Equal(t, lookupHit, status)
+	assert.Equal(t, "w1", p.Model().Id)
+}
+
+func TestParentIndex_BigFlatDocLookups(t *testing.T) {
+	// smoke test that hits the fast path at some scale
+	children := make([]string, 300)
+	blocks := map[string]simple.Block{}
+	for i := range children {
+		id := fmt.Sprintf("b%d", i)
+		children[i] = id
+		blocks[id] = simple.New(piTextModel(id))
+	}
+	blocks["root"] = simple.New(&model.Block{Id: "root", ChildrenIds: children})
+	d := NewDoc("root", blocks).(*State)
+	d.EnableParentIndex()
+	for _, id := range children {
+		require.Equal(t, "root", d.PickParentOf(id).Model().Id)
+	}
+}

--- a/core/block/editor/state/position.go
+++ b/core/block/editor/state/position.go
@@ -171,6 +171,13 @@ func (s *State) moveFromSide(target, parent simple.Block, pos model.BlockPositio
 }
 
 func (s *State) wrapToRow(opId string, parent, b simple.Block) (row simple.Block, err error) {
+	// b is legitimately re-parented into the fresh column below: hand its
+	// index entry over first, otherwise the column's assert sees a conflict
+	// and flags b permanently ambiguous, which poisons chain verification for
+	// b's entire subtree
+	if s.parentIdx != nil {
+		s.parentIdx.remove(b.Model().Id, parent.Model().Id)
+	}
 	column := s.addNewBlockAndWrapToColumn(opId, b)
 	row = s.addNewColumnToRow(opId, column)
 	pos := slice.FindPos(parent.Model().ChildrenIds, b.Model().Id)
@@ -179,6 +186,9 @@ func (s *State) wrapToRow(opId string, parent, b simple.Block) (row simple.Block
 	}
 	// do not need to remove from cache
 	parent.Model().ChildrenIds[pos] = row.Model().Id
+	// in-place slot write bypasses the children helpers — keep the parent
+	// index aware of the row's placement
+	s.assertParentIds(parent.Model().Id, row.Model().Id)
 	return
 }
 
@@ -188,23 +198,32 @@ func (s *State) setChildrenIds(parent *model.Block, childrenIds []string) {
 
 // do not use this method outside of normalization
 func (s *State) SetChildrenIds(parent *model.Block, childrenIds []string) {
+	// callers (normalization, table editor) replace lists wholesale, often on
+	// blocks the state doesn't own — unsafe for the parent index
+	s.DisableParentIndex()
 	s.setChildrenIds(parent, childrenIds)
 }
 
 func (s *State) removeChildren(parent *model.Block, childrenId string) {
 	parent.ChildrenIds = slice.RemoveMut(parent.ChildrenIds, childrenId)
+	if s.parentIdx != nil {
+		s.parentIdx.remove(childrenId, parent.Id)
+	}
 }
 
 func (s *State) prependChildrenIds(block *model.Block, ids ...string) {
 	s.setChildrenIds(block, append(block.ChildrenIds, ids...))
+	s.assertParentIds(block.Id, ids...)
 }
 
 func (s *State) appendChildrenIds(block *model.Block, ids ...string) {
 	s.setChildrenIds(block, append(ids, block.ChildrenIds...))
+	s.assertParentIds(block.Id, ids...)
 }
 
 func (s *State) insertChildrenIds(block *model.Block, pos int, ids ...string) {
 	s.setChildrenIds(block, slice.Insert(block.ChildrenIds, pos, ids...))
+	s.assertParentIds(block.Id, ids...)
 }
 
 func (s *State) addNewColumn(opId string, ids []string) simple.Block {
@@ -272,7 +291,13 @@ func (s *State) insertReplace(target simple.Block, targetParentM *model.Block, t
 			}
 		}
 		if !idsIsChild && canInheritChildren {
-			s.setChildrenIds(id0Block.Model(), target.Model().ChildrenIds)
+			// copy: the target is unlinked below but stays alive in the blocks
+			// map; sharing the slice header would let later mutations of one
+			// list corrupt the other
+			inherited := make([]string, len(target.Model().ChildrenIds))
+			copy(inherited, target.Model().ChildrenIds)
+			s.setChildrenIds(id0Block.Model(), inherited)
+			s.assertParentIds(id0Block.Model().Id, inherited...)
 		}
 	}
 	s.insertChildrenIds(targetParentM, pos, ids...)

--- a/core/block/editor/state/state.go
+++ b/core/block/editor/state/state.go
@@ -136,6 +136,11 @@ type State struct {
 
 	changesStructureIgnoreIds []string
 
+	// replay-only childId→parentId index; see parentindex.go. Deliberately not
+	// propagated by NewState/Copy — it is only sound on the single-layer
+	// replay state inside BuildState.
+	parentIdx *parentIndex
+
 	stringBuf []string
 
 	groupId                  string
@@ -269,6 +274,7 @@ func (s *State) Add(b simple.Block) (ok bool) {
 		s.blocks[id] = b
 		s.blockInit(b)
 		s.setChildrenIds(b.Model(), b.Model().ChildrenIds)
+		s.assertParentIds(id, b.Model().ChildrenIds...)
 		return true
 	}
 	return false
@@ -279,6 +285,7 @@ func (s *State) Set(b simple.Block) {
 		s.Add(b)
 	} else {
 		s.setChildrenIds(b.Model(), b.Model().ChildrenIds)
+		s.assertParentIds(b.Model().Id, b.Model().ChildrenIds...)
 		s.blocks[b.Model().Id] = b
 		s.blockInit(b)
 	}
@@ -346,6 +353,28 @@ func (s *State) Unlink(blockId string) (ok bool) {
 func (s *State) UnlinkAll(ids []string) {
 	if len(ids) == 0 {
 		return
+	}
+	if s.parentIdx != nil {
+		// resolve parents through the index; ids it can't answer for keep the
+		// tree-scan path below
+		var missed []string
+		for _, id := range ids {
+			p, ok := s.lookupParent(id)
+			if !ok {
+				missed = append(missed, id)
+				continue
+			}
+			parent := s.Get(p.Model().Id)
+			if parent == nil {
+				missed = append(missed, id)
+				continue
+			}
+			s.removeChildren(parent.Model(), id)
+		}
+		if len(missed) == 0 {
+			return
+		}
+		ids = missed
 	}
 	if len(ids) == 1 {
 		s.Unlink(ids[0])
@@ -423,6 +452,9 @@ func (s *State) HasParent(id, parentId string) bool {
 }
 
 func (s *State) PickParentOf(id string) (res simple.Block) {
+	if p, ok := s.lookupParent(id); ok {
+		return p
+	}
 	s.Iterate(func(b simple.Block) bool {
 		if slice.FindPos(b.Model().ChildrenIds, id) != -1 {
 			res = b

--- a/core/block/editor/state/treebuild_bench_test.go
+++ b/core/block/editor/state/treebuild_bench_test.go
@@ -1,0 +1,183 @@
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// Benchmarks the tree-replay cost (the un-snapshotted object open path, see
+// sourceimpl.BuildState) of a big flat document produced by three editing
+// patterns for "press Enter, then type into the new block":
+//
+//   - settext:        BlockCreate(empty) + BlockSetText into the same id (old clients)
+//   - replace:        BlockCreate(empty) + BlockReplace → fresh id (LWW-fork trick)
+//   - createWithText: one BlockCreate already carrying the text (virtual placeholder ideal)
+//
+// The editing session is simulated through the real ApplyState pipeline
+// (withLayouts=true, so div-wrap normalization ops are recorded like in
+// production) and the recorded changes are replayed from marshaled bytes the
+// same way BuildState does: unmarshal, SetChangeId, ApplyChangeIgnoreErr per
+// change, then ApplyStateFastOne + BlocksInit + Normalize + ApplyState.
+
+type editPattern struct {
+	name string
+	// edit appends the changes for one "Enter + type" iteration and returns
+	// the id of the block that ends up holding the text (the next anchor)
+	edit func(tb testing.TB, d Doc, rec *changeRecorder, i int, prev string) string
+}
+
+type changeRecorder struct {
+	raw       [][]byte
+	changeIds []string
+	bytes     int
+}
+
+func (r *changeRecorder) record(tb testing.TB, d Doc) {
+	chs := d.(*State).GetChanges()
+	data, err := (&pb.Change{Content: chs}).Marshal()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	r.raw = append(r.raw, data)
+	r.changeIds = append(r.changeIds, fmt.Sprintf("c%d", len(r.changeIds)))
+	r.bytes += len(data)
+}
+
+func newEmptyTextModel(id string) *model.Block {
+	return &model.Block{Id: id, Content: &model.BlockContentOfText{Text: &model.BlockContentText{}}}
+}
+
+func newFilledTextModel(id string, i int) *model.Block {
+	return &model.Block{Id: id, Content: &model.BlockContentOfText{
+		Text: &model.BlockContentText{Text: fmt.Sprintf("line %d: some regular typed text content", i)},
+	}}
+}
+
+func applyEdit(tb testing.TB, d Doc, s *State, rec *changeRecorder) {
+	if _, _, err := ApplyState("", s, true); err != nil {
+		tb.Fatal(err)
+	}
+	rec.record(tb, d)
+}
+
+func createEmptyBlock(tb testing.TB, d Doc, rec *changeRecorder, id, prev string) {
+	s := d.NewState()
+	s.Add(simple.New(newEmptyTextModel(id)))
+	if err := s.InsertTo(prev, model.Block_Bottom, id); err != nil {
+		tb.Fatal(err)
+	}
+	applyEdit(tb, d, s, rec)
+}
+
+var editPatterns = []editPattern{
+	{
+		name: "settext",
+		edit: func(tb testing.TB, d Doc, rec *changeRecorder, i int, prev string) string {
+			id := fmt.Sprintf("e%d", i)
+			createEmptyBlock(tb, d, rec, id, prev)
+			s := d.NewState()
+			s.Get(id).Model().GetText().Text = newFilledTextModel(id, i).GetText().Text
+			applyEdit(tb, d, s, rec)
+			return id
+		},
+	},
+	{
+		name: "replace",
+		edit: func(tb testing.TB, d Doc, rec *changeRecorder, i int, prev string) string {
+			eid := fmt.Sprintf("e%d", i)
+			createEmptyBlock(tb, d, rec, eid, prev)
+			rid := fmt.Sprintf("r%d", i)
+			s := d.NewState()
+			s.Add(simple.New(newFilledTextModel(rid, i)))
+			if err := s.InsertTo(eid, model.Block_Replace, rid); err != nil {
+				tb.Fatal(err)
+			}
+			applyEdit(tb, d, s, rec)
+			return rid
+		},
+	},
+	{
+		name: "createWithText",
+		edit: func(tb testing.TB, d Doc, rec *changeRecorder, i int, prev string) string {
+			id := fmt.Sprintf("t%d", i)
+			s := d.NewState()
+			s.Add(simple.New(newFilledTextModel(id, i)))
+			if err := s.InsertTo(prev, model.Block_Bottom, id); err != nil {
+				tb.Fatal(err)
+			}
+			applyEdit(tb, d, s, rec)
+			return id
+		},
+	},
+}
+
+func simulateEditingSession(tb testing.TB, p editPattern, n int) *changeRecorder {
+	d := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root"}),
+	})
+	rec := &changeRecorder{}
+	prev := ""
+	for i := 0; i < n; i++ {
+		prev = p.edit(tb, d, rec, i, prev)
+	}
+	return rec
+}
+
+// replayTree mirrors sourceimpl.BuildState + treeSource.buildState
+func replayTree(tb testing.TB, rec *changeRecorder, withParentIndex bool) *State {
+	d := NewDoc("root", map[string]simple.Block{
+		"root": simple.New(&model.Block{Id: "root"}),
+	}).(*State)
+	if withParentIndex {
+		d.EnableParentIndex()
+	}
+	for i, raw := range rec.raw {
+		var ch pb.Change
+		if err := ch.Unmarshal(raw); err != nil {
+			tb.Fatal(err)
+		}
+		d.SetChangeId(rec.changeIds[i])
+		d.ApplyChangeIgnoreErr(ch.Content...)
+	}
+	d.DisableParentIndex()
+	if _, _, err := ApplyStateFastOne("", d); err != nil {
+		tb.Fatal(err)
+	}
+	d.BlocksInit(d)
+	if err := d.Normalize(false); err != nil {
+		tb.Fatal(err)
+	}
+	if _, _, err := ApplyState("", d, false); err != nil {
+		tb.Fatal(err)
+	}
+	return d
+}
+
+func BenchmarkTreeBuild(b *testing.B) {
+	for _, n := range []int{100, 1000, 5000} {
+		for _, p := range editPatterns {
+			for _, indexed := range []bool{false, true} {
+				name := fmt.Sprintf("%s/blocks=%d", p.name, n)
+				if indexed {
+					name += "/indexed"
+				}
+				b.Run(name, func(b *testing.B) {
+					rec := simulateEditingSession(b, p, n)
+					st := replayTree(b, rec, indexed)
+					var blocks int
+					_ = st.Iterate(func(simple.Block) bool { blocks++; return true })
+					b.Logf("changes=%d treeBytes=%d finalBlocks=%d", len(rec.raw), rec.bytes, blocks)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						replayTree(b, rec, indexed)
+					}
+				})
+			}
+		}
+	}
+}

--- a/core/block/editor/state/treereplay_debug_test.go
+++ b/core/block/editor/state/treereplay_debug_test.go
@@ -1,0 +1,78 @@
+package state
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/pb"
+)
+
+// TestReplayTreeDumpShadow replays a debugtree JSON dump (the files logged by
+// the parentIndex shadow sweep / debugtree export) in shadow-verification mode
+// and asserts zero index mismatches, plus structural equality between the
+// indexed and plain replays. Skipped unless ANYTYPE_TREE_DUMP points to a
+// dump file:
+//
+//	ANYTYPE_TREE_DUMP=/path/tree_XXX.json go test ./core/block/editor/state/ -run TestReplayTreeDumpShadow -v
+func TestReplayTreeDumpShadow(t *testing.T) {
+	dumpPath := os.Getenv("ANYTYPE_TREE_DUMP")
+	if dumpPath == "" {
+		t.Skip("set ANYTYPE_TREE_DUMP to a debugtree json dump to run")
+	}
+	raw, err := os.ReadFile(dumpPath)
+	require.NoError(t, err)
+
+	var dump struct {
+		Id      string `json:"id"`
+		Changes []struct {
+			Id     string          `json:"id"`
+			Ord    int             `json:"ord"`
+			Change json.RawMessage `json:"change"`
+		} `json:"changes"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &dump))
+	sort.Slice(dump.Changes, func(i, j int) bool { return dump.Changes[i].Ord < dump.Changes[j].Ord })
+
+	t.Logf("dump %s: %d changes", dump.Id, len(dump.Changes))
+
+	// each run must unmarshal its own copy: changeBlockCreate wraps the
+	// change's block models by reference, so sharing parsed changes between
+	// replicas aliases their states and corrupts the comparison
+	run := func(indexed bool) *State {
+		unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
+		d := NewDoc(dump.Id, nil).(*State)
+		if indexed {
+			d.EnableParentIndex()
+		}
+		for _, ch := range dump.Changes {
+			if ch.Id == dump.Id {
+				continue // the tree root change is not applied (see BuildState)
+			}
+			var model pb.Change
+			require.NoError(t, unmarshaler.Unmarshal(bytes.NewReader(ch.Change), &model), "change %s", ch.Id)
+			d.SetChangeId(ch.Id)
+			d.ApplyChangeIgnoreErr(model.Content...)
+		}
+		return d
+	}
+
+	prev := parentIndexDebug
+	parentIndexDebug = true
+	defer func() { parentIndexDebug = prev }()
+
+	plain := run(false)
+	indexed := run(true)
+
+	require.NotNil(t, indexed.parentIdx)
+	t.Logf("shadow: %d lookups, %d mismatches, %d fallbacks",
+		indexed.parentIdx.debugLookups, indexed.parentIdx.debugMismatches, indexed.parentIdx.debugFallbacks)
+	assert.Zero(t, indexed.parentIdx.debugMismatches)
+	assert.Equal(t, plain.String(), indexed.String())
+}

--- a/core/block/source/sourceimpl/source.go
+++ b/core/block/source/sourceimpl/source.go
@@ -614,6 +614,14 @@ func BuildState(spaceId string, initState *state.State, ot objecttree.ReadableOb
 		st = initState
 		startId = st.ChangeId()
 	}
+	// the replay-scoped parent index makes PickParentOf/UnlinkAll O(1) during
+	// change application (it no-ops on layered states, i.e. the incremental
+	// initState path); it must be off again before normalization runs
+	defer func() {
+		if st != nil {
+			st.DisableParentIndex()
+		}
+	}()
 
 	// todo: can we avoid unmarshaling here? we already had this data
 	sbt, uniqueKeyInternalKey, err := typeprovider.GetTypeAndKeyFromRoot(ot.Header())
@@ -638,6 +646,7 @@ func BuildState(spaceId string, initState *state.State, ot objecttree.ReadableOb
 				} else {
 					st = state.NewDoc(ot.Id(), nil).(*state.State)
 				}
+				st.EnableParentIndex()
 				st.SetChangeId(change.Id)
 				return true
 			}
@@ -658,6 +667,7 @@ func BuildState(spaceId string, initState *state.State, ot objecttree.ReadableOb
 					if iterErr != nil {
 						return false
 					}
+					st.EnableParentIndex()
 				} else {
 					st = st.NewState()
 				}


### PR DESCRIPTION
## Summary

Two related deliverables improving tree-replay performance and concurrent-edit safety in `core/block/editor/state`.

### 1. Replay-scoped parent index

Tree replay (`BuildState`, the un-snapshotted object-open path, and every rebuild triggered by out-of-order changes) was O(n²): every structural op ran a whole-document `Iterate` via `PickParentOf`/`UnlinkAll`.

A childId→parentId index now lives **only** on the single-layer replay state inside `BuildState` (enabled at state construction, defer-disabled before normalization; never propagated to editing states).

It is a **verified cache**, not a blind map:
- A hit requires the whole ancestor chain (resolved through the index) to verify hop-by-hop up to the root — reachability, not just map-aliveness.
- Ambiguous ids (duplicate-parent merge windows) permanently fall back to traversal, preserving resolution semantics exactly.

Includes:
- Shadow-verification mode (`ANYTYPE_PARENT_INDEX_DEBUG=1`): every lookup also runs the full traversal, the traversal answer wins, and disagreements are logged.
- A tree-dump replayer test (`ANYTYPE_TREE_DUMP` env).
- A source-scan guard test freezing the direct-`ChildrenIds`-write whitelist.
- A replay benchmark (`treebuild_bench_test.go`).

**Benchmark** (M2, 5000-block flat doc):

| Pattern | Before | After | Speedup |
|---|---|---|---|
| settext | 770ms | 79ms | ~10x |
| replace | 1954ms | 80ms | ~24x |

Memory: +3-5%.

### 2. Concurrent-replace safety fixes

Support for the upcoming client-side `BlockReplace`-on-empty-block strategy against last-block LWW text loss:

- **`makeStructureChanges`/`makeTarget` anchor fallback**: a first-position insert no longer anchors on a sibling deleted in the same change (two users concurrently replacing the same first block would silently drop the second user's block on replay — creates/moves targeting missing ids are swallowed by `ApplyChangeIgnoreErr`). Falls back to the first surviving previous sibling, or parent+`InnerFirst`.
- **Paste-into-empty-block forks the block id server-side** (`pasteCtrl.forkFilledEmptyBlock`): filling a peer-known empty block in place kept a shared LWW register; now the filled block gets a fresh id (children preserved), the new id is prepended to the response `blockIds`, and `caretPosition=-1` for the intoBlock case (clients focus via `blockIds`, standard multi-block-paste behavior).

## Validation

- 4 review rounds.
- Lockstep equivalence tests: indexed lookups vs. full traversal must always agree.
- Shadow-verified (`ANYTYPE_PARENT_INDEX_DEBUG=1`) against a full real account with zero mismatches.
- Guard test (`parentindex_guard_test.go`) freezing the whitelist of code sites allowed to write `ChildrenIds` directly, so future direct writes can't silently bypass the index.
- `go build ./core/...` and targeted suites (`core/block/editor/state`, `core/block/editor/clipboard`, `core/block/source/...`) pass.

## Linear

GO-7356: Replay-scoped parent index for tree building + concurrent-replace safety fixes
