### PR TITLE
GO-7379 Diagnostics for the desktop empty-peers stall

### DIFF
--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -56,6 +56,15 @@ const (
 	// early lets the fast retry below re-enter GetOneOf, whose active-conn
 	// check then returns any node that connected meanwhile.
 	responsibleNodeDialTimeout = time.Second * 10
+	// responsibleNodeDialTimeoutSlow replaces the bound after consecutive
+	// failures. The tight bound is right for the common case (live conn or a
+	// fast dial) but it is shorter than a full scheme fallback: on networks
+	// that blackhole QUIC (VPNs, some carriers) every dial needs the whole
+	// quic-attempts-then-yamux chain (observed 20-35s on a desktop with a VPN
+	// up), and a 10s cancel-and-retry loop re-runs the doomed prefix forever —
+	// sync never comes up. Once failures repeat, give the chain room to reach
+	// the working transport.
+	responsibleNodeDialTimeoutSlow = time.Second * 40
 	// responsiblePeersRetryInterval is the re-fetch cadence right after a
 	// failed node lookup while the device believes it is online: quick enough
 	// to pick up a connection established by another space's dial in the
@@ -377,8 +386,13 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 	// Bound the lookup: GetOneOf may park single-flight behind another
 	// space's in-flight dial to an unreachable node; waitLoad honors ctx, so
 	// the retry loop stays in control instead of inheriting the slowest
-	// dial's schedule.
-	dialCtx, cancel := context.WithTimeout(n.ctx, responsibleNodeDialTimeout)
+	// dial's schedule. After repeated failures the bound escalates so a slow
+	// but working scheme fallback (QUIC-blocked networks) can complete.
+	bound := responsibleNodeDialTimeout
+	if n.consecutiveFetchFailures.Load() >= 2 {
+		bound = responsibleNodeDialTimeoutSlow
+	}
+	dialCtx, cancel := context.WithTimeout(n.ctx, bound)
 	p, err := n.p.pool.GetOneOf(dialCtx, n.getNodeIds())
 	cancel()
 	if err == nil {

--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -118,6 +118,10 @@ type clientPeerManager struct {
 	// previous state was steady failure (LAN-only device walking out to
 	// cellular).
 	consecutiveFetchFailures atomic.Int32
+	// loopRunning marks the manageResponsiblePeers goroutine as alive; the
+	// provider stat counts dead loops to expose managers that can no longer
+	// refresh their peers (diagnostics for field stalls).
+	loopRunning atomic.Bool
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -234,6 +238,7 @@ func (n *clientPeerManager) GetResponsiblePeers(ctx context.Context) (peers []pe
 		}
 		ch := n.availableResponsiblePeers
 		n.Unlock()
+		n.warnEmptyPeersWait()
 		if err = n.waitResponsiblePeers(ctx, ch); err != nil {
 			return nil, err
 		}
@@ -242,6 +247,28 @@ func (n *clientPeerManager) GetResponsiblePeers(ctx context.Context) (peers []pe
 	n.Unlock()
 	log.Debug("get responsible peers", zap.Int("peerCount", len(peers)), zap.String("spaceId", n.spaceId))
 	return
+}
+
+// warnEmptyPeersWait surfaces (rate-limited process-wide, 30s) that callers
+// are waiting on an empty responsible-peers list, with the fields that decide
+// whether the manager can ever refresh it — the exact data needed to diagnose
+// a field stall where sync waits silently.
+func (n *clientPeerManager) warnEmptyPeersWait() {
+	if n.p == nil {
+		return
+	}
+	now := time.Now().Unix()
+	last := n.p.stats.lastEmptyWaitWarnUnix.Load()
+	if now-last < 30 || !n.p.stats.lastEmptyWaitWarnUnix.CompareAndSwap(last, now) {
+		return
+	}
+	log.Warn("waiting on empty responsible peers",
+		zap.String("spaceId", n.spaceId),
+		zap.Bool("managerClosed", n.ctx.Err() != nil),
+		zap.Bool("loopRunning", n.loopRunning.Load()),
+		zap.Bool("offline", n.p.isOffline()),
+		zap.Int("localPeers", len(n.peerStore.LocalPeerIds(n.spaceId))),
+		zap.Int32("consecutiveFetchFailures", n.consecutiveFetchFailures.Load()))
 }
 
 // waitResponsiblePeers blocks until a rebuild publishes live peers (ch is
@@ -305,6 +332,8 @@ func (n *clientPeerManager) getStreamResponsiblePeers(ctx context.Context) (peer
 }
 
 func (n *clientPeerManager) manageResponsiblePeers() {
+	n.loopRunning.Store(true)
+	defer n.loopRunning.Store(false)
 	for {
 		n.fetchResponsiblePeers()
 		select {
@@ -326,11 +355,18 @@ func (n *clientPeerManager) manageResponsiblePeers() {
 // setups) the cadence decays back to normal.
 func (n *clientPeerManager) nextCheckInterval() time.Duration {
 	if n.p != nil && n.p.isOffline() && len(n.peerStore.LocalPeerIds(n.spaceId)) == 0 {
+		n.p.stats.choseOfflineInterval.Inc()
 		return responsiblePeersCheckIntervalOffline
 	}
 	if n.nodeStatus != nil && n.nodeStatus.GetNodeStatus(n.spaceId) == nodestatus.ConnectionError &&
 		n.consecutiveFetchFailures.Load() <= fastRetryMaxAttempts {
+		if n.p != nil {
+			n.p.stats.choseFastRetry.Inc()
+		}
 		return responsiblePeersRetryInterval
+	}
+	if n.p != nil {
+		n.p.stats.choseNormalInterval.Inc()
 	}
 	return responsiblePeersCheckInterval
 }

--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -131,6 +131,10 @@ type clientPeerManager struct {
 	// provider stat counts dead loops to expose managers that can no longer
 	// refresh their peers (diagnostics for field stalls).
 	loopRunning atomic.Bool
+	// lastFetchError carries the most recent node-lookup failure so the
+	// empty-peers warning can say WHY the list is empty ("can't get node
+	// peers" is Info-level and filtered from the default file sink).
+	lastFetchError atomic.String
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -277,7 +281,8 @@ func (n *clientPeerManager) warnEmptyPeersWait() {
 		zap.Bool("loopRunning", n.loopRunning.Load()),
 		zap.Bool("offline", n.p.isOffline()),
 		zap.Int("localPeers", len(n.peerStore.LocalPeerIds(n.spaceId))),
-		zap.Int32("consecutiveFetchFailures", n.consecutiveFetchFailures.Load()))
+		zap.Int32("consecutiveFetchFailures", n.consecutiveFetchFailures.Load()),
+		zap.String("lastFetchError", n.lastFetchError.Load()))
 }
 
 // waitResponsiblePeers blocks until a rebuild publishes live peers (ch is
@@ -412,6 +417,7 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 		}
 	} else {
 		n.consecutiveFetchFailures.Inc()
+		n.lastFetchError.Store(err.Error())
 		log.Info("can't get node peers", zap.Error(err))
 		n.nodeStatus.SetNodesStatus(n.spaceId, nodestatus.ConnectionError)
 	}

--- a/space/spacecore/peermanager/manager_test.go
+++ b/space/spacecore/peermanager/manager_test.go
@@ -634,3 +634,30 @@ func Test_fetchResponsiblePeers_boundsLocalDials(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, peers, 2, "node and local peer must both be served after the full fetch")
 }
+
+func Test_fetchResponsiblePeers_escalatesDialBound(t *testing.T) {
+	spaceId := "spaceId"
+	f := newFixtureManager(t, spaceId)
+	f.updater.EXPECT().Refresh(spaceId).Times(2)
+	// first attempt: tight bound
+	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, ids []string) (peer.Peer, error) {
+			deadline, ok := ctx.Deadline()
+			assert.True(t, ok)
+			assert.LessOrEqual(t, time.Until(deadline), responsibleNodeDialTimeout)
+			return nil, fmt.Errorf("dial canceled by tight bound")
+		})
+	f.cm.fetchResponsiblePeers()
+	f.cm.consecutiveFetchFailures.Store(2) // as if a second failure occurred
+
+	// after repeated failures: room for the full scheme fallback
+	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, ids []string) (peer.Peer, error) {
+			deadline, ok := ctx.Deadline()
+			assert.True(t, ok)
+			assert.Greater(t, time.Until(deadline), responsibleNodeDialTimeout,
+				"repeated failures must escalate the bound so a QUIC-blocked network's yamux fallback can complete")
+			return newTestPeer("node"), nil
+		})
+	f.cm.fetchResponsiblePeers()
+}

--- a/space/spacecore/peermanager/provider.go
+++ b/space/spacecore/peermanager/provider.go
@@ -70,6 +70,13 @@ type providerStats struct {
 	rebuildSignals      atomic.Int64
 	reconnectDiffKicks  atomic.Int64
 	closedPeersFiltered atomic.Int64
+	// interval decisions per manage-loop cycle: names which cadence branch
+	// fired, so a field dump shows why loops wait as long as they do
+	choseOfflineInterval atomic.Int64
+	choseFastRetry       atomic.Int64
+	choseNormalInterval  atomic.Int64
+	// lastEmptyWaitWarnUnix rate-limits the empty-peers wait warning
+	lastEmptyWaitWarnUnix atomic.Int64
 }
 
 type providerStat struct {
@@ -79,11 +86,29 @@ type providerStat struct {
 	RebuildSignals      int64 `json:"rebuildSignals"`
 	ReconnectDiffKicks  int64 `json:"reconnectDiffKicks"`
 	ClosedPeersFiltered int64 `json:"closedPeersFiltered"`
+
+	ChoseOfflineInterval int64 `json:"choseOfflineInterval"`
+	ChoseFastRetry       int64 `json:"choseFastRetry"`
+	ChoseNormalInterval  int64 `json:"choseNormalInterval"`
+	// live registry introspection (computed on stat query only)
+	ManagersNoPeers  int `json:"managersNoPeers"`
+	ManagersLoopDead int `json:"managersLoopDead"`
 }
 
 func (p *provider) ProvideStat() any {
 	p.mu.Lock()
 	managers := len(p.managers)
+	noPeers, loopDead := 0, 0
+	for m := range p.managers {
+		m.Lock()
+		if len(m.responsiblePeers) == 0 {
+			noPeers++
+		}
+		m.Unlock()
+		if !m.loopRunning.Load() {
+			loopDead++
+		}
+	}
 	p.mu.Unlock()
 	return providerStat{
 		Managers:            managers,
@@ -92,6 +117,12 @@ func (p *provider) ProvideStat() any {
 		RebuildSignals:      p.stats.rebuildSignals.Load(),
 		ReconnectDiffKicks:  p.stats.reconnectDiffKicks.Load(),
 		ClosedPeersFiltered: p.stats.closedPeersFiltered.Load(),
+
+		ChoseOfflineInterval: p.stats.choseOfflineInterval.Load(),
+		ChoseFastRetry:       p.stats.choseFastRetry.Load(),
+		ChoseNormalInterval:  p.stats.choseNormalInterval.Load(),
+		ManagersNoPeers:      noPeers,
+		ManagersLoopDead:     loopDead,
 	}
 }
 


### PR DESCRIPTION
Instrumentation to pin the desktop stall reported on GO-7379 (all periodic rounds waiting on empty responsible-peers lists while healthy node conns sit idle; every artifact-compatible theory eliminated — see the Linear thread). Adds interval-choice counters, live registry introspection (managersNoPeers / managersLoopDead), a manager loop-liveness flag, and a rate-limited WARN at the empty-peers wait carrying the deciding fields (manager ctx closed, loop alive, offline verdict, local peers, failure count). Zero steady-state overhead: atomics on existing paths, registry iteration only on stat queries.