### PR TITLE
GO-7374 Replay the full tree when a store-backed object has never been replayed

### DIFF
--- a/core/block/editor/storestate/tx.go
+++ b/core/block/editor/storestate/tx.go
@@ -8,15 +8,22 @@ import (
 	"github.com/anyproto/any-store/anyenc"
 )
 
-const addSeqKey = "q"
+const (
+	addSeqKey = "q"
+	// replayedKey marks that the whole change tree has been replayed into the store at
+	// least once, which is what makes addSeqKey usable as an incremental watermark.
+	replayedKey = "r"
+)
 
 type StoreStateTx struct {
-	tx              anystore.WriteTx
-	ctx             context.Context
-	state           *StoreState
-	arena           *anyenc.Arena
-	maxAddSeq       uint64
-	maxAddSeqChanged bool
+	tx                   anystore.WriteTx
+	ctx                  context.Context
+	state                *StoreState
+	arena                *anyenc.Arena
+	maxAddSeq            uint64
+	maxAddSeqChanged     bool
+	fullyReplayed        bool
+	fullyReplayedChanged bool
 }
 
 func (stx *StoreStateTx) Context() context.Context {
@@ -33,11 +40,30 @@ func (stx *StoreStateTx) init() (err error) {
 		return findErr
 	}
 	stx.maxAddSeq = uint64(doc.Value().GetInt(addSeqKey))
+	stx.fullyReplayed = doc.Value().GetBool(replayedKey)
 	return nil
 }
 
 func (stx *StoreStateTx) GetMaxAddSeq() uint64 {
 	return stx.maxAddSeq
+}
+
+// IsFullyReplayed reports whether the object's whole change tree has already been replayed
+// into the store. Until that has happened once, GetMaxAddSeq is NOT a usable watermark:
+// addSeq is a local per-insert sequence that older builds never assigned, so changes stored
+// back then carry addSeq == 0, and the tree only hands out changes with an addSeq strictly
+// greater than the watermark — it can never reach them.
+func (stx *StoreStateTx) IsFullyReplayed() bool {
+	return stx.fullyReplayed
+}
+
+// MarkFullyReplayed records that the whole tree has been replayed, so that subsequent
+// applies can use the addSeq watermark and only read changes added since.
+func (stx *StoreStateTx) MarkFullyReplayed() {
+	if !stx.fullyReplayed {
+		stx.fullyReplayed = true
+		stx.fullyReplayedChanged = true
+	}
 }
 
 func (stx *StoreStateTx) UpdateMaxAddSeq(seq uint64) {
@@ -64,11 +90,16 @@ func (stx *StoreStateTx) applyChangeSet(ch ChangeSet, returnAllErrors bool) (err
 }
 
 func (stx *StoreStateTx) Commit() (err error) {
-	if stx.maxAddSeqChanged {
+	if stx.maxAddSeqChanged || stx.fullyReplayedChanged {
+		// UpsertOne replaces the whole document, so both fields are always written out,
+		// not just the changed one.
 		stx.arena.Reset()
 		obj := stx.arena.NewObject()
 		obj.Set("id", stx.arena.NewString(stx.state.id))
 		obj.Set(addSeqKey, stx.arena.NewNumberInt(int(stx.maxAddSeq)))
+		if stx.fullyReplayed {
+			obj.Set(replayedKey, stx.arena.NewTrue())
+		}
 		if err = stx.state.collMeta.UpsertOne(stx.ctx, obj); err != nil {
 			return
 		}

--- a/core/block/source/sourceimpl/store_apply.go
+++ b/core/block/source/sourceimpl/store_apply.go
@@ -26,9 +26,7 @@ func (a *storeApply) Apply(ctx context.Context) error {
 		a.hook.BeforeIteration(a.ot)
 	}
 
-	maxAddSeq := a.tx.GetMaxAddSeq()
-
-	err := a.ot.IterateAfterAddSeq(ctx, maxAddSeq, UnmarshalStoreChange, func(change *objecttree.Change) bool {
+	iterate := func(change *objecttree.Change) bool {
 		a.tx.UpdateMaxAddSeq(change.AddSeq)
 
 		if a.hook != nil {
@@ -36,14 +34,26 @@ func (a *storeApply) Apply(ctx context.Context) error {
 		}
 
 		lastErr = a.applyChange(change)
-		if lastErr != nil {
-			return false
-		}
+		return lastErr == nil
+	}
 
-		return true
-	})
+	if a.tx.IsFullyReplayed() {
+		err := a.ot.IterateAfterAddSeq(ctx, a.tx.GetMaxAddSeq(), UnmarshalStoreChange, iterate)
+		return errors.Join(err, lastErr)
+	}
 
-	return errors.Join(err, lastErr)
+	// Nothing has been replayed into the store yet, so the addSeq watermark cannot be used
+	// to pick up where we left off: addSeq is a local per-insert sequence that older builds
+	// never assigned, and IterateAfterAddSeq only yields changes whose addSeq is strictly
+	// greater than the watermark. Starting from 0 therefore silently skips every change
+	// stored before addSeq existed. Walk the tree instead — it yields the complete history
+	// in order (store-backed objects never snapshot, so the tree spans the genesis root).
+	err := a.ot.IterateRoot(UnmarshalStoreChange, iterate)
+	if err = errors.Join(err, lastErr); err != nil {
+		return err
+	}
+	a.tx.MarkFullyReplayed()
+	return nil
 }
 
 func (a *storeApply) applyChange(change *objecttree.Change) (err error) {

--- a/core/block/source/sourceimpl/store_apply_legacy_test.go
+++ b/core/block/source/sourceimpl/store_apply_legacy_test.go
@@ -1,0 +1,163 @@
+package sourceimpl
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-store/anyenc"
+	"github.com/anyproto/any-store/query"
+	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
+	"github.com/anyproto/any-sync/commonspace/object/tree/treechangeproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/storestate"
+)
+
+// recordingHook captures every change the replay walks over, which is exactly what the
+// legacy-addSeq bug silently truncated.
+type recordingHook struct {
+	iterated []string
+}
+
+func (h *recordingHook) BeforeIteration(objecttree.ObjectTree) {}
+
+func (h *recordingHook) OnIteration(_ objecttree.ObjectTree, change *objecttree.Change) {
+	h.iterated = append(h.iterated, change.Id)
+}
+
+func (h *recordingHook) AfterDiffManagersInit(context.Context) error { return nil }
+
+// stripAddSeq removes the addSeq key from every stored change, reproducing storage written
+// by builds from before any-sync assigned an addSeq. Such changes read back as addSeq == 0.
+func stripAddSeq(t testing.TB, treeDb anystore.DB) {
+	coll, err := treeDb.OpenCollection(ctx, objecttree.CollName)
+	require.NoError(t, err)
+
+	iter, err := coll.Find(nil).Iter(ctx)
+	require.NoError(t, err)
+	var ids []string
+	for iter.Next() {
+		doc, err := iter.Doc()
+		require.NoError(t, err)
+		ids = append(ids, doc.Value().GetString("id"))
+	}
+	require.NoError(t, iter.Close())
+
+	unsetAddSeq := query.ModifyFunc(func(_ *anyenc.Arena, v *anyenc.Value) (*anyenc.Value, bool, error) {
+		if v.Get(objecttree.AddSeqKey) == nil {
+			return v, false, nil
+		}
+		v.Del(objecttree.AddSeqKey)
+		return v, true, nil
+	})
+	for _, id := range ids {
+		_, err = coll.UpdateId(ctx, id, unsetAddSeq)
+		require.NoError(t, err)
+	}
+}
+
+// newLegacyTreeFx builds a real object tree whose changes are all stored without an addSeq,
+// paired with an empty store state — i.e. the state after the object store is wiped and the
+// pre-existing tree has to be replayed from scratch.
+func newLegacyTreeFx(t *testing.T) (*storestate.StoreState, objecttree.ObjectTree) {
+	var treeDb anystore.DB
+	changeCreator := objecttree.NewMockChangeCreator(func() anystore.DB {
+		treeDb = createStore(ctx, t)
+		return treeDb
+	})
+	aclList, _ := prepareAclList(t)
+	treeStorage := changeCreator.CreateNewTreeStorage(t, "0", aclList.Head().Id, false)
+
+	tree, err := objecttree.BuildTestableTree(treeStorage, aclList)
+	require.NoError(t, err)
+	tree.SetFlusher(objecttree.MarkNewChangeFlusher())
+
+	_, err = tree.AddRawChanges(ctx, objecttree.RawChangesPayload{
+		NewHeads: []string{"3", "5"},
+		RawChanges: []*treechangeproto.RawTreeChangeWithId{
+			changeCreator.CreateRaw("1", aclList.Head().Id, "0", false, "0"),
+			changeCreator.CreateRaw("2", aclList.Head().Id, "0", false, "1"),
+			changeCreator.CreateRaw("3", aclList.Head().Id, "0", true, "2"),
+			changeCreator.CreateRaw("4", aclList.Head().Id, "0", false, "0"),
+			changeCreator.CreateRaw("5", aclList.Head().Id, "0", true, "4"),
+		},
+	})
+	require.NoError(t, err)
+
+	stripAddSeq(t, treeDb)
+
+	// rebuild so the in-memory changes carry the stripped (zero) addSeq, like a real reopen
+	legacyTree, err := objecttree.BuildTestableTree(treeStorage, aclList)
+	require.NoError(t, err)
+
+	stateDb, err := anystore.Open(ctx, filepath.Join(t.TempDir(), "crdt.db"), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stateDb.Close() })
+
+	state, err := storestate.New(ctx, "source_test", stateDb, storestate.DefaultHandler{Name: "default"})
+	require.NoError(t, err)
+
+	return state, legacyTree
+}
+
+// Changes stored before any-sync assigned an addSeq carry addSeq == 0. IterateAfterAddSeq
+// only yields changes with an addSeq strictly greater than the watermark, so replaying such
+// a tree from watermark 0 used to skip its entire history: chat details and messages were
+// silently dropped whenever the object store was rebuilt (a reindex, or a deleted
+// objectstore folder).
+func TestStoreApply_ReplaysChangesWithoutAddSeq(t *testing.T) {
+	state, tree := newLegacyTreeFx(t)
+
+	tx, err := state.NewTx(ctx)
+	require.NoError(t, err)
+	require.False(t, tx.IsFullyReplayed(), "a fresh store state has replayed nothing yet")
+
+	hook := &recordingHook{}
+	applier := &storeApply{tx: tx, ot: tree, hook: hook}
+	require.NoError(t, applier.Apply(ctx))
+	require.NoError(t, tx.Commit())
+
+	assert.Subset(t, hook.iterated, []string{"1", "2", "3", "4", "5"},
+		"every change must be replayed even though none of them has an addSeq")
+
+	// the full replay is recorded, so later applies can use the incremental path
+	tx, err = state.NewTx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	assert.True(t, tx.IsFullyReplayed())
+}
+
+// Once the tree has been fully replayed, applies must go back to reading only what was added
+// since the watermark instead of rescanning the whole history on every open.
+func TestStoreApply_IncrementalAfterFullReplay(t *testing.T) {
+	state, tree := newLegacyTreeFx(t)
+
+	tx, err := state.NewTx(ctx)
+	require.NoError(t, err)
+	applier := &storeApply{tx: tx, ot: tree, hook: &recordingHook{}}
+	require.NoError(t, applier.Apply(ctx))
+	require.NoError(t, tx.Commit())
+
+	// a new change arrives; it gets a real addSeq, unlike the legacy ones
+	_, err = tree.AddRawChanges(ctx, objecttree.RawChangesPayload{
+		NewHeads: []string{"6"},
+		RawChanges: []*treechangeproto.RawTreeChangeWithId{
+			objecttree.NewMockChangeCreator(func() anystore.DB { return createStore(ctx, t) }).
+				CreateRaw("6", tree.AclList().Head().Id, "0", false, "3", "5"),
+		},
+	})
+	require.NoError(t, err)
+
+	tx, err = state.NewTx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback()
+
+	hook := &recordingHook{}
+	applier = &storeApply{tx: tx, ot: tree, hook: hook}
+	require.NoError(t, applier.Apply(ctx))
+
+	assert.Equal(t, []string{"6"}, hook.iterated, "only the change added since the watermark")
+}

--- a/core/debug/changedataconverter.go
+++ b/core/debug/changedataconverter.go
@@ -3,20 +3,38 @@ package debug
 import (
 	"fmt"
 
+	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
+
 	"github.com/anyproto/anytype-heart/core/block/source/sourceimpl"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/util/anonymize"
 )
 
+// changeDataConverter (de)serializes tree changes for export/import. Regular
+// smartblocks encode changes as pb.Change; store-backed objects (chats,
+// discussions, etc., see smartblock.SmartBlockType.IsStoreBacked) encode
+// changes as pb.StoreChange instead. storeBacked picks which wire format to use.
 type changeDataConverter struct {
-	anonymize bool
+	anonymize   bool
+	storeBacked bool
 }
 
 func (c *changeDataConverter) Unmarshall(dataType string, decrypted []byte) (res any, err error) {
+	if c.storeBacked {
+		return sourceimpl.UnmarshalStoreChange(&objecttree.Change{DataType: dataType}, decrypted)
+	}
 	return sourceimpl.UnmarshalChangeWithDataType(dataType, decrypted)
 }
 
 func (c *changeDataConverter) Marshall(model any) (data []byte, dataType string, err error) {
+	if c.storeBacked {
+		ch, ok := model.(*pb.StoreChange)
+		if !ok {
+			return nil, "", fmt.Errorf("can't convert the model")
+		}
+		data, err = ch.Marshal()
+		return
+	}
 	ch, ok := model.(*pb.Change)
 	if !ok {
 		return nil, "", fmt.Errorf("can't convert the model")

--- a/core/debug/treeexporter.go
+++ b/core/debug/treeexporter.go
@@ -12,14 +12,28 @@ import (
 
 	anystore "github.com/anyproto/any-store"
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
+	"github.com/gogo/protobuf/proto"
 
 	"github.com/anyproto/anytype-heart/core/debug/exporter"
 	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/anonymize"
 	"github.com/anyproto/anytype-heart/util/pbtypes"
 	"github.com/anyproto/anytype-heart/util/ziputil"
 )
+
+// treeSmartBlockType reads the smartblock type out of the tree's root change
+// payload, so the exporter knows whether to (de)serialize changes as
+// pb.Change or pb.StoreChange (see smartblock.SmartBlockType.IsStoreBacked).
+func treeSmartBlockType(tree objecttree.ReadableObjectTree) (smartblock.SmartBlockType, error) {
+	payload := &model.ObjectChangePayload{}
+	if err := proto.Unmarshal(tree.ChangeInfo().ChangePayload, payload); err != nil {
+		return 0, fmt.Errorf("unmarshal change payload: %w", err)
+	}
+	return smartblock.SmartBlockType(payload.SmartBlockType), nil
+}
 
 type treeExporter struct {
 	log        *stdlog.Logger
@@ -50,10 +64,14 @@ func (e *treeExporter) Export(ctx context.Context, path string, tree objecttree.
 	defer func() {
 		_ = anyStore.Close()
 	}()
+	sbt, sbtErr := treeSmartBlockType(tree)
+	if sbtErr != nil {
+		log.Errorf("can't determine smartblock type for %s, assuming pb.Change: %v", e.id, sbtErr)
+	}
 	exportParams := exporter.ExportParams{
 		Readable:  tree,
 		Store:     anyStore,
-		Converter: &changeDataConverter{anonymize: e.anonymized},
+		Converter: &changeDataConverter{anonymize: e.anonymized, storeBacked: sbtErr == nil && sbt.IsStoreBacked()},
 	}
 	st := time.Now()
 	err = exporter.ExportTree(ctx, exportParams)


### PR DESCRIPTION
Fixes [GO-7374](https://linear.app/anytype/issue/GO-7374/chats-lose-details-and-messages-when-the-crdt-store-is-rebuilt-addseq).

## The bug

Chats came back as **"Untitled"** after a full local reindex — and, unnoticed, also came back **missing about half their messages**. Vault previews read straight from the crdt store, so their last-message and unread counts were wrong too.

any-sync writes the `q` (addSeq) key onto a stored change only `if AddSeq > 0`. Changes stored **before any-sync introduced addSeq have no `q` key at all** and read back as `0`. Replay uses `IterateAfterAddSeq(watermark)`, whose storage filter is `q > watermark` — *strictly* greater — so a first replay (watermark `0`) can never see them.

This only bites when the crdt store is rebuilt from the tree (`reindexChats`/`reindexDiscussions` wiping the collections, or a deleted `objectstore/` folder). Normally `crdt.db` is never rebuilt, which is why it stayed hidden since GO-7104 introduced the watermark.

On a real chat: the tree has **477 changes, 313 of them with `addSeq == 0`** — including all 6 rename/details changes and the first 139 message creates. `crdt.db` held exactly the 124 creates with `q > 0`; the sets match element for element. No errors were logged, because those changes were never handed to the apply layer at all.

## The fix

`_meta` gains an `r` (fullyReplayed) marker alongside the `q` watermark. `storeApply.Apply` walks the **whole tree** (`IterateRoot` — ordered, and it does see addSeq-less changes) until that marker is set, then switches back to the incremental `IterateAfterAddSeq` path. Re-applying is idempotent (creates hit `ErrDocExists` → `ErrIgnore`), so an affected object repairs itself the next time it's opened.

Applies to every store-backed type: `chatDerived`, `discussion`, `accountObject`, `techSpace`.

**No reindex-counter bump in this PR.** Note that means already-corrupted installs are not repaired automatically: since GO-7302 vault previews subscribe with `OnlyLastMessage` and deliberately never open the chat tree, so `Init` — and therefore the replay — only runs for a chat the user actually opens. A counter bump (`ForceInvalidateObjectsIndexCounter`, or the chat/discussion counters) is what would force every chat open once and repair them; deliberately left for a follow-up decision.

## Also included

The debug tree exporter (`core/debug/`) hardcoded `pb.Change` for every change, silently corrupting the export of **any** store-backed object. It now reads the smartblock type from the tree's root change payload and branches on `pb.Change` vs `pb.StoreChange`. This was needed to get trustworthy evidence for the bug above, and is worth having on its own.

## Tests

`store_apply_legacy_test.go` drives a **real** any-sync object tree with the `addSeq` key stripped from storage, exactly as legacy storage looks. Without the fix it replays **zero** changes; with it, all of them. A second test pins that once the tree is fully replayed, applies go back to reading only what was added since the watermark, rather than rescanning the whole history on every open.

## Follow-ups (found, not fixed here)

- `storestate/modifier.go` `makeModifier`: the LWW order guard reads `getFieldOrder(val, …)` where `val` is the *incoming* value — should be `v`, the stored doc. As written the guard can never trip, so concurrent modifies resolve by replay order instead of lexid order. Inert for this bug, but a real convergence bug.
- Ideal upstream fix: any-sync `GetAfterAddSeq` should not filter on `q` when the watermark is `0`.
- `reindexChats` wipes the collections and *then* calls `space.Do`; an already-cached object is a cache hit, skips `Init`, and is left with emptied collections until its next cold open.