### PR TITLE
GO-7378 Fix chat unread counters inflated by reindex reopen

### DIFF
--- a/core/block/chats/chatsubscription/manager.go
+++ b/core/block/chats/chatsubscription/manager.go
@@ -144,6 +144,48 @@ func (s *subscriptionManager) GetChatState() *model.ChatState {
 	return copyChatState(s.chatState)
 }
 
+// ReconcileChatState re-derives the ChatState and message count from the repository — the
+// persisted read-flags are the source of truth — and replaces the in-memory copies only when
+// they diverged. The in-memory counters can drift from the DB: a change replayed over an
+// already-stored message bumps them before the insert is ignored with ErrDocExists, and an
+// apply error rolls the DB back after they were already bumped. Managers are also cached
+// across object reopens, so drift survives until something reloads. Called under Lock on
+// object open, before the first flush, so clients never observe drifted values.
+func (s *subscriptionManager) ReconcileChatState() {
+	dbState, err := s.repository.LoadChatState(s.componentCtx)
+	if err != nil {
+		log.Error("reconcile chat state: load from repository", zap.Error(err))
+		return
+	}
+	if !chatStateValuesEqual(s.chatState, dbState) {
+		s.UpdateChatState(func(*model.ChatState) *model.ChatState {
+			return dbState
+		})
+	}
+	count, err := s.repository.CountMessages(s.componentCtx)
+	if err != nil {
+		log.Error("reconcile chat state: count messages", zap.Error(err))
+		return
+	}
+	if int32(count) != s.messageCount {
+		s.messageCount = int32(count)
+		s.messageCountUpdated = true
+	}
+}
+
+// chatStateValuesEqual compares everything clients consume (counters and watermarks),
+// ignoring the local event-ordering field Order.
+func chatStateValuesEqual(a, b *model.ChatState) bool {
+	return unreadStateEqual(a.GetMessages(), b.GetMessages()) &&
+		unreadStateEqual(a.GetMentions(), b.GetMentions()) &&
+		a.GetLastStateId() == b.GetLastStateId() &&
+		a.GetUnreadReactionOrderId() == b.GetUnreadReactionOrderId()
+}
+
+func unreadStateEqual(a, b *model.ChatStateUnreadState) bool {
+	return a.GetOldestOrderId() == b.GetOldestOrderId() && a.GetCounter() == b.GetCounter()
+}
+
 func (s *subscriptionManager) UpdateChatState(updater func(*model.ChatState) *model.ChatState) {
 	s.chatState = updater(s.chatState)
 	s.chatStateOrder++

--- a/core/block/chats/chatsubscription/mock_chatsubscription/mock_Manager.go
+++ b/core/block/chats/chatsubscription/mock_chatsubscription/mock_Manager.go
@@ -157,6 +157,38 @@ func (_c *MockManager_ForceReloadReactionState_Call) RunAndReturn(run func()) *M
 	return _c
 }
 
+// ReconcileChatState provides a mock function with no fields
+func (_m *MockManager) ReconcileChatState() {
+	_m.Called()
+}
+
+// MockManager_ReconcileChatState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconcileChatState'
+type MockManager_ReconcileChatState_Call struct {
+	*mock.Call
+}
+
+// ReconcileChatState is a helper method to define mock.On call
+func (_e *MockManager_Expecter) ReconcileChatState() *MockManager_ReconcileChatState_Call {
+	return &MockManager_ReconcileChatState_Call{Call: _e.mock.On("ReconcileChatState")}
+}
+
+func (_c *MockManager_ReconcileChatState_Call) Run(run func()) *MockManager_ReconcileChatState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockManager_ReconcileChatState_Call) Return() *MockManager_ReconcileChatState_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockManager_ReconcileChatState_Call) RunAndReturn(run func()) *MockManager_ReconcileChatState_Call {
+	_c.Run(run)
+	return _c
+}
+
 // ForceSendingChatState provides a mock function with no fields
 func (_m *MockManager) ForceSendingChatState() {
 	_m.Called()

--- a/core/block/chats/chatsubscription/service.go
+++ b/core/block/chats/chatsubscription/service.go
@@ -70,6 +70,7 @@ type Manager interface {
 	UpdateReactionReadStatus(msgId string, unread bool)
 	ReadReactions(newOrderId string, idsModified []string)
 	ForceReloadReactionState()
+	ReconcileChatState()
 }
 
 type Service interface {

--- a/core/block/editor/chatobject/chathandler.go
+++ b/core/block/editor/chatobject/chathandler.go
@@ -71,6 +71,23 @@ func (d *ChatHandler) Init(ctx context.Context, s *storestate.StoreState) (err e
 }
 
 func (d *ChatHandler) BeforeCreate(ctx context.Context, ch storestate.ChangeOp) error {
+	coll, err := ch.State.Collection(ctx, CollectionName)
+	if err != nil {
+		return fmt.Errorf("get collection: %w", err)
+	}
+	_, err = coll.FindId(ctx, ch.Value.GetString("id"))
+	if err == nil {
+		// The message is already stored: this create is being replayed over an existing
+		// store (e.g. the one-time full-tree replay storeApply runs for a store without
+		// the fullyReplayed marker, which a reindex triggers for every chat). The insert
+		// would hit ErrDocExists anyway; bail out before mutating the subscription
+		// counters, so already-read messages are not resurrected as unread.
+		return storestate.ErrIgnore
+	}
+	if !errors.Is(err, anystore.ErrDocNotFound) {
+		return fmt.Errorf("check for existing message: %w", err)
+	}
+
 	msg, err := chatmodel.UnmarshalMessage(ch.Value)
 	if err != nil {
 		return fmt.Errorf("unmarshal message: %w", err)

--- a/core/block/editor/chatobject/chatobject.go
+++ b/core/block/editor/chatobject/chatobject.go
@@ -326,6 +326,12 @@ func (s *storeObject) onInit(ctx *smartblock.InitContext) {
 	s.subscription.Lock()
 	defer s.subscription.Unlock()
 
+	// The cached manager's in-memory counters may have drifted from the persisted
+	// read-flags (e.g. a failed apply rolled the DB back after the counters were bumped).
+	// The repository is authoritative — reconcile before the first flush so clients never
+	// see drifted values.
+	s.subscription.ReconcileChatState()
+
 	// It's important to flush updates to subscriptions after reading a store document, or we can lose some important
 	// updates such as unread counters state
 	s.subscription.Flush(true)

--- a/core/block/editor/chatobject/chatobject_test.go
+++ b/core/block/editor/chatobject/chatobject_test.go
@@ -96,6 +96,11 @@ type fixture struct {
 
 	generateOrderIdFunc func(tx *storestate.StoreStateTx) string
 	lastOrder           string
+
+	// appliedChangeSets records every change set committed through applyToStore so a
+	// test can faithfully re-drive the store's replay (as storeApply does on reopen)
+	// without needing a real object tree.
+	appliedChangeSets []storestate.ChangeSet
 }
 
 const (
@@ -607,13 +612,14 @@ func (fx *fixture) applyToStore(ctx context.Context, params source.PushStoreChan
 		_ = tx.Rollback()
 	}()
 	order := fx.generateOrderId(tx)
-	err = tx.ApplyChangeSetReturnAllErrors(storestate.ChangeSet{
+	changeSet := storestate.ChangeSet{
 		Id:        changeId,
 		Order:     order,
 		Changes:   params.Changes,
 		Creator:   fx.sourceCreator,
 		Timestamp: params.Time.Unix(),
-	})
+	}
+	err = tx.ApplyChangeSetReturnAllErrors(changeSet)
 	if err != nil {
 		return "", fmt.Errorf("apply change set: %w", err)
 	}
@@ -621,6 +627,7 @@ func (fx *fixture) applyToStore(ctx context.Context, params source.PushStoreChan
 	if err != nil {
 		return "", err
 	}
+	fx.appliedChangeSets = append(fx.appliedChangeSets, changeSet)
 	fx.onUpdate()
 	return changeId, nil
 }

--- a/core/block/editor/chatobject/reindex_reopen_repro_test.go
+++ b/core/block/editor/chatobject/reindex_reopen_repro_test.go
@@ -1,0 +1,129 @@
+package chatobject
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/chats/chatmodel"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// TestReindexReopenDoesNotResetUnreadCounter guards against the chat unread-counter "reset"
+// that a bump of ForceInvalidateObjectsIndexCounter used to cause (fixed by the existence
+// check in ChatHandler.BeforeCreate).
+//
+// The whole flow (core/indexer/reindex.go):
+//   - Bumping ForceInvalidateObjectsIndexCounter sets flags.invalidateObjectsIndex, which
+//     ClearHeadsState()s the objectstore heads collection and then reindexOutdatedObjects
+//     re-opens EVERY object in the space via space.Do(). The iterator over HeadStorage has
+//     no smartblock-type filter, so chat/discussion derived objects are re-opened too.
+//   - Opening a chat runs source.ReadStoreDoc -> storeApply.Apply. For a chat whose store
+//     predates the `_meta.r` (fullyReplayed) marker, Apply walks the WHOLE tree with
+//     IterateRoot (core/block/source/sourceimpl/store_apply.go), i.e. it re-applies every
+//     already-stored message change.
+//   - storestate.applyCreate calls ChatHandler.BeforeCreate for every such change and only
+//     THEN Insert()s it. Already-stored messages hit ErrDocExists -> ErrIgnore, so the
+//     persisted read-flags in crdt.db are preserved — but BeforeCreate has already bumped
+//     the in-memory unread counter (subscription.UpdateChatState). Nothing sets
+//     needReloadState on a create-only replay (only Delete does), so Flush never reloads
+//     the true count from the DB, and the inflated counter is what the client sees.
+//
+// Net effect: a fully-read chat comes back with its unread counter equal to the number of
+// not-own messages, even though every message is still marked read in the DB.
+//
+// The test drives the store through a faithful stand-in for that one-time full replay: it
+// re-applies the exact change sets the store already holds, which is precisely what
+// storeApply.applyChange does for each change IterateRoot yields on reopen. No object tree
+// is needed to exhibit the counter divergence.
+func TestReindexReopenDoesNotResetUnreadCounter(t *testing.T) {
+	ctx := context.Background()
+	fx := newFixture(t)
+	// forceNotRead makes every applied message land as unread, standing in for messages
+	// authored by other participants (Creator != currentIdentity) — the case that inflates
+	// the counter on replay.
+	fx.chatHandler.forceNotRead = true
+
+	const n = 5
+	for i := 0; i < n; i++ {
+		_, err := fx.AddMessage(ctx, nil, givenSimpleMessage(fmt.Sprintf("message %d", i+1)))
+		require.NoError(t, err)
+	}
+
+	// The user reads the whole chat: counter goes to zero and every message is read in the DB.
+	_, err := fx.MarkReadMessages(ctx, ReadMessagesRequest{
+		All:         true,
+		CounterType: chatmodel.CounterTypeMessage,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, int32(0), fx.subscription.GetChatState().Messages.Counter,
+		"precondition: a fully-read chat must have a zero unread counter")
+
+	// Reindex reopen: replay the store's own changes, exactly as storeApply.Apply does on
+	// the one-time full IterateRoot pass for a chat without the fullyReplayed marker.
+	tx, err := fx.store.NewTx(ctx)
+	require.NoError(t, err)
+	for _, cs := range fx.appliedChangeSets {
+		// Already-stored creates hit ErrDocExists, which applyChangeSet swallows as ErrIgnore.
+		require.NoError(t, tx.ApplyChangeSet(cs))
+	}
+	require.NoError(t, tx.Commit())
+
+	// The persisted state is untouched: every message is still read (the Insert was ignored).
+	dbState, err := fx.repository.LoadChatState(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), dbState.Messages.Counter,
+		"replay must not change the persisted read-flags")
+
+	// Before the fix the replay's BeforeCreate calls inflated the in-memory counter the
+	// client sees, resurrecting every already-read message as unread.
+	got := fx.subscription.GetChatState().Messages.Counter
+	assert.Equal(t, int32(0), got,
+		"reopening a fully-read chat during reindex must not resurrect %d unread messages", n)
+}
+
+// TestReconcileChatStateHealsDriftedCounters covers the self-healing backstop: whatever
+// manages to desynchronize the cached manager's in-memory counters from the persisted
+// read-flags (a rolled-back apply after the counters were bumped, a past inflation shipped
+// before the BeforeCreate fix), the reconcile run on every object open restores DB truth.
+func TestReconcileChatStateHealsDriftedCounters(t *testing.T) {
+	ctx := context.Background()
+	fx := newFixture(t)
+	fx.chatHandler.forceNotRead = true
+
+	const n = 3
+	for i := 0; i < n; i++ {
+		_, err := fx.AddMessage(ctx, nil, givenSimpleMessage(fmt.Sprintf("message %d", i+1)))
+		require.NoError(t, err)
+	}
+
+	// Drift the in-memory state away from the DB truth (n unread, oldest = first message).
+	fx.subscription.Lock()
+	fx.subscription.UpdateChatState(func(state *model.ChatState) *model.ChatState {
+		state.Messages.Counter += 100
+		state.Messages.OldestOrderId = ""
+		return state
+	})
+	fx.subscription.UpdateMessageCount(100)
+	fx.subscription.Unlock()
+
+	dbState, err := fx.repository.LoadChatState(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int32(n), dbState.Messages.Counter, "precondition: DB truth is untouched")
+
+	// Reopen path: onInit reconciles under lock before flushing.
+	fx.subscription.Lock()
+	fx.subscription.ReconcileChatState()
+	fx.subscription.Unlock()
+
+	assert.Equal(t, int32(n), fx.subscription.GetChatState().Messages.Counter,
+		"reconcile must restore the unread counter from the persisted read-flags")
+	assert.Equal(t, dbState.Messages.OldestOrderId, fx.subscription.GetChatState().Messages.OldestOrderId,
+		"reconcile must restore the oldest unread order id")
+	assert.Equal(t, int32(n), fx.subscription.GetMessageCount(),
+		"reconcile must restore the message count")
+}


### PR DESCRIPTION
## Problem

Bumping `ForceInvalidateObjectsIndexCounter` makes `reindexOutdatedObjects` reopen every object in the space — chats included. For a chat store without the `_meta.r` fullyReplayed marker (any store created before the GO-7374 fix), the open runs a full `IterateRoot` replay over already-stored messages: `ChatHandler.BeforeCreate` bumps the in-memory unread counter / message count / subscription state **before** the insert fails with `ErrDocExists → ErrIgnore`. The persisted read-flags stay correct, but the cached subscription manager diverges and nothing reloads it (`needReloadState` is only set by Delete) — so fully-read chats come back with their whole history counted as unread.

Since the 4→5 bump (GO-7377) is already on develop, every legacy install runs that full replay once on next start — this fix should ship in the same release.

## Fix (two independent parts)

1. **Root cause** — `BeforeCreate` checks the collection first and returns `ErrIgnore` when the message is already stored, before any counter/subscription/FT side effects. Also makes the one-time replay cheaper: skips `GetPrevOrderId` and the FT re-enqueue per stored message.
2. **Self-healing backstop** — new `Manager.ReconcileChatState()` reloads ChatState + message count from the repository iff the values diverged (Order-insensitive compare, so an unchanged state emits no phantom event); called in `storeObject.onInit` before the first flush. Heals clients already inflated by the bump before this fix, and drift from applies rolled back after the counters were bumped.

Rejected alternative — suppressing counter side effects during replay — breaks cold sync: with an empty store the DB seed is 0 and the suppressed increments are the only source, leaving the counter at 0 while the DB says N unread.

## Tests

- `reindex_reopen_repro_test.go`: replay-over-populated-store repro (failed with counter 5 vs 0 before the fix) + reconcile drift-healing test.
- Suites green: chatobject, chats, chatmodel, chatrepository, chatsubscription, storestate, sourceimpl, accountobject, indexer.

Resolves GO-7378