### PR TITLE
GO-7379 Cut cellular-switch recovery latency: bounded node lookups, fast retry, prioritized sweep

### DIFF
--- a/core/block/space_cname_test.go
+++ b/core/block/space_cname_test.go
@@ -1,0 +1,16 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/space"
+)
+
+// The space service looks the block service up by a copied name (importing
+// this package would be a cycle); if the constants drift, the head-sync
+// sweep silently loses its opened-spaces priority.
+func TestSpaceBlockServiceCNameInSync(t *testing.T) {
+	assert.Equal(t, CName, space.BlockServiceCName)
+}

--- a/space/dedupqueue/dedupqueue_test.go
+++ b/space/dedupqueue/dedupqueue_test.go
@@ -18,7 +18,7 @@ func TestNewDedupQueue(t *testing.T) {
 	assert.NotNil(t, dq.batch)
 	assert.NotNil(t, dq.entries)
 	assert.Equal(t, uint64(0), dq.cnt.Load())
-	
+
 	err := dq.Close()
 	assert.NoError(t, err)
 }
@@ -26,26 +26,26 @@ func TestNewDedupQueue(t *testing.T) {
 func TestDedupQueue_Replace_SingleCall(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var callCount atomic.Int32
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 		close(done)
 	})
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 1)
 	assert.Contains(t, dq.entries, "test1")
 	dq.mx.Unlock()
-	
+
 	dq.Run()
-	
+
 	<-done
-	
+
 	assert.Equal(t, int32(1), callCount.Load())
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 0)
 	dq.mx.Unlock()
@@ -54,39 +54,39 @@ func TestDedupQueue_Replace_SingleCall(t *testing.T) {
 func TestDedupQueue_Replace_MultipleCalls(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var callCount atomic.Int32
 	var lastValue atomic.Int32
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 		lastValue.Store(1)
 	})
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 		lastValue.Store(2)
 	})
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 		lastValue.Store(3)
 		close(done)
 	})
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 1)
 	assert.Contains(t, dq.entries, "test1")
 	dq.mx.Unlock()
-	
+
 	dq.Run()
-	
+
 	<-done
-	
+
 	assert.Equal(t, int32(1), callCount.Load())
 	assert.Equal(t, int32(3), lastValue.Load())
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 0)
 	dq.mx.Unlock()
@@ -95,41 +95,41 @@ func TestDedupQueue_Replace_MultipleCalls(t *testing.T) {
 func TestDedupQueue_Replace_DifferentIds(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var callCount1 atomic.Int32
 	var callCount2 atomic.Int32
 	var wg sync.WaitGroup
 	wg.Add(2)
-	
+
 	dq.Replace("test1", func() {
 		callCount1.Add(1)
 		wg.Done()
 	})
-	
+
 	dq.Replace("test2", func() {
 		callCount2.Add(1)
 		wg.Done()
 	})
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 2)
 	assert.Contains(t, dq.entries, "test1")
 	assert.Contains(t, dq.entries, "test2")
 	dq.mx.Unlock()
-	
+
 	dq.Run()
-	
+
 	go func() {
 		wg.Wait()
 		close(done)
 	}()
-	
+
 	<-done
-	
+
 	assert.Equal(t, int32(1), callCount1.Load())
 	assert.Equal(t, int32(1), callCount2.Load())
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 0)
 	dq.mx.Unlock()
@@ -138,23 +138,23 @@ func TestDedupQueue_Replace_DifferentIds(t *testing.T) {
 func TestDedupQueue_Replace_NilCall(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
-	
+
 	dq.Replace("test1", nil)
 	dq.Replace("test2", func() {
 		close(done)
 	})
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 2)
 	assert.Contains(t, dq.entries, "test1")
 	dq.mx.Unlock()
-	
+
 	dq.Run()
-	
+
 	<-done
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 0)
 	dq.mx.Unlock()
@@ -163,22 +163,22 @@ func TestDedupQueue_Replace_NilCall(t *testing.T) {
 func TestDedupQueue_Replace_FullQueue(t *testing.T) {
 	dq := New(1)
 	defer dq.Close()
-	
+
 	var callCount1 atomic.Int32
 	var callCount2 atomic.Int32
-	
+
 	dq.Replace("test1", func() {
 		callCount1.Add(1)
 	})
-	
+
 	dq.Replace("test2", func() {
 		callCount2.Add(1)
 	})
-	
+
 	dq.mx.Lock()
 	entriesLen := len(dq.entries)
 	dq.mx.Unlock()
-	
+
 	assert.Equal(t, 1, entriesLen)
 	assert.Equal(t, int32(0), callCount1.Load())
 	assert.Equal(t, int32(0), callCount2.Load())
@@ -187,38 +187,38 @@ func TestDedupQueue_Replace_FullQueue(t *testing.T) {
 func TestDedupQueue_Run_MultipleRuns(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var callCount atomic.Int32
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 		close(done)
 	})
-	
+
 	dq.Run()
 	dq.Run()
 	dq.Run()
-	
+
 	<-done
-	
+
 	assert.Equal(t, int32(1), callCount.Load())
 }
 
 func TestDedupQueue_ConcurrentReplace(t *testing.T) {
 	dq := New(100)
 	defer dq.Close()
-	
+
 	dq.Run()
-	
+
 	var wg sync.WaitGroup
 	var totalCalls atomic.Int32
 	numGoroutines := 10
 	numReplacesPerGoroutine := 100
 	done := make(chan struct{})
-	
+
 	wg.Add(numGoroutines)
-	
+
 	for i := 0; i < numGoroutines; i++ {
 		go func(id int) {
 			defer wg.Done()
@@ -231,19 +231,19 @@ func TestDedupQueue_ConcurrentReplace(t *testing.T) {
 			}
 		}(i)
 	}
-	
+
 	go func() {
 		wg.Wait()
 		time.Sleep(100 * time.Millisecond)
 		close(done)
 	}()
-	
+
 	<-done
-	
+
 	calls := totalCalls.Load()
 	assert.Greater(t, calls, int32(0))
 	assert.LessOrEqual(t, calls, int32(numGoroutines*numReplacesPerGoroutine))
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 0)
 	dq.mx.Unlock()
@@ -252,17 +252,17 @@ func TestDedupQueue_ConcurrentReplace(t *testing.T) {
 func TestDedupQueue_ConcurrentReplaceDifferentIds(t *testing.T) {
 	dq := New(100)
 	defer dq.Close()
-	
+
 	dq.Run()
-	
+
 	var wg sync.WaitGroup
 	var totalCalls atomic.Int32
 	numGoroutines := 5
 	numReplacesPerGoroutine := 5
 	done := make(chan struct{})
-	
+
 	wg.Add(numGoroutines)
-	
+
 	for i := 0; i < numGoroutines; i++ {
 		go func(id int) {
 			defer wg.Done()
@@ -275,19 +275,19 @@ func TestDedupQueue_ConcurrentReplaceDifferentIds(t *testing.T) {
 			}
 		}(i)
 	}
-	
+
 	go func() {
 		wg.Wait()
 		time.Sleep(50 * time.Millisecond)
 		close(done)
 	}()
-	
+
 	<-done
-	
+
 	calls := totalCalls.Load()
 	assert.Greater(t, calls, int32(0))
 	assert.LessOrEqual(t, calls, int32(numGoroutines*numReplacesPerGoroutine))
-	
+
 	dq.mx.Lock()
 	assert.Len(t, dq.entries, 0)
 	dq.mx.Unlock()
@@ -295,27 +295,27 @@ func TestDedupQueue_ConcurrentReplaceDifferentIds(t *testing.T) {
 
 func TestDedupQueue_Close(t *testing.T) {
 	dq := New(10)
-	
+
 	var callCount atomic.Int32
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 	})
-	
+
 	dq.Run()
-	
+
 	err := dq.Close()
 	assert.NoError(t, err)
-	
+
 	assert.Equal(t, int32(0), callCount.Load())
 }
 
 func TestDedupQueue_CloseMultipleTimes(t *testing.T) {
 	dq := New(10)
-	
+
 	err1 := dq.Close()
 	assert.NoError(t, err1)
-	
+
 	err2 := dq.Close()
 	assert.Error(t, err2)
 }
@@ -323,15 +323,15 @@ func TestDedupQueue_CloseMultipleTimes(t *testing.T) {
 func TestDedupQueue_CounterIncrement(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	initialCnt := dq.cnt.Load()
-	
+
 	dq.Replace("test1", func() {})
 	assert.Equal(t, initialCnt+1, dq.cnt.Load())
-	
+
 	dq.Replace("test2", func() {})
 	assert.Equal(t, initialCnt+2, dq.cnt.Load())
-	
+
 	dq.Replace("test1", func() {})
 	assert.Equal(t, initialCnt+3, dq.cnt.Load())
 }
@@ -339,40 +339,40 @@ func TestDedupQueue_CounterIncrement(t *testing.T) {
 func TestDedupQueue_EntryCounter(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	dq.Replace("test1", func() {})
-	
+
 	dq.mx.Lock()
 	entry1 := dq.entries["test1"]
 	cnt1 := entry1.cnt
 	dq.mx.Unlock()
-	
+
 	dq.Replace("test1", func() {})
-	
+
 	dq.mx.Lock()
 	entry2 := dq.entries["test1"]
 	cnt2 := entry2.cnt
 	dq.mx.Unlock()
-	
+
 	assert.Greater(t, cnt2, cnt1)
 }
 
 func TestDedupQueue_CallLoopExecution(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	executed := make(chan string, 10)
-	
+
 	dq.Replace("test1", func() {
 		executed <- "test1"
 	})
-	
+
 	dq.Replace("test2", func() {
 		executed <- "test2"
 	})
-	
+
 	dq.Run()
-	
+
 	var results []string
 	for i := 0; i < 2; i++ {
 		select {
@@ -382,7 +382,7 @@ func TestDedupQueue_CallLoopExecution(t *testing.T) {
 			t.Fatal("timeout waiting for execution")
 		}
 	}
-	
+
 	assert.Len(t, results, 2)
 	assert.Contains(t, results, "test1")
 	assert.Contains(t, results, "test2")
@@ -391,12 +391,12 @@ func TestDedupQueue_CallLoopExecution(t *testing.T) {
 func TestDedupQueue_ReplaceDuringExecution(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	var executionOrder []int
 	var mu sync.Mutex
 	started := make(chan struct{})
 	finished := make(chan struct{})
-	
+
 	dq.Replace("test1", func() {
 		mu.Lock()
 		executionOrder = append(executionOrder, 1)
@@ -404,20 +404,20 @@ func TestDedupQueue_ReplaceDuringExecution(t *testing.T) {
 		close(started)
 		time.Sleep(20 * time.Millisecond)
 	})
-	
+
 	dq.Run()
-	
+
 	<-started
-	
+
 	dq.Replace("test1", func() {
 		mu.Lock()
 		executionOrder = append(executionOrder, 2)
 		mu.Unlock()
 		close(finished)
 	})
-	
+
 	<-finished
-	
+
 	mu.Lock()
 	assert.Equal(t, []int{1, 2}, executionOrder)
 	mu.Unlock()
@@ -426,34 +426,34 @@ func TestDedupQueue_ReplaceDuringExecution(t *testing.T) {
 func TestDedupQueue_EmptyId(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var called atomic.Bool
-	
+
 	dq.Replace("", func() {
 		called.Store(true)
 		close(done)
 	})
-	
+
 	dq.Run()
-	
+
 	<-done
-	
+
 	assert.True(t, called.Load())
 }
 
 func TestDedupQueue_LongRunningCall(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	var wg sync.WaitGroup
 	wg.Add(2)
-	
+
 	var call1Started atomic.Bool
 	var call1Done atomic.Bool
 	var call2Done atomic.Bool
 	call1StartedChan := make(chan struct{})
-	
+
 	dq.Replace("test1", func() {
 		call1Started.Store(true)
 		close(call1StartedChan)
@@ -461,17 +461,17 @@ func TestDedupQueue_LongRunningCall(t *testing.T) {
 		call1Done.Store(true)
 		wg.Done()
 	})
-	
+
 	dq.Replace("test2", func() {
 		<-call1StartedChan
 		call2Done.Store(true)
 		wg.Done()
 	})
-	
+
 	dq.Run()
-	
+
 	wg.Wait()
-	
+
 	assert.True(t, call1Started.Load())
 	assert.True(t, call1Done.Load())
 	assert.True(t, call2Done.Load())
@@ -480,43 +480,43 @@ func TestDedupQueue_LongRunningCall(t *testing.T) {
 func TestDedupQueue_PanicInCall(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var call2Done atomic.Bool
-	
+
 	dq.Replace("test1", func() {
 		defer func() {
 			recover()
 		}()
 		panic("test panic")
 	})
-	
+
 	dq.Replace("test2", func() {
 		call2Done.Store(true)
 		close(done)
 	})
-	
+
 	dq.Run()
-	
+
 	<-done
-	
+
 	assert.True(t, call2Done.Load())
 }
 
 func TestDedupQueue_ZeroMaxSize(t *testing.T) {
 	dq := New(0)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var callCount atomic.Int32
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 		close(done)
 	})
-	
+
 	dq.Run()
-	
+
 	select {
 	case <-done:
 		assert.Equal(t, int32(1), callCount.Load())
@@ -527,22 +527,22 @@ func TestDedupQueue_ZeroMaxSize(t *testing.T) {
 
 func TestDedupQueue_ReplaceAfterClose(t *testing.T) {
 	dq := New(10)
-	
+
 	var callCount atomic.Int32
-	
+
 	dq.Close()
-	
+
 	dq.Replace("test1", func() {
 		callCount.Add(1)
 	})
-	
+
 	assert.Equal(t, int32(0), callCount.Load())
 }
 
 func TestDedupQueue_ReplaceWithSameFunction(t *testing.T) {
 	dq := New(10)
 	defer dq.Close()
-	
+
 	done := make(chan struct{})
 	var callCount atomic.Int32
 	fn := func() {
@@ -553,28 +553,28 @@ func TestDedupQueue_ReplaceWithSameFunction(t *testing.T) {
 			close(done)
 		}
 	}
-	
+
 	dq.Replace("test1", fn)
 	dq.Replace("test1", fn)
 	dq.Replace("test1", fn)
-	
+
 	dq.Run()
-	
+
 	<-done
-	
+
 	assert.Equal(t, int32(1), callCount.Load())
 }
 
 func TestDedupQueue_ManyUniqueIds(t *testing.T) {
 	dq := New(1000)
 	defer dq.Close()
-	
+
 	var totalCalls atomic.Int32
 	numIds := 100
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(numIds)
-	
+
 	for i := range numIds {
 		id := "test" + string(rune(i))
 		dq.Replace(id, func() {
@@ -582,15 +582,15 @@ func TestDedupQueue_ManyUniqueIds(t *testing.T) {
 			wg.Done()
 		})
 	}
-	
+
 	dq.Run()
-	
+
 	go func() {
 		wg.Wait()
 		close(done)
 	}()
-	
+
 	<-done
-	
+
 	assert.Equal(t, int32(numIds), totalCalls.Load())
 }

--- a/space/internal/components/participantwatcher/participantwatcher_test.go
+++ b/space/internal/components/participantwatcher/participantwatcher_test.go
@@ -259,7 +259,6 @@ func TestUpdateParticipantFromAclState(t *testing.T) {
 	})
 }
 
-
 func TestConvertPermissions_Admin(t *testing.T) {
 	require.Equal(t, model.ParticipantPermissions_Admin, convertPermissions(list.AclPermissionsAdmin))
 }

--- a/space/service.go
+++ b/space/service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
 	"github.com/anyproto/any-sync/util/crypto"
 	"github.com/ipfs/go-cid"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/anytype/config"
@@ -178,8 +179,20 @@ type service struct {
 	syncAllMu      sync.Mutex
 	syncAllRunning bool
 	syncAllPending bool
+	openedObjects  openedObjectsProvider
 
 	firstCreatedSpaceId string
+}
+
+// BlockServiceCName mirrors core/block.CName: the block service imports this
+// package, so the sweep's opened-objects source is looked up by name via the
+// minimal interface below. A drift test in core/block keeps them in sync.
+const BlockServiceCName = "block-service"
+
+// openedObjectsProvider is the part of the block service the head-sync sweep
+// needs to know which spaces the user is currently looking at.
+type openedObjectsProvider interface {
+	GetOpenedObjects() []lo.Entry[string, string]
 }
 
 func (s *service) Delete(ctx context.Context, id string) (err error) {
@@ -210,6 +223,10 @@ func (s *service) Init(a *app.App) (err error) {
 	s.spaceLoaderListener = app.MustComponent[aclobjectmanager.SpaceLoaderListener](a)
 	s.identityService = app.MustComponent[dependencies.IdentityService](a)
 	s.inboxSender = app.MustComponent[inboxservice.Sender](a)
+	// optional (absent in tests): sweep priority source
+	if c := a.Component(BlockServiceCName); c != nil {
+		s.openedObjects, _ = c.(openedObjectsProvider)
+	}
 	s.waiting = make(map[string]controllerWaiter)
 	s.deferredStatuses = make(map[string]spaceViewStatus)
 	s.preferredSpaceId = s.config.PreferredSpaceId
@@ -830,9 +847,19 @@ func (s *service) SyncAllSpaceHeads() {
 	go s.runSyncAllSpaceHeads()
 }
 
+// syncAllHeadsPeerFindDeadline bounds each sweep worker's wait for responsible
+// peers. It must be short: workers hold semaphore slots while waiting, and
+// after a network switch the spaces whose node dial is stuck must not block
+// the slots from spaces whose node is already reachable (observed in the
+// field: all 10 workers parked behind one slow cellular dial). Stragglers are
+// covered by the per-space reconnect diff-kick and the fast retry cadence.
+const syncAllHeadsPeerFindDeadline = time.Second * 15
+
 func (s *service) runSyncAllSpaceHeads() {
 	for {
-		ids := s.AllLoadedSpaceIds()
+		// The user-visible spaces must not wait behind dozens of background
+		// spaces: sweep spaces with currently-open objects first.
+		ids := orderSpacesOpenedFirst(s.AllLoadedSpaceIds(), s.openedSpaceIds())
 		sem := make(chan struct{}, syncAllHeadsParallelism)
 		var wg sync.WaitGroup
 		for _, id := range ids {
@@ -848,9 +875,7 @@ func (s *service) runSyncAllSpaceHeads() {
 					}
 					return
 				}
-				// Bound the wait for responsible peers: without a deadline an
-				// offline device parks these goroutines until reconnect.
-				ctx := context.WithValue(s.ctx, peermanager.ContextPeerFindDeadlineKey, time.Now().Add(time.Minute))
+				ctx := context.WithValue(s.ctx, peermanager.ContextPeerFindDeadlineKey, time.Now().Add(syncAllHeadsPeerFindDeadline))
 				if err := sp.CommonSpace().SyncHeads(ctx); err != nil && s.ctx.Err() == nil {
 					if errors.Is(err, peermanager.ErrPeerFindDeadlineExceeded) {
 						// expected while offline; one warn per loaded space per
@@ -874,6 +899,37 @@ func (s *service) runSyncAllSpaceHeads() {
 		s.syncAllMu.Unlock()
 		return
 	}
+}
+
+// openedSpaceIds returns the set of spaces with currently-open objects; empty
+// when the block service is unavailable (tests).
+func (s *service) openedSpaceIds() map[string]struct{} {
+	if s.openedObjects == nil {
+		return nil
+	}
+	opened := map[string]struct{}{}
+	for _, entry := range s.openedObjects.GetOpenedObjects() {
+		opened[entry.Value] = struct{}{}
+	}
+	return opened
+}
+
+// orderSpacesOpenedFirst moves the spaces from the opened set to the front,
+// keeping the relative order stable within both groups.
+func orderSpacesOpenedFirst(ids []string, opened map[string]struct{}) []string {
+	if len(opened) == 0 {
+		return ids
+	}
+	ordered := make([]string, 0, len(ids))
+	var rest []string
+	for _, id := range ids {
+		if _, ok := opened[id]; ok {
+			ordered = append(ordered, id)
+		} else {
+			rest = append(rest, id)
+		}
+	}
+	return append(ordered, rest...)
 }
 
 func (s *service) TechSpaceId() string {

--- a/space/service_test.go
+++ b/space/service_test.go
@@ -704,3 +704,17 @@ func TestService_OnWorkspaceChanged(t *testing.T) {
 		assert.Equal(t, int64(5), lastDetails.GetInt64(bundle.RelationKeyIconOption))
 	})
 }
+
+func TestOrderSpacesOpenedFirst(t *testing.T) {
+	t.Run("opened spaces move to the front, order stable", func(t *testing.T) {
+		got := orderSpacesOpenedFirst(
+			[]string{"a", "b", "c", "d"},
+			map[string]struct{}{"c": {}, "d": {}},
+		)
+		assert.Equal(t, []string{"c", "d", "a", "b"}, got)
+	})
+	t.Run("no opened spaces: unchanged", func(t *testing.T) {
+		ids := []string{"a", "b"}
+		assert.Equal(t, ids, orderSpacesOpenedFirst(ids, nil))
+	})
+}

--- a/space/spacecore/credentialprovider/credentialprovider.go
+++ b/space/spacecore/credentialprovider/credentialprovider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
 	"github.com/anyproto/any-sync/coordinator/coordinatorclient"
 	"github.com/gogo/protobuf/proto"
-
 )
 
 func New() app.Component {

--- a/space/spacecore/localdiscovery/localdiscovery.go
+++ b/space/spacecore/localdiscovery/localdiscovery.go
@@ -50,9 +50,9 @@ type localDiscovery struct {
 	// refresh reassigning it.
 	closeWait       *sync.WaitGroup
 	interfacesAddrs addrs.InterfacesAddrs
-	periodicCheck      periodicsync.PeriodicSync
-	drpcServer         clientserver.ClientServer
-	nodeConf           nodeconf.Configuration
+	periodicCheck   periodicsync.PeriodicSync
+	drpcServer      clientserver.ClientServer
+	nodeConf        nodeconf.Configuration
 
 	ipv4        []string
 	ipv6        []string
@@ -306,7 +306,7 @@ func (l *localDiscovery) startServer() (err error) {
 		l.ipv4, // do not include ipv6 addresses, because they are disabled
 		nil,
 		l.interfacesAddrs.NetInterfaces(),
-		zeroconf.TTL(3600),                            // big ttl because we don't have re-broadcasting
+		zeroconf.TTL(3600), // big ttl because we don't have re-broadcasting
 		zeroconf.ServerSelectIPTraffic(zeroconf.IPv4), // disable ipv6 for now
 		zeroconf.WriteTimeout(time.Second*3),
 	)

--- a/space/spacecore/localdiscovery/localdiscovery_test.go
+++ b/space/spacecore/localdiscovery/localdiscovery_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/anyproto/anytype-heart/core/anytype/config"
 	"github.com/anyproto/anytype-heart/core/device/mock_device"
+	"github.com/anyproto/anytype-heart/core/event/mock_event"
 	"github.com/anyproto/anytype-heart/net/addrs"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
-	"github.com/anyproto/anytype-heart/core/event/mock_event"
 	"github.com/anyproto/anytype-heart/space/spacecore/clientserver/mock_clientserver"
 	"github.com/anyproto/anytype-heart/tests/testutil"
 )

--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -46,6 +46,22 @@ const (
 	// parks a worker per broadcast indefinitely and freezes the send path.
 	// Dropped broadcasts are recovered by the periodic head-sync.
 	broadcastPeerFindDeadline = time.Second * 30
+	// responsibleNodeDialTimeout bounds the node lookup in
+	// fetchResponsiblePeers. pool.GetOneOf parks single-flight behind an
+	// in-flight dial of whichever node id the shuffle picked; on a fresh
+	// cellular path one unreachable node's address chain (schemes x addrs
+	// dialed sequentially, 10s each) can hold that park for tens of seconds
+	// while another responsible node is already connected (observed in the
+	// field: iOS Wi-Fi->cellular, 71 spaces parked behind one dial). Giving up
+	// early lets the fast retry below re-enter GetOneOf, whose active-conn
+	// check then returns any node that connected meanwhile.
+	responsibleNodeDialTimeout = time.Second * 10
+	// responsiblePeersRetryInterval is the re-fetch cadence right after a
+	// failed node lookup while the device believes it is online: quick enough
+	// to pick up a connection established by another space's dial in the
+	// meantime, and not a dial storm — dials are single-flighted in the pool,
+	// so concurrent retries share one attempt.
+	responsiblePeersRetryInterval = time.Second * 5
 )
 
 type NodeStatus interface {
@@ -280,10 +296,16 @@ func (n *clientPeerManager) manageResponsiblePeers() {
 
 // nextCheckInterval stretches the re-dial cadence while the device is known
 // offline — unless LAN peers are present: "no internet" does not mean "no
-// sync" (local-only P2P must keep refreshing at full cadence).
+// sync" (local-only P2P must keep refreshing at full cadence). Conversely,
+// after a failed node lookup while online it shortens the cadence: the
+// failure was likely a bounded wait behind a slow dial, and another space's
+// dial may land a usable connection any moment.
 func (n *clientPeerManager) nextCheckInterval() time.Duration {
 	if n.p != nil && n.p.isOffline() && len(n.peerStore.LocalPeerIds(n.spaceId)) == 0 {
 		return responsiblePeersCheckIntervalOffline
+	}
+	if n.nodeStatus != nil && n.nodeStatus.GetNodeStatus(n.spaceId) == nodestatus.ConnectionError {
+		return responsiblePeersRetryInterval
 	}
 	return responsiblePeersCheckInterval
 }
@@ -291,7 +313,13 @@ func (n *clientPeerManager) nextCheckInterval() time.Duration {
 func (n *clientPeerManager) fetchResponsiblePeers() {
 	var peers []peer.Peer
 	prevStatus := n.nodeStatus.GetNodeStatus(n.spaceId)
-	p, err := n.p.pool.GetOneOf(n.ctx, n.getNodeIds())
+	// Bound the lookup: GetOneOf may park single-flight behind another
+	// space's in-flight dial to an unreachable node; waitLoad honors ctx, so
+	// the retry loop stays in control instead of inheriting the slowest
+	// dial's schedule.
+	dialCtx, cancel := context.WithTimeout(n.ctx, responsibleNodeDialTimeout)
+	p, err := n.p.pool.GetOneOf(dialCtx, n.getNodeIds())
+	cancel()
 	if err == nil {
 		peers = []peer.Peer{p}
 		n.nodeStatus.SetNodesStatus(n.spaceId, nodestatus.Online)

--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -62,6 +62,12 @@ const (
 	// meantime, and not a dial storm — dials are single-flighted in the pool,
 	// so concurrent retries share one attempt.
 	responsiblePeersRetryInterval = time.Second * 5
+	// fastRetryMaxAttempts bounds how many consecutive failed lookups keep the
+	// fast cadence. The fast retry exists for the transient window right after
+	// a network switch; when the node stays unreachable (LAN without internet,
+	// captive portal — local-only P2P keeps syncing meanwhile), decaying back
+	// to the normal cadence avoids permanent doomed-dial pressure every 5s.
+	fastRetryMaxAttempts = 3
 )
 
 type NodeStatus interface {
@@ -99,6 +105,12 @@ type clientPeerManager struct {
 	streamPool                streampool.StreamPool
 	headSync                  headsync.HeadSync
 	diffKickRunning           atomic.Bool
+	// consecutiveFetchFailures counts failed node lookups since the last
+	// success or rebuild signal. A rebuild signal resets it so every fresh
+	// connectivity event gets its own fast-retry window, even when the
+	// previous state was steady failure (LAN-only device walking out to
+	// cellular).
+	consecutiveFetchFailures atomic.Int32
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -153,8 +165,11 @@ func (n *clientPeerManager) Run(ctx context.Context) (err error) {
 }
 
 // signalRebuild requests an immediate responsible-peers re-fetch (non-blocking;
-// coalesces with an already-pending request).
+// coalesces with an already-pending request). It also opens a fresh fast-retry
+// window: the signal means connectivity plausibly changed, so prior steady
+// failures must not slow the retries that follow.
 func (n *clientPeerManager) signalRebuild() {
+	n.consecutiveFetchFailures.Store(0)
 	select {
 	case n.rebuildResponsiblePeers <- struct{}{}:
 	default:
@@ -297,14 +312,17 @@ func (n *clientPeerManager) manageResponsiblePeers() {
 // nextCheckInterval stretches the re-dial cadence while the device is known
 // offline — unless LAN peers are present: "no internet" does not mean "no
 // sync" (local-only P2P must keep refreshing at full cadence). Conversely,
-// after a failed node lookup while online it shortens the cadence: the
-// failure was likely a bounded wait behind a slow dial, and another space's
-// dial may land a usable connection any moment.
+// for the first few failed node lookups it shortens the cadence: right after
+// a network switch the failure was likely a bounded wait behind a slow dial,
+// and another space's dial may land a usable connection any moment. Once the
+// failures look steady-state (node genuinely unreachable, e.g. LAN-only
+// setups) the cadence decays back to normal.
 func (n *clientPeerManager) nextCheckInterval() time.Duration {
 	if n.p != nil && n.p.isOffline() && len(n.peerStore.LocalPeerIds(n.spaceId)) == 0 {
 		return responsiblePeersCheckIntervalOffline
 	}
-	if n.nodeStatus != nil && n.nodeStatus.GetNodeStatus(n.spaceId) == nodestatus.ConnectionError {
+	if n.nodeStatus != nil && n.nodeStatus.GetNodeStatus(n.spaceId) == nodestatus.ConnectionError &&
+		n.consecutiveFetchFailures.Load() <= fastRetryMaxAttempts {
 		return responsiblePeersRetryInterval
 	}
 	return responsiblePeersCheckInterval
@@ -321,6 +339,7 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 	p, err := n.p.pool.GetOneOf(dialCtx, n.getNodeIds())
 	cancel()
 	if err == nil {
+		n.consecutiveFetchFailures.Store(0)
 		peers = []peer.Peer{p}
 		n.nodeStatus.SetNodesStatus(n.spaceId, nodestatus.Online)
 		if prevStatus == nodestatus.ConnectionError {
@@ -335,6 +354,7 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 			n.kickDiffSyncOnReconnect()
 		}
 	} else {
+		n.consecutiveFetchFailures.Inc()
 		log.Info("can't get node peers", zap.Error(err))
 		n.nodeStatus.SetNodesStatus(n.spaceId, nodestatus.ConnectionError)
 	}

--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -68,6 +68,13 @@ const (
 	// captive portal — local-only P2P keeps syncing meanwhile), decaying back
 	// to the normal cadence avoids permanent doomed-dial pressure every 5s.
 	fastRetryMaxAttempts = 3
+	// localPeerDialTimeout is the shared budget for refreshing all local (mDNS)
+	// peers in one fetch cycle. After a network switch the peer store still
+	// lists peers from the previous network whose addresses are unroutable;
+	// unbounded dials to them parked every manager single-flight for the whole
+	// scheme x addr chain (~20-40s) while a healthy node connection sat idle.
+	// A bounded failure also actually triggers the stale peer's removal.
+	localPeerDialTimeout = time.Second * 5
 )
 
 type NodeStatus interface {
@@ -359,21 +366,42 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 		n.nodeStatus.SetNodesStatus(n.spaceId, nodestatus.ConnectionError)
 	}
 	n.spaceSyncService.Refresh(n.spaceId)
-	peerIds := n.peerStore.LocalPeerIds(n.spaceId)
-	for _, peerId := range peerIds {
-		p, err := n.p.pool.Get(n.ctx, peerId)
-		if err != nil {
-			n.peerStore.RemoveLocalPeer(peerId)
-			log.Warn("failed to get local from net pool", zap.String("peerId", peerId), zap.Error(err))
-			continue
-		}
-		peers = append(peers, p)
+	if len(peers) > 0 {
+		// Publish the node connection before touching local peers: the
+		// head-sync sweep and broadcasts wait on this list, and the local
+		// dials below can burn seconds on stale mDNS entries after a network
+		// switch (observed in the field: all managers parked behind one dial
+		// to a Wi-Fi-era local peer unroutable from cellular, while a healthy
+		// node connection sat idle until the fetch finished).
+		n.publishResponsiblePeers(peers)
 	}
+	peerIds := n.peerStore.LocalPeerIds(n.spaceId)
+	if len(peerIds) > 0 {
+		// Bound the local dials as one budget: on failure the stale peer is
+		// removed, so a Wi-Fi-era entry costs at most one bounded pass after
+		// the switch instead of an unbounded dial chain per cycle.
+		localCtx, cancelLocal := context.WithTimeout(n.ctx, localPeerDialTimeout)
+		for _, peerId := range peerIds {
+			p, err := n.p.pool.Get(localCtx, peerId)
+			if err != nil {
+				n.peerStore.RemoveLocalPeer(peerId)
+				log.Warn("failed to get local from net pool", zap.String("peerId", peerId), zap.Error(err))
+				continue
+			}
+			peers = append(peers, p)
+		}
+		cancelLocal()
+	}
+	n.publishResponsiblePeers(peers)
+}
 
+// publishResponsiblePeers swaps the served list and wakes the waiters; safe to
+// call more than once per fetch (watchers are registered once per peer).
+func (n *clientPeerManager) publishResponsiblePeers(peers []peer.Peer) {
 	n.Lock()
 	defer n.Unlock()
 
-	for _, p = range peers {
+	for _, p := range peers {
 		if _, ok := n.watchingPeers[p.Id()]; !ok {
 			n.watchingPeers[p.Id()] = struct{}{}
 			go func(pr peer.Peer) {

--- a/space/spacecore/peermanager/manager_test.go
+++ b/space/spacecore/peermanager/manager_test.go
@@ -528,3 +528,30 @@ func Test_provider_ProvideStat(t *testing.T) {
 	assert.Equal(t, int64(1), st.ReconnectDiffKicks)
 	assert.Equal(t, int64(3), st.ClosedPeersFiltered)
 }
+
+func Test_nextCheckInterval_fastRetryAfterFailure(t *testing.T) {
+	spaceId := "spaceId"
+	f := newFixtureManager(t, spaceId)
+
+	f.cm.nodeStatus.SetNodesStatus(spaceId, nodestatus.Online)
+	assert.Equal(t, responsiblePeersCheckInterval, f.cm.nextCheckInterval(), "online + healthy: full cadence")
+
+	// a failed node lookup while online was likely a bounded wait behind a
+	// slow dial — retry quickly to pick up a conn landed by another space
+	f.cm.nodeStatus.SetNodesStatus(spaceId, nodestatus.ConnectionError)
+	assert.Equal(t, responsiblePeersRetryInterval, f.cm.nextCheckInterval(), "online + failed lookup: fast retry")
+}
+
+func Test_fetchResponsiblePeers_boundsNodeLookup(t *testing.T) {
+	spaceId := "spaceId"
+	f := newFixtureManager(t, spaceId)
+	f.updater.EXPECT().Refresh(spaceId)
+	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, ids []string) (peer.Peer, error) {
+			deadline, ok := ctx.Deadline()
+			assert.True(t, ok, "node lookup must carry a deadline so it can't park behind a slow dial")
+			assert.LessOrEqual(t, time.Until(deadline), responsibleNodeDialTimeout)
+			return newTestPeer("id"), nil
+		})
+	f.cm.fetchResponsiblePeers()
+}

--- a/space/spacecore/peermanager/manager_test.go
+++ b/space/spacecore/peermanager/manager_test.go
@@ -113,7 +113,7 @@ func Test_fetchResponsiblePeers(t *testing.T) {
 
 		// when
 		f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).Return(newTestPeer("id"), nil)
-		f.pool.EXPECT().Get(f.cm.ctx, "peerId").Return(newTestPeer("id1"), nil)
+		f.pool.EXPECT().Get(gomock.Any(), "peerId").Return(newTestPeer("id1"), nil)
 		f.updater.EXPECT().Refresh(spaceId)
 		f.cm.fetchResponsiblePeers()
 
@@ -125,7 +125,7 @@ func Test_fetchResponsiblePeers(t *testing.T) {
 
 		// when
 		f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).Return(newTestPeer("id"), nil)
-		f.pool.EXPECT().Get(f.cm.ctx, "peerId").Return(nil, fmt.Errorf("error"))
+		f.pool.EXPECT().Get(gomock.Any(), "peerId").Return(nil, fmt.Errorf("error"))
 		f.updater.EXPECT().Refresh(spaceId)
 		f.cm.fetchResponsiblePeers()
 	})
@@ -567,4 +567,70 @@ func Test_fetchResponsiblePeers_boundsNodeLookup(t *testing.T) {
 			return newTestPeer("id"), nil
 		})
 	f.cm.fetchResponsiblePeers()
+}
+
+func Test_fetchResponsiblePeers_nodePublishedBeforeLocalDials(t *testing.T) {
+	// the field failure: a stale mDNS peer from the previous network parks the
+	// fetch in an unroutable dial while a healthy node connection sits idle —
+	// the node peer must be served to waiters before the local dials settle
+	spaceId := "spaceId"
+	f := newFixtureManager(t, spaceId)
+	f.store.UpdateLocalPeer("staleWifiPeer", []string{spaceId})
+	f.updater.EXPECT().Refresh(spaceId)
+
+	localDialStarted := make(chan struct{})
+	releaseLocalDial := make(chan struct{})
+	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).Return(newTestPeer("node"), nil)
+	f.pool.EXPECT().Get(gomock.Any(), "staleWifiPeer").DoAndReturn(
+		func(ctx context.Context, id string) (peer.Peer, error) {
+			close(localDialStarted)
+			select {
+			case <-releaseLocalDial:
+			case <-ctx.Done():
+			}
+			return nil, fmt.Errorf("unroutable from cellular")
+		})
+
+	fetchDone := make(chan struct{})
+	go func() {
+		defer close(fetchDone)
+		f.cm.fetchResponsiblePeers()
+	}()
+
+	<-localDialStarted
+	// local dial is parked; the node peer must already be served
+	ctx := context.WithValue(context.Background(), ContextPeerFindDeadlineKey, time.Now().Add(time.Second))
+	peers, err := f.cm.GetResponsiblePeers(ctx)
+	require.NoError(t, err, "node peer must be available while local dials are in flight")
+	require.Len(t, peers, 1)
+	assert.Equal(t, "node", peers[0].Id())
+
+	close(releaseLocalDial)
+	select {
+	case <-fetchDone:
+	case <-time.After(time.Second * 2):
+		t.Fatal("fetch must finish")
+	}
+	// the failed local dial must evict the stale peer
+	assert.Empty(t, f.store.LocalPeerIds(spaceId), "stale local peer must be removed after a failed bounded dial")
+}
+
+func Test_fetchResponsiblePeers_boundsLocalDials(t *testing.T) {
+	spaceId := "spaceId"
+	f := newFixtureManager(t, spaceId)
+	f.store.UpdateLocalPeer("localPeer", []string{spaceId})
+	f.updater.EXPECT().Refresh(spaceId)
+	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).Return(newTestPeer("node"), nil)
+	f.pool.EXPECT().Get(gomock.Any(), "localPeer").DoAndReturn(
+		func(ctx context.Context, id string) (peer.Peer, error) {
+			deadline, ok := ctx.Deadline()
+			assert.True(t, ok, "local dials must carry a deadline: stale mDNS peers must not park the fetch")
+			assert.LessOrEqual(t, time.Until(deadline), localPeerDialTimeout)
+			return newTestPeer("localPeer"), nil
+		})
+	f.cm.fetchResponsiblePeers()
+
+	peers, err := f.cm.GetResponsiblePeers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, peers, 2, "node and local peer must both be served after the full fetch")
 }

--- a/space/spacecore/peermanager/manager_test.go
+++ b/space/spacecore/peermanager/manager_test.go
@@ -539,7 +539,20 @@ func Test_nextCheckInterval_fastRetryAfterFailure(t *testing.T) {
 	// a failed node lookup while online was likely a bounded wait behind a
 	// slow dial — retry quickly to pick up a conn landed by another space
 	f.cm.nodeStatus.SetNodesStatus(spaceId, nodestatus.ConnectionError)
+	f.cm.consecutiveFetchFailures.Store(1)
 	assert.Equal(t, responsiblePeersRetryInterval, f.cm.nextCheckInterval(), "online + failed lookup: fast retry")
+
+	// steady-state failure (LAN without internet, captive portal): the fast
+	// window decays so nodes aren't hammered every 5s forever while local-only
+	// P2P keeps syncing
+	f.cm.consecutiveFetchFailures.Store(fastRetryMaxAttempts + 1)
+	assert.Equal(t, responsiblePeersCheckInterval, f.cm.nextCheckInterval(), "steady failure: back to normal cadence")
+
+	// a fresh connectivity event (rebuild signal) reopens the fast window
+	// even after steady failure — e.g. a LAN-only device walking out to cellular
+	f.cm.rebuildResponsiblePeers = make(chan struct{}, 1)
+	f.cm.signalRebuild()
+	assert.Equal(t, responsiblePeersRetryInterval, f.cm.nextCheckInterval(), "rebuild signal: fast window reopened")
 }
 
 func Test_fetchResponsiblePeers_boundsNodeLookup(t *testing.T) {


### PR DESCRIPTION
Follow-up to #3211, driven by a field test on iOS ([GO-7379](https://linear.app/anytype/issue/GO-7379)): Wi-Fi→cellular switch with 71 spaces — the recovery pipeline fired correctly (debug stats: CELLULAR reported with networkId, 2 recoveries, coalescing worked), but chat messages still took ~30s to flow.

## Diagnosis (from the new debugstat + a goroutine dump taken mid-stall)

The goroutine dump at recovery+6s showed the entire stall in three numbers: **71** `fetchResponsiblePeers` parked in ocache single-flight dial waits, **all 10** `SyncAllSpaceHeads` workers parked in `waitResponsiblePeers` behind them, **1** QUIC dial in flight. `pool.GetOneOf` shuffles the responsible node ids and parks behind the picked node's in-flight dial; on a fresh cellular path one node's sequential scheme×addr dial chain (10s per attempt) held every space that picked it — including the visible chat — while a different node had already connected at +6.6s and helped nobody.

## Fixes

- **Bounded node lookup** in `fetchResponsiblePeers` (10s): `ocache.waitLoad` honors ctx, so a fetch parked behind a slow dial gives up instead of inheriting the slowest dial's schedule.
- **Fast retry** (5s, was 20s) after a failed lookup while online: the next `GetOneOf`'s active-conn check returns any node that connected meanwhile, and the `ConnectionError→Online` edge then fires the existing per-space reconnect diff-kick. Offline behavior (2min backoff, LAN exception) unchanged.
- **Sweep can't be starved**: worker peer-find deadline 1min→15s (workers hold semaphore slots while waiting; stragglers are covered by the reconnect kick + fast retry), and the sweep orders **spaces with currently-open objects first** (block service looked up by component name to avoid the import cycle; drift test added in `core/block`).

Net effect for the observed incident: the visible space syncs as soon as *any* responsible connection is up (~7s incl. iOS path settle + first cellular dial), instead of ~30s.

Race suites green (`core/device`, `peermanager`, `space`, `core/block` drift test); full build green.