### PR TITLE
GO-7222 Prefer the workspace invite when it and the space view disagree

### DIFF
--- a/core/block/editor/workspaces.go
+++ b/core/block/editor/workspaces.go
@@ -204,7 +204,10 @@ func (w *Workspaces) SetInviteFileInfo(info domain.InviteInfo) (err error) {
 func (w *Workspaces) GetExistingInviteInfo() (inviteInfo domain.InviteInfo) {
 	details := w.CombinedDetails()
 	inviteInfo = getInviteDetails(details)
-	inviteInfo.HeldByOwner = details.GetBool(bundle.RelationKeySpaceInviteHeldByOwner)
+	// a cid in the workspace is a shared invite, so it is not held by the owner — even if the marker is
+	// still set. An old client can write a cid without clearing the marker (it does not know about it),
+	// and the held-by-owner marker only means anything when there is no cid to read.
+	inviteInfo.HeldByOwner = inviteInfo.InviteFileCid == "" && details.GetBool(bundle.RelationKeySpaceInviteHeldByOwner)
 	return
 }
 

--- a/core/block/editor/workspaces_test.go
+++ b/core/block/editor/workspaces_test.go
@@ -98,6 +98,21 @@ func TestWorkspaces_FileInfo(t *testing.T) {
 		require.Equal(t, domain.InviteInfo{HeldByOwner: true}, removed)
 		require.Empty(t, fx.GetExistingInviteInfo())
 	})
+	t.Run("a cid alongside a stale marker reads as a shared invite", func(t *testing.T) {
+		// an old client can write a cid without clearing the held-by-owner marker (it knows about
+		// neither). The cid means a shared invite, so the marker must not make it look owner-held.
+		fx := newWorkspacesFixture(t)
+		defer fx.finish()
+		st := fx.NewState()
+		st.SetDetailAndBundledRelation(bundle.RelationKeySpaceInviteHeldByOwner, domain.Bool(true))
+		st.SetDetailAndBundledRelation(bundle.RelationKeySpaceInviteFileCid, domain.String("fileId"))
+		st.SetDetailAndBundledRelation(bundle.RelationKeySpaceInviteFileKey, domain.String("fileKey"))
+		require.NoError(t, fx.Apply(st))
+
+		info := fx.GetExistingInviteInfo()
+		require.Equal(t, "fileId", info.InviteFileCid)
+		require.False(t, info.HeldByOwner)
+	})
 }
 
 type migratorStub struct {

--- a/core/inviteservice/inviteservice.go
+++ b/core/inviteservice/inviteservice.go
@@ -185,24 +185,35 @@ func (i *inviteService) ShareWithinSpace(ctx context.Context, spaceId string) (d
 // devices. The workspace then answers for everyone else — with a shared invite, or with the marker
 // of an owner-held one.
 func (i *inviteService) getExisting(ctx context.Context, spaceId string) (info domain.InviteInfo, err error) {
-	err = i.doSpaceView(ctx, spaceId, func(obj domain.InviteInfoObject) error {
-		info = obj.GetExistingInviteInfo()
-		return nil
-	})
-	if err != nil {
-		return domain.InviteInfo{}, fmt.Errorf("read invite info from space view: %w", err)
-	}
-	if info.InviteFileCid != "" {
-		return info, nil
-	}
+	// The workspace is read first and wins whenever it holds a cid. Normally exactly one of the two
+	// objects holds the invite, but an old client can write a cid to the workspace without clearing the
+	// owner's space view (it knows about neither the space view storage nor the marker). That later
+	// write is the live invite, so when both hold a cid the workspace one is the one to trust.
+	var workspaceInfo domain.InviteInfo
 	err = i.doWorkspace(ctx, spaceId, func(obj domain.InviteObject) error {
-		info = obj.GetExistingInviteInfo()
+		workspaceInfo = obj.GetExistingInviteInfo()
 		return nil
 	})
 	if err != nil {
 		return domain.InviteInfo{}, fmt.Errorf("read invite info from workspace: %w", err)
 	}
-	return info, nil
+	if workspaceInfo.InviteFileCid != "" {
+		return workspaceInfo, nil
+	}
+	// no cid in the workspace: on the owner's device the invite may be held in their space view
+	var spaceViewInfo domain.InviteInfo
+	err = i.doSpaceView(ctx, spaceId, func(obj domain.InviteInfoObject) error {
+		spaceViewInfo = obj.GetExistingInviteInfo()
+		return nil
+	})
+	if err != nil {
+		return domain.InviteInfo{}, fmt.Errorf("read invite info from space view: %w", err)
+	}
+	if spaceViewInfo.InviteFileCid != "" {
+		return spaceViewInfo, nil
+	}
+	// neither holds a cid: the workspace answer carries the held-by-owner marker for members
+	return workspaceInfo, nil
 }
 
 // setInviteInfo writes the invite to the object that holds its cid and key, and updates the other

--- a/core/inviteservice/inviteservice_test.go
+++ b/core/inviteservice/inviteservice_test.go
@@ -73,10 +73,9 @@ func newCidFromBytes(data []byte) (cid.Cid, error) {
 
 func TestInviteService_GetCurrent(t *testing.T) {
 	t.Run("invite shared within the space is read from the workspace", func(t *testing.T) {
-		// given a space whose invite the members can share
+		// given a space whose invite the members can share: it lives in the workspace, which is read first
 		fx := newFixture(t)
 		defer fx.ctrl.Finish()
-		fx.expectSpaceView()
 		fx.expectInviteObject()
 		want := domain.InviteInfo{
 			InviteFileCid: "fileCid",
@@ -84,8 +83,32 @@ func TestInviteService_GetCurrent(t *testing.T) {
 			InviteType:    domain.InviteTypeAnyone,
 			Permissions:   list.AclPermissionsWriter,
 		}
-		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{})
 		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(want)
+
+		// when the current invite is asked for
+		got, err := fx.GetCurrent(ctx, "spaceId")
+
+		// then it comes back whole, and the space view is never consulted
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("invite held by the owner is read from their space view", func(t *testing.T) {
+		// given the owner's device: the workspace holds only the marker, so the invite is read from the
+		// space view after the workspace comes back without a cid
+		fx := newFixture(t)
+		defer fx.ctrl.Finish()
+		fx.expectInviteObject()
+		fx.expectSpaceView()
+		want := domain.InviteInfo{
+			InviteFileCid: "fileCid",
+			InviteFileKey: "fileKey",
+			InviteType:    domain.InviteTypeAnyone,
+			Permissions:   list.AclPermissionsWriter,
+			HeldByOwner:   true,
+		}
+		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{HeldByOwner: true})
+		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(want)
 
 		// when the current invite is asked for
 		got, err := fx.GetCurrent(ctx, "spaceId")
@@ -95,26 +118,27 @@ func TestInviteService_GetCurrent(t *testing.T) {
 		require.Equal(t, want, got)
 	})
 
-	t.Run("invite held by the owner is read from their space view", func(t *testing.T) {
-		// given the owner's device, which is the only one that holds the invite
+	t.Run("a stale space view invite is ignored when the workspace holds one too", func(t *testing.T) {
+		// given the anomaly an old client can leave behind: it wrote a cid to the workspace without
+		// clearing the owner's space view, so both hold a cid. The workspace one is the live invite.
 		fx := newFixture(t)
 		defer fx.ctrl.Finish()
-		fx.expectSpaceView()
-		want := domain.InviteInfo{
-			InviteFileCid: "fileCid",
-			InviteFileKey: "fileKey",
+		fx.expectInviteObject()
+		workspaceInvite := domain.InviteInfo{
+			InviteFileCid: "liveCid",
+			InviteFileKey: "liveKey",
 			InviteType:    domain.InviteTypeAnyone,
-			Permissions:   list.AclPermissionsWriter,
-			HeldByOwner:   true,
+			Permissions:   list.AclPermissionsReader,
 		}
-		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(want)
+		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(workspaceInvite)
 
 		// when the current invite is asked for
 		got, err := fx.GetCurrent(ctx, "spaceId")
 
-		// then it comes back whole, and the workspace is never consulted
+		// then the workspace invite wins and the stale space view is never read
 		require.NoError(t, err)
-		require.Equal(t, want, got)
+		require.Equal(t, workspaceInvite, got)
+		require.False(t, got.HeldByOwner)
 	})
 
 	t.Run("member of a space gets the marker without the invite", func(t *testing.T) {
@@ -255,6 +279,8 @@ func TestInviteService_ShareWithinSpace(t *testing.T) {
 		}
 		want := held
 		want.HeldByOwner = false
+		// the workspace is read first and carries only the marker, so the invite is read from the space view
+		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{HeldByOwner: true})
 		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(held)
 		fx.mockSpaceView.EXPECT().RemoveExistingInviteInfo().Return(held, nil)
 		fx.mockInviteObject.EXPECT().SetInviteFileInfo(want).Return(nil)
@@ -270,14 +296,12 @@ func TestInviteService_ShareWithinSpace(t *testing.T) {
 	t.Run("an invite that is already shared is left alone", func(t *testing.T) {
 		fx := newFixture(t)
 		defer fx.ctrl.Finish()
-		fx.expectSpaceView()
 		fx.expectInviteObject()
 		want := domain.InviteInfo{
 			InviteFileCid: "fileCid",
 			InviteFileKey: "fileKey",
 			InviteType:    domain.InviteTypeDefault,
 		}
-		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{})
 		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(want)
 
 		got, err := fx.ShareWithinSpace(ctx, "spaceId")
@@ -289,7 +313,9 @@ func TestInviteService_ShareWithinSpace(t *testing.T) {
 		// given an anyoneCanJoin invite that lets whoever holds the link write in the space
 		fx := newFixture(t)
 		defer fx.ctrl.Finish()
+		fx.expectInviteObject()
 		fx.expectSpaceView()
+		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{HeldByOwner: true})
 		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{
 			InviteFileCid: "fileCid",
 			InviteFileKey: "fileKey",
@@ -380,7 +406,6 @@ func TestInviteService_Generate(t *testing.T) {
 			InviteType:    domain.InviteTypeDefault,
 			Permissions:   list.AclPermissionsReader,
 		}
-		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{})
 		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(returnedInfo)
 		acc, err := accountdata.NewRandom()
 		require.NoError(t, err)
@@ -531,6 +556,7 @@ func TestInviteService_Generate(t *testing.T) {
 	t.Run("generate invite anyone, invite exists", func(t *testing.T) {
 		fx := newFixture(t)
 		defer fx.ctrl.Finish()
+		fx.expectInviteObject()
 		fx.expectSpaceView()
 		returnedInfo := domain.InviteInfo{
 			InviteFileCid: "fileCid",
@@ -540,6 +566,7 @@ func TestInviteService_Generate(t *testing.T) {
 			HeldByOwner:   true,
 		}
 		fx.mockAccountService.EXPECT().PersonalSpaceID().Return("personal")
+		fx.mockInviteObject.EXPECT().GetExistingInviteInfo().Return(domain.InviteInfo{HeldByOwner: true})
 		fx.mockSpaceView.EXPECT().GetExistingInviteInfo().Return(returnedInfo)
 		info, err := fx.inviteService.Generate(ctx, GenerateInviteParams{
 			SpaceId:     "spaceId",


### PR DESCRIPTION
## Problem

An old client (pre owner-held invites) can write an invite cid to the workspace without clearing the owner's space view or the `spaceInviteHeldByOwner` marker — it knows about neither. That leaves the invite present in both objects (and a cid sitting next to a stale marker), and `getExisting` (space-view-first) would then hand back the stale space-view invite, or a cid would read as held-by-owner because of the leftover marker.

## Change

Resolve the disagreement deterministically. The workspace copy is always the live one when both hold a cid: an old client can only write the workspace, and only after the space view was set, so it is the later write.

- The workspace reader treats a cid as a shared invite — a stale marker no longer makes it read as held by the owner (`HeldByOwner` is false whenever a cid is present).
- `getExisting` reads the workspace first and returns its invite whenever it has a cid, so the owner's device prefers the live workspace invite over a stale space-view one.

Normal cases are unchanged: an owner-held invite leaves no cid in the workspace (marker only), so it is still read from the space view; members still see the marker.
