### PR TITLE
GO-7361 p2pstatus: only broadcast status for registered spaces

### DIFF
--- a/core/peerstatus/status.go
+++ b/core/peerstatus/status.go
@@ -179,6 +179,14 @@ func (p *p2pStatus) setNotPossibleStatus(state localdiscovery.DiscoveryPossibili
 // RegisterSpace registers spaceId to be monitored for p2p status changes
 // must be called only when p2pStatus is Running
 func (p *p2pStatus) RegisterSpace(spaceId string) {
+	// Mark the space as registered before triggering a refresh. Only registered
+	// spaces are tracked and broadcast; processSpaceStatusUpdate ignores everything
+	// else. This is the single place where a monitored space is created.
+	p.Lock()
+	if _, ok := p.spaceIds[spaceId]; !ok {
+		p.spaceIds[spaceId] = &spaceStatus{status: Unknown}
+	}
+	p.Unlock()
 	select {
 	case <-p.ctx.Done():
 		return
@@ -233,21 +241,17 @@ func (p *p2pStatus) refreshSpaces(spaceIds []string) error {
 	return nil
 }
 
-// updateSpaceP2PStatus updates status for specific spaceId and sends event if status changed
+// processSpaceStatusUpdate updates status for specific spaceId and sends event if status changed.
+// spaceIds that were never registered via RegisterSpace are ignored: peers discovered on the local
+// network (e.g. via mDNS) advertise all of their own spaces, and those flow in through the peerStore
+// observer. Broadcasting p2pStatusUpdate for them would leak status for spaces this account is not a
+// member of, so we only ever refresh spaces this account explicitly registered.
 func (p *p2pStatus) processSpaceStatusUpdate(spaceId string) {
 	p.Lock()
 	defer p.Unlock()
-	var (
-		currentStatus *spaceStatus
-		ok            bool
-	)
-	if currentStatus, ok = p.spaceIds[spaceId]; !ok {
-		currentStatus = &spaceStatus{
-			status:           Unknown,
-			connectionsCount: 0,
-		}
-
-		p.spaceIds[spaceId] = currentStatus
+	currentStatus, ok := p.spaceIds[spaceId]
+	if !ok {
+		return
 	}
 	connectionCount := p.countOpenConnections(spaceId)
 	newStatus := p.getResultStatus(p.p2pLastState, connectionCount)

--- a/core/peerstatus/status_test.go
+++ b/core/peerstatus/status_test.go
@@ -393,6 +393,30 @@ func TestP2pStatus_UnregisterSpace(t *testing.T) {
 	})
 }
 
+func TestP2pStatus_IgnoreUnregisteredSpace(t *testing.T) {
+	t.Run("peer advertising a space this account has not registered is ignored", func(t *testing.T) {
+		// given: only "spaceId" is registered (by the fixture)
+		f := newFixture(t, "spaceId", pb.EventP2PStatus_NotConnected, 1)
+
+		// when: a peer discovered on the LAN (e.g. via mDNS) advertises a space this
+		// account does not have. The strict mock sender fails the test if any Broadcast
+		// is sent for "otherSpaceId".
+		f.store.UpdateLocalPeer("strangerPeer", []string{"otherSpaceId"})
+
+		// then: the unregistered space is neither tracked nor broadcast
+		time.Sleep(time.Millisecond * 300)
+		f.p2pStatus.Lock()
+		_, tracked := f.p2pStatus.spaceIds["otherSpaceId"]
+		trackedLen := len(f.p2pStatus.spaceIds)
+		f.p2pStatus.Unlock()
+
+		assert.False(t, tracked, "unregistered space must not be tracked")
+		assert.Equal(t, 1, trackedLen, "only the registered space should remain tracked")
+
+		f.Close(nil)
+	})
+}
+
 func newFixture(t *testing.T, spaceId string, initialStatus pb.EventP2PStatusStatus, deviceCount int) *fixture {
 	ctrl := gomock.NewController(t)
 	sender := mock_event.NewMockSender(t)


### PR DESCRIPTION
## Problem

The client receives a flood of separate `p2pStatusUpdate` events, each carrying a `spaceId` the account does not have — the spaceIds belong to other devices discovered on the local network via mDNS.

## Root cause

`p2pStatus` (`core/peerstatus/status.go`) is a purely cosmetic per-space connection indicator. Two paths feed spaceIds into `processSpaceStatusUpdate` through the shared `refreshSpaceId` channel:

1. `RegisterSpace(spaceId)` — called once per space the account actually loads (from `peermanager/manager.go`). Legitimate.
2. The `peerStore` observer — fired by `UpdateLocalPeer` (`space/spacecore/peer.go`, `rpchandler.go`). A LAN peer advertises **all of its own** spaceIds, which flow into the observer.

`processSpaceStatusUpdate` unconditionally created a map entry and broadcast `p2pStatusUpdate{Status: Connected, DevicesCounter: N}` for **any** spaceId — including strangers' spaces the account is not a member of.

## Fix

- `RegisterSpace` becomes the single place that creates a monitored entry (under lock).
- `processSpaceStatusUpdate` returns early if the spaceId was never registered.

Also closes a latent zombie-reregistration bug: a stale refresh arriving after `UnregisterSpace` previously re-created and re-broadcast the deleted space.

## Cold sync is unaffected

The change is confined to the cosmetic component. `peerStore` population (`UpdateLocalPeer` callers) and sync peer selection — which reads `peerStore.LocalPeerIds(spaceId)` directly in `peermanager/manager.go` — are untouched. So pulling/cold-syncing a space from a p2p node still works; once loaded, the space is registered and tracked normally.

## Testing

- New `TestP2pStatus_IgnoreUnregisteredSpace` reproduces the leak (fails without the fix: broadcasts `{otherSpaceId, Connected, 1}` and tracks it) and passes with it.
- Full `core/peerstatus` suite passes with `-race`, stable over repeated runs; `go vet` clean.
- Independent review confirmed correctness, concurrency safety (no deadlock / no lock-order inversion), completeness (single create site, single broadcast site), and that the existing connect-after-register path still broadcasts correctly.

Closes GO-7361