### PR TITLE
GO-7358 Make FileCacheDownload cheap when file already cached

### DIFF
--- a/core/file.go
+++ b/core/file.go
@@ -279,11 +279,22 @@ func (mw *Middleware) FileAutoDownloadSetLimit(ctx context.Context, req *pb.RpcF
 
 func (mw *Middleware) FileCacheDownload(ctx context.Context, req *pb.RpcFileCacheDownloadRequest) *pb.RpcFileCacheDownloadResponse {
 	handle := func() error {
-		file, err := mustService[fileobject.Service](mw).GetFileData(ctx, req.FileObjectId)
+		fileObjectService := mustService[fileobject.Service](mw)
+		// Fast path: resolve the file id from the indexed object store without
+		// opening the smartblock. CacheFile then skips the warm-up entirely when
+		// the file is already cached locally.
+		fullId, err := fileObjectService.GetFileIdFromObject(req.FileObjectId)
 		if err != nil {
-			return fmt.Errorf("get file data: %w", err)
+			// The file id could not be read from the index — the object is not
+			// indexed yet, or its file id relation is still empty mid-upload. Fall
+			// back to loading the file data, which also warms up the object itself.
+			file, err := fileObjectService.GetFileData(ctx, req.FileObjectId)
+			if err != nil {
+				return fmt.Errorf("get file data: %w", err)
+			}
+			fullId = domain.FullFileId{SpaceId: file.SpaceId(), FileId: file.FileId()}
 		}
-		mustService[filedownloader.Service](mw).CacheFile(file.SpaceId(), file.FileId())
+		mustService[filedownloader.Service](mw).CacheFile(fullId.SpaceId, fullId.FileId)
 		return nil
 	}
 	err := handle()

--- a/core/files/filedownloader/cache.go
+++ b/core/files/filedownloader/cache.go
@@ -3,6 +3,7 @@ package filedownloader
 import (
 	"context"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -25,6 +26,14 @@ type cacheWarmer struct {
 	blocksLimit int
 	tasksLimit  int
 	downloadFn  func(ctx context.Context, spaceId string, cid domain.FileId, blocksLimit int) error
+
+	// lifecycle counters, read by the service's stat provider.
+	enqueued atomic.Int64 // tasks accepted into the queue
+	// warmedUp counts tasks whose downloadFn returned without error. Note that
+	// DownloadToLocalStore currently swallows mid-walk errors (timeout/cancel), so
+	// this means "root block fetched, no hard error" rather than "fully warmed".
+	warmedUp             atomic.Int64
+	cancelledBeforeStart atomic.Int64 // tasks cancelled while still queued (never started)
 }
 
 func newCacheWarmer(ctx context.Context, blocksLimit int, tasksLimit int, timeout time.Duration, downloadFn func(ctx context.Context, spaceId string, cid domain.FileId, blocksLimit int) error) *cacheWarmer {
@@ -59,6 +68,8 @@ func (w *cacheWarmer) runWorker() {
 		err = w.downloadFn(task.ctx, task.spaceId, task.cid, w.blocksLimit)
 		if err != nil {
 			log.Error("cache warmer: download file", zap.Error(err))
+		} else {
+			w.warmedUp.Add(1)
 		}
 
 		err = w.markDone(task.cid)
@@ -81,7 +92,9 @@ func (w *cacheWarmer) enqueue(spaceId string, cid domain.FileId) {
 
 	select {
 	case w.enqueueCh <- task:
+		w.enqueued.Add(1)
 	case <-w.ctx.Done():
+		cancel()
 	}
 }
 
@@ -170,6 +183,8 @@ func (w *cacheWarmer) handleCancel(fileId domain.FileId) {
 	for i, task := range w.tasks {
 		if task.cid == fileId {
 			w.tasks = slices.Delete(w.tasks, i, i+1)
+			// The task was still queued, so its warm-up had not started yet.
+			w.cancelledBeforeStart.Add(1)
 			break
 		}
 	}

--- a/core/files/filedownloader/service.go
+++ b/core/files/filedownloader/service.go
@@ -26,12 +26,16 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/app/debugstat"
+	"github.com/anyproto/any-sync/commonfile/fileblockstore"
 	"github.com/anyproto/any-sync/commonfile/fileservice"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/anytype/config"
 	"github.com/anyproto/anytype-heart/core/block/cache"
@@ -62,11 +66,18 @@ type service struct {
 	ctxCancel context.CancelFunc
 
 	dagService           ipld.DAGService
+	commonFile           fileservice.FileService
 	crossSpaceSubService crossspacesub.Service
 	objectGetter         cache.ObjectGetter
 	config               *config.Config
 	networkState         device.NetworkState
+	statService          debugstat.StatService
 	cacheWarmer          *cacheWarmer
+
+	// skippedFiles counts CacheFile requests skipped because the file's root block
+	// was already cached locally. The enqueue/warm-up/cancel counters live on the
+	// cacheWarmer, where those transitions happen.
+	skippedFiles atomic.Int64
 
 	lock        sync.Mutex
 	isEnabled   bool
@@ -91,12 +102,18 @@ func (s *service) Init(a *app.App) error {
 	s.crossSpaceSubService = app.MustComponent[crossspacesub.Service](a)
 	s.objectGetter = app.MustComponent[cache.ObjectGetter](a)
 	commonFile := app.MustComponent[fileservice.FileService](a)
+	s.commonFile = commonFile
 	s.dagService = commonFile.DAGService()
 	s.config = app.MustComponent[*config.Config](a)
 	s.networkState = app.MustComponent[device.NetworkState](a)
 	s.networkState.RegisterHook(s.networkStateChanged)
 
 	s.cacheWarmer = newCacheWarmer(s.ctx, 10, 20, 2*time.Minute, s.DownloadToLocalStore)
+
+	if statService, _ := app.GetComponent[debugstat.StatService](a); statService != nil {
+		s.statService = statService
+		s.statService.AddProvider(s)
+	}
 
 	return nil
 }
@@ -114,6 +131,9 @@ func (s *service) Run(ctx context.Context) error {
 }
 
 func (s *service) Close(ctx context.Context) error {
+	if s.statService != nil {
+		s.statService.RemoveProvider(s)
+	}
 	if s.ctxCancel != nil {
 		s.ctxCancel()
 	}
@@ -167,7 +187,62 @@ func (s *service) setDownloadState(enabled bool, wifiOnly bool, sizeLimitMb int6
 }
 
 func (s *service) CacheFile(spaceId string, fileId domain.FileId) {
+	if s.hasRootBlock(spaceId, fileId) {
+		// The file's root block is already present in the local flatfs, so the
+		// file has (almost certainly) been cached before. Skip the warm-up to
+		// avoid a redundant DAG walk. Missing child blocks are a tolerated edge
+		// case: the proxy store refetches them on demand when the file is read.
+		s.skippedFiles.Add(1)
+		return
+	}
 	s.cacheWarmer.enqueue(spaceId, fileId)
+}
+
+type stat struct {
+	// SkippedFiles is the number of CacheFile requests skipped because the file's
+	// root block was already cached locally.
+	SkippedFiles int64 `json:"skippedFiles"`
+	// EnqueuedFiles is the number of files accepted into the warm-up queue.
+	EnqueuedFiles int64 `json:"enqueuedFiles"`
+	// WarmedUpFiles is the number of files whose warm-up finished successfully.
+	WarmedUpFiles int64 `json:"warmedUpFiles"`
+	// CancelledBeforeStart is the number of queued warm-ups cancelled before they started.
+	CancelledBeforeStart int64 `json:"cancelledBeforeStart"`
+}
+
+func (s *service) ProvideStat() any {
+	st := stat{SkippedFiles: s.skippedFiles.Load()}
+	if s.cacheWarmer != nil {
+		st.EnqueuedFiles = s.cacheWarmer.enqueued.Load()
+		st.WarmedUpFiles = s.cacheWarmer.warmedUp.Load()
+		st.CancelledBeforeStart = s.cacheWarmer.cancelledBeforeStart.Load()
+	}
+	return st
+}
+
+func (s *service) StatId() string {
+	return "cache"
+}
+
+func (s *service) StatType() string {
+	return CName
+}
+
+// hasRootBlock reports whether the file's root block already exists in the local
+// blockstore. It is a pure local key-existence check (flatfs stat) — no block is
+// read, decrypted or fetched from a remote peer.
+func (s *service) hasRootBlock(spaceId string, fileId domain.FileId) bool {
+	rootCid, err := cid.Parse(fileId.String())
+	if err != nil {
+		return false
+	}
+	ctx := fileblockstore.CtxWithSpaceId(s.ctx, spaceId)
+	exists, err := s.commonFile.HasCid(ctx, rootCid)
+	if err != nil {
+		log.Warn("cache file: check root block existence", zap.Error(err))
+		return false
+	}
+	return exists
 }
 
 func (s *service) CancelFileCaching(fileId domain.FileId) {

--- a/core/files/filedownloader/service_test.go
+++ b/core/files/filedownloader/service_test.go
@@ -1,6 +1,7 @@
 package filedownloader
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -8,7 +9,9 @@ import (
 	"time"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/anyproto/any-sync/commonfile/fileblockstore"
 	"github.com/anyproto/any-sync/commonfile/fileservice"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -111,6 +114,76 @@ func findSizeFilter(filters []database.FilterRequest) (domain.Value, bool) {
 		}
 	}
 	return domain.Value{}, false
+}
+
+func TestCacheFileRootBlockCheck(t *testing.T) {
+	fx := newServiceFixture(t)
+
+	// Replace the warmer with an observable one so we can tell whether a
+	// warm-up was actually scheduled.
+	downloadCh := make(chan domain.FileId, 4)
+	fx.cacheWarmer = newCacheWarmer(fx.ctx, 10, 20, time.Minute,
+		func(ctx context.Context, spaceId string, fileCid domain.FileId, blocksLimit int) error {
+			downloadCh <- fileCid
+			return nil
+		})
+	go fx.cacheWarmer.run()
+	go fx.cacheWarmer.runWorker()
+
+	t.Run("skips warm-up when root block already cached", func(t *testing.T) {
+		ctx := fileblockstore.CtxWithSpaceId(context.Background(), "space1")
+		node, err := fx.commonFile.AddFile(ctx, bytes.NewReader([]byte("already cached file")))
+		require.NoError(t, err)
+		cachedFileId := domain.FileId(node.Cid().String())
+
+		fx.CacheFile("space1", cachedFileId)
+
+		select {
+		case got := <-downloadCh:
+			t.Fatalf("expected warm-up to be skipped, but download ran for %s", got)
+		case <-time.After(200 * time.Millisecond):
+		}
+	})
+
+	t.Run("warms up when root block is missing", func(t *testing.T) {
+		absentCid := blocks.NewBlock([]byte("never stored in the blockstore")).Cid()
+		missingFileId := domain.FileId(absentCid.String())
+
+		fx.CacheFile("space1", missingFileId)
+
+		select {
+		case got := <-downloadCh:
+			assert.Equal(t, missingFileId, got)
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected warm-up to run for a missing root block")
+		}
+	})
+
+	t.Run("reports skipped, enqueued and warmed-up counters", func(t *testing.T) {
+		want := stat{SkippedFiles: 1, EnqueuedFiles: 1, WarmedUpFiles: 1}
+		assert.Eventually(t, func() bool {
+			return fx.ProvideStat() == want
+		}, 2*time.Second, 10*time.Millisecond)
+	})
+}
+
+func TestCacheWarmerCancelBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// No worker is started, so the enqueued task stays queued and is cancelled
+	// before its warm-up can begin.
+	w := newCacheWarmer(ctx, 10, 10, time.Minute, func(context.Context, string, domain.FileId, int) error {
+		return nil
+	})
+	go w.run()
+
+	w.enqueue("space1", "file1")
+	w.cancelTask("file1")
+
+	assert.Eventually(t, func() bool {
+		return w.cancelledBeforeStart.Load() == 1 && w.warmedUp.Load() == 0
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestManger(t *testing.T) {


### PR DESCRIPTION
## Why

`FileCacheDownload` is called very frequently by **iOS** — per chat message/file — to warm the local cache. Previously every call did real work even when the file was already fully downloaded: it opened the smartblock (`GetFileData`) just to get spaceId+fileId, then enqueued a DAG walk of up to 10 blocks. There was no "already cached" short-circuit.

## What

- **Skip when already cached.** `filedownloader.CacheFile` checks the file's **root block** via `commonFile.HasCid` — a pure local flatfs key-stat (no block read, no decrypt, no remote fetch). If present, the warm-up is skipped. Tolerated edge case: root present but some child blocks missing — the proxy store refetches on demand at read time.
- **Avoid opening the smartblock.** The handler resolves spaceId+fileId via the indexed `GetFileIdFromObject`, falling back to `GetFileData` only when the object isn't indexed yet (which also warms the object itself). Net cost on an already-cached file: one indexed details read + one flatfs stat.
- **Component stat** (`debugstat.StatProvider`): `skippedFiles`, `enqueuedFiles`, `warmedUpFiles`, `cancelledBeforeStart` — surfaced via `Rpc.Debug.Stat`, to measure effectiveness under real iOS load. Also fixes a context leak in `cacheWarmer.enqueue` on shutdown.

The auto-downloader path is unaffected (it calls `DownloadToLocalStore` directly, bypassing the skip guard).

## Tests

- `TestCacheFileRootBlockCheck` — skip when root block cached, warm when missing, and asserts the counters.
- `TestCacheWarmerCancelBeforeStart` — cancel-before-start counting.

Verified: `go build ./core/...` and `go test ./core/files/filedownloader/... -race` pass against latest `develop`.

## Notes

- Reviewed by an Opus review pass (verdict: ship). One follow-up split out as **GO-7359**: `DownloadToLocalStore` swallows DAG-walk errors, which makes `warmedUp` count timed-out/cancelled walks and lets the auto-downloader mismark `fileAvailableOffline`. Kept out of this PR to keep scope tight.