### PR TITLE
GO-7363 Fix mDNS recv syscall storm on iOS

### DIFF
--- a/core/device/networkstate_test.go
+++ b/core/device/networkstate_test.go
@@ -145,6 +145,35 @@ func TestNetworkState_SetNetworkState(t *testing.T) {
 		assert.Equal(t, model.DeviceNetworkType_WIFI, state.networkState)
 		assert.Equal(t, model.DeviceNetworkType_WIFI, hookState)
 	})
+	t.Run("same value is a cheap no-op (hook not called)", func(t *testing.T) {
+		// given: default state is WIFI(0)
+		state := &networkState{}
+		var calls int
+		var last model.DeviceNetworkType
+		state.RegisterHook(func(n model.DeviceNetworkType) {
+			calls++
+			last = n
+		})
+
+		// when/then: setting the same-as-current value must not fire the hook
+		state.SetNetworkState(model.DeviceNetworkType_WIFI)
+		assert.Equal(t, 0, calls, "same-as-default value must not fire the hook")
+
+		// a real change fires exactly once
+		state.SetNetworkState(model.DeviceNetworkType_CELLULAR)
+		assert.Equal(t, 1, calls)
+		assert.Equal(t, model.DeviceNetworkType_CELLULAR, last)
+
+		// repeating the same value is a no-op — no extra hook calls
+		state.SetNetworkState(model.DeviceNetworkType_CELLULAR)
+		state.SetNetworkState(model.DeviceNetworkType_CELLULAR)
+		assert.Equal(t, 1, calls, "repeated same value must be a no-op")
+
+		// switching back fires once more
+		state.SetNetworkState(model.DeviceNetworkType_WIFI)
+		assert.Equal(t, 2, calls)
+		assert.Equal(t, model.DeviceNetworkType_WIFI, last)
+	})
 }
 
 func TestNetworkState_GetNetworkState(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -308,7 +308,7 @@ replace github.com/dgraph-io/badger/v4 => github.com/anyproto/badger/v4 v4.2.1-0
 
 replace github.com/dgraph-io/ristretto => github.com/anyproto/ristretto v0.1.2-0.20240221153107-2b23839cc50c
 
-replace github.com/libp2p/zeroconf/v2 => github.com/anyproto/zeroconf/v2 v2.2.1-0.20240228113933-f90a5cc4439d
+replace github.com/libp2p/zeroconf/v2 => github.com/anyproto/zeroconf/v2 v2.2.1-0.20260708184030-4b038d2205c0
 
 replace github.com/JohannesKaufmann/html-to-markdown => github.com/anyproto/html-to-markdown v0.0.0-20231025221133-830bf0a6f139
 

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/anyproto/ristretto v0.1.2-0.20240221153107-2b23839cc50c h1:GicoaTUyB2
 github.com/anyproto/ristretto v0.1.2-0.20240221153107-2b23839cc50c/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/anyproto/tantivy-go v1.0.6 h1:8FI8otTeq5OFXK7Fw7vwG2vrwW1R1Yvcbiy4rO4YfoQ=
 github.com/anyproto/tantivy-go v1.0.6/go.mod h1:LtipOpRjGtcYMGcop6gQN7rVl1Pc6BlIs9BTMqeWMsk=
-github.com/anyproto/zeroconf/v2 v2.2.1-0.20240228113933-f90a5cc4439d h1:5bj7nX/AS8sxGpTIrapE7PC4oPlhkHMwMqXlJbUHBlg=
-github.com/anyproto/zeroconf/v2 v2.2.1-0.20240228113933-f90a5cc4439d/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
+github.com/anyproto/zeroconf/v2 v2.2.1-0.20260708184030-4b038d2205c0 h1:wWRZsuDYVoxyOSMKe+fujlqOck/wmzmmxBqVt8hHBHU=
+github.com/anyproto/zeroconf/v2 v2.2.1-0.20260708184030-4b038d2205c0/go.mod h1:fuJqLnUwZTshS3U/bMRJ3+ow/v9oid1n0DmyYyNO1Xs=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/space/spacecore/localdiscovery/localdiscovery.go
+++ b/space/spacecore/localdiscovery/localdiscovery.go
@@ -48,6 +48,7 @@ type localDiscovery struct {
 	started     bool
 	notifier    Notifier
 	m           sync.Mutex
+	refreshMu   sync.Mutex // serializes refreshInterfaces so l.m can be released across the server teardown
 
 	hookMu       sync.Mutex
 	hookState    DiscoveryPossibility
@@ -95,10 +96,7 @@ func (l *localDiscovery) Start() (err error) {
 	}
 	l.started = true
 	l.networkState.RegisterHook(func(_ model.DeviceNetworkType) {
-		err = l.refreshInterfaces(l.componentCtx)
-		if err != nil {
-			log.Warn("refreshing interfaces on networkState failed", zap.Error(err))
-		}
+		l.onNetworkStateChanged()
 	})
 
 	l.port = l.drpcServer.Port()
@@ -150,9 +148,31 @@ func (l *localDiscovery) Close(ctx context.Context) (err error) {
 	return nil
 }
 
-func (l *localDiscovery) refreshInterfaces(ctx context.Context) (err error) {
+// onNetworkStateChanged is called when the device network type changes (e.g.
+// cellular -> wifi, or plugging the phone into a Mac by cable). After such a
+// transition the previous mDNS socket is usually dead — iOS leaves it in
+// ENOTCONN — yet its interface addresses can look unchanged, so refreshInterfaces
+// would skip the rebuild and the recv loop would keep hitting the dead socket
+// (throttled by the backoff, but never recovering). We clear the cached
+// addresses to force a full teardown + rebuild on the fresh interface. Network
+// type is intentionally ignored: we can't tell wifi from a USB-cable LAN here,
+// and both should keep discovery running.
+func (l *localDiscovery) onNetworkStateChanged() {
 	l.m.Lock()
-	defer l.m.Unlock()
+	l.interfacesAddrs = addrs.InterfacesAddrs{}
+	l.m.Unlock()
+	if err := l.refreshInterfaces(l.componentCtx); err != nil {
+		log.Warn("refreshing interfaces on network change failed", zap.Error(err))
+	}
+}
+
+func (l *localDiscovery) refreshInterfaces(ctx context.Context) (err error) {
+	// refreshMu serializes the whole refresh so the periodic check and the
+	// network-change hook can't interleave a rebuild while l.m is released below.
+	l.refreshMu.Lock()
+	defer l.refreshMu.Unlock()
+
+	l.m.Lock()
 	newAddrs, err := addrs.GetInterfacesAddrs()
 	if addrs.NetAddrsEqualUnordered(l.interfacesAddrs.Addrs, newAddrs.Addrs) {
 		// this optimization allows to save syscalls to get addrs for every iface
@@ -164,6 +184,7 @@ func (l *localDiscovery) refreshInterfaces(ctx context.Context) (err error) {
 			// do the check only if we are in restricted state, just in case it was disabled
 			return l.getDiscoveryPossibility(newAddrs)
 		})
+		l.m.Unlock()
 		return
 	}
 
@@ -174,17 +195,29 @@ func (l *localDiscovery) refreshInterfaces(ctx context.Context) (err error) {
 	if newAddrs.Equal(l.interfacesAddrs) && l.server != nil {
 		// we do additional check after we filter and sort multicast interfaces
 		// so this equal check is more precise
+		l.m.Unlock()
 		return
 	}
 	log.With(zap.Strings("ifaces", newAddrs.InterfaceNames())).Info("net interfaces configuration changed")
 	l.interfacesAddrs = newAddrs
-	if l.server != nil {
+	server := l.server
+	l.server = nil
+	if server != nil {
 		l.queryCtxCancel()
-		l.server.Shutdown()
+	}
+	l.m.Unlock()
+
+	// Tear the old server down WITHOUT holding l.m: Shutdown + closeWait.Wait can
+	// block on readAnswers, which itself needs l.m — holding it here deadlocks
+	// (this mirrors Close). refreshMu keeps concurrent refreshes out of this window.
+	if server != nil {
+		server.Shutdown()
 		l.closeWait.Wait()
 		l.closeWait = sync.WaitGroup{}
-		l.server = nil
 	}
+
+	l.m.Lock()
+	defer l.m.Unlock()
 	if len(l.interfacesAddrs.Interfaces) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Problem
On iOS a Wi-Fi/cellular network transition can leave the mDNS multicast socket in a persistent error state (`ENOTCONN`) without closing it or calling `Shutdown`. The zeroconf `recv4`/`recv6` loop then spun on `recvmsg` with no delay — confirmed on-device at **~1.6M calls/s** (≈34M syscalls over ~3 minutes per episode), pegging a CPU core and heating the device. This matches the `recv4` hotspot seen in the iOS CPU profile.

## Fix
1. **Backoff (zeroconf fork bump):** points at the fork commit that adds a growing backoff on recv errors (50ms → 5s, reset on a successful read). Kills the busy-spin regardless of network state. (anyproto/zeroconf `recv-backoff`, commit `4b038d2`.)
2. **Recover discovery on network change:** `localdiscovery` now rebuilds the mDNS server on every device network-type change, replacing the dead socket on the settled interface. The interface address can look unchanged after a transition, so `refreshInterfaces` would otherwise skip the rebuild.
3. **Deadlock fix in `refreshInterfaces`:** it held `l.m` across `server.Shutdown()` + `closeWait.Wait()` while `readAnswers` needs `l.m` — a latent deadlock the force-rebuild now exercises on every transition. Release `l.m` across the teardown (mirrors `Close()`), serialized by a new `refreshMu`.
4. **Test:** pins that a same-value `SetNetworkState` is a no-op, so a redundant call can't trigger a needless rebuild.

## Verification
On-device, before/after the same Wi-Fi/cellular flip: recv error rate **1,733,739/s → 1/s**. `localdiscovery` passes `-race`; device tests pass.

## Notes
- Depends on the fork PR (anyproto/zeroconf `recv-backoff`). Once that merges, the `go.mod` replace can be repointed at the merged commit/tag.
- Debug tracing (HTTP `/trace` server + per-packet logs) is intentionally **not** in this PR; it lives on a separate branch for a future proper tracer.