### PR TITLE
acl: disable invite link creation for admins

### DIFF
--- a/core/acl/aclservice.go
+++ b/core/acl/aclservice.go
@@ -893,8 +893,16 @@ func (a *aclService) GenerateInvite(ctx context.Context, spaceId string, invType
 		return
 	}
 	commonSpace := acceptSpace.CommonSpace()
-	aclClient := commonSpace.AclClient()
 	acl := commonSpace.Acl()
+	// only the owner may create an invite. The any-sync node rejects a non-owner's invite record too, but
+	// checking here keeps admins from ever building or storing one in the first place.
+	acl.RLock()
+	isOwner := acl.AclState().Permissions(acl.AclState().Identity()).IsOwner()
+	acl.RUnlock()
+	if !isOwner {
+		return domain.InviteInfo{}, ErrIncorrectPermissions
+	}
+	aclClient := commonSpace.AclClient()
 	aclPermissions := domain.ConvertParticipantPermissions(permissions)
 	invitePayload := aclclient.InvitePayload{
 		Permissions: aclPermissions,

--- a/core/acl/aclservice_test.go
+++ b/core/acl/aclservice_test.go
@@ -928,6 +928,39 @@ func TestService_GenerateInvite(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "testCid", info.InviteFileCid)
 	})
+
+	t.Run("admin cannot generate invite", func(t *testing.T) {
+		// given a space where "e" is an admin, not the owner
+		fx := newFixture(t)
+		defer fx.finish(t)
+		spaceId := "spaceId"
+		fx.mockAccountService.EXPECT().PersonalSpaceID().Return("personal")
+		fx.mockInviteService.EXPECT().GetCurrent(ctx, spaceId).Return(domain.InviteInfo{}, inviteservice.ErrInviteNotExists)
+		mockSpace := mock_clientspace.NewMockSpace(t)
+		mockCommonSpace := mock_commonspace.NewMockSpace(fx.ctrl)
+		mockSpace.EXPECT().CommonSpace().Return(mockCommonSpace)
+		fx.mockSpaceService.EXPECT().Get(ctx, spaceId).Return(mockSpace, nil)
+
+		exec := list.NewAclExecutor(spaceId)
+		cmds := []struct {
+			cmd string
+			err error
+		}{
+			{"a.init::a", nil},
+			{"a.invite::invId", nil},
+			{"e.join::invId", nil},
+			{"a.approve::e,adm", nil},
+		}
+		for _, c := range cmds {
+			require.Equal(t, c.err, exec.Execute(c.cmd), c.cmd)
+		}
+		// the acl is seen from the admin's point of view, so the owner check fails before any invite is built
+		mockCommonSpace.EXPECT().Acl().Return(mockSyncAcl{exec.ActualAccounts()["e"].Acl})
+
+		info, err := fx.GenerateInvite(ctx, spaceId, model.InviteType_Member, model.ParticipantPermissions_Reader, false)
+		require.ErrorIs(t, err, ErrIncorrectPermissions)
+		require.Empty(t, info.InviteFileCid)
+	})
 }
 
 func TestService_Join(t *testing.T) {


### PR DESCRIPTION
Client-side guard for GO-7367: only the space owner can create invite links. Previously `GenerateInvite` had no permission check and relied entirely on the any-sync node rejecting the record; this fails fast without a round trip and without waiting on the any-sync dependency bump (anyproto/any-sync#729).

Invite lookup (returning an already-existing invite), invite permission change, and invite revoke are unaffected — only creating a new invite record is restricted.

GO-7367

## Test plan
- [x] Added `admin cannot generate invite` subtest to `TestService_GenerateInvite`
- [x] Updated existing owner-path subtests/concurrency tests to mock the new `Acl()` call
- [x] `go test ./core/acl/...` passes