### PR TITLE
GO-7366 Fix files stuck in Syncing: confirm sync via file node without local blocks

### DIFF
--- a/core/files/fileobject/service.go
+++ b/core/files/fileobject/service.go
@@ -270,6 +270,11 @@ func (s *service) ensureNotSyncedFilesAddedToQueue() error {
 				Condition:   model.BlockContentDataviewFilter_NotEqual,
 				Value:       domain.Int64(int64(filesyncstatus.Synced)),
 			},
+			{
+				RelationKey: bundle.RelationKeyIsDeleted,
+				Condition:   model.BlockContentDataviewFilter_NotEqual,
+				Value:       domain.Bool(true),
+			},
 		},
 	})
 	if err != nil {

--- a/core/files/filestorage/rpcstore/inmemory.go
+++ b/core/files/filestorage/rpcstore/inmemory.go
@@ -62,6 +62,11 @@ type InMemoryStore struct {
 	errMu        sync.Mutex
 	spaceInfoErr error
 
+	// availabilityOmit cids are silently dropped from CheckAvailability
+	// responses. Used in tests to simulate a node that doesn't answer for
+	// some of the requested cids.
+	availabilityOmit map[cid.Cid]struct{}
+
 	stats *InMemoryStoreStats
 }
 
@@ -113,6 +118,9 @@ func (t *InMemoryStore) CheckAvailability(ctx context.Context, spaceId string, c
 
 	checkResult := make([]*fileproto.BlockAvailability, 0, len(cids))
 	for _, cid := range cids {
+		if _, omit := t.availabilityOmit[cid]; omit {
+			continue
+		}
 		status := fileproto.AvailabilityStatus_NotExists
 		if _, ok := t.store[cid]; ok {
 			status = fileproto.AvailabilityStatus_Exists
@@ -135,8 +143,13 @@ func (t *InMemoryStore) BindCids(ctx context.Context, spaceId string, fileId dom
 
 	var bytesToBind int
 	for _, cid := range cids {
+		b, ok := t.store[cid]
+		if !ok {
+			// The real node refuses to bind a cid it doesn't have
+			return fileprotoerr.ErrCIDNotFound
+		}
 		if !t.isCidBinded(spaceId, cid) {
-			bytesToBind += len(t.store[cid].RawData())
+			bytesToBind += len(b.RawData())
 		}
 	}
 	if !t.isWithinLimits(bytesToBind) {
@@ -299,6 +312,18 @@ func (t *InMemoryStore) SetSpaceInfoError(err error) {
 	t.errMu.Lock()
 	defer t.errMu.Unlock()
 	t.spaceInfoErr = err
+}
+
+// SetOmitFromAvailability makes subsequent CheckAvailability calls silently
+// drop the given cids from responses, simulating a node that doesn't answer
+// for some requested cids
+func (t *InMemoryStore) SetOmitFromAvailability(cids ...cid.Cid) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.availabilityOmit = make(map[cid.Cid]struct{}, len(cids))
+	for _, c := range cids {
+		t.availabilityOmit[c] = struct{}{}
+	}
 }
 
 func (t *InMemoryStore) AccountInfo(ctx context.Context) (*fileproto.AccountInfoResponse, error) {

--- a/core/files/filesync/bind_test.go
+++ b/core/files/filesync/bind_test.go
@@ -1,0 +1,338 @@
+package filesync
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/files/filesync/filequeue"
+	"github.com/anyproto/anytype-heart/core/syncstatus/filesyncstatus"
+)
+
+// Reproducers for the "Notion-imported files stuck in Syncing forever" bug
+// (docs/FileSyncStuckQueued.md): a file object whose blocks are already on the
+// file node (uploaded earlier, e.g. from another space or device) but absent
+// from the local flat store must still reach Synced — by binding the cids the
+// node already has, without downloading or re-uploading file data.
+
+type statusRecorder struct {
+	mu       sync.Mutex
+	statuses map[string][]filesyncstatus.Status
+}
+
+func newStatusRecorder(fx *fixture) *statusRecorder {
+	rec := &statusRecorder{statuses: map[string][]filesyncstatus.Status{}}
+	fx.OnStatusUpdated(func(objectId string, _ domain.FullFileId, status filesyncstatus.Status) error {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		rec.statuses[objectId] = append(rec.statuses[objectId], status)
+		return nil
+	})
+	return rec
+}
+
+func (r *statusRecorder) lastStatus(objectId string) (filesyncstatus.Status, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	statuses := r.statuses[objectId]
+	if len(statuses) == 0 {
+		return 0, false
+	}
+	return statuses[len(statuses)-1], true
+}
+
+// collectDAGBlocks returns all blocks of a file DAG in walk order, root first
+func (fx *fixture) collectDAGBlocks(t *testing.T, fileNode ipld.Node) []blocks.Block {
+	rootBlock, err := blocks.NewBlockWithCid(fileNode.RawData(), fileNode.Cid())
+	require.NoError(t, err)
+	result := []blocks.Block{rootBlock}
+	walker := ipld.NewWalker(ctx, ipld.NewNavigableIPLDNode(fileNode, fx.fileService.DAGService()))
+	err = walker.Iterate(func(navNode ipld.NavigableNode) error {
+		node := navNode.GetIPLDNode()
+		if node.Cid() == fileNode.Cid() {
+			return nil
+		}
+		b, err := blocks.NewBlockWithCid(node.RawData(), node.Cid())
+		if err != nil {
+			return err
+		}
+		result = append(result, b)
+		return nil
+	})
+	if !errors.Is(err, ipld.EndOfDag) {
+		require.NoError(t, err)
+	}
+	return result
+}
+
+func (fx *fixture) waitItemState(t *testing.T, objectId string, wantState FileState, timeout time.Duration) FileInfo {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	it, err := fx.queue.GetNext(waitCtx, filequeue.GetNextRequest[FileInfo]{
+		Subscribe:   true,
+		StoreFilter: filterByState(wantState),
+		Filter: func(info FileInfo) bool {
+			return info.ObjectId == objectId && info.State == wantState
+		},
+	})
+	require.NoError(t, err, "waiting for object %s to reach state %d", objectId, wantState)
+	require.NoError(t, fx.queue.ReleaseAndUpdate(it.ObjectId, it))
+	return it
+}
+
+func TestFileSync_BindFileAlreadyOnNode(t *testing.T) {
+	t.Run("no local blocks at all: synced via bind, nothing uploaded or downloaded", func(t *testing.T) {
+		// given
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		// A multi-chunk file: root file node + 3 leaf chunks
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+		require.Greater(t, len(dagBlocks), 3, "expect a multi-block DAG")
+
+		// Another client uploaded the same file to the node, under another space
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks))
+		blocksUploadedBefore := fx.rpcStore.Stats().BlocksAdded()
+
+		// This device never had the blocks (dedup on import reuses the fileId
+		// without writing blocks locally)
+		for _, b := range dagBlocks {
+			require.NoError(t, fx.localFileStorage.Delete(ctx, b.Cid()))
+		}
+
+		// when
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+			Imported:     true,
+		}))
+
+		// then
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok, "status update must be emitted")
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+
+		// Nothing was uploaded: sync was confirmed by binding existing cids
+		assert.Equal(t, blocksUploadedBefore, fx.rpcStore.Stats().BlocksAdded())
+
+		// Every cid of the DAG is bound to the requesting space
+		spaceInfo, err := fx.rpcStore.SpaceInfo(ctx, "space1")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(len(dagBlocks)), spaceInfo.CidsCount)
+
+		// Leaf data was not downloaded: only structural nodes may be fetched
+		leafCids := blockCids(dagBlocks[1:])
+		exists, err := fx.localFileStorage.ExistsCids(ctx, leafCids)
+		require.NoError(t, err)
+		assert.Empty(t, exists, "leaf chunks must not be downloaded to confirm sync")
+	})
+
+	t.Run("partial local blocks: synced via bind, nothing uploaded", func(t *testing.T) {
+		// The state left by viewing a file: root and content chunks cached
+		// locally, but some blocks (e.g. exif, thumbnail) never fetched
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks))
+		blocksUploadedBefore := fx.rpcStore.Stats().BlocksAdded()
+
+		// Remove one leaf locally, keep the rest
+		require.NoError(t, fx.localFileStorage.Delete(ctx, dagBlocks[len(dagBlocks)-1].Cid()))
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+		assert.Equal(t, blocksUploadedBefore, fx.rpcStore.Stats().BlocksAdded())
+	})
+
+	t.Run("mixed: node misses some blocks, they are uploaded from local store", func(t *testing.T) {
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		// Node has all blocks except the last leaf; all blocks are local
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks[:len(dagBlocks)-1]))
+		blocksUploadedBefore := fx.rpcStore.Stats().BlocksAdded()
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+
+		// Only the block missing on the node was uploaded
+		assert.Equal(t, blocksUploadedBefore+1, fx.rpcStore.Stats().BlocksAdded())
+
+		spaceInfo, err := fx.rpcStore.SpaceInfo(ctx, "space1")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(len(dagBlocks)), spaceInfo.CidsCount)
+	})
+}
+
+func TestFileSync_MissingBlocksIsRetried(t *testing.T) {
+	t.Run("blocks available nowhere: parked with future retry, then recovers when node gets the file", func(t *testing.T) {
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		// Blocks exist neither locally nor on the node
+		for _, b := range dagBlocks {
+			require.NoError(t, fx.localFileStorage.Delete(ctx, b.Cid()))
+		}
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		it := fx.waitItemState(t, objectId, FileStateMissingBlocks, 5*time.Second)
+		assert.True(t, it.ScheduledAt.After(time.Now()), "missing-blocks item must be scheduled for a future retry")
+
+		_, ok := statuses.lastStatus(objectId)
+		assert.False(t, ok, "no premature status update for a file we can't act on")
+
+		// The file appears on the node (e.g. the original uploader came online)
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks))
+
+		// Make the retry due now
+		queueIt, err := fx.queue.GetById(objectId)
+		require.NoError(t, err)
+		queueIt.ScheduledAt = time.Now()
+		require.NoError(t, fx.queue.ReleaseAndUpdate(objectId, queueIt))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+	})
+
+	t.Run("parked from upload phase: stale plan is dropped, retry re-checks the node", func(t *testing.T) {
+		// The item parks AFTER a successful availability check (all blocks
+		// were locally enumerable, one leaf's data was missing everywhere),
+		// so a to-upload plan was computed. The retry must re-check the node
+		// instead of replaying the stale plan.
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		// Node has nothing; one leaf's data is missing locally too
+		require.NoError(t, fx.localFileStorage.Delete(ctx, dagBlocks[len(dagBlocks)-1].Cid()))
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		it := fx.waitItemState(t, objectId, FileStateMissingBlocks, 5*time.Second)
+		assert.Empty(t, it.CidsToUpload, "parked item must not keep a stale plan")
+		assert.Empty(t, it.CidsToBind, "parked item must not keep a stale plan")
+
+		// The whole file appears on the node
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks))
+
+		queueIt, err := fx.queue.GetById(objectId)
+		require.NoError(t, err)
+		queueIt.ScheduledAt = time.Now()
+		require.NoError(t, fx.queue.ReleaseAndUpdate(objectId, queueIt))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+	})
+
+	t.Run("AddFile wakes a parked item when blocks become available", func(t *testing.T) {
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		// Blocks exist neither locally nor on the node
+		for _, b := range dagBlocks {
+			require.NoError(t, fx.localFileStorage.Delete(ctx, b.Cid()))
+		}
+
+		objectId := "fileObjectId1"
+		req := AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}
+		require.NoError(t, fx.AddFile(req))
+
+		it := fx.waitItemState(t, objectId, FileStateMissingBlocks, 5*time.Second)
+		assert.Positive(t, it.MissingBlocksRetries)
+
+		// The file is re-added by the user: blocks are local again
+		require.NoError(t, fx.localFileStorage.Add(ctx, dagBlocks))
+
+		// The explicit AddFile must wake the parked item immediately
+		require.NoError(t, fx.AddFile(req))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+	})
+}
+
+func blockCids(bs []blocks.Block) []cid.Cid {
+	out := make([]cid.Cid, 0, len(bs))
+	for _, b := range bs {
+		out = append(out, b.Cid())
+	}
+	return out
+}

--- a/core/files/filesync/bind_test.go
+++ b/core/files/filesync/bind_test.go
@@ -3,6 +3,7 @@ package filesync
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anyproto/anytype-heart/core/domain"
+	rpcstore2 "github.com/anyproto/anytype-heart/core/files/filestorage/rpcstore"
 	"github.com/anyproto/anytype-heart/core/files/filesync/filequeue"
 	"github.com/anyproto/anytype-heart/core/syncstatus/filesyncstatus"
 )
@@ -171,6 +173,97 @@ func TestFileSync_BindFileAlreadyOnNode(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, filesyncstatus.Synced, gotStatus)
 		assert.Equal(t, blocksUploadedBefore, fx.rpcStore.Stats().BlocksAdded())
+	})
+
+	t.Run("more blocks than one availability/bind batch: every cid is checked and bound", func(t *testing.T) {
+		// 66 MiB → 66 leaf chunks + root = 67 cids, crossing the 64-cid
+		// batch boundary of both CheckAvailability and BindCids
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 66*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+		require.Greater(t, len(dagBlocks), checkAvailabilityBatchSize)
+		require.Greater(t, len(dagBlocks), bindBatchSize)
+
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks))
+		blocksUploadedBefore := fx.rpcStore.Stats().BlocksAdded()
+		for _, b := range dagBlocks {
+			require.NoError(t, fx.localFileStorage.Delete(ctx, b.Cid()))
+		}
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		fx.waitItemState(t, objectId, FileStateDone, 10*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+		assert.Equal(t, blocksUploadedBefore, fx.rpcStore.Stats().BlocksAdded())
+
+		spaceInfo, err := fx.rpcStore.SpaceInfo(ctx, "space1")
+		require.NoError(t, err)
+		assert.Equal(t, uint64(len(dagBlocks)), spaceInfo.CidsCount)
+	})
+
+	t.Run("already bound to the space: synced without binding or uploading anything", func(t *testing.T) {
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		statuses := newStatusRecorder(fx)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		// The file is already fully bound to the requesting space
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "space1", fileId, dagBlocks))
+		blocksUploadedBefore := fx.rpcStore.Stats().BlocksAdded()
+		cidsBoundBefore := fx.rpcStore.Stats().CidsBinded()
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		gotStatus, ok := statuses.lastStatus(objectId)
+		require.True(t, ok)
+		assert.Equal(t, filesyncstatus.Synced, gotStatus)
+		assert.Equal(t, blocksUploadedBefore, fx.rpcStore.Stats().BlocksAdded())
+		assert.Equal(t, cidsBoundBefore, fx.rpcStore.Stats().CidsBinded())
+	})
+
+	t.Run("cid omitted from the availability response is treated as missing and uploaded", func(t *testing.T) {
+		fx := newFixtureNotStarted(t, 1024*1024*1024)
+		require.NoError(t, fx.a.Start(ctx))
+		defer fx.Finish(t)
+
+		fileId, fileNode := fx.givenFileAddedToDAG(t, 3*1024*1024)
+		dagBlocks := fx.collectDAGBlocks(t, fileNode)
+
+		// Node has every block, but doesn't answer for one of them
+		require.NoError(t, fx.rpcStore.AddToFile(ctx, "spaceOld", fileId, dagBlocks))
+		blocksUploadedBefore := fx.rpcStore.Stats().BlocksAdded()
+		fx.rpcStore.SetOmitFromAvailability(dagBlocks[len(dagBlocks)-1].Cid())
+
+		objectId := "fileObjectId1"
+		require.NoError(t, fx.AddFile(AddFileRequest{
+			FileObjectId: objectId,
+			FileId:       domain.FullFileId{SpaceId: "space1", FileId: fileId},
+		}))
+
+		fx.waitItemState(t, objectId, FileStateDone, 5*time.Second)
+
+		// The unanswered cid was uploaded rather than silently counted as synced
+		assert.Equal(t, blocksUploadedBefore+1, fx.rpcStore.Stats().BlocksAdded())
 	})
 
 	t.Run("mixed: node misses some blocks, they are uploaded from local store", func(t *testing.T) {
@@ -335,4 +428,145 @@ func blockCids(bs []blocks.Block) []cid.Cid {
 		out = append(out, b.Cid())
 	}
 	return out
+}
+
+func TestFileSync_RecoveredParkedItemGetsShortTransientRetry(t *testing.T) {
+	// A parked item whose availability check finally succeeds must leave the
+	// MissingBlocks state immediately: a transient failure in a later step
+	// (here: SpaceInfo) must produce the normal ~1-minute retry, not the
+	// multi-hour missing-blocks backoff earned by its parking history.
+	transientErr := errors.New("transient space info failure")
+
+	fx := newFixtureNotStarted(t, 1024*1024*1024)
+	fx.rpcStore.SetSpaceInfoError(transientErr)
+	require.NoError(t, fx.a.Start(ctx))
+	defer fx.Finish(t)
+
+	spaceId := "space1"
+	fx.waitCondition(t, 2*time.Second, func() bool {
+		_, err := fx.limitManager.getSpace(spaceId)
+		return err == nil
+	})
+
+	// Blocks are fully available locally, so the availability check succeeds
+	fileId, _ := fx.givenFileAddedToDAG(t, 1024)
+
+	it := FileInfo{
+		FileId:               fileId,
+		SpaceId:              spaceId,
+		ObjectId:             "fileObjectId1",
+		State:                FileStateMissingBlocks,
+		MissingBlocksRetries: 5, // long backoff earned before recovery
+		ScheduledAt:          time.Now(),
+		CidsToUpload:         map[cid.Cid]struct{}{},
+		CidsToBind:           map[cid.Cid]struct{}{},
+	}
+
+	result, err := fx.processFilePendingUpload(ctx, it)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transientErr)
+	assert.Equal(t, FileStatePendingUpload, result.State, "recovered item must leave MissingBlocks once the check succeeds")
+	assert.Zero(t, result.MissingBlocksRetries)
+	assert.WithinDuration(t, time.Now().Add(time.Minute), result.ScheduledAt, 15*time.Second,
+		"transient failure after a successful check must get the short retry")
+}
+
+func TestFileSync_BindNotFoundDropsCachedPlan(t *testing.T) {
+	// The node lost a block between BlocksCheck and BlocksBind (GC race): the
+	// cached plan must be dropped so the next attempt re-enumerates instead of
+	// replaying the stale plan forever
+	fx := newFixture(t, 1024*1024*1024)
+	defer fx.Finish(t)
+
+	spaceId := "space1"
+	fx.waitCondition(t, 2*time.Second, func() bool {
+		_, err := fx.limitManager.getSpace(spaceId)
+		return err == nil
+	})
+
+	fileId, _ := fx.givenFileAddedToDAG(t, 1024)
+	goneCid := cid.MustParse("bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku")
+
+	it := FileInfo{
+		FileId:              fileId,
+		SpaceId:             spaceId,
+		ObjectId:            "fileObjectId1",
+		State:               FileStatePendingUpload,
+		ScheduledAt:         time.Now(),
+		BytesToUploadOrBind: 1024,
+		CidsToBind:          map[cid.Cid]struct{}{goneCid: {}},
+		CidsToUpload:        map[cid.Cid]struct{}{},
+	}
+
+	result, err := fx.processFilePendingUpload(ctx, it)
+
+	require.Error(t, err)
+	assert.Empty(t, result.CidsToBind, "stale plan must be dropped after a bind not-found error")
+	assert.Empty(t, result.CidsToUpload)
+	assert.Zero(t, result.BytesToUploadOrBind)
+	assert.Equal(t, FileStatePendingUpload, result.State)
+}
+
+func TestFileSync_DeleteResetsParkedSchedule(t *testing.T) {
+	// Deleting a file parked with a long backoff must not wait the backoff out
+	fx := newFixture(t, 1024*1024*1024)
+	defer fx.Finish(t)
+
+	fileId, _ := fx.givenFileAddedToDAG(t, 1024)
+	objectId := "fileObjectId1"
+
+	err := fx.queue.Upsert(objectId, func(exists bool, prev FileInfo) FileInfo {
+		return FileInfo{
+			FileId:      fileId,
+			SpaceId:     "space1",
+			ObjectId:    objectId,
+			State:       FileStateMissingBlocks,
+			ScheduledAt: time.Now().Add(20 * time.Hour),
+		}
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, fx.DeleteFile(objectId, domain.FullFileId{SpaceId: "space1", FileId: fileId}))
+
+	it, err := fx.queue.GetById(objectId)
+	require.NoError(t, err)
+	assert.Equal(t, FileStatePendingDeletion, it.State)
+	assert.True(t, it.ScheduledAt.Before(time.Now().Add(5*time.Minute)),
+		"deletion must be scheduled promptly, not after the parked backoff")
+	require.NoError(t, fx.queue.ReleaseAndUpdate(objectId, it))
+}
+
+func TestMissingBlocksRetryDelay(t *testing.T) {
+	want := []time.Duration{
+		10 * time.Minute,
+		40 * time.Minute,
+		160 * time.Minute,
+		640 * time.Minute,
+		24 * time.Hour, // 2560min capped
+		24 * time.Hour,
+	}
+	for retries, wantDelay := range want {
+		assert.Equal(t, wantDelay, missingBlocksRetryDelay(retries), "retries=%d", retries)
+	}
+}
+
+func TestRescheduleTransient(t *testing.T) {
+	t.Run("parked item keeps its long backoff", func(t *testing.T) {
+		it := FileInfo{State: FileStateMissingBlocks, MissingBlocksRetries: 2}
+		got := rescheduleTransient(it, errors.New("any transient error"))
+		assert.WithinDuration(t, time.Now().Add(160*time.Minute), got.ScheduledAt, 15*time.Second)
+	})
+
+	t.Run("connectivity error gets the longer delay", func(t *testing.T) {
+		it := FileInfo{State: FileStatePendingUpload}
+		got := rescheduleTransient(it, fmt.Errorf("get node: %w", rpcstore2.ErrNoConnectionToAnyFileClient))
+		assert.WithinDuration(t, time.Now().Add(connectivityRetryDelay), got.ScheduledAt, 15*time.Second)
+	})
+
+	t.Run("other transient errors get the short retry", func(t *testing.T) {
+		it := FileInfo{State: FileStatePendingUpload}
+		got := rescheduleTransient(it, errors.New("some rpc error"))
+		assert.WithinDuration(t, time.Now().Add(time.Minute), got.ScheduledAt, 15*time.Second)
+	})
 }

--- a/core/files/filesync/delete.go
+++ b/core/files/filesync/delete.go
@@ -22,6 +22,9 @@ func (s *fileSync) DeleteFile(objectId string, fileId domain.FullFileId) error {
 	return s.process(objectId, func(exists bool, info FileInfo) (FileInfo, bool, error) {
 		if exists {
 			info.State = FileStatePendingDeletion
+			// Deletion must not wait out a long retry backoff the item may
+			// carry from MissingBlocks parking
+			info.ScheduledAt = time.Now()
 			return info, true, nil
 		}
 

--- a/core/files/filesync/fileinfo.go
+++ b/core/files/filesync/fileinfo.go
@@ -45,6 +45,10 @@ type FileInfo struct {
 	BytesToUploadOrBind int
 	CidsToBind          map[cid.Cid]struct{}
 	CidsToUpload        map[cid.Cid]struct{}
+
+	// MissingBlocksRetries counts how many times the file was found in
+	// MissingBlocks state; used to grow the retry backoff
+	MissingBlocksRetries int
 }
 
 func (i FileInfo) FullFileId() domain.FullFileId {
@@ -79,6 +83,7 @@ func marshalFileInfo(arena *anyenc.Arena, info FileInfo) *anyenc.Value {
 	obj.Set("addedByUser", newBool(arena, info.AddedByUser))
 	obj.Set("imported", newBool(arena, info.Imported))
 	obj.Set("bytesToUploadOrBind", arena.NewNumberInt(info.BytesToUploadOrBind))
+	obj.Set("missingBlocksRetries", arena.NewNumberInt(info.MissingBlocksRetries))
 
 	cidsToUpload := arena.NewArray()
 	var i int
@@ -132,16 +137,17 @@ func unmarshalFileInfo(doc *anyenc.Value) (FileInfo, error) {
 		return FileInfo{}, fmt.Errorf("invalid file id: %q", fileId.String())
 	}
 	return FileInfo{
-		FileId:              fileId,
-		SpaceId:             doc.GetString("spaceId"),
-		ObjectId:            doc.GetString("id"),
-		State:               FileState(doc.GetInt("state")),
-		ScheduledAt:         time.Unix(int64(doc.GetInt("scheduledAt")), 0).UTC(),
-		Variants:            variants,
-		AddedByUser:         doc.GetBool("addedByUser"),
-		Imported:            doc.GetBool("imported"),
-		BytesToUploadOrBind: doc.GetInt("bytesToUploadOrBind"),
-		CidsToBind:          cidsToBind,
-		CidsToUpload:        cidsToUpload,
+		FileId:               fileId,
+		SpaceId:              doc.GetString("spaceId"),
+		ObjectId:             doc.GetString("id"),
+		State:                FileState(doc.GetInt("state")),
+		ScheduledAt:          time.Unix(int64(doc.GetInt("scheduledAt")), 0).UTC(),
+		Variants:             variants,
+		AddedByUser:          doc.GetBool("addedByUser"),
+		Imported:             doc.GetBool("imported"),
+		BytesToUploadOrBind:  doc.GetInt("bytesToUploadOrBind"),
+		CidsToBind:           cidsToBind,
+		CidsToUpload:         cidsToUpload,
+		MissingBlocksRetries: doc.GetInt("missingBlocksRetries"),
 	}, nil
 }

--- a/core/files/filesync/fileinfo_test.go
+++ b/core/files/filesync/fileinfo_test.go
@@ -51,5 +51,6 @@ func givenFileInfo() FileInfo {
 			testCid2:                           {},
 			testCid3:                           {},
 		},
+		MissingBlocksRetries: 2,
 	}
 }

--- a/core/files/filesync/service.go
+++ b/core/files/filesync/service.go
@@ -18,6 +18,7 @@ Scope: global
 - batchUploader (x10): sends batched block upload requests to backup node [runBatchUploader]
 - requestsBatcher: batches small files together, splits large files across requests [requestsBatcher.run]
 - limitedUploader: retries uploads when space becomes available [runLimitedUploader]
+- missingBlocksRetrier: retries files whose blocks were found neither locally nor on the node [runMissingBlocksRetrier]
 - deleter: processes pending deletions from queue [runDeleter]
 - spaceUsage (per space): periodically updates per-space limits from backup node [spaceUsage.update]
 
@@ -26,16 +27,24 @@ Scope: global
 
 ## Documentation
 File states: PendingUpload -> Uploading -> Done (or Limited if quota exceeded)
+                          -> MissingBlocks (blocks found neither locally nor on node; retried with backoff)
                           -> PendingDeletion -> Deleted
 
 Upload flow:
-1. AddFile enqueues file with PendingUpload state
-2. Uploader checks block availability on node (which blocks need upload vs bind)
+1. AddFile enqueues file with PendingUpload state. The file's blocks are not
+   required to exist locally: a file object may reference a fileId whose
+   blocks live only on the file node (e.g. import dedup reused a fileId
+   uploaded from another space or device).
+2. Uploader enumerates the file's cids without fetching leaf data (structural
+   nodes are read locally with a fallback to the node) and checks their
+   availability on the node: blocks the node already has are bound, the rest
+   are uploaded from the local store.
 3. Allocates space in local limit tracker
-4. Walks DAG and batches blocks via requestsBatcher
+4. Binds cids, then batches locally-present blocks via requestsBatcher
 5. batchUploader sends BlockPushMany requests to node
 6. On completion, marks file as Done; on limit error, marks as Limited
 
+A file whose bytes are already on the node reaches Done with zero uploads.
 Limited files are retried when spaceUsageManager detects more free space available.
 */
 
@@ -226,6 +235,8 @@ func (s *fileSync) Run(ctx context.Context) error {
 	for range 10 {
 		go s.runUploader(s.loopCtx)
 	}
+
+	go s.runMissingBlocksRetrier(s.loopCtx)
 
 	go s.runLimitedUploader(s.loopCtx)
 

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anyproto/any-sync/commonfile/fileproto"
 	"github.com/anyproto/any-sync/commonfile/fileproto/fileprotoerr"
 	"github.com/anyproto/any-sync/commonspace/spacestorage"
+	"github.com/anyproto/any-sync/net"
 	"github.com/anyproto/any-sync/net/peer"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/core/event"
+	rpcstore2 "github.com/anyproto/anytype-heart/core/files/filestorage/rpcstore"
 	"github.com/anyproto/anytype-heart/core/files/filesync/filequeue"
 	"github.com/anyproto/anytype-heart/core/syncstatus/filesyncstatus"
 	"github.com/anyproto/anytype-heart/pb"
@@ -127,7 +129,7 @@ func (s *fileSync) runUploader(ctx context.Context) {
 		default:
 			err := s.processNextPendingUploadItem(ctx, FileStatePendingUpload)
 			if err != nil && !errors.Is(err, filequeue.ErrClosed) {
-				log.Error("process next pending upload item", zap.Error(err))
+				logProcessingError("process next pending upload item", err)
 			}
 		}
 	}
@@ -144,10 +146,20 @@ func (s *fileSync) runMissingBlocksRetrier(ctx context.Context) {
 		default:
 			err := s.processNextPendingUploadItem(ctx, FileStateMissingBlocks)
 			if err != nil && !errors.Is(err, filequeue.ErrClosed) {
-				log.Error("process next missing-blocks item", zap.Error(err))
+				logProcessingError("process next missing-blocks item", err)
 			}
 		}
 	}
+}
+
+// logProcessingError logs an expected degraded-environment condition (device
+// offline, node unreachable) at WARN and everything else at ERROR
+func logProcessingError(msg string, err error) {
+	if isConnectivityError(err) {
+		log.Warn(msg+": no connection to file node", zap.Error(err))
+		return
+	}
+	log.Error(msg, zap.Error(err))
 }
 
 func (s *fileSync) processNextPendingUploadItem(ctx context.Context, state FileState) error {
@@ -182,13 +194,22 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		if errors.Is(err, errBlockNotFound) {
 			return s.parkMissingBlocks(it, err), nil
 		}
-		it = rescheduleTransient(it)
+		it = rescheduleTransient(it, err)
 		return it, fmt.Errorf("check blocks availability: %w", err)
 	}
 
 	it.BytesToUploadOrBind = blocksAvailability.bytesToUploadOrBind
 	it.CidsToBind = blocksAvailability.cidsToBind
 	it.CidsToUpload = blocksAvailability.cidsToUpload
+
+	// The blocks were enumerated and checked successfully, so the
+	// missing-blocks condition no longer holds: leave the parked state now, so
+	// that a transient failure below gets the normal short retry instead of
+	// the long missing-blocks backoff
+	if it.State == FileStateMissingBlocks {
+		it.State = FileStatePendingUpload
+		it.MissingBlocksRetries = 0
+	}
 
 	spaceLimits, err := s.limitManager.getSpace(it.SpaceId)
 	// If space is deleted, move file to deletion queue. It'll help to reclaim space if file is partially uploaded
@@ -198,7 +219,7 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		return it, nil
 	}
 	if err != nil {
-		it = rescheduleTransient(it)
+		it = rescheduleTransient(it, err)
 		return it, fmt.Errorf("get space limits: %w", err)
 	}
 
@@ -208,7 +229,7 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		if !errors.As(allocateErr, &limitErr) {
 			// Transient infra failure (e.g. SpaceInfo failed). Reschedule for
 			// retry instead of marking the file as Limited.
-			it = rescheduleTransient(it)
+			it = rescheduleTransient(it, allocateErr)
 			return it, fmt.Errorf("allocate file: %w", allocateErr)
 		}
 
@@ -238,7 +259,7 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		if errors.Is(err, errBlockNotFound) {
 			return s.parkMissingBlocks(it, err), nil
 		}
-		it = rescheduleTransient(it)
+		it = rescheduleTransient(it, err)
 		return it, err
 	}
 
@@ -311,7 +332,7 @@ func (s *fileSync) bindCids(ctx context.Context, it FileInfo, cids []cid.Cid) er
 		end := min(start+bindBatchSize, len(cids))
 		err := s.rpcStore.BindCids(ctx, it.SpaceId, it.FileId, cids[start:end])
 		if err != nil {
-			return err
+			return fmt.Errorf("bind batch %d..%d of %d: %w", start, end, len(cids), err)
 		}
 	}
 	return nil
@@ -380,16 +401,25 @@ func (s *fileSync) parkMissingBlocks(it FileInfo, err error) FileInfo {
 	return it
 }
 
-// rescheduleTransient delays an item after a transient failure (network
-// error, node unavailable). Items parked in MissingBlocks keep their long
-// backoff instead of the 1-minute retry, so an offline device doesn't churn
-// its parked items every minute.
-func rescheduleTransient(it FileInfo) FileInfo {
+// rescheduleTransient delays an item after a transient failure. Items parked
+// in MissingBlocks keep their long backoff instead of the 1-minute retry, and
+// connectivity failures (device offline, node unreachable) get a longer delay
+// than other transient errors — so an offline device doesn't churn its whole
+// queue with dial attempts every minute.
+func rescheduleTransient(it FileInfo, err error) FileInfo {
 	if it.State == FileStateMissingBlocks {
 		it.ScheduledAt = time.Now().Add(missingBlocksRetryDelay(it.MissingBlocksRetries))
 		return it
 	}
+	if isConnectivityError(err) {
+		it.ScheduledAt = time.Now().Add(connectivityRetryDelay)
+		return it
+	}
 	return it.Reschedule()
+}
+
+func isConnectivityError(err error) bool {
+	return errors.Is(err, rpcstore2.ErrNoConnectionToAnyFileClient) || errors.Is(err, net.ErrUnableToConnect)
 }
 
 func missingBlocksRetryDelay(retries int) time.Duration {
@@ -440,6 +470,10 @@ const (
 	// batcher at once
 	uploadBatchSize = 10
 )
+
+// connectivityRetryDelay is used instead of the 1-minute reschedule when the
+// file node cannot be reached at all
+const connectivityRetryDelay = 5 * time.Minute
 
 type blocksAvailabilityResponse struct {
 	bytesToUploadOrBind int

--- a/core/files/filesync/upload.go
+++ b/core/files/filesync/upload.go
@@ -13,7 +13,6 @@ import (
 	"github.com/anyproto/any-sync/net/peer"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/domain"
@@ -40,34 +39,36 @@ func (s *fileSync) AddFile(req AddFileRequest) error {
 		return fmt.Errorf("invalid file id: %q", req.FileId)
 	}
 
-	fileCid, err := req.FileId.FileId.Cid()
-	if err != nil {
-		return fmt.Errorf("parse file CID: %w", err)
-	}
-	existingCids, err := s.fileStorage.ExistsCids(context.Background(), []cid.Cid{fileCid})
-	if err != nil {
-		return fmt.Errorf("check local block existence: %w", err)
-	}
-	// Skip upload: root block not found locally
-	if len(existingCids) == 0 {
-		return nil
-	}
-
+	// Note: the file's blocks are not required to exist locally. A file object
+	// may reference a fileId whose blocks live only on the file node — e.g.
+	// import dedup reuses a fileId uploaded earlier from another space or
+	// device. The uploader confirms such files by checking the node and
+	// binding the cids it already has.
 	return s.process(req.FileObjectId, func(exists bool, info FileInfo) (FileInfo, bool, error) {
-		if exists && (info.State.IsUploadingState() || info.State == FileStateMissingBlocks) {
+		if exists && info.State.IsUploadingState() {
 			return info, false, nil
 		}
+		// A parked missing-blocks item is woken for an immediate re-check: an
+		// explicit AddFile means the file was re-added or its object was
+		// opened, so its blocks may have just become available locally. The
+		// retry counter is kept, so a still-broken file returns to its long
+		// backoff after one attempt.
+		var missingBlocksRetries int
+		if exists {
+			missingBlocksRetries = info.MissingBlocksRetries
+		}
 		info = FileInfo{
-			FileId:       req.FileId.FileId,
-			SpaceId:      req.FileId.SpaceId,
-			ObjectId:     req.FileObjectId,
-			State:        FileStatePendingUpload,
-			ScheduledAt:  time.Now(),
-			Variants:     req.Variants,
-			AddedByUser:  req.UploadedByUser,
-			Imported:     req.Imported,
-			CidsToUpload: map[cid.Cid]struct{}{},
-			CidsToBind:   map[cid.Cid]struct{}{},
+			FileId:               req.FileId.FileId,
+			SpaceId:              req.FileId.SpaceId,
+			ObjectId:             req.FileObjectId,
+			State:                FileStatePendingUpload,
+			ScheduledAt:          time.Now(),
+			Variants:             req.Variants,
+			AddedByUser:          req.UploadedByUser,
+			Imported:             req.Imported,
+			CidsToUpload:         map[cid.Cid]struct{}{},
+			CidsToBind:           map[cid.Cid]struct{}{},
+			MissingBlocksRetries: missingBlocksRetries,
 		}
 		return info, true, nil
 	})
@@ -132,6 +133,23 @@ func (s *fileSync) runUploader(ctx context.Context) {
 	}
 }
 
+// runMissingBlocksRetrier re-processes items parked in MissingBlocks state:
+// their blocks may have appeared since — uploaded to the node by another
+// device, or cached locally by viewing the file
+func (s *fileSync) runMissingBlocksRetrier(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			err := s.processNextPendingUploadItem(ctx, FileStateMissingBlocks)
+			if err != nil && !errors.Is(err, filequeue.ErrClosed) {
+				log.Error("process next missing-blocks item", zap.Error(err))
+			}
+		}
+	}
+}
+
 func (s *fileSync) processNextPendingUploadItem(ctx context.Context, state FileState) error {
 	item, err := s.queue.GetNextScheduled(ctx, filequeue.GetNextScheduledRequest[FileInfo]{
 		Subscribe:   true,
@@ -149,6 +167,9 @@ func (s *fileSync) processNextPendingUploadItem(ctx context.Context, state FileS
 	}
 
 	next, err := s.processFilePendingUpload(ctx, item)
+	if err != nil {
+		err = fmt.Errorf("object %s, file %s: %w", item.ObjectId, item.FileId, err)
+	}
 
 	releaseErr := s.queue.ReleaseAndUpdate(item.ObjectId, next)
 
@@ -159,10 +180,9 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 	blocksAvailability, err := s.checkBlocksAvailability(ctx, it)
 	if err != nil {
 		if errors.Is(err, errBlockNotFound) {
-			it.State = FileStateMissingBlocks
-			return it, nil
+			return s.parkMissingBlocks(it, err), nil
 		}
-		it = it.Reschedule()
+		it = rescheduleTransient(it)
 		return it, fmt.Errorf("check blocks availability: %w", err)
 	}
 
@@ -178,7 +198,7 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		return it, nil
 	}
 	if err != nil {
-		it = it.Reschedule()
+		it = rescheduleTransient(it)
 		return it, fmt.Errorf("get space limits: %w", err)
 	}
 
@@ -188,7 +208,7 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 		if !errors.As(allocateErr, &limitErr) {
 			// Transient infra failure (e.g. SpaceInfo failed). Reschedule for
 			// retry instead of marking the file as Limited.
-			it = it.Reschedule()
+			it = rescheduleTransient(it)
 			return it, fmt.Errorf("allocate file: %w", allocateErr)
 		}
 
@@ -215,7 +235,10 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 			it.ScheduledAt = time.Now()
 			return it, nil
 		}
-		it = it.Reschedule()
+		if errors.Is(err, errBlockNotFound) {
+			return s.parkMissingBlocks(it, err), nil
+		}
+		it = rescheduleTransient(it)
 		return it, err
 	}
 
@@ -231,15 +254,9 @@ func (s *fileSync) processFilePendingUpload(ctx context.Context, it FileInfo) (F
 }
 
 func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *blocksAvailabilityResponse) (FileInfo, error) {
-	var totalBytesToUpload int
-	err := s.walkFileBlocks(ctx, it.SpaceId, it.FileId, it.Variants, func(fileBlocks []blocks.Block) error {
-		bytesToUpload, err := s.uploadOrBindBlocks(ctx, it, fileBlocks, blocksAvailability.cidsToBind)
-		if err != nil {
-			return fmt.Errorf("select blocks to upload: %w", err)
-		}
-		totalBytesToUpload += bytesToUpload
-		return nil
-	})
+	// Bind the blocks the node already has: needs no block data, so it works
+	// even when the file is not present locally at all
+	err := s.bindCids(ctx, it, blocksAvailability.orderedCids(blocksAvailability.cidsToBind))
 	if err != nil {
 		if isNodeLimitReachedError(err) {
 			it.State = FileStateLimited
@@ -250,14 +267,21 @@ func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *
 			}
 			return it, nil
 		}
-		return it, fmt.Errorf("walk file blocks: %w", err)
+		if isBlockNotFoundError(err) {
+			// The node lost a block between BlocksCheck and BlocksBind (GC
+			// race): drop the cached plan so the next attempt re-enumerates
+			// and re-checks availability
+			it.CidsToBind = nil
+			it.CidsToUpload = nil
+			it.BytesToUploadOrBind = 0
+		}
+		return it, fmt.Errorf("bind cids: %w", err)
 	}
-
 	// All cids should be bind at this time
 	it.CidsToBind = nil
 
 	// Means that we only had to bind blocks
-	if totalBytesToUpload == 0 {
+	if len(blocksAvailability.cidsToUpload) == 0 {
 		err = s.updateStatus(it, filesyncstatus.Synced)
 		if err != nil {
 			return it, fmt.Errorf("add to status update queue: %w", err)
@@ -266,7 +290,12 @@ func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *
 		return it, nil
 	}
 
-	if it.ObjectId != "" && it.State != FileStateLimited {
+	err = s.uploadBlocks(ctx, it, blocksAvailability.orderedCids(blocksAvailability.cidsToUpload))
+	if err != nil {
+		return it, fmt.Errorf("upload blocks: %w", err)
+	}
+
+	if it.ObjectId != "" {
 		err = s.updateStatus(it, filesyncstatus.Syncing)
 		if err != nil {
 			return it, fmt.Errorf("update status: %w", err)
@@ -275,6 +304,104 @@ func (s *fileSync) upload(ctx context.Context, it FileInfo, blocksAvailability *
 
 	it.State = FileStateUploading
 	return it, nil
+}
+
+func (s *fileSync) bindCids(ctx context.Context, it FileInfo, cids []cid.Cid) error {
+	for start := 0; start < len(cids); start += bindBatchSize {
+		end := min(start+bindBatchSize, len(cids))
+		err := s.rpcStore.BindCids(ctx, it.SpaceId, it.FileId, cids[start:end])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// uploadBlocks pushes blocks to the file node in batches. Block data is read
+// from the local store only: these blocks are missing on the node, so there is
+// nowhere else to fetch them from.
+func (s *fileSync) uploadBlocks(ctx context.Context, it FileInfo, cids []cid.Cid) error {
+	dagService := s.dagServiceForSpace(it.SpaceId)
+	batch := make([]blocks.Block, 0, uploadBatchSize)
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		err := s.requestsBatcher.addFile(it.SpaceId, it.FileId.String(), it.ObjectId, batch)
+		if err != nil {
+			return fmt.Errorf("add file to requests batcher: %w", err)
+		}
+		batch = make([]blocks.Block, 0, uploadBatchSize)
+		return nil
+	}
+	for _, c := range cids {
+		node, err := dagService.Get(ctx, c)
+		if err != nil {
+			if isBlockNotFoundError(err) {
+				return fmt.Errorf("get local block %s: %w", c, errors.Join(err, errBlockNotFound))
+			}
+			return fmt.Errorf("get local block %s: %w", c, err)
+		}
+		b, err := blocks.NewBlockWithCid(node.RawData(), c)
+		if err != nil {
+			return fmt.Errorf("new block: %w", err)
+		}
+		batch = append(batch, b)
+		if len(batch) == uploadBatchSize {
+			if err = flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
+}
+
+// parkMissingBlocks puts an item aside when its blocks are found neither
+// locally nor on the file node: nothing can be done right now, but the blocks
+// may appear later — another device uploads the file, or viewing the file
+// caches its data locally — so the item is retried with a growing backoff
+// instead of being dropped silently.
+func (s *fileSync) parkMissingBlocks(it FileInfo, err error) FileInfo {
+	log.Warn("file blocks are missing both locally and on the file node, parking for retry",
+		zap.String("objectId", it.ObjectId),
+		zap.String("fileId", it.FileId.String()),
+		zap.String("spaceId", it.SpaceId),
+		zap.Int("retries", it.MissingBlocksRetries),
+		zap.Error(err))
+	it.State = FileStateMissingBlocks
+	it.ScheduledAt = time.Now().Add(missingBlocksRetryDelay(it.MissingBlocksRetries))
+	it.MissingBlocksRetries++
+	// Drop the cached availability plan: the situation may change while the
+	// item is parked (another device uploads the file, node GC), and a retry
+	// must re-enumerate and re-check instead of replaying a stale plan
+	it.CidsToBind = nil
+	it.CidsToUpload = nil
+	it.BytesToUploadOrBind = 0
+	return it
+}
+
+// rescheduleTransient delays an item after a transient failure (network
+// error, node unavailable). Items parked in MissingBlocks keep their long
+// backoff instead of the 1-minute retry, so an offline device doesn't churn
+// its parked items every minute.
+func rescheduleTransient(it FileInfo) FileInfo {
+	if it.State == FileStateMissingBlocks {
+		it.ScheduledAt = time.Now().Add(missingBlocksRetryDelay(it.MissingBlocksRetries))
+		return it
+	}
+	return it.Reschedule()
+}
+
+func missingBlocksRetryDelay(retries int) time.Duration {
+	const (
+		baseDelay = 10 * time.Minute
+		maxDelay  = 24 * time.Hour
+	)
+	delay := baseDelay
+	for i := 0; i < retries && delay < maxDelay; i++ {
+		delay *= 4
+	}
+	return min(delay, maxDelay)
 }
 
 type errLimitReached struct {
@@ -304,12 +431,47 @@ func (s *fileSync) addImportEvent(spaceID string) {
 		}}))
 }
 
+const (
+	// checkAvailabilityBatchSize limits the number of cids per BlocksCheck request
+	checkAvailabilityBatchSize = 64
+	// bindBatchSize limits the number of cids per BlocksBind request
+	bindBatchSize = 64
+	// uploadBatchSize limits how many blocks are handed to the requests
+	// batcher at once
+	uploadBatchSize = 10
+)
+
 type blocksAvailabilityResponse struct {
 	bytesToUploadOrBind int
 	cidsToBind          map[cid.Cid]struct{}
 	cidsToUpload        map[cid.Cid]struct{}
+	// order holds the enumeration order of the whole DAG (small variants
+	// first); empty for a plan restored from a persisted queue item
+	order []cid.Cid
 }
 
+// orderedCids returns the members of the set in enumeration order when it is
+// known, or in arbitrary order for a restored plan
+func (r *blocksAvailabilityResponse) orderedCids(set map[cid.Cid]struct{}) []cid.Cid {
+	out := make([]cid.Cid, 0, len(set))
+	if len(r.order) > 0 {
+		for _, c := range r.order {
+			if _, ok := set[c]; ok {
+				out = append(out, c)
+			}
+		}
+		return out
+	}
+	for c := range set {
+		out = append(out, c)
+	}
+	return out
+}
+
+// checkBlocksAvailability enumerates the file's cids (without requiring its
+// data to be present locally, see enumerateFileCids) and asks the file node
+// which of them it already has: those are bound to the space, the rest are
+// uploaded from the local store.
 func (s *fileSync) checkBlocksAvailability(ctx context.Context, info FileInfo) (*blocksAvailabilityResponse, error) {
 	if len(info.CidsToBind) > 0 || len(info.CidsToUpload) > 0 {
 		return &blocksAvailabilityResponse{
@@ -319,89 +481,56 @@ func (s *fileSync) checkBlocksAvailability(ctx context.Context, info FileInfo) (
 		}, nil
 	}
 
+	entries, err := s.enumerateFileCids(ctx, info.SpaceId, info.FileId, info.Variants)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate file cids: %w", err)
+	}
+
 	response := blocksAvailabilityResponse{
 		cidsToBind:   map[cid.Cid]struct{}{},
 		cidsToUpload: map[cid.Cid]struct{}{},
+		order:        make([]cid.Cid, 0, len(entries)),
 	}
-	err := s.walkFileBlocks(ctx, info.SpaceId, info.FileId, nil, func(fileBlocks []blocks.Block) error {
-		fileCids := lo.Map(fileBlocks, func(b blocks.Block, _ int) cid.Cid {
-			return b.Cid()
-		})
-		availabilities, err := s.rpcStore.CheckAvailability(ctx, info.SpaceId, fileCids)
+	sizes := make(map[cid.Cid]int, len(entries))
+	for _, entry := range entries {
+		response.order = append(response.order, entry.cid)
+		sizes[entry.cid] = entry.size
+	}
+
+	for start := 0; start < len(entries); start += checkAvailabilityBatchSize {
+		end := min(start+checkAvailabilityBatchSize, len(entries))
+		batch := response.order[start:end]
+
+		availabilities, err := s.rpcStore.CheckAvailability(ctx, info.SpaceId, batch)
 		if err != nil {
-			return fmt.Errorf("check availability: %w", err)
+			return nil, fmt.Errorf("check availability: %w", err)
 		}
+		statusByCid := make(map[cid.Cid]fileproto.AvailabilityStatus, len(availabilities))
 		for _, availability := range availabilities {
 			blockCid, err := cid.Cast(availability.Cid)
 			if err != nil {
-				return fmt.Errorf("cast cid: %w", err)
+				return nil, fmt.Errorf("cast cid: %w", err)
 			}
-
-			getBlock := func() (blocks.Block, error) {
-				b, ok := lo.Find(fileBlocks, func(b blocks.Block) bool {
-					return b.Cid() == blockCid
-				})
-				if !ok {
-					return nil, fmt.Errorf("block %s not found", blockCid)
-				}
-				return b, nil
+			statusByCid[blockCid] = availability.Status
+		}
+		for _, blockCid := range batch {
+			status, answered := statusByCid[blockCid]
+			// A cid the node did not answer for is treated as missing on the node
+			if !answered {
+				status = fileproto.AvailabilityStatus_NotExists
 			}
-
-			if availability.Status == fileproto.AvailabilityStatus_NotExists {
-				b, err := getBlock()
-				if err != nil {
-					return err
-				}
-				response.bytesToUploadOrBind += len(b.RawData())
+			switch status {
+			case fileproto.AvailabilityStatus_NotExists:
 				response.cidsToUpload[blockCid] = struct{}{}
-			} else if availability.Status == fileproto.AvailabilityStatus_Exists {
-				// Block exists in node, but not in user's space
-				b, err := getBlock()
-				if err != nil {
-					return err
-				}
+				response.bytesToUploadOrBind += sizes[blockCid]
+			case fileproto.AvailabilityStatus_Exists:
+				// Block exists on the node, but not in user's space
 				response.cidsToBind[blockCid] = struct{}{}
-				response.bytesToUploadOrBind += len(b.RawData())
+				response.bytesToUploadOrBind += sizes[blockCid]
 			}
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("walk DAG: %w", err)
 	}
 	return &response, nil
-}
-
-func (s *fileSync) uploadOrBindBlocks(ctx context.Context, fi FileInfo, fileBlocks []blocks.Block, needToBind map[cid.Cid]struct{}) (int, error) {
-	var (
-		bytesToUpload  int
-		blocksToUpload []blocks.Block
-		cidsToBind     []cid.Cid
-	)
-
-	for _, b := range fileBlocks {
-		blockCid := b.Cid()
-		if _, ok := needToBind[blockCid]; ok {
-			cidsToBind = append(cidsToBind, blockCid)
-		} else {
-			blocksToUpload = append(blocksToUpload, b)
-			bytesToUpload += len(b.RawData())
-		}
-	}
-
-	if len(cidsToBind) > 0 {
-		if bindErr := s.rpcStore.BindCids(ctx, fi.SpaceId, fi.FileId, cidsToBind); bindErr != nil {
-			return 0, fmt.Errorf("bind cids: %w", bindErr)
-		}
-	}
-
-	if len(blocksToUpload) > 0 {
-		err := s.requestsBatcher.addFile(fi.SpaceId, fi.FileId.String(), fi.ObjectId, blocksToUpload)
-		if err != nil {
-			return 0, fmt.Errorf("add to file: %w", err)
-		}
-	}
-	return bytesToUpload, nil
 }
 
 func isObjectDeletedError(err error) bool {

--- a/core/files/filesync/upload_test.go
+++ b/core/files/filesync/upload_test.go
@@ -210,7 +210,12 @@ func TestFileSync_AddFile(t *testing.T) {
 	})
 }
 
-func TestFileSync_AddFile_SkipWhenNotLocal(t *testing.T) {
+func TestFileSync_AddFile_QueuedWhenNotLocal(t *testing.T) {
+	// A file object may legitimately reference blocks that were never written
+	// locally (e.g. import dedup reused a fileId uploaded from another space or
+	// device). Such files must still be queued: the uploader confirms sync
+	// against the node. Here the blocks exist nowhere, so the item must park in
+	// MissingBlocks instead of being silently dropped.
 	fx := newFixture(t, 1024*1024*1024)
 	defer fx.Finish(t)
 
@@ -223,14 +228,9 @@ func TestFileSync_AddFile_SkipWhenNotLocal(t *testing.T) {
 	err := fx.AddFile(req)
 	require.NoError(t, err)
 
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	_, err = fx.queue.GetNext(timeoutCtx, filequeue.GetNextRequest[FileInfo]{
-		Subscribe:   true,
-		StoreFilter: filterByState(FileStatePendingUpload),
-		Filter:      func(info FileInfo) bool { return info.FileId == nonExistentFileId },
-	})
-	assert.Error(t, err, "file without local blocks should not be queued")
+	it := fx.waitItemState(t, "objectId1", FileStateMissingBlocks, 5*time.Second)
+	assert.Equal(t, nonExistentFileId, it.FileId)
+	assert.True(t, it.ScheduledAt.After(time.Now()), "missing-blocks item must be scheduled for a future retry")
 }
 
 func TestFileSync_MarkUploaded(t *testing.T) {

--- a/core/files/filesync/walker.go
+++ b/core/files/filesync/walker.go
@@ -6,82 +6,199 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/anyproto/any-sync/commonfile/fileblockstore"
 	"github.com/anyproto/any-sync/commonfile/fileproto/fileprotoerr"
+	"github.com/anyproto/any-sync/commonfile/fileservice"
+	"github.com/ipfs/boxo/ipld/merkledag"
+	"github.com/ipfs/boxo/ipld/unixfs"
+	"github.com/ipfs/boxo/ipld/unixfs/importer/helpers"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/domain"
 )
 
 var errBlockNotFound = errors.New("block not found")
 
-const batchSize = 10
+// leafSizeSlack covers the dag-pb and unixfs envelope around a leaf chunk when
+// comparing a link's cumulative size against the chunk size
+const leafSizeSlack = 4096
 
-func (s *fileSync) walkFileBlocks(ctx context.Context, spaceId string, fileId domain.FileId, priorityBranches []domain.FileId, proc func(fileBlocks []blocks.Block) error) error {
-	blocksBuf := make([]blocks.Block, 0, batchSize)
+// maxSingleLayerFileSize is the largest file content the balanced unixfs
+// importer lays out as a single layer of leaf chunks under one file node.
+// Larger files get intermediate nodes, so children of their top node are not
+// leaves.
+var maxSingleLayerFileSize = uint64(helpers.DefaultLinksPerBlock) * uint64(fileservice.ChunkSize)
 
-	err := s.walkDAG(ctx, spaceId, fileId, priorityBranches, func(node ipld.Node) error {
-		b, err := blocks.NewBlockWithCid(node.RawData(), node.Cid())
-		if err != nil {
-			return err
-		}
-		blocksBuf = append(blocksBuf, b)
-		if len(blocksBuf) == batchSize {
-			err = proc(blocksBuf)
-			if err != nil {
-				return fmt.Errorf("process batch: %w", err)
-			}
-			blocksBuf = blocksBuf[:0]
-		}
-		return nil
-	})
-	if err != nil {
-		if ipld.IsNotFound(err) || strings.Contains(err.Error(), "failed to fetch all nodes") || errors.Is(err, fileprotoerr.ErrCIDNotFound) {
-			return errors.Join(err, errBlockNotFound)
-		}
-		return fmt.Errorf("walk DAG: %w", err)
-	}
-
-	if len(blocksBuf) > 0 {
-		err = proc(blocksBuf)
-		if err != nil {
-			return fmt.Errorf("process batch: %w", err)
-		}
-	}
-	return nil
+type dagEntry struct {
+	cid  cid.Cid
+	size int
 }
 
-func (s *fileSync) walkDAG(ctx context.Context, spaceId string, fileId domain.FileId, priorityBranches []domain.FileId, visit func(node ipld.Node) error) error {
-	dagService := s.dagServiceForSpace(spaceId)
+// enumerateFileCids collects every cid of a file DAG together with its block
+// size, without requiring the file's data to be present locally.
+//
+// Structural nodes (directories, file nodes with links) are read from the
+// local store first, with a fallback to the file node (and cached locally).
+// Leaf chunks are never fetched: when a node is provably a single layer of
+// leaf chunks, its children are enumerated from the node's links (cid +
+// size). A fully-remote file thus costs a few KB of structural nodes to
+// enumerate, not the whole file.
+//
+// Returns errBlockNotFound (wrapped) when a node to fetch exists neither
+// locally nor on the file node.
+//
+// Branches are walked in the given order, so that entries of small file
+// variants come first; the file root is walked last and covers everything not
+// visited yet.
+func (s *fileSync) enumerateFileCids(ctx context.Context, spaceId string, fileId domain.FileId, priorityBranches []domain.FileId) ([]dagEntry, error) {
+	type stackItem struct {
+		c    cid.Cid
+		size uint64
+		leaf bool
+	}
+
+	branchIds := make([]domain.FileId, 0, len(priorityBranches)+1)
+	branchIds = append(branchIds, priorityBranches...)
+	branchIds = append(branchIds, fileId)
+
+	branches := make([]cid.Cid, 0, len(branchIds))
+	for _, branchId := range branchIds {
+		branchCid, err := cid.Parse(branchId.String())
+		if err != nil {
+			return nil, fmt.Errorf("parse CID %s: %w", branchId, err)
+		}
+		branches = append(branches, branchCid)
+	}
 
 	visited := map[cid.Cid]struct{}{}
+	var entries []dagEntry
+	for _, branch := range branches {
+		stack := []stackItem{{c: branch}}
+		for len(stack) > 0 {
+			item := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
 
-	priorityBranches = append(priorityBranches, fileId)
-	for _, branchId := range priorityBranches {
-		fileCid, err := cid.Parse(branchId.String())
-		if err != nil {
-			return fmt.Errorf("parse CID %s: %w", branchId, err)
-		}
-		rootNode, err := dagService.Get(ctx, fileCid)
-		if err != nil {
-			return fmt.Errorf("get root node: %w", err)
-		}
-		walker := ipld.NewWalker(ctx, ipld.NewNavigableIPLDNode(rootNode, dagService))
-		err = walker.Iterate(func(navNode ipld.NavigableNode) error {
-			node := navNode.GetIPLDNode()
-			if _, ok := visited[node.Cid()]; !ok {
-				visited[node.Cid()] = struct{}{}
-				return visit(node)
+			if _, ok := visited[item.c]; ok {
+				continue
 			}
-			return nil
-		})
-		if errors.Is(err, ipld.EndOfDag) {
-			err = nil
-		}
-		if err != nil {
-			return err
+			visited[item.c] = struct{}{}
+
+			// A raw block can't have children; its size is known from the
+			// parent's link, no need to fetch it
+			if item.leaf || (item.c.Prefix().Codec == cid.Raw && item.size > 0) {
+				entries = append(entries, dagEntry{cid: item.c, size: int(item.size)})
+				continue
+			}
+
+			node, err := s.getNode(ctx, spaceId, item.c)
+			if err != nil {
+				return nil, fmt.Errorf("get node %s: %w", item.c, err)
+			}
+			entries = append(entries, dagEntry{cid: item.c, size: len(node.RawData())})
+
+			links := node.Links()
+			if len(links) == 0 {
+				continue
+			}
+			leafChildren := childrenAreLeafChunks(node, links)
+			// Push in reverse so children pop in link order
+			for i := len(links) - 1; i >= 0; i-- {
+				link := links[i]
+				stack = append(stack, stackItem{
+					c:    link.Cid,
+					size: link.Size,
+					leaf: leafChildren && link.Size <= uint64(fileservice.ChunkSize)+leafSizeSlack,
+				})
+			}
 		}
 	}
-	return nil
+	return entries, nil
+}
+
+// childrenAreLeafChunks reports whether every child of the node is provably a
+// leaf chunk of file content, so that children can be enumerated from links
+// without fetching them.
+//
+// This holds for a unixfs file node whose content fits in a single layer of
+// chunks: the balanced importer then puts all leaves directly under it. The
+// check is exact for DAGs built with our chunk size (fileservice.ChunkSize).
+// A DAG built with a smaller chunker can, when its chunk count is ≡1 modulo
+// the link fanout, hide a one-chunk intermediate node behind a small link and
+// have it misread as a leaf; the consequence is one unenumerated block, never
+// a wrong upload. When in doubt this function returns false and the children
+// are fetched, which is always correct.
+func childrenAreLeafChunks(node ipld.Node, links []*ipld.Link) bool {
+	protoNode, ok := node.(*merkledag.ProtoNode)
+	if !ok {
+		return false
+	}
+	fsNode, err := unixfs.FSNodeFromBytes(protoNode.Data())
+	if err != nil {
+		return false
+	}
+	if fsNode.Type() != unixfs.TFile {
+		return false
+	}
+	if fsNode.NumChildren() != len(links) {
+		return false
+	}
+	if fsNode.FileSize() > maxSingleLayerFileSize {
+		return false
+	}
+	for i := range links {
+		if fsNode.BlockSize(i) > uint64(fileservice.ChunkSize) {
+			return false
+		}
+	}
+	return true
+}
+
+// getNode reads a DAG node from the local store, falling back to the file
+// node. Remotely fetched blocks are cached locally, so repeated enumerations
+// of the same file hit the local store.
+func (s *fileSync) getNode(ctx context.Context, spaceId string, c cid.Cid) (ipld.Node, error) {
+	ctx = fileblockstore.CtxWithSpaceId(ctx, spaceId)
+	node, err := s.dagServiceForSpace(spaceId).Get(ctx, c)
+	if err == nil {
+		return node, nil
+	}
+	if !isBlockNotFoundError(err) {
+		return nil, fmt.Errorf("get local node: %w", err)
+	}
+
+	b, err := s.rpcStore.Get(ctx, c)
+	if err != nil {
+		if isBlockNotFoundError(err) {
+			return nil, errors.Join(err, errBlockNotFound)
+		}
+		return nil, fmt.Errorf("get remote node: %w", err)
+	}
+	node, err = decodeBlock(b)
+	if err != nil {
+		return nil, fmt.Errorf("decode remote node: %w", err)
+	}
+	if addErr := s.fileStorage.Add(ctx, []blocks.Block{b}); addErr != nil {
+		log.Warn("cache remotely fetched node locally", zap.String("cid", c.String()), zap.Error(addErr))
+	}
+	return node, nil
+}
+
+func decodeBlock(b blocks.Block) (ipld.Node, error) {
+	switch b.Cid().Prefix().Codec {
+	case cid.DagProtobuf:
+		return merkledag.DecodeProtobufBlock(b)
+	case cid.Raw:
+		return merkledag.DecodeRawBlock(b)
+	default:
+		return nil, fmt.Errorf("unsupported codec %d", b.Cid().Prefix().Codec)
+	}
+}
+
+func isBlockNotFoundError(err error) bool {
+	return ipld.IsNotFound(err) ||
+		errors.Is(err, fileprotoerr.ErrCIDNotFound) ||
+		strings.Contains(err.Error(), "failed to fetch all nodes")
 }

--- a/core/files/filesync/walker.go
+++ b/core/files/filesync/walker.go
@@ -122,14 +122,17 @@ func (s *fileSync) enumerateFileCids(ctx context.Context, spaceId string, fileId
 // leaf chunk of file content, so that children can be enumerated from links
 // without fetching them.
 //
-// This holds for a unixfs file node whose content fits in a single layer of
-// chunks: the balanced importer then puts all leaves directly under it. The
-// check is exact for DAGs built with our chunk size (fileservice.ChunkSize).
-// A DAG built with a smaller chunker can, when its chunk count is ≡1 modulo
-// the link fanout, hide a one-chunk intermediate node behind a small link and
-// have it misread as a leaf; the consequence is one unenumerated block, never
-// a wrong upload. When in doubt this function returns false and the children
-// are fetched, which is always correct.
+// In a balanced unixfs DAG a node's children are either all leaves or all
+// intermediate nodes, and among intermediate children the first one always
+// covers a fully filled subtree of DefaultLinksPerBlock chunks. The per-child
+// blocksize check below therefore rejects any node with intermediate children
+// as long as the writer's chunk size exceeds ChunkSize/DefaultLinksPerBlock
+// (~6 KB); for anytype's fixed 1 MiB chunker the classification is exact.
+// Should a foreign sub-6KB-chunk DAG ever slip through, a skipped
+// intermediate node would leave its subtree unenumerated — not bound to the
+// space and so exposed to node-side garbage collection — which is why, when
+// in doubt, this function returns false and the children are fetched: that is
+// always correct.
 func childrenAreLeafChunks(node ipld.Node, links []*ipld.Link) bool {
 	protoNode, ok := node.(*merkledag.ProtoNode)
 	if !ok {

--- a/core/files/queries.go
+++ b/core/files/queries.go
@@ -44,6 +44,13 @@ func (s *service) getFileVariantBySourceChecksum(ctx context.Context, mill strin
 				Condition:   model.BlockContentDataviewFilter_Equal,
 				Value:       domain.String(options),
 			},
+			{
+				// A deleted file's blocks may be gone from the node, so its
+				// DAG must not be reused
+				RelationKey: bundle.RelationKeyIsDeleted,
+				Condition:   model.BlockContentDataviewFilter_NotEqual,
+				Value:       domain.Bool(true),
+			},
 		},
 		Limit: 1,
 	})
@@ -88,6 +95,13 @@ func (s *service) getFileVariantByChecksum(ctx context.Context, mill string, var
 				RelationKey: bundle.RelationKeyFileVariantChecksums,
 				Condition:   model.BlockContentDataviewFilter_Equal,
 				Value:       domain.String(variantChecksum),
+			},
+			{
+				// A deleted file's blocks may be gone from the node, so its
+				// DAG must not be reused
+				RelationKey: bundle.RelationKeyIsDeleted,
+				Condition:   model.BlockContentDataviewFilter_NotEqual,
+				Value:       domain.Bool(true),
 			},
 		},
 		Limit: 1,

--- a/core/files/queries_test.go
+++ b/core/files/queries_test.go
@@ -1,0 +1,80 @@
+package files
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore/spaceindex"
+)
+
+func givenFileVariantRecord(isDeleted bool) spaceindex.TestObject {
+	obj := spaceindex.TestObject{
+		bundle.RelationKeyId:                   domain.String("existingFileObjectId"),
+		bundle.RelationKeyFileId:               domain.String("existingFileId"),
+		bundle.RelationKeyFileSourceChecksum:   domain.String("sourceChecksum1"),
+		bundle.RelationKeyFileVariantIds:       domain.StringList([]string{"variantCid1"}),
+		bundle.RelationKeyFileVariantChecksums: domain.StringList([]string{"variantChecksum1"}),
+		bundle.RelationKeyFileVariantMills:     domain.StringList([]string{"/blob"}),
+		bundle.RelationKeyFileVariantPaths:     domain.StringList([]string{"file"}),
+		bundle.RelationKeyFileVariantKeys:      domain.StringList([]string{"key1"}),
+		bundle.RelationKeyFileVariantOptions:   domain.StringList([]string{"options1"}),
+		bundle.RelationKeyFileVariantWidths:    domain.Int64List([]int64{0}),
+	}
+	if isDeleted {
+		obj[bundle.RelationKeyIsDeleted] = domain.Bool(true)
+	}
+	return obj
+}
+
+func TestGetFileVariantBySourceChecksum(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("existing file object is reused", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.objectStore.(*objectstore.StoreFixture).AddObjects(t, spaceId, []spaceindex.TestObject{
+			givenFileVariantRecord(false),
+		})
+
+		// when
+		got, err := fx.Service.(*service).getFileVariantBySourceChecksum(ctx, "/blob", "sourceChecksum1", "options1")
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, domain.FileId("existingFileId"), got.fileId)
+	})
+
+	t.Run("deleted file object is not reused: its blocks may be gone from the node", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.objectStore.(*objectstore.StoreFixture).AddObjects(t, spaceId, []spaceindex.TestObject{
+			givenFileVariantRecord(true),
+		})
+
+		// when
+		_, err := fx.Service.(*service).getFileVariantBySourceChecksum(ctx, "/blob", "sourceChecksum1", "options1")
+
+		// then
+		require.Error(t, err)
+	})
+
+	t.Run("deleted file object is not reused by variant checksum either", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.objectStore.(*objectstore.StoreFixture).AddObjects(t, spaceId, []spaceindex.TestObject{
+			givenFileVariantRecord(true),
+		})
+
+		// when
+		_, _, err := fx.Service.(*service).getFileVariantByChecksum(ctx, "/blob", "variantChecksum1")
+
+		// then
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Problem

File objects can get stuck showing "Syncing" forever (`fileBackupStatus = Queued`, no `syncError`), with nothing actionable in the UI or logs. The bytes are typically already on the file node — the client just can never confirm it:

1. **`filesync.AddFile` silently dropped files whose root block wasn't in the local store** — no queue item, no log. But a file object may legitimately reference a fileId with no local blocks: import dedup reuses an existing fileId **cross-space** without re-adding blocks, while the file-object lookup is space-scoped. Importing the same content into a second space therefore creates a fresh object born at `Queued` that filesync never touches.
2. Even for queued files, confirming "already backed up" required **walking the entire DAG through the local-only store**: any locally-missing block failed the walk and parked the item in `FileStateMissingBlocks` — terminal and silent since GO-7034. The bind path (`BlocksCheck` → `BlocksBind` → `Synced`) was unreachable exactly for the files that needed it.
3. Dedup had **no `isDeleted` filter**, so a canceled/rolled-back import (objects deleted, blocks offloaded) followed by a re-import reuses fileIds whose blocks were just wiped.

## Solution

- `AddFile` always enqueues; local presence is no longer a precondition.
- New `enumerateFileCids` collects the full cid set + sizes **without leaf data**: structural dag-pb nodes are read local-first with file-node fallback (cached locally); leaf chunks are enumerated from parent links when provably leaves (unixfs metadata; exact for our 1MiB chunker). Enumerating a fully-remote 10GB file costs ~500KB of structural fetches — content is never downloaded.
- Plan-driven upload: cids the node already has are **bound by cid** (batches of 64); only `NotExists` blocks are read from the local store and pushed. A file already on the node reaches `Synced` with zero bytes transferred in either direction. Side effect: `ExistsInSpace` blocks are no longer re-uploaded on resume.
- `FileStateMissingBlocks` now means "blocks found neither locally nor on the node": logged at WARN **with objectId/fileId/spaceId**, retried by a dedicated queue consumer with capped exponential backoff (10min ×4ⁿ, max 24h), woken immediately by `AddFile`/`MarkUploaded`. Parking drops the cached availability plan so retries re-check the node; transient (offline) errors keep the long backoff instead of the 1-minute retry.
- `isDeleted` filters on both dedup queries and on the startup re-enqueue sweep.

## Repair of already-stuck files

No migration needed: the existing startup sweep (`ensureNotSyncedFilesAddedToQueue`) re-enqueues own non-Synced file objects; they now get verified against the node, bound, and flipped to `Synced`, which replicates to other devices. No re-upload, no content download (~120KB of structural/small-variant fetches per image-class file, cached).

## Compatibility / resources

- Only pre-existing `fileBackupStatus` values are written; old clients converge via their `markUploadedHook` when `Synced` replicates in. Queue-item schema change (`missingBlocksRetries`) is tolerated in both up-/downgrade directions.
- Node-side `BlocksBind` is idempotent and quota-enforced; the limit error routes to the existing `Limited` path. Simultaneous repair from two devices is safe.
- Steady-state cost of a permanently-missing file: ~1 BlockGet + 1 WARN line per day.

## Testing

- New reproducers in `core/files/filesync/bind_test.go` (all fail on the old code): bind-without-local-blocks, partial-local, mixed bind+upload, missing-everywhere → park → recover via retrier, stale-plan drop, `AddFile` wake.
- `TestFileSync_AddFile_SkipWhenNotLocal` inverted to assert the new queueing behavior; dedup `isDeleted` tests in `core/files/queries_test.go`.
- Full `./core/files/...` and `./core/syncstatus/...` suites pass.

Linear: GO-7366