### PR TITLE
GO-7377 Index bookmark blocks as outgoing links; set createdInContext on bookmarks

### DIFF
--- a/core/block/editor/bookmark/bookmark.go
+++ b/core/block/editor/bookmark/bookmark.go
@@ -15,6 +15,7 @@ import (
 	"github.com/anyproto/anytype-heart/core/domain/objectorigin"
 	"github.com/anyproto/anytype-heart/core/session"
 	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 	"github.com/anyproto/anytype-heart/util/uri"
@@ -138,7 +139,15 @@ func (b *sbookmark) updateBlock(block bookmark.Block, templateId string, apply f
 	}
 
 	content := block.GetContent()
-	pageID, _, err := b.bookmarkSvc.CreateBookmarkObject(context.Background(), b.SpaceID(), templateId, block.ToDetails(origin), func() *bookmark.ObjectContent {
+	details := block.ToDetails(origin)
+	// Record the object and block the bookmark was created in, so the bookmark
+	// object keeps a reference back to its origin context. The context (object)
+	// id lives on the smartblock; the inner locator is the bookmark block id.
+	if contextId := b.Id(); contextId != "" {
+		details.SetString(bundle.RelationKeyCreatedInContext, contextId)
+		details.SetString(bundle.RelationKeyCreatedInContextRef, block.Model().Id)
+	}
+	pageID, _, err := b.bookmarkSvc.CreateBookmarkObject(context.Background(), b.SpaceID(), templateId, details, func() *bookmark.ObjectContent {
 		return &bookmark.ObjectContent{BookmarkContent: content}
 	})
 	if err != nil {

--- a/core/block/editor/bookmark/bookmark_test.go
+++ b/core/block/editor/bookmark/bookmark_test.go
@@ -1,0 +1,56 @@
+package bookmark
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bookmarksvc "github.com/anyproto/anytype-heart/core/block/bookmark"
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock/smarttest"
+	simplebookmark "github.com/anyproto/anytype-heart/core/block/simple/bookmark"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/core/domain/objectorigin"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+type fakeBookmarkService struct {
+	gotDetails *domain.Details
+}
+
+func (f *fakeBookmarkService) FetchAsync(spaceID string, blockID string, params simplebookmark.FetchParams) {
+}
+
+func (f *fakeBookmarkService) CreateBookmarkObject(
+	ctx context.Context, spaceId, templateId string, details *domain.Details, getContent bookmarksvc.ContentFuture,
+) (string, *domain.Details, error) {
+	f.gotDetails = details
+	return "bookmarkObjectId", details, nil
+}
+
+func newBookmarkBlock(id, url string) simplebookmark.Block {
+	return simplebookmark.NewBookmark(&model.Block{
+		Id:      id,
+		Content: &model.BlockContentOfBookmark{Bookmark: &model.BlockContentBookmark{Url: url}},
+	}).(simplebookmark.Block)
+}
+
+func TestSbookmark_updateBlock(t *testing.T) {
+	t.Run("records createdInContext (object) and ref (block) of the containing object", func(t *testing.T) {
+		// given
+		fake := &fakeBookmarkService{}
+		b := &sbookmark{SmartBlock: smarttest.New("pageObjectId"), bookmarkSvc: fake}
+		block := newBookmarkBlock("bookmarkBlockId", "http://example.com")
+
+		// when
+		err := b.updateBlock(block, "", func(simplebookmark.Block) error { return nil }, objectorigin.None())
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, fake.gotDetails)
+		assert.Equal(t, "pageObjectId", fake.gotDetails.GetString(bundle.RelationKeyCreatedInContext))
+		assert.Equal(t, "bookmarkBlockId", fake.gotDetails.GetString(bundle.RelationKeyCreatedInContextRef))
+	})
+}

--- a/core/block/editor/smartblock/smartblock.go
+++ b/core/block/editor/smartblock/smartblock.go
@@ -1504,6 +1504,17 @@ func (sb *smartBlock) collectOutgoingLinks(st *state.State) []OutgoingLink {
 			})
 		}
 
+		// A bookmark block points at its bookmark object via TargetObjectId. Without this
+		// the bookmark object gets no backlink from the containing page and objectgc
+		// misclassifies it as an orphan (GO-7377).
+		if bm := blockModel.GetBookmark(); bm != nil && bm.TargetObjectId != "" && bm.TargetObjectId != objectId && !linkSet[bm.TargetObjectId] {
+			linkSet[bm.TargetObjectId] = true
+			outgoingLinks = append(outgoingLinks, OutgoingLink{
+				TargetID:      bm.TargetObjectId,
+				SourceBlockID: blockModel.Id,
+			})
+		}
+
 		if text := blockModel.GetText(); text != nil && text.Marks != nil {
 			// Extract mentions and inline-object marks from text marks. Object marks
 			// (e.g. @page references) are semantically equivalent to mentions for the

--- a/core/block/editor/smartblock/smartblock_test.go
+++ b/core/block/editor/smartblock/smartblock_test.go
@@ -322,6 +322,44 @@ func TestSmartBlock_CollectOutgoingLinks(t *testing.T) {
 		assert.Equal(t, "file1", links[0].SourceBlockID)
 	})
 
+	t.Run("collect link from bookmark block", func(t *testing.T) {
+		// given
+		objectId := "root"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{
+			{Id: objectId, ChildrenIds: []string{"bookmark1"}},
+			{Id: "bookmark1", Content: &model.BlockContentOfBookmark{
+				Bookmark: &model.BlockContentBookmark{TargetObjectId: "bookmarkTarget1"},
+			}},
+		})
+
+		// when
+		links := fx.collectOutgoingLinks(fx.NewState())
+
+		// then
+		require.Len(t, links, 1)
+		assert.Equal(t, "bookmarkTarget1", links[0].TargetID)
+		assert.Equal(t, "bookmark1", links[0].SourceBlockID)
+	})
+
+	t.Run("skip self-reference in bookmark block", func(t *testing.T) {
+		// given
+		objectId := "root"
+		fx := newFixture(objectId, t)
+		fx.init(t, []*model.Block{
+			{Id: objectId, ChildrenIds: []string{"bookmark1"}},
+			{Id: "bookmark1", Content: &model.BlockContentOfBookmark{
+				Bookmark: &model.BlockContentBookmark{TargetObjectId: objectId}, // self-reference
+			}},
+		})
+
+		// when
+		links := fx.collectOutgoingLinks(fx.NewState())
+
+		// then
+		assert.Empty(t, links)
+	})
+
 	t.Run("collect link from text mention", func(t *testing.T) {
 		// given
 		objectId := "root"

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -75,7 +75,10 @@ const (
 	// reindexes objects asynchronously and continue reindex after app F
 	// Bumped to 4 for GO-7237: collection members, inline dataview embeds, and Object-marks
 	// are now indexed as outgoing links — existing objects need a one-shot reindex pass.
-	ForceInvalidateObjectsIndexCounter int32 = 4
+	// Bumped to 5 for GO-7377: bookmark blocks are now indexed as outgoing links, so
+	// existing pages must be reindexed to restore the missing page→bookmark backlinks
+	// (which otherwise make bookmark objects look like orphans in objectgc).
+	ForceInvalidateObjectsIndexCounter int32 = 5
 )
 
 type allDeletedIdsProvider interface {


### PR DESCRIPTION
## Problem

Bookmark blocks were never collected as outgoing links. `collectOutgoingLinks`
(`core/block/editor/smartblock/smartblock.go`) handles link blocks, file blocks,
text mentions / object marks, inline dataview embeds, collection members and
relations — but **not bookmark blocks**. So a bookmark block's `TargetObjectId`
never became an outgoing link, and the referenced bookmark object never received
a backlink from the page holding it.

The context-aware objectgc / orphan detector (`core/block/objectgc/orphanlist.go`)
treats a GC-eligible object as an orphan when it has `createdInContext` set but
its parent context has no backlink to it. Bookmark objects in the **Get Started**
archive ship with `createdInContext` already set, so with no backlink they were
all misclassified as orphans and suggested for removal in the new UI.

## Fix

- **`collectOutgoingLinks`**: emit the page→bookmark link from bookmark blocks
  (`SourceBlockID` = bookmark block id), mirroring the existing file-block case.
- **bookmark editor** (`core/block/editor/bookmark/bookmark.go`): set
  `createdInContext` (page id) and `createdInContextRef` (bookmark block id) on
  newly created bookmark objects, matching the file upload flows.
- **`ForceInvalidateObjectsIndexCounter` 4→5**: existing pages must reindex so
  the missing page→bookmark backlinks are restored. A plain reindex replaces each
  object's link set (`updateObjectLinksDetailed`), so the new link — and its
  inverse backlink — is picked up without erasing links first.

## Not doing: backfill

`runObjectContextMigration` stays file-only. The false-orphan symptom is fixed by
restoring backlinks, not by stamping `createdInContext` onto more bookmarks —
which would only widen the objectgc candidate pool. The migration also can't
resolve bookmark contexts until backlinks exist, so it would be a no-op anyway.

## Testing

- `TestSmartBlock_CollectOutgoingLinks`: added `collect link from bookmark block`
  and `skip self-reference in bookmark block` subtests.
- `TestSbookmark_updateBlock`: verifies `createdInContext`/`Ref` are set to the
  containing object and bookmark block ids.
- `go test ./core/block/editor/smartblock/... ./core/block/editor/bookmark/... ./core/block/simple/bookmark/...` — all green.

Linear: GO-7377
