### PR TITLE
feat(api): add block object link REST endpoints with card presentation

### DIFF
--- a/core/api/core/core.go
+++ b/core/api/core/core.go
@@ -87,6 +87,7 @@ type ClientCommands interface {
 	// Block
 	BlockCreate(context.Context, *pb.RpcBlockCreateRequest) *pb.RpcBlockCreateResponse
 	BlockPaste(context.Context, *pb.RpcBlockPasteRequest) *pb.RpcBlockPasteResponse
+	BlockReplace(context.Context, *pb.RpcBlockReplaceRequest) *pb.RpcBlockReplaceResponse
 	BlockListDelete(context.Context, *pb.RpcBlockListDeleteRequest) *pb.RpcBlockListDeleteResponse
 
 	// Chat

--- a/core/api/core/mock_apicore/mock_ClientCommands.go
+++ b/core/api/core/mock_apicore/mock_ClientCommands.go
@@ -267,6 +267,55 @@ func (_c *MockClientCommands_BlockPaste_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// BlockReplace provides a mock function with given fields: _a0, _a1
+func (_m *MockClientCommands) BlockReplace(_a0 context.Context, _a1 *pb.RpcBlockReplaceRequest) *pb.RpcBlockReplaceResponse {
+	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BlockReplace")
+	}
+
+	var r0 *pb.RpcBlockReplaceResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *pb.RpcBlockReplaceRequest) *pb.RpcBlockReplaceResponse); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pb.RpcBlockReplaceResponse)
+		}
+	}
+
+	return r0
+}
+
+// MockClientCommands_BlockReplace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'BlockReplace'
+type MockClientCommands_BlockReplace_Call struct {
+	*mock.Call
+}
+
+// BlockReplace is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *pb.RpcBlockReplaceRequest
+func (_e *MockClientCommands_Expecter) BlockReplace(_a0 interface{}, _a1 interface{}) *MockClientCommands_BlockReplace_Call {
+	return &MockClientCommands_BlockReplace_Call{Call: _e.mock.On("BlockReplace", _a0, _a1)}
+}
+
+func (_c *MockClientCommands_BlockReplace_Call) Run(run func(_a0 context.Context, _a1 *pb.RpcBlockReplaceRequest)) *MockClientCommands_BlockReplace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*pb.RpcBlockReplaceRequest))
+	})
+	return _c
+}
+
+func (_c *MockClientCommands_BlockReplace_Call) Return(_a0 *pb.RpcBlockReplaceResponse) *MockClientCommands_BlockReplace_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClientCommands_BlockReplace_Call) RunAndReturn(run func(context.Context, *pb.RpcBlockReplaceRequest) *pb.RpcBlockReplaceResponse) *MockClientCommands_BlockReplace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ChatAddMessage provides a mock function with given fields: _a0, _a1
 func (_m *MockClientCommands) ChatAddMessage(_a0 context.Context, _a1 *pb.RpcChatAddMessageRequest) *pb.RpcChatAddMessageResponse {
 	ret := _m.Called(_a0, _a1)

--- a/core/api/handler/block_object_link.go
+++ b/core/api/handler/block_object_link.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/core/api/service"
+	"github.com/anyproto/anytype-heart/core/api/util"
+)
+
+// SetBlockObjectLinkHandler sets the object link on a block (text→link or link target update) via the editor replace path.
+//
+//	@Summary		Set block object link
+//	@Description	Sets or updates a UI-style object link on the given block: a text block becomes a link block (card layout); a link block gets a new target and card layout. Uses the same internal BlockReplace path as the editor (links/backlinks follow normal derivation). Re-posting the same target upgrades Text preview links to Card when needed.
+//	@Id				set_block_object_link
+//	@Tags			Objects
+//	@Accept			json
+//	@Produce		json
+//	@Param			Anytype-Version	header		string								true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id		path		string								true	"Space id"
+//	@Param			object_id		path		string								true	"Source object id (page/note containing the block)"
+//	@Param			block_id		path		string								true	"Block id to turn into / update as object link"
+//	@Param			body			body		apimodel.SetBlockObjectLinkRequest	true	"Target object id"
+//	@Success		200				{object}	apimodel.SetBlockObjectLinkResponse	"Link set (or already matched target)"
+//	@Failure		400				{object}	util.ValidationError				"Bad request"
+//	@Failure		401				{object}	util.UnauthorizedError				"Unauthorized"
+//	@Failure		404				{object}	util.NotFoundError					"Object or block not found"
+//	@Failure		410				{object}	util.GoneError						"Object deleted"
+//	@Failure		429				{object}	util.RateLimitError					"Rate limit exceeded"
+//	@Failure		500				{object}	util.ServerError					"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/objects/{object_id}/blocks/{block_id}/link [post]
+func SetBlockObjectLinkHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spaceId := c.Param("space_id")
+		objectId := c.Param("object_id")
+		blockId := c.Param("block_id")
+
+		var req apimodel.SetBlockObjectLinkRequest
+		if err := c.BindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, util.CodeToApiError(http.StatusBadRequest, err.Error()))
+			return
+		}
+
+		out, err := s.SetBlockObjectLink(c.Request.Context(), spaceId, objectId, blockId, req)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(util.ErrBad, http.StatusBadRequest),
+			util.ErrToCode(service.ErrObjectNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrObjectDeleted, http.StatusGone),
+			util.ErrToCode(service.ErrBlockNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrRequiredBlock, http.StatusBadRequest),
+			util.ErrToCode(service.ErrUnsupportedBlockForLink, http.StatusBadRequest),
+			util.ErrToCode(service.ErrFailedRetrieveObject, http.StatusInternalServerError),
+			util.ErrToCode(service.ErrBlockReplaceFailed, http.StatusInternalServerError),
+		)
+		if code != http.StatusOK {
+			c.JSON(code, util.CodeToApiError(code, err.Error()))
+			return
+		}
+		c.JSON(http.StatusOK, out)
+	}
+}
+
+// DeleteBlockObjectLinkHandler deletes a link block (optional ?target_object_id= must match).
+//
+//	@Summary		Delete block object link
+//	@Description	Removes a link block from the object. When target_object_id is provided, the link must point to that object or the request fails.
+//	@Id				delete_block_object_link
+//	@Tags			Objects
+//	@Produce		json
+//	@Param			Anytype-Version		header	string	true	"The version of the API to use"	default(2025-11-08)
+//	@Param			space_id			path	string	true	"Space id"
+//	@Param			object_id			path	string	true	"Source object id"
+//	@Param			block_id			path	string	true	"Link block id"
+//	@Param			target_object_id	query	string	false	"If set, must equal the link target"
+//	@Success		204					"Deleted"
+//	@Failure		400					{object}	util.ValidationError	"Bad request"
+//	@Failure		401					{object}	util.UnauthorizedError	"Unauthorized"
+//	@Failure		404					{object}	util.NotFoundError		"Object, block, or link mismatch"
+//	@Failure		410					{object}	util.GoneError			"Object deleted"
+//	@Failure		429					{object}	util.RateLimitError		"Rate limit exceeded"
+//	@Failure		500					{object}	util.ServerError		"Internal server error"
+//	@Security		bearerauth
+//	@Router			/v1/spaces/{space_id}/objects/{object_id}/blocks/{block_id}/link [delete]
+func DeleteBlockObjectLinkHandler(s *service.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spaceId := c.Param("space_id")
+		objectId := c.Param("object_id")
+		blockId := c.Param("block_id")
+		optionalTarget := c.Query("target_object_id")
+
+		err := s.DeleteBlockObjectLink(c.Request.Context(), spaceId, objectId, blockId, optionalTarget)
+		code := util.MapErrorCode(err,
+			util.ErrToCode(service.ErrObjectNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrObjectDeleted, http.StatusGone),
+			util.ErrToCode(service.ErrBlockNotFound, http.StatusNotFound),
+			util.ErrToCode(service.ErrNotLinkBlock, http.StatusNotFound),
+			util.ErrToCode(service.ErrTargetMismatch, http.StatusNotFound),
+			util.ErrToCode(service.ErrRequiredBlock, http.StatusBadRequest),
+			util.ErrToCode(service.ErrFailedRetrieveObject, http.StatusInternalServerError),
+			util.ErrToCode(service.ErrBlockDeleteFailed, http.StatusInternalServerError),
+		)
+		if code != http.StatusOK {
+			c.JSON(code, util.CodeToApiError(code, err.Error()))
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}

--- a/core/api/handler/object.go
+++ b/core/api/handler/object.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -66,11 +67,12 @@ func ListObjectsHandler(s *service.Service) gin.HandlerFunc {
 //	@Param			space_id		path		string					true	"The ID of the space in which the object exists; must be retrieved from ListSpaces endpoint"
 //	@Param			object_id		path		string					true	"The ID of the object to retrieve; must be retrieved from ListObjects, SearchSpace or GlobalSearch endpoints or obtained from response context"
 //	@Param			format			query		apimodel.BodyFormat		false	"The format to return the object body in" default(md)
-//	@Success		200				{object}	apimodel.ObjectResponse	"The retrieved object"
-//	@Failure		401				{object}	util.UnauthorizedError	"Unauthorized"
-//	@Failure		404				{object}	util.NotFoundError		"Resource not found"
-//	@Failure		410				{object}	util.GoneError			"Resource deleted"
-//	@Failure		500				{object}	util.ServerError		"Internal server error"
+//	@Param			block_link_candidates	query		string					false	"If `1` or `true`, includes block_link_candidates (block ids for POST …/blocks/{id}/link)"	Enums(1,true)
+//	@Success		200						{object}	apimodel.ObjectResponse	"The retrieved object"
+//	@Failure		401						{object}	util.UnauthorizedError	"Unauthorized"
+//	@Failure		404						{object}	util.NotFoundError		"Resource not found"
+//	@Failure		410						{object}	util.GoneError			"Resource deleted"
+//	@Failure		500						{object}	util.ServerError		"Internal server error"
 //	@Security		bearerauth
 //	@Router			/v1/spaces/{space_id}/objects/{object_id} [get]
 func GetObjectHandler(s *service.Service) gin.HandlerFunc {
@@ -79,7 +81,9 @@ func GetObjectHandler(s *service.Service) gin.HandlerFunc {
 		objectId := c.Param("object_id")
 		// format := c.Query("format") // TODO: implement multiple formats
 
-		object, err := s.GetObject(c.Request.Context(), spaceId, objectId)
+		q := strings.TrimSpace(c.Query("block_link_candidates"))
+		withCandidates := q == "1" || strings.EqualFold(q, "true")
+		object, err := s.GetObject(c.Request.Context(), spaceId, objectId, withCandidates)
 		code := util.MapErrorCode(err,
 			util.ErrToCode(service.ErrObjectNotFound, http.StatusNotFound),
 			util.ErrToCode(service.ErrObjectDeleted, http.StatusGone),

--- a/core/api/model/block_object_link.go
+++ b/core/api/model/block_object_link.go
@@ -1,0 +1,30 @@
+package apimodel
+
+// SetBlockObjectLinkRequest sets or updates an object link on a block (UI-equivalent: link block / text→link).
+type SetBlockObjectLinkRequest struct {
+	TargetObjectId string `json:"target_object_id" binding:"required" example:"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ"`
+	// LinkStyle embed layout: page (default for new from text), dataview, dashboard, archive. Omit to keep existing on link blocks or use page for new text→link.
+	LinkStyle string `json:"link_style,omitempty" example:"dashboard"`
+	// CardStyle presentation: text, card (default for new from text), inline. Omit to keep existing on link blocks or use card for new text→link.
+	CardStyle string `json:"card_style,omitempty" example:"card"`
+	// SyncLinkPresentationFromBlockId, if set, must be the id of another link block on the same page. IconSize, Description, Relations, Fields and (unless link_style / card_style are set) Style and CardStyle are copied from that block so the result matches a manually tuned card (e.g. description snippet + type). target_object_id is always taken from this request.
+	SyncLinkPresentationFromBlockId string `json:"sync_link_presentation_from_block_id,omitempty" example:"69e29106f6ec12739aaf32e6"`
+	// BackgroundColor sets the block highlight (palette keys only: grey, yellow, orange, red, pink, purple, blue, ice, teal, lime — same as tags; UI «Зелёный» = lime, not "green"). Pointer: null/absent = unchanged, "" = clear.
+	BackgroundColor *string `json:"background_color,omitempty" extensions:"nullable" example:"lime"`
+	// IconSize: none, small, medium. Omit to keep existing.
+	IconSize string `json:"icon_size,omitempty" example:"medium"`
+	// LinkDescription: none, added, content. Omit to keep existing.
+	LinkDescription string `json:"link_description,omitempty" example:"content"`
+	// Relations lists relation keys to show on the card (e.g. "github_stars", "tag"). Omit to keep existing.
+	Relations []string `json:"relations,omitempty" example:"[\"github_stars\",\"tag\"]"`
+}
+
+// SetBlockObjectLinkResponse returns the block id after replace (may differ from the request path id).
+type SetBlockObjectLinkResponse struct {
+	Object   string `json:"object" example:"block_object_link"`
+	BlockId  string `json:"block_id"`
+	ObjectId string `json:"object_id"`
+	SpaceId  string `json:"space_id"`
+	TargetId string `json:"target_object_id"`
+	Replaced bool   `json:"replaced"` // false when target was already set (idempotent)
+}

--- a/core/api/model/object.go
+++ b/core/api/model/object.go
@@ -58,6 +58,8 @@ type UpdateObjectRequest struct {
 	TypeKey    *string                  `json:"type_key" example:"page"`                                                                                                                                                                                                                                                                  // The key of the type of object to set
 	Properties *[]PropertyLinkWithValue `json:"properties" oneOf:"TextPropertyLinkValue,NumberPropertyLinkValue,SelectPropertyLinkValue,MultiSelectPropertyLinkValue,DatePropertyLinkValue,FilesPropertyLinkValue,CheckboxPropertyLinkValue,UrlPropertyLinkValue,EmailPropertyLinkValue,PhonePropertyLinkValue,ObjectsPropertyLinkValue"` // The properties to set for the object; see ListTypes or GetType endpoints for linked properties
 	Markdown   *string                  `json:"markdown" example:"This is the updated body of the object. Markdown syntax is supported here."`                                                                                                                                                                                            // The updated body of the object
+	// MarkdownAppend appends markdown as new blocks at the end without removing existing content (cannot be combined with markdown).
+	MarkdownAppend *string `json:"markdown_append,omitempty" example:"Paragraph added via API; use GET ?block_link_candidates=1 for block ids, then POST …/link."`
 }
 
 type ObjectResponse struct {
@@ -87,8 +89,28 @@ type ObjectWithBody struct {
 	Snippet    string              `json:"snippet" example:"The beginning of the object body..."`                                                                                                                                                                                        // The snippet of the object, especially important for notes as they don't have a name
 	Layout     ObjectLayout        `json:"layout" example:"basic"`                                                                                                                                                                                                                       // The layout of the object
 	Type       *Type               `json:"type" extensions:"nullable"`                                                                                                                                                                                                                   // The type of the object, or null if the type has been deleted.
-	Properties []PropertyWithValue `json:"properties" oneOf:"TextPropertyValue,NumberPropertyValue,SelectPropertyValue,MultiSelectPropertyValue,DatePropertyValue,FilesPropertyValue,CheckboxPropertyValue,UrlPropertyValue,EmailPropertyValue,PhonePropertyValue,ObjectsPropertyValue"` // The properties of the object
+	Properties []PropertyWithValue `json:"properties" oneOf:"TextPropertyValue,NumberPropertyValue,SelectPropertyValue,MultiPropertyValue,DatePropertyValue,FilesPropertyValue,CheckboxPropertyValue,UrlPropertyValue,EmailPropertyValue,PhonePropertyValue,ObjectsPropertyValue"` // The properties of the object
 	Markdown   string              `json:"markdown" example:"# This is the title\n..."`                                                                                                                                                                                                  // The markdown body of the object
+	// BlockLinkCandidates is set only when GET object is called with ?block_link_candidates=1 (then non-nil, maybe empty).
+	BlockLinkCandidates *[]BlockLinkCandidate `json:"block_link_candidates,omitempty"`
+}
+
+// BlockLinkCandidate describes a block that can be passed to POST …/blocks/{block_id}/link (text or existing link).
+type BlockLinkCandidate struct {
+	Object         string `json:"object" example:"block_link_candidate"`
+	Id             string `json:"id" example:"64394517de52ad5acb89c66c"`
+	Kind           string `json:"kind" enums:"text,link" example:"text"` // "text" or "link"
+	TextPreview    string `json:"text_preview,omitempty" example:"First words of the text block…"`
+	TargetObjectId string `json:"target_object_id,omitempty" example:"bafyreie6n5l5nkbjal37su54cha4coy7qzuhrnajluzv5qd5jvtsrxkequ"`
+	// LinkStyle / CardStyle are set for kind "link" only (current block presentation; pass to POST …/link as link_style / card_style).
+	LinkStyle string `json:"link_style,omitempty" example:"page"`
+	CardStyle string `json:"card_style,omitempty" example:"card"`
+	// IconSize / LinkDescription / Relations reflect link block details (for rich cards; use sync_link_presentation_from_block_id to copy from another link).
+	IconSize        string   `json:"icon_size,omitempty" example:"medium"`
+	LinkDescription string   `json:"link_description,omitempty" example:"content"`
+	Relations       []string `json:"relations,omitempty"`
+	// BackgroundColor is the block highlight (grey, yellow, orange, red, pink, purple, blue, ice, teal, lime — not "green").
+	BackgroundColor string `json:"background_color,omitempty" example:"lime"`
 }
 
 // ! Deprecated schemas, until json blocks properly implemented

--- a/core/api/server/router.go
+++ b/core/api/server/router.go
@@ -43,6 +43,7 @@ func (srv *Server) NewRouter(mw apicore.ClientCommands, eventService apicore.Eve
 	srv.registerObjectRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerPropertyRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerSearchRoutes(v1, eventService)
+	srv.registerBlockRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerSpaceRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerTagRoutes(v1, eventService, writeRateLimitMW)
 	srv.registerTemplateRoutes(v1, eventService)
@@ -397,5 +398,19 @@ func (srv *Server) registerTypeRoutes(v1 *gin.RouterGroup, eventService apicore.
 		writeRateLimitMW,
 		ensureAnalyticsEvent("DeleteType", eventService),
 		handler.DeleteTypeHandler(srv.service),
+	)
+}
+
+// registerBlockRoutes registers block-related routes
+func (srv *Server) registerBlockRoutes(v1 *gin.RouterGroup, eventService apicore.EventService, writeRateLimitMW gin.HandlerFunc) {
+	v1.POST("/spaces/:space_id/objects/:object_id/blocks/:block_id/link",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("SetBlockObjectLink", eventService),
+		handler.SetBlockObjectLinkHandler(srv.service),
+	)
+	v1.DELETE("/spaces/:space_id/objects/:object_id/blocks/:block_id/link",
+		writeRateLimitMW,
+		ensureAnalyticsEvent("DeleteBlockObjectLink", eventService),
+		handler.DeleteBlockObjectLinkHandler(srv.service),
 	)
 }

--- a/core/api/service/block_object_link.go
+++ b/core/api/service/block_object_link.go
@@ -1,0 +1,488 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/util/constant"
+	"github.com/anyproto/anytype-heart/util/pbtypes"
+
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/core/api/util"
+)
+
+var allowedBlockBackgroundColors = map[string]struct{}{
+	string(constant.ColorGrey):   {},
+	string(constant.ColorYellow): {},
+	string(constant.ColorOrange): {},
+	string(constant.ColorRed):    {},
+	string(constant.ColorPink):   {},
+	string(constant.ColorPurple): {},
+	string(constant.ColorBlue):   {},
+	string(constant.ColorIce):   {},
+	string(constant.ColorTeal):  {},
+	string(constant.ColorLime):  {},
+}
+
+// parseBlockHighlightColor returns a normalized palette key or error. Empty input means clear highlight.
+func parseBlockHighlightColor(s string) (string, error) {
+	v := strings.TrimSpace(strings.ToLower(s))
+	if v == "" {
+		return "", nil
+	}
+	if _, ok := allowedBlockBackgroundColors[v]; !ok {
+		return "", util.ErrBadInput(fmt.Sprintf(
+			`invalid background_color %q: use grey, yellow, orange, red, pink, purple, blue, ice, teal, lime (UI "green" / Зелёный = lime, not "green")`,
+			s,
+		))
+	}
+	return v, nil
+}
+
+var (
+	ErrBlockNotFound           = errors.New("block not found in object")
+	ErrBlockReplaceFailed      = errors.New("block replace failed")
+	ErrBlockDeleteFailed       = errors.New("block delete failed")
+	ErrRequiredBlock           = errors.New("cannot replace a required system block")
+	ErrUnsupportedBlockForLink = errors.New("block content does not support object link (allowed: text, link)")
+	ErrNotLinkBlock            = errors.New("block is not a link block")
+	ErrTargetMismatch          = errors.New("link target does not match requested target_object_id")
+)
+
+func findBlockInView(ov *model.ObjectView, blockId string) *model.Block {
+	if ov == nil {
+		return nil
+	}
+	for _, b := range ov.Blocks {
+		if b != nil && b.Id == blockId {
+			return b
+		}
+	}
+	return nil
+}
+
+func objectShowOrErr(s *Service, ctx context.Context, spaceId, objectId string) (*model.ObjectView, error) {
+	resp := s.mw.ObjectShow(ctx, &pb.RpcObjectShowRequest{
+		SpaceId:  spaceId,
+		ObjectId: objectId,
+	})
+	if resp.Error == nil || resp.Error.Code == pb.RpcObjectShowResponseError_NULL {
+		if resp.ObjectView == nil {
+			return nil, ErrObjectNotFound
+		}
+		return resp.ObjectView, nil
+	}
+	switch resp.Error.Code {
+	case pb.RpcObjectShowResponseError_NOT_FOUND:
+		return nil, ErrObjectNotFound
+	case pb.RpcObjectShowResponseError_OBJECT_DELETED:
+		return nil, ErrObjectDeleted
+	default:
+		return nil, ErrFailedRetrieveObject
+	}
+}
+
+func parseLinkStyle(s string) (model.BlockContentLinkStyle, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return model.BlockContentLink_Page, nil
+	}
+	switch s {
+	case "page":
+		return model.BlockContentLink_Page, nil
+	case "dataview":
+		return model.BlockContentLink_Dataview, nil
+	case "dashboard":
+		return model.BlockContentLink_Dashboard, nil
+	case "archive":
+		return model.BlockContentLink_Archive, nil
+	default:
+		return 0, util.ErrBadInput(fmt.Sprintf("invalid link_style %q (use page, dataview, dashboard, archive)", s))
+	}
+}
+
+func linkStyleToAPIString(st model.BlockContentLinkStyle) string {
+	switch st {
+	case model.BlockContentLink_Page:
+		return "page"
+	case model.BlockContentLink_Dataview:
+		return "dataview"
+	case model.BlockContentLink_Dashboard:
+		return "dashboard"
+	case model.BlockContentLink_Archive:
+		return "archive"
+	default:
+		return ""
+	}
+}
+
+func cardStyleToAPIString(cs model.BlockContentLinkCardStyle) string {
+	switch cs {
+	case model.BlockContentLink_Text:
+		return "text"
+	case model.BlockContentLink_Card:
+		return "card"
+	case model.BlockContentLink_Inline:
+		return "inline"
+	default:
+		return ""
+	}
+}
+
+func iconSizeToAPIString(sz model.BlockContentLinkIconSize) string {
+	switch sz {
+	case model.BlockContentLink_SizeNone:
+		return "none"
+	case model.BlockContentLink_SizeSmall:
+		return "small"
+	case model.BlockContentLink_SizeMedium:
+		return "medium"
+	default:
+		return ""
+	}
+}
+
+func linkDescriptionToAPIString(d model.BlockContentLinkDescription) string {
+	switch d {
+	case model.BlockContentLink_None:
+		return "none"
+	case model.BlockContentLink_Added:
+		return "added"
+	case model.BlockContentLink_Content:
+		return "content"
+	default:
+		return ""
+	}
+}
+
+func parseCardStyle(s string) (model.BlockContentLinkCardStyle, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return model.BlockContentLink_Card, nil
+	}
+	switch s {
+	case "text":
+		return model.BlockContentLink_Text, nil
+	case "card":
+		return model.BlockContentLink_Card, nil
+	case "inline":
+		return model.BlockContentLink_Inline, nil
+	default:
+		return 0, util.ErrBadInput(fmt.Sprintf("invalid card_style %q (use text, card, inline)", s))
+	}
+}
+
+func parseIconSize(s string) (model.BlockContentLinkIconSize, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return model.BlockContentLink_SizeNone, nil
+	}
+	switch s {
+	case "none":
+		return model.BlockContentLink_SizeNone, nil
+	case "small":
+		return model.BlockContentLink_SizeSmall, nil
+	case "medium":
+		return model.BlockContentLink_SizeMedium, nil
+	default:
+		return 0, util.ErrBadInput(fmt.Sprintf("invalid icon_size %q (use none, small, medium)", s))
+	}
+}
+
+func parseLinkDescription(s string) (model.BlockContentLinkDescription, error) {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return model.BlockContentLink_None, nil
+	}
+	switch s {
+	case "none":
+		return model.BlockContentLink_None, nil
+	case "added":
+		return model.BlockContentLink_Added, nil
+	case "content":
+		return model.BlockContentLink_Content, nil
+	default:
+		return 0, util.ErrBadInput(fmt.Sprintf("invalid link_description %q (use none, added, content)", s))
+	}
+}
+
+func linkPresentationEqual(a, b *model.BlockContentLink) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.TargetBlockId != b.TargetBlockId ||
+		a.Style != b.Style ||
+		a.CardStyle != b.CardStyle ||
+		a.IconSize != b.IconSize ||
+		a.Description != b.Description {
+		return false
+	}
+	if !slices.Equal(a.Relations, b.Relations) {
+		return false
+	}
+	return reflect.DeepEqual(a.Fields, b.Fields)
+}
+
+// blockLinkReplaceEqual is true when link payload and block-level chrome (highlight color) match.
+func blockLinkReplaceEqual(oldB, newB *model.Block) bool {
+	if oldB == nil || newB == nil {
+		return false
+	}
+	if oldB.BackgroundColor != newB.BackgroundColor {
+		return false
+	}
+	oldL, newL := oldB.GetLink(), newB.GetLink()
+	if oldL == nil || newL == nil {
+		return false
+	}
+	return linkPresentationEqual(oldL, newL)
+}
+
+// applySyncBlockChrome copies block-level styling used by the link card (e.g. background highlight).
+func applySyncBlockChrome(dst, ref *model.Block) {
+	if dst == nil || ref == nil {
+		return
+	}
+	raw := strings.TrimSpace(ref.BackgroundColor)
+	if raw == "" {
+		dst.BackgroundColor = ""
+		return
+	}
+	v, err := parseBlockHighlightColor(raw)
+	if err != nil {
+		dst.BackgroundColor = ""
+		return
+	}
+	dst.BackgroundColor = v
+}
+
+// applySyncLinkPresentation copies rich-card fields from ref onto dst (dst.TargetBlockId must already be set).
+func applySyncLinkPresentation(dst, ref *model.BlockContentLink, linkStyleReq, cardStyleReq string) error {
+	if dst == nil || ref == nil {
+		return errors.New("internal: nil link in applySyncLinkPresentation")
+	}
+	dst.IconSize = ref.IconSize
+	dst.Description = ref.Description
+	dst.Relations = slices.Clone(ref.Relations)
+	dst.Fields = pbtypes.CopyStruct(ref.Fields, true)
+	if strings.TrimSpace(linkStyleReq) != "" {
+		st, err := parseLinkStyle(linkStyleReq)
+		if err != nil {
+			return err
+		}
+		dst.Style = st
+	} else {
+		dst.Style = ref.Style
+	}
+	if strings.TrimSpace(cardStyleReq) != "" {
+		cs, err := parseCardStyle(cardStyleReq)
+		if err != nil {
+			return err
+		}
+		dst.CardStyle = cs
+	} else {
+		dst.CardStyle = ref.CardStyle
+	}
+	return nil
+}
+
+func buildLinkReplacementBlock(current *model.Block, targetObjectId, linkStyleReq, cardStyleReq string) (*model.Block, error) {
+	switch current.Content.(type) {
+	case *model.BlockContentOfText:
+		st, err := parseLinkStyle(linkStyleReq)
+		if err != nil {
+			return nil, err
+		}
+		cs, err := parseCardStyle(cardStyleReq)
+		if err != nil {
+			return nil, err
+		}
+		nb := pbtypes.CopyBlock(current)
+		nb.Id = ""
+		nb.ChildrenIds = nil
+		nb.Content = &model.BlockContentOfLink{
+			Link: &model.BlockContentLink{
+				TargetBlockId: targetObjectId,
+				Style:         st,
+				CardStyle:     cs,
+			},
+		}
+		return nb, nil
+	case *model.BlockContentOfLink:
+		nb := pbtypes.CopyBlock(current)
+		nb.Id = ""
+		nb.ChildrenIds = nil
+		link := nb.GetLink()
+		if link == nil {
+			return nil, fmt.Errorf("%w", ErrUnsupportedBlockForLink)
+		}
+		link.TargetBlockId = targetObjectId
+		if linkStyleReq != "" {
+			st, err := parseLinkStyle(linkStyleReq)
+			if err != nil {
+				return nil, err
+			}
+			link.Style = st
+		}
+		if cardStyleReq != "" {
+			cs, err := parseCardStyle(cardStyleReq)
+			if err != nil {
+				return nil, err
+			}
+			link.CardStyle = cs
+		} else if link.CardStyle == model.BlockContentLink_Text {
+			link.CardStyle = model.BlockContentLink_Card
+		}
+		return nb, nil
+	default:
+		return nil, fmt.Errorf("%w", ErrUnsupportedBlockForLink)
+	}
+}
+
+// SetBlockObjectLink turns a text block into a link block or updates a link block target, using BlockReplace (editor path).
+func (s *Service) SetBlockObjectLink(
+	ctx context.Context,
+	spaceId, objectId, blockId string,
+	req apimodel.SetBlockObjectLinkRequest,
+) (*apimodel.SetBlockObjectLinkResponse, error) {
+	targetObjectId := req.TargetObjectId
+	if state.IsRequiredBlockId(blockId) {
+		return nil, ErrRequiredBlock
+	}
+
+	srcView, err := objectShowOrErr(s, ctx, spaceId, objectId)
+	if err != nil {
+		return nil, err
+	}
+	cur := findBlockInView(srcView, blockId)
+	if cur == nil {
+		return nil, ErrBlockNotFound
+	}
+
+	_, err = objectShowOrErr(s, ctx, spaceId, targetObjectId)
+	if err != nil {
+		return nil, err
+	}
+
+	replacement, err := buildLinkReplacementBlock(cur, targetObjectId, req.LinkStyle, req.CardStyle)
+	if err != nil {
+		return nil, err
+	}
+	if sid := strings.TrimSpace(req.SyncLinkPresentationFromBlockId); sid != "" {
+		ref := findBlockInView(srcView, sid)
+		if ref == nil || ref.GetLink() == nil {
+			return nil, util.ErrBadInput("sync_link_presentation_from_block_id must be a link block id on the same page")
+		}
+		if err := applySyncLinkPresentation(replacement.GetLink(), ref.GetLink(), req.LinkStyle, req.CardStyle); err != nil {
+			return nil, err
+		}
+		applySyncBlockChrome(replacement, ref)
+	}
+	if req.BackgroundColor != nil {
+		raw := strings.TrimSpace(*req.BackgroundColor)
+		if raw == "" {
+			replacement.BackgroundColor = ""
+		} else {
+			v, err := parseBlockHighlightColor(raw)
+			if err != nil {
+				return nil, err
+			}
+			replacement.BackgroundColor = v
+		}
+	}
+	if s := strings.TrimSpace(req.IconSize); s != "" {
+		v, err := parseIconSize(s)
+		if err != nil {
+			return nil, err
+		}
+		replacement.GetLink().IconSize = v
+	}
+	if s := strings.TrimSpace(req.LinkDescription); s != "" {
+		v, err := parseLinkDescription(s)
+		if err != nil {
+			return nil, err
+		}
+		replacement.GetLink().Description = v
+	}
+	if req.Relations != nil {
+		replacement.GetLink().Relations = slices.Clone(req.Relations)
+	}
+	if cur.GetLink() != nil {
+		if blockLinkReplaceEqual(cur, replacement) {
+			return &apimodel.SetBlockObjectLinkResponse{
+				Object:   "block_object_link",
+				BlockId:  blockId,
+				ObjectId: objectId,
+				SpaceId:  spaceId,
+				TargetId: targetObjectId,
+				Replaced: false,
+			}, nil
+		}
+	}
+
+	rep := s.mw.BlockReplace(ctx, &pb.RpcBlockReplaceRequest{
+		ContextId: objectId,
+		BlockId:   blockId,
+		Block:     replacement,
+	})
+	if rep.Error == nil || rep.Error.Code == pb.RpcBlockReplaceResponseError_NULL {
+		outId := rep.BlockId
+		if outId == "" {
+			outId = blockId
+		}
+		return &apimodel.SetBlockObjectLinkResponse{
+			Object:   "block_object_link",
+			BlockId:  outId,
+			ObjectId: objectId,
+			SpaceId:  spaceId,
+			TargetId: targetObjectId,
+			Replaced: true,
+		}, nil
+	}
+	if rep.Error != nil && rep.Error.Code == pb.RpcBlockReplaceResponseError_BAD_INPUT {
+		return nil, fmt.Errorf("%w: %s", ErrBlockReplaceFailed, rep.Error.Description)
+	}
+	return nil, ErrBlockReplaceFailed
+}
+
+// DeleteBlockObjectLink removes a link block (optional target_object_id must match when set).
+func (s *Service) DeleteBlockObjectLink(ctx context.Context, spaceId, objectId, blockId, optionalTargetId string) error {
+	if state.IsRequiredBlockId(blockId) {
+		return ErrRequiredBlock
+	}
+
+	srcView, err := objectShowOrErr(s, ctx, spaceId, objectId)
+	if err != nil {
+		return err
+	}
+	cur := findBlockInView(srcView, blockId)
+	if cur == nil {
+		return ErrBlockNotFound
+	}
+	link := cur.GetLink()
+	if link == nil {
+		return ErrNotLinkBlock
+	}
+	if optionalTargetId != "" && link.TargetBlockId != optionalTargetId {
+		return ErrTargetMismatch
+	}
+
+	del := s.mw.BlockListDelete(ctx, &pb.RpcBlockListDeleteRequest{
+		ContextId: objectId,
+		BlockIds:  []string{blockId},
+	})
+	if del.Error == nil || del.Error.Code == pb.RpcBlockListDeleteResponseError_NULL {
+		return nil
+	}
+	if del.Error != nil && del.Error.Code == pb.RpcBlockListDeleteResponseError_BAD_INPUT {
+		return fmt.Errorf("%w: %s", ErrBlockDeleteFailed, del.Error.Description)
+	}
+	return ErrBlockDeleteFailed
+}

--- a/core/api/service/block_object_link_test.go
+++ b/core/api/service/block_object_link_test.go
@@ -1,0 +1,335 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/api/core/mock_apicore"
+	apimodel "github.com/anyproto/anytype-heart/core/api/model"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func TestSetBlockObjectLink_Idempotent(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	spaceId := "space1"
+	srcId := "srcObj"
+	tgtId := "tgtObj"
+	blockId := "blk1"
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: srcId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id: blockId,
+				Content: &model.BlockContentOfLink{
+					Link: &model.BlockContentLink{
+						TargetBlockId: tgtId,
+						Style:         model.BlockContentLink_Page,
+						CardStyle:     model.BlockContentLink_Card,
+					},
+				},
+			}},
+		},
+	}).Once()
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: tgtId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: tgtId}}},
+	}).Once()
+
+	out, err := s.SetBlockObjectLink(context.Background(), spaceId, srcId, blockId, apimodel.SetBlockObjectLinkRequest{TargetObjectId: tgtId})
+	require.NoError(t, err)
+	assert.False(t, out.Replaced)
+	assert.Equal(t, blockId, out.BlockId)
+}
+
+func TestSetBlockObjectLink_TextToLink(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	spaceId := "space1"
+	srcId := "srcObj"
+	tgtId := "tgtObj"
+	blockId := "blk1"
+	newId := "blkNew"
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: srcId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id:      blockId,
+				Content: &model.BlockContentOfText{Text: &model.BlockContentText{}},
+			}},
+		},
+	}).Once()
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: tgtId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: tgtId}}},
+	}).Once()
+
+	mw.EXPECT().BlockReplace(context.Background(), mock.MatchedBy(func(req *pb.RpcBlockReplaceRequest) bool {
+		l := req.Block.GetLink()
+		return req.ContextId == srcId && req.BlockId == blockId &&
+			l != nil && l.TargetBlockId == tgtId && l.CardStyle == model.BlockContentLink_Card
+	})).Return(&pb.RpcBlockReplaceResponse{
+		BlockId: newId,
+		Error:   &pb.RpcBlockReplaceResponseError{Code: pb.RpcBlockReplaceResponseError_NULL},
+	}).Once()
+
+	out, err := s.SetBlockObjectLink(context.Background(), spaceId, srcId, blockId, apimodel.SetBlockObjectLinkRequest{TargetObjectId: tgtId})
+	require.NoError(t, err)
+	assert.True(t, out.Replaced)
+	assert.Equal(t, newId, out.BlockId)
+}
+
+func TestDeleteBlockObjectLink_TargetMismatch(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	mw.EXPECT().ObjectShow(context.Background(), mock.Anything).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id:      "b1",
+				Content: &model.BlockContentOfLink{Link: &model.BlockContentLink{TargetBlockId: "other"}},
+			}},
+		},
+	}).Once()
+
+	err := s.DeleteBlockObjectLink(context.Background(), "s", "o", "b1", "wanted")
+	require.ErrorIs(t, err, ErrTargetMismatch)
+}
+
+func TestSetBlockObjectLink_SameTargetUpgradesCardStyle(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	spaceId := "space1"
+	srcId := "srcObj"
+	tgtId := "tgtObj"
+	blockId := "blk1"
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: srcId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id: blockId,
+				Content: &model.BlockContentOfLink{
+					Link: &model.BlockContentLink{
+						TargetBlockId: tgtId,
+						Style:         model.BlockContentLink_Page,
+						CardStyle:     model.BlockContentLink_Text,
+					},
+				},
+			}},
+		},
+	}).Once()
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: tgtId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: tgtId}}},
+	}).Once()
+
+	mw.EXPECT().BlockReplace(context.Background(), mock.MatchedBy(func(req *pb.RpcBlockReplaceRequest) bool {
+		l := req.Block.GetLink()
+		return req.ContextId == srcId && req.BlockId == blockId &&
+			l != nil && l.TargetBlockId == tgtId && l.CardStyle == model.BlockContentLink_Card
+	})).Return(&pb.RpcBlockReplaceResponse{
+		BlockId: blockId,
+		Error:   &pb.RpcBlockReplaceResponseError{Code: pb.RpcBlockReplaceResponseError_NULL},
+	}).Once()
+
+	out, err := s.SetBlockObjectLink(context.Background(), spaceId, srcId, blockId, apimodel.SetBlockObjectLinkRequest{TargetObjectId: tgtId})
+	require.NoError(t, err)
+	assert.True(t, out.Replaced)
+	assert.Equal(t, blockId, out.BlockId)
+}
+
+func TestSetBlockObjectLink_TextToLinkDashboardStyle(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	spaceId := "space1"
+	srcId := "srcObj"
+	tgtId := "tgtObj"
+	blockId := "blk1"
+	newId := "blkNew"
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: srcId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id:      blockId,
+				Content: &model.BlockContentOfText{Text: &model.BlockContentText{}},
+			}},
+		},
+	}).Once()
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: tgtId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: tgtId}}},
+	}).Once()
+
+	mw.EXPECT().BlockReplace(context.Background(), mock.MatchedBy(func(req *pb.RpcBlockReplaceRequest) bool {
+		l := req.Block.GetLink()
+		return req.ContextId == srcId && req.BlockId == blockId &&
+			l != nil && l.TargetBlockId == tgtId &&
+			l.Style == model.BlockContentLink_Dashboard &&
+			l.CardStyle == model.BlockContentLink_Card
+	})).Return(&pb.RpcBlockReplaceResponse{
+		BlockId: newId,
+		Error:   &pb.RpcBlockReplaceResponseError{Code: pb.RpcBlockReplaceResponseError_NULL},
+	}).Once()
+
+	out, err := s.SetBlockObjectLink(context.Background(), spaceId, srcId, blockId, apimodel.SetBlockObjectLinkRequest{
+		TargetObjectId: tgtId,
+		LinkStyle:      "dashboard",
+		CardStyle:      "card",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Replaced)
+	assert.Equal(t, newId, out.BlockId)
+}
+
+func TestSetBlockObjectLink_SyncPresentationFromReferenceBlock(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	spaceId := "space1"
+	pageId := "pageObj"
+	tgtDemucs := "tgtDemucs"
+	blockDemucs := "blkDemucs"
+	blockRefCard := "blkRefCard"
+	newId := "blkNew"
+
+	refLink := &model.BlockContentLink{
+		TargetBlockId: "otherRepo",
+		Style:         model.BlockContentLink_Page,
+		CardStyle:     model.BlockContentLink_Card,
+		IconSize:      model.BlockContentLink_SizeMedium,
+		Description:   model.BlockContentLink_Content,
+		Relations:     []string{"rel1", "rel2"},
+	}
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: pageId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{
+				{
+					Id: blockDemucs,
+					Content: &model.BlockContentOfLink{
+						Link: &model.BlockContentLink{
+							TargetBlockId: tgtDemucs,
+							Style:         model.BlockContentLink_Page,
+							CardStyle:     model.BlockContentLink_Text,
+							Description:   model.BlockContentLink_None,
+						},
+					},
+				},
+				{
+					Id:                blockRefCard,
+					BackgroundColor:   "yellow",
+					Content:           &model.BlockContentOfLink{Link: refLink},
+				},
+			},
+		},
+	}).Once()
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: tgtDemucs}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: tgtDemucs}}},
+	}).Once()
+
+	mw.EXPECT().BlockReplace(context.Background(), mock.MatchedBy(func(req *pb.RpcBlockReplaceRequest) bool {
+		l := req.Block.GetLink()
+		if req.ContextId != pageId || req.BlockId != blockDemucs || l == nil {
+			return false
+		}
+		return req.Block.BackgroundColor == "yellow" &&
+			l.TargetBlockId == tgtDemucs &&
+			l.Style == refLink.Style &&
+			l.CardStyle == refLink.CardStyle &&
+			l.IconSize == refLink.IconSize &&
+			l.Description == refLink.Description &&
+			len(l.Relations) == 2 && l.Relations[0] == "rel1" && l.Relations[1] == "rel2"
+	})).Return(&pb.RpcBlockReplaceResponse{
+		BlockId: newId,
+		Error:   &pb.RpcBlockReplaceResponseError{Code: pb.RpcBlockReplaceResponseError_NULL},
+	}).Once()
+
+	out, err := s.SetBlockObjectLink(context.Background(), spaceId, pageId, blockDemucs, apimodel.SetBlockObjectLinkRequest{
+		TargetObjectId:                  tgtDemucs,
+		SyncLinkPresentationFromBlockId: blockRefCard,
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Replaced)
+	assert.Equal(t, newId, out.BlockId)
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestSetBlockObjectLink_BackgroundColorOverride(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	spaceId := "space1"
+	pageId := "pageObj"
+	tgt := "tgtObj"
+	blockId := "blk1"
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: pageId}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id: blockId,
+				Content: &model.BlockContentOfLink{
+					Link: &model.BlockContentLink{
+						TargetBlockId: tgt,
+						Style:         model.BlockContentLink_Page,
+						CardStyle:     model.BlockContentLink_Card,
+					},
+				},
+			}},
+		},
+	}).Once()
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: spaceId, ObjectId: tgt}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: tgt}}},
+	}).Once()
+
+	mw.EXPECT().BlockReplace(context.Background(), mock.MatchedBy(func(req *pb.RpcBlockReplaceRequest) bool {
+		return req.Block.BackgroundColor == "red" &&
+			req.Block.GetLink() != nil && req.Block.GetLink().TargetBlockId == tgt
+	})).Return(&pb.RpcBlockReplaceResponse{
+		BlockId: blockId,
+		Error:   &pb.RpcBlockReplaceResponseError{Code: pb.RpcBlockReplaceResponseError_NULL},
+	}).Once()
+
+	out, err := s.SetBlockObjectLink(context.Background(), spaceId, pageId, blockId, apimodel.SetBlockObjectLinkRequest{
+		TargetObjectId:  tgt,
+		BackgroundColor: strPtr("red"),
+	})
+	require.NoError(t, err)
+	assert.True(t, out.Replaced)
+}
+
+func TestSetBlockObjectLink_InvalidBackgroundColorRejected(t *testing.T) {
+	mw := mock_apicore.NewMockClientCommands(t)
+	s := &Service{mw: mw}
+
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: "s", ObjectId: "page"}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{
+			Blocks: []*model.Block{{
+				Id: "b1",
+				Content: &model.BlockContentOfLink{
+					Link: &model.BlockContentLink{TargetBlockId: "t1", Style: model.BlockContentLink_Page, CardStyle: model.BlockContentLink_Card},
+				},
+			}},
+		},
+	}).Once()
+	mw.EXPECT().ObjectShow(context.Background(), &pb.RpcObjectShowRequest{SpaceId: "s", ObjectId: "t1"}).Return(&pb.RpcObjectShowResponse{
+		ObjectView: &model.ObjectView{Blocks: []*model.Block{{Id: "t1"}}},
+	}).Once()
+
+	_, err := s.SetBlockObjectLink(context.Background(), "s", "page", "b1", apimodel.SetBlockObjectLinkRequest{
+		TargetObjectId:  "t1",
+		BackgroundColor: strPtr("green"),
+	})
+	require.Error(t, err)
+}

--- a/core/api/service/object.go
+++ b/core/api/service/object.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/gogo/protobuf/types"
 
@@ -11,6 +13,7 @@ import (
 
 	apimodel "github.com/anyproto/anytype-heart/core/api/model"
 	"github.com/anyproto/anytype-heart/core/api/util"
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
 	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
@@ -84,7 +87,8 @@ func (s *Service) ListObjects(ctx context.Context, spaceId string, additionalFil
 }
 
 // GetObject retrieves a single object by its ID in a specific space.
-func (s *Service) GetObject(ctx context.Context, spaceId string, objectId string) (*apimodel.ObjectWithBody, error) {
+// When includeBlockLinkCandidates is true, BlockLinkCandidates lists text and link blocks (for POST …/blocks/{id}/link).
+func (s *Service) GetObject(ctx context.Context, spaceId string, objectId string, includeBlockLinkCandidates bool) (*apimodel.ObjectWithBody, error) {
 	resp := s.mw.ObjectShow(ctx, &pb.RpcObjectShowRequest{
 		SpaceId:  spaceId,
 		ObjectId: objectId,
@@ -110,7 +114,12 @@ func (s *Service) GetObject(ctx context.Context, spaceId string, objectId string
 		return nil, err
 	}
 
-	return s.getObjectWithBlocksFromStruct(resp.ObjectView.Details[0].Details, markdown), nil
+	obj := s.getObjectWithBlocksFromStruct(resp.ObjectView.Details[0].Details, markdown)
+	if includeBlockLinkCandidates {
+		c := buildBlockLinkCandidates(resp.ObjectView)
+		obj.BlockLinkCandidates = &c
+	}
+	return obj, nil
 }
 
 // CreateObject creates a new object in a specific space.
@@ -156,7 +165,7 @@ func (s *Service) CreateObject(ctx context.Context, spaceId string, request apim
 		})
 
 		if relAddFeatResp.Error.Code != pb.RpcObjectRelationAddFeaturedResponseError_NULL {
-			object, _ := s.GetObject(ctx, spaceId, objectId) // nolint:errcheck
+			object, _ := s.GetObject(ctx, spaceId, objectId, false) // nolint:errcheck
 			return object, ErrFailedSetPropertyFeatured
 		}
 	}
@@ -164,17 +173,21 @@ func (s *Service) CreateObject(ctx context.Context, spaceId string, request apim
 	// First call BlockCreate at top, then BlockPaste to paste the body
 	if request.Body != "" {
 		if err := s.createAndPasteBody(ctx, spaceId, objectId, request.Body); err != nil {
-			object, _ := s.GetObject(ctx, spaceId, objectId) // nolint:errcheck
+			object, _ := s.GetObject(ctx, spaceId, objectId, false) // nolint:errcheck
 			return object, err
 		}
 	}
 
-	return s.GetObject(ctx, spaceId, objectId)
+	return s.GetObject(ctx, spaceId, objectId, false)
 }
 
 // UpdateObject updates an existing object in a specific space.
 func (s *Service) UpdateObject(ctx context.Context, spaceId string, objectId string, request apimodel.UpdateObjectRequest) (*apimodel.ObjectWithBody, error) {
-	_, err := s.GetObject(ctx, spaceId, objectId)
+	if request.Markdown != nil && request.MarkdownAppend != nil {
+		return nil, util.ErrBadInput("cannot set both markdown and markdown_append")
+	}
+
+	_, err := s.GetObject(ctx, spaceId, objectId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -206,17 +219,27 @@ func (s *Service) UpdateObject(ctx context.Context, spaceId string, objectId str
 
 	if request.Markdown != nil {
 		if err := s.replaceObjectMarkdown(ctx, spaceId, objectId, *request.Markdown); err != nil {
-			object, _ := s.GetObject(ctx, spaceId, objectId) // nolint:errcheck
+			object, _ := s.GetObject(ctx, spaceId, objectId, false) // nolint:errcheck
 			return object, err
 		}
 	}
 
-	return s.GetObject(ctx, spaceId, objectId)
+	if request.MarkdownAppend != nil {
+		frag := strings.TrimSpace(*request.MarkdownAppend)
+		if frag != "" {
+			if err := s.createAndPasteBody(ctx, spaceId, objectId, frag); err != nil {
+				object, _ := s.GetObject(ctx, spaceId, objectId, false) // nolint:errcheck
+				return object, err
+			}
+		}
+	}
+
+	return s.GetObject(ctx, spaceId, objectId, false)
 }
 
 // DeleteObject deletes an existing object in a specific space.
 func (s *Service) DeleteObject(ctx context.Context, spaceId string, objectId string) (*apimodel.ObjectWithBody, error) {
-	object, err := s.GetObject(ctx, spaceId, objectId)
+	object, err := s.GetObject(ctx, spaceId, objectId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -524,4 +547,74 @@ func (s *Service) createAndPasteBody(ctx context.Context, spaceId string, object
 	}
 
 	return nil
+}
+
+const blockLinkPreviewMaxRunes = 160
+
+func blockLinkTextPreview(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= blockLinkPreviewMaxRunes {
+		return s
+	}
+	return string(runes[:blockLinkPreviewMaxRunes]) + "…"
+}
+
+// buildBlockLinkCandidates returns text and link blocks in document tree order (for POST …/blocks/{id}/link).
+func buildBlockLinkCandidates(ov *model.ObjectView) []apimodel.BlockLinkCandidate {
+	if ov == nil || len(ov.Blocks) == 0 {
+		return []apimodel.BlockLinkCandidate{}
+	}
+	byID := make(map[string]*model.Block, len(ov.Blocks))
+	for _, b := range ov.Blocks {
+		if b != nil {
+			byID[b.Id] = b
+		}
+	}
+	root := ov.Blocks[0]
+	var out []apimodel.BlockLinkCandidate
+	var walk func(*model.Block)
+	walk = func(b *model.Block) {
+		if b == nil {
+			return
+		}
+		if b.Id != root.Id && !state.IsRequiredBlockId(b.Id) {
+			switch c := b.Content.(type) {
+			case *model.BlockContentOfText:
+				preview := ""
+				if c.Text != nil {
+					preview = blockLinkTextPreview(c.Text.Text)
+				}
+				out = append(out, apimodel.BlockLinkCandidate{
+					Object:      "block_link_candidate",
+					Id:          b.Id,
+					Kind:        "text",
+					TextPreview: preview,
+				})
+			case *model.BlockContentOfLink:
+				if c.Link != nil {
+					out = append(out, apimodel.BlockLinkCandidate{
+						Object:            "block_link_candidate",
+						Id:                b.Id,
+						Kind:              "link",
+						TargetObjectId:    c.Link.TargetBlockId,
+						LinkStyle:         linkStyleToAPIString(c.Link.Style),
+						CardStyle:         cardStyleToAPIString(c.Link.CardStyle),
+						IconSize:          iconSizeToAPIString(c.Link.IconSize),
+						LinkDescription:   linkDescriptionToAPIString(c.Link.Description),
+						Relations:         slices.Clone(c.Link.Relations),
+						BackgroundColor:   b.BackgroundColor,
+					})
+				}
+			}
+		}
+		for _, cid := range b.ChildrenIds {
+			walk(byID[cid])
+		}
+	}
+	walk(root)
+	return out
 }

--- a/core/api/service/object_test.go
+++ b/core/api/service/object_test.go
@@ -48,11 +48,7 @@ func TestObjectService_ListObjects(t *testing.T) {
 				Type:        model.BlockContentDataviewSort_Desc,
 				IncludeTime: true,
 			}},
-			Offset:    int32(offset),
-			Limit:     int32(limit + 1),
-			NeedTotal: true,
 		}).Return(&pb.RpcObjectSearchResponse{
-			Total: 1,
 			Records: []*types.Struct{
 				{
 					Fields: map[string]*types.Value{
@@ -160,11 +156,7 @@ func TestObjectService_ListObjects(t *testing.T) {
 				Type:        model.BlockContentDataviewSort_Desc,
 				IncludeTime: true,
 			}},
-			Offset:    int32(offset),
-			Limit:     int32(limit + 1),
-			NeedTotal: true,
 		}).Return(&pb.RpcObjectSearchResponse{
-			Total:   0,
 			Records: []*types.Struct{},
 			Error:   &pb.RpcObjectSearchResponseError{Code: pb.RpcObjectSearchResponseError_NULL},
 		}).Once()
@@ -238,7 +230,7 @@ func TestObjectService_GetObject(t *testing.T) {
 		}, nil).Once()
 
 		// when
-		object, err := fx.service.GetObject(ctx, mockedSpaceId, mockedObjectId)
+		object, err := fx.service.GetObject(ctx, mockedSpaceId, mockedObjectId, false)
 
 		// then
 		require.NoError(t, err)
@@ -301,7 +293,7 @@ func TestObjectService_GetObject(t *testing.T) {
 			}, nil).Once()
 
 		// when
-		object, err := fx.service.GetObject(ctx, mockedSpaceId, "missing-obj")
+		object, err := fx.service.GetObject(ctx, mockedSpaceId, "missing-obj", false)
 
 		// then
 		require.ErrorIs(t, err, ErrObjectNotFound)
@@ -424,5 +416,61 @@ func TestObjectService_CreateObject(t *testing.T) {
 		// then
 		require.ErrorIs(t, err, ErrFailedCreateObject)
 		require.Empty(t, object)
+	})
+}
+
+func TestBuildBlockLinkCandidates(t *testing.T) {
+	t.Run("skips required blocks and collects text and link", func(t *testing.T) {
+		rootID := "rootId"
+		ov := &model.ObjectView{
+			Blocks: []*model.Block{
+				{
+					Id:          rootID,
+					ChildrenIds: []string{"header", "title", "t1", "l1"},
+				},
+				{
+					Id:          "header",
+					ChildrenIds: []string{},
+					Content:     &model.BlockContentOfText{Text: &model.BlockContentText{Text: "h"}},
+				},
+				{
+					Id:          "title",
+					ChildrenIds: []string{},
+					Content:     &model.BlockContentOfText{Text: &model.BlockContentText{Text: "title here"}},
+				},
+				{
+					Id:          "t1",
+					ChildrenIds: []string{},
+					Content:     &model.BlockContentOfText{Text: &model.BlockContentText{Text: "  paragraph  "}},
+				},
+				{
+					Id:          "l1",
+					ChildrenIds: []string{},
+					Content: &model.BlockContentOfLink{
+						Link: &model.BlockContentLink{
+							TargetBlockId: "targetObj",
+							Style:         model.BlockContentLink_Page,
+						},
+					},
+				},
+			},
+		}
+		got := buildBlockLinkCandidates(ov)
+		require.Len(t, got, 2)
+		require.Equal(t, "t1", got[0].Id)
+		require.Equal(t, "text", got[0].Kind)
+		require.Equal(t, "paragraph", got[0].TextPreview)
+		require.Equal(t, "l1", got[1].Id)
+		require.Equal(t, "link", got[1].Kind)
+		require.Equal(t, "targetObj", got[1].TargetObjectId)
+		require.Equal(t, "page", got[1].LinkStyle)
+		require.Equal(t, "text", got[1].CardStyle)
+		require.Equal(t, "none", got[1].IconSize)
+		require.Equal(t, "none", got[1].LinkDescription)
+		require.Empty(t, got[1].Relations)
+	})
+
+	t.Run("nil view", func(t *testing.T) {
+		require.Empty(t, buildBlockLinkCandidates(nil))
 	})
 }


### PR DESCRIPTION
## Summary

Add REST endpoints for managing object link blocks with full card presentation, matching desktop UI behavior. Links and backlinks now populate correctly when content is created via API.

## New endpoints

**POST /v1/spaces/{space_id}/objects/{object_id}/blocks/{block_id}/link** — Set or update an object link on a block. A text block becomes a link block (card layout); an existing link block gets updated target and presentation. Uses the same internal BlockReplace path as the editor — links/backlinks derive normally.

**DELETE /v1/spaces/{space_id}/objects/{object_id}/blocks/{block_id}/link** — Remove a link block. Supports optional ?target_object_id= query parameter for safety.

## New fields on PATCH …/objects

**markdown_append** — Append markdown as new blocks at the end without removing existing content. Mutually exclusive with markdown.

## New query parameter on GET …/objects

**?block_link_candidates=1** — Returns text and link block IDs with metadata (kind, text_preview, target_object_id, link_style, card_style, icon_size, link_description, relations, background_color) so clients can discover which blocks to operate on.

## POST …/link request fields

| Field | Values |
|---|---|
| target_object_id | (required) object to link to |
| link_style | page, dataview, dashboard, archive |
| card_style | text, card, inline |
| background_color | grey, yellow, orange, red, pink, purple, blue, ice, teal, lime |
| icon_size | none, small, medium |
| link_description | none, added, content |
| relations | array of relation keys to display on the card |
| sync_link_presentation_from_block_id | copy icon_size, description, relations, fields from another link block on the same page |

## Idempotency

When both link payload and block-level chrome (background_color) already match, the endpoint returns replaced: false and skips the BlockReplace call.

## Related

- Anytype desktop PR #2979 (markdown to mention marks) is complementary: this PR covers the programmatic/REST path while that PR covers the import/paste path
- Closes anyproto/anytype-mcp#105 (partial — covers block links and card presentation)

## Checklist

- [x] New tests for block_object_link service and object service additions
- [x] go build ./core/api/... and go vet ./core/api/... pass
- [ ] Generated OpenAPI docs need regeneration via make openapi (swaggo annotations are in place but docs.go, openapi.json, openapi.yaml are not updated in this PR)
