### PR TITLE
GO-7323 Exclude chat content from ObjectCleanupSuggestions

### DIFF
--- a/core/block/objectgc/orphanlist.go
+++ b/core/block/objectgc/orphanlist.go
@@ -2,6 +2,7 @@ package objectgc
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/anyproto/anytype-heart/core/domain"
@@ -39,16 +40,28 @@ const (
 	parentActive
 )
 
-// queryParentStates resolves existence + archived/deleted state for the given ids using QueryRaw,
-// which (unlike Query) applies no implicit isArchived/isDeleted filters. Ids not returned are absent.
-func (gc *objectGC) queryParentStates(idx spaceindex.Store, ids map[string]struct{}) (map[string]parentState, error) {
-	states := make(map[string]parentState, len(ids))
+// parentInfo is a candidate's createdInContext parent as the store knows it: its lifecycle state,
+// plus the layout needed to decide whether it can own GC-tracked children at all.
+//
+// layout is only meaningful when the parent is present with real details (parentActive /
+// parentArchived). DeleteObject replaces a deleted object's details with {id, spaceId, isDeleted},
+// so a tombstone carries no layout at all.
+type parentInfo struct {
+	state  parentState
+	layout model.ObjectTypeLayout
+}
+
+// queryParentInfo resolves existence, archived/deleted state and layout for the given ids using
+// QueryRaw, which (unlike Query) applies no implicit isArchived/isDeleted filters. Ids not returned
+// are absent.
+func (gc *objectGC) queryParentInfo(idx spaceindex.Store, ids map[string]struct{}) (map[string]parentInfo, error) {
+	infos := make(map[string]parentInfo, len(ids))
 	if len(ids) == 0 {
-		return states, nil
+		return infos, nil
 	}
 	values := make([]domain.Value, 0, len(ids))
 	for id := range ids {
-		states[id] = parentAbsent
+		infos[id] = parentInfo{state: parentAbsent}
 		values = append(values, domain.String(id))
 	}
 	records, err := idx.QueryRaw(&database.Filters{FilterObj: database.FilterIn{
@@ -56,20 +69,42 @@ func (gc *objectGC) queryParentStates(idx spaceindex.Store, ids map[string]struc
 		Value: values,
 	}}, 0, 0)
 	if err != nil {
-		return nil, fmt.Errorf("query parent states: %w", err)
+		return nil, fmt.Errorf("query parent info: %w", err)
 	}
 	for _, r := range records {
 		id := r.Details.GetString(bundle.RelationKeyId)
+		info := parentInfo{layout: model.ObjectTypeLayout(r.Details.GetInt64(bundle.RelationKeyResolvedLayout))}
 		switch {
 		case r.Details.GetBool(bundle.RelationKeyIsDeleted):
-			states[id] = parentDeleted
+			info.state = parentDeleted
 		case r.Details.GetBool(bundle.RelationKeyIsArchived):
-			states[id] = parentArchived
+			info.state = parentArchived
 		default:
-			states[id] = parentActive
+			info.state = parentActive
 		}
+		infos[id] = info
 	}
-	return states, nil
+	return infos, nil
+}
+
+// canOwnOrphans reports whether a live parent is the kind of object that can own GC-tracked
+// children. It mirrors the gate CheckObjectsOnObjectArchived already applies to the object it is
+// asked about: system and unsupported layouts cannot.
+//
+// This is what keeps chat content out of the orphan list. A chat attachment carries
+// createdInContext = the chat object and createdInContextRef = the message id, but it can never
+// acquire a backlink: chat messages live in anystore, chatobject contributes no outgoing links, and
+// the indexer only feeds smartblock links into the links table. Without this gate a live attachment
+// -- still visible in the chat -- looks exactly like an unlinked orphan and would be offered to the
+// user for removal.
+//
+// Only applied to parents whose details exist. A deleted parent has no layout (tombstone), and its
+// children are genuinely orphaned whatever it used to be, including a deleted chat's attachments.
+func canOwnOrphans(info parentInfo) bool {
+	if info.state != parentActive && info.state != parentArchived {
+		return true
+	}
+	return slices.Contains(domain.GCEligibleLayouts, info.layout)
 }
 
 // ListOrphans computes the space's orphan forest.
@@ -127,8 +162,9 @@ func (gc *objectGC) ListOrphans(spaceId string) ([]OrphanItem, error) {
 		isCandidate[id] = struct{}{}
 	}
 
-	// 2) Parent states, for the sync-gap guard and the per-root reason. Parents that are themselves
-	// candidates are active by construction and need no lookup.
+	// 2) Parent info, for the sync-gap guard, the parent-eligibility gate and the per-root reason.
+	// Parents that are themselves candidates need no lookup: they are active, and they passed the
+	// GC-eligible layout filter of the candidate query by construction.
 	toLookup := make(map[string]struct{})
 	for _, d := range candidates {
 		p := d.GetString(bundle.RelationKeyCreatedInContext)
@@ -136,19 +172,23 @@ func (gc *objectGC) ListOrphans(spaceId string) ([]OrphanItem, error) {
 			toLookup[p] = struct{}{}
 		}
 	}
-	parentStates, err := gc.queryParentStates(idx, toLookup)
+	parentInfos, err := gc.queryParentInfo(idx, toLookup)
 	if err != nil {
-		return nil, fmt.Errorf("resolve parent states: %w", err)
+		return nil, fmt.Errorf("resolve parent info: %w", err)
 	}
 
-	// Sync-gap guard: a parent absent from the store was never synced (deletion tombstones the row),
-	// so we must not recommend removing its children.
+	// Drop candidates whose parent cannot own orphans:
+	//   - absent from the store: never synced (deletion tombstones the row rather than removing it),
+	//     so we must not recommend removing its children;
+	//   - a live chat or system object: it can't own GC-tracked children, and its "children" (chat
+	//     attachments) have no backlinks by construction, so they would all look unlinked.
 	for id, d := range candidates {
 		p := d.GetString(bundle.RelationKeyCreatedInContext)
 		if _, ok := isCandidate[p]; ok {
 			continue
 		}
-		if parentStates[p] == parentAbsent {
+		info := parentInfos[p]
+		if info.state == parentAbsent || !canOwnOrphans(info) {
 			delete(candidates, id)
 		}
 	}
@@ -180,7 +220,7 @@ func (gc *objectGC) ListOrphans(spaceId string) ([]OrphanItem, error) {
 	if len(inS) == 0 {
 		return nil, nil
 	}
-	return gc.buildForest(candidates, inS, parentStates), nil
+	return gc.buildForest(candidates, inS, parentInfos), nil
 }
 
 // evictToFixedPoint returns the greatest subset of candidates whose active backlinks all fall
@@ -239,7 +279,7 @@ func (gc *objectGC) evictToFixedPoint(candidates map[string]*domain.Details, act
 
 // buildForest marks roots (parent outside S), resolves each root's reason, and handles
 // createdInContext cycles (a component with no parent-outside-S) by electing the lowest id as root.
-func (gc *objectGC) buildForest(candidates map[string]*domain.Details, inS map[string]struct{}, parentStates map[string]parentState) []OrphanItem {
+func (gc *objectGC) buildForest(candidates map[string]*domain.Details, inS map[string]struct{}, parentInfos map[string]parentInfo) []OrphanItem {
 	parentOf := func(id string) string {
 		return candidates[id].GetString(bundle.RelationKeyCreatedInContext)
 	}
@@ -320,7 +360,7 @@ func (gc *objectGC) buildForest(candidates map[string]*domain.Details, inS map[s
 			// Both mean: the context is alive but no longer references this object.
 			return OrphanReasonContextUnlinked
 		}
-		switch parentStates[p] {
+		switch parentInfos[p].state {
 		case parentArchived:
 			return OrphanReasonContextArchived
 		case parentDeleted:

--- a/core/block/objectgc/orphanlist_test.go
+++ b/core/block/objectgc/orphanlist_test.go
@@ -242,3 +242,108 @@ func TestListOrphans_Ignored_Excluded_AndDropsSubtree(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, items)
 }
+
+// -- parent eligibility --
+
+// tombstoneObject mimics a real deletion tombstone: DeleteObject replaces the details with
+// {id, spaceId, isDeleted} only, so resolvedLayout is gone.
+func tombstoneObject(id string) objectstore.TestObject {
+	return objectstore.TestObject{
+		bundle.RelationKeyId:        domain.String(id),
+		bundle.RelationKeyIsDeleted: domain.Bool(true),
+	}
+}
+
+func TestListOrphans_ChatParent_Excluded(t *testing.T) {
+	// A live chat attachment has exactly the store shape of an unlinked orphan: createdInContext is
+	// the chat object, createdInContextRef is the message id, and backlinks are empty forever —
+	// chat messages live in anystore, so they never enter the links table. The message is still on
+	// screen; the file must never be offered for removal.
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:             domain.String("chatObj"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_chatDerived)),
+		},
+	})
+	fx.addObject(t, fileObjectWithRef("photo", "chatObj", "msg1", nil))
+
+	items, err := fx.ListOrphans(testSpaceId)
+
+	require.NoError(t, err)
+	assert.Empty(t, items, "a live chat attachment is not an orphan")
+}
+
+func TestListOrphans_ChatCreatedObject_Excluded(t *testing.T) {
+	// Objects created from a chat message (link targets) carry the same createdInContext.
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:             domain.String("chatObj"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_chatDeprecated)),
+		},
+	})
+	fx.addObject(t, basicObjectWithRef("page", "chatObj", "msg1", nil))
+
+	items, err := fx.ListOrphans(testSpaceId)
+
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestListOrphans_SystemLayoutParent_Excluded(t *testing.T) {
+	// Mirrors the gate CheckObjectsOnObjectArchived already applies: a non-GC-eligible object
+	// cannot own GC-tracked children.
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:             domain.String("participant"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_participant)),
+		},
+	})
+	fx.addObject(t, basicObjectWithRef("child", "participant", "block1", nil))
+
+	items, err := fx.ListOrphans(testSpaceId)
+
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestListOrphans_DeletedParent_Tombstone_StillListed(t *testing.T) {
+	// A real tombstone has no resolvedLayout, so the parent-layout gate cannot be applied to it.
+	// Deleting a context genuinely orphans its children -- including a deleted chat's attachments --
+	// so they must still be listed.
+	fx := newFixture(t)
+	fx.addObject(t, tombstoneObject("goneChat"))
+	fx.addObject(t, fileObjectWithRef("photo", "goneChat", "msg1", nil))
+
+	items, err := fx.ListOrphans(testSpaceId)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"photo"}, ids(items))
+	assert.Equal(t, OrphanReasonContextDeleted, find(t, items, "photo").Reason)
+}
+
+func TestListOrphans_DeletedChatParent_StillListed(t *testing.T) {
+	// Locks the intent of canOwnOrphans's state check, which a tombstone alone cannot: a missing
+	// resolvedLayout reads as 0 (== ObjectType_basic, GC-eligible), so the tombstone test would keep
+	// passing even if the layout gate were wrongly applied to deleted parents. Here the deleted
+	// parent carries a chat layout, so only the state check can keep its children listed.
+	//
+	// Deleting a chat genuinely orphans its attachments -- there is no message left to show them.
+	fx := newFixture(t)
+	fx.store.AddObjects(t, testSpaceId, []objectstore.TestObject{
+		{
+			bundle.RelationKeyId:             domain.String("goneChat"),
+			bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_chatDerived)),
+			bundle.RelationKeyIsDeleted:      domain.Bool(true),
+		},
+	})
+	fx.addObject(t, fileObjectWithRef("photo", "goneChat", "msg1", nil))
+
+	items, err := fx.ListOrphans(testSpaceId)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"photo"}, ids(items))
+	assert.Equal(t, OrphanReasonContextDeleted, find(t, items, "photo").Reason)
+}

--- a/docs/GO-7323-cascade-deletion-client-impl.md
+++ b/docs/GO-7323-cascade-deletion-client-impl.md
@@ -142,6 +142,13 @@ Reconstruct the tree by joining each item's `details.createdInContext` to its pa
 items with `isRoot = true` are the roots. `reason` explains *why* a root is orphaned and is only
 meaningful on roots — descendants inherit their root's reason and carry `none`.
 
+**Chat content is never suggested.** Files and objects created in a live chat carry
+`createdInContext = <chat object>` but can never acquire a backlink (chat messages live in anystore,
+not in block state), so they would otherwise look exactly like unlinked orphans. Objects whose
+creation context is a live chat — or any other non-GC-eligible layout — are excluded. Once the chat
+itself is deleted its attachments *are* genuinely orphaned, and they appear with
+`reason = contextDeleted`.
+
 `keys` selects which relations come back in `details`. Pass what you need to render (e.g. `name`,
 `iconEmoji`, `iconImage`, `snippet`). `id`, `createdInContext`, and `resolvedLayout` are **always**
 included regardless — you cannot render the forest without them. Passing no keys yields the default

--- a/docs/GO-7323-cascade-deletion-client-impl.md
+++ b/docs/GO-7323-cascade-deletion-client-impl.md
@@ -10,9 +10,9 @@ When a user creates an object **inside** another object, the backend records the
 a created object) **implicitly archived** the whole nested subtree — objects and files alike.
 User feedback: silently archiving nested *objects* is surprising.
 
-> **Status:** the backend lives on branch `go-7323-cascade-deletion-orphan-events`, **not yet merged
-> to `develop` and not yet pushed**. Regenerate protos from that branch, not from `develop`. Nothing
-> described here has shipped, so the protocol can still be changed cheaply — raise objections now.
+> **Status:** the backend is merged to `develop` (PR #3201). Regenerate protos from `develop`.
+> Nothing has been *released* to users, so the protocol can still be changed cheaply — raise
+> objections now.
 
 New behavior:
 


### PR DESCRIPTION
Fast-follow on #3201, before any client ships UI against `ObjectCleanupSuggestions`.

## The bug

`ListOrphans` offered **every live chat attachment** to the user as a removable orphan.

A file uploaded into a chat gets `createdInContext = <chat object>` (`fileuploader/uploader.go:857`) and `createdInContextRef = <message id>` (`chats/service.go`). But it can never acquire a backlink: chat messages live in anystore, `chatobject` contributes no outgoing links, and the indexer only feeds smartblock links into the links table (`indexer/spaceindexer.go:218/224`).

So a photo whose message is still on screen has *exactly* the store shape of an unlinked orphan — active parent, non-empty ref, empty backlinks. `ListOrphans` made it a forest root with `reason = contextUnlinked`. Reproduced before the fix:

```
ListOrphans returned 1 item(s)
  id=photo isRoot=true reason=3   // OrphanReasonContextUnlinked
```

A user trusting the cleanup list would archive or delete files their chat history still displays. Same for objects created *from* a chat message (link targets carry the same context).

## Why the cascade GC never hit this

`CheckObjectsOnObjectArchived` bails when the acted-on object's layout isn't GC-eligible — "system/unsupported objects can't have GC-tracked children" — and chats cannot be archived, so it never visited chat children. `ListOrphans` checked the *candidate's* layout but never the *parent's*. That omission is the whole bug.

## The fix

Gate on the parent, mirroring the rule the cascade already applies: an object whose creation context is a **live chat or system object** cannot own GC-tracked children.

The gate applies **only to parents whose details exist** (active or archived). `DeleteObject` replaces a deleted object's details with `{id, spaceId, isDeleted}` (`spaceindex/delete.go:48-54`), so a tombstone carries no layout — and a deleted context genuinely orphans its children whatever it used to be. A deleted chat's attachments *should* be listed, with `reason = contextDeleted`.

`queryParentStates` becomes `queryParentInfo`, returning `state + layout` from the `QueryRaw` batch it already ran. **No extra query**, no measurable cost.

Parents that are themselves candidates skip the lookup, as before — they passed the candidate query's GC-eligible layout filter by construction.

## Tests

Four new, each mutation-checked:

- `ChatParent_Excluded` — the live attachment, the actual bug.
- `ChatCreatedObject_Excluded` — link targets from a chat message.
- `SystemLayoutParent_Excluded` — a participant-layout parent.
- `DeletedChatParent_StillListed` — a deleted chat's attachments are real orphans.

The last one exists because a tombstone test alone passes **vacuously**: a missing `resolvedLayout` reads as `0`, which is `ObjectType_basic`, which is GC-eligible. Removing the state check from `canOwnOrphans` leaves the tombstone test green and only `DeletedChatParent_StillListed` red. Verified by mutation.

Full `objectgc` suite green, including under `-race`; `go build ./...`, `go vet`, `gofmt` clean; `detailservice`, `smartblock`, `chats`, `core` unaffected.

Client brief updated to state that chat content is never suggested.

## Not in scope

Reviewers of #3201 also flagged that `ArchiveOrphansOnLinksRemoval(skipBin=true)` can permanently delete a file a *different* live message still shows: upload dedupes identical bytes to one object, and `updateAttachmentsContext` only sets `createdInContextRef` when it is empty, so a re-posted photo keeps pointing at the first message. Deleting that first message deletes the file out from under the second. Pre-existing; deliberately left for a separate change.
