### PR TITLE
GO-7382 Cap reindex peak memory with cross-space concurrency limiter

### DIFF
--- a/core/indexer/fulltext_test.go
+++ b/core/indexer/fulltext_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -92,6 +93,10 @@ func newFixture(t *testing.T) *fixture {
 	techSpaceIdProvider := mock_spacesyncstatus.NewMockSpaceIdGetter(t)
 	techSpaceIdProvider.EXPECT().TechSpaceId().Return("").Maybe()
 	runCtx, cancel := context.WithCancel(ctx)
+	// registered after the store fixture so it fires first on cleanup: reindex
+	// passes still queued on the limiter exit instead of running against the
+	// closed store and finished mocks
+	t.Cleanup(cancel)
 
 	chatRepo := chatrepository.New()
 	require.NoError(t, chatRepo.Init(testApp))
@@ -110,6 +115,7 @@ func newFixture(t *testing.T) *fixture {
 		config:              &config.Config{NetworkMode: pb.RpcAccount_LocalOnly},
 		btHash:              hasher,
 		forceFt:             make(chan struct{}),
+		reindexLimiter:      newReindexLimiter(maxConcurrentSpaceReindexFor(runtime.GOOS), nil),
 		spaceIndexers:       make(map[string]*spaceIndexer),
 		techSpaceIdProvider: techSpaceIdProvider,
 		spaces:              make(map[string]struct{}),

--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/core/anytype/config"
@@ -27,8 +29,16 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/localstore/objectstore"
 	"github.com/anyproto/anytype-heart/pkg/lib/logging"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	"github.com/anyproto/anytype-heart/space"
 	"github.com/anyproto/anytype-heart/space/clientspace"
 )
+
+// openedObjectsProvider is the part of the block service used to prioritize
+// reindex slots for spaces the user currently has objects open in; entry.Value
+// is the object's space id.
+type openedObjectsProvider interface {
+	GetOpenedObjects() []lo.Entry[string, string]
+}
 
 const (
 	CName = "indexer"
@@ -70,6 +80,9 @@ type indexer struct {
 	ftQueueStop     context.CancelFunc
 	ftQueueFinished chan struct{}
 	config          *config.Config
+	// reindexLimiter bounds cross-space concurrency of the outdated-objects
+	// reindex pass and prioritizes spaces the user is looking at
+	reindexLimiter *reindexLimiter
 
 	btHash  Hasher
 	forceFt chan struct{}
@@ -93,6 +106,21 @@ func (i *indexer) Init(a *app.App) (err error) {
 	i.picker = app.MustComponent[cache.CachedObjectGetter](a)
 	i.runCtx, i.runCtxCancel = context.WithCancel(context.Background())
 	i.forceFt = make(chan struct{})
+	// optional (absent in tests): reindex slot priority source, resolved by name
+	// to avoid importing core/block (same pattern as space/service.go's sweep)
+	var openedSpaceIds func() map[string]struct{}
+	if c := a.Component(space.BlockServiceCName); c != nil {
+		if provider, ok := c.(openedObjectsProvider); ok {
+			openedSpaceIds = func() map[string]struct{} {
+				opened := map[string]struct{}{}
+				for _, entry := range provider.GetOpenedObjects() {
+					opened[entry.Value] = struct{}{}
+				}
+				return opened
+			}
+		}
+	}
+	i.reindexLimiter = newReindexLimiter(maxConcurrentSpaceReindexFor(runtime.GOOS), openedSpaceIds)
 	i.config = app.MustComponent[*config.Config](a)
 	i.spaceIndexers = map[string]*spaceIndexer{}
 	i.techSpaceIdProvider = app.MustComponent[objectstore.TechSpaceIdProvider](a)

--- a/core/indexer/reindex.go
+++ b/core/indexer/reindex.go
@@ -237,12 +237,17 @@ func (i *indexer) ReindexSpace(space clientspace.Space) (err error) {
 		// this may happen e.g. if the app got closed in the middle of object updates processing
 		// So here we reindexOutdatedObjects which compare the last indexed heads hash with the actual one
 		go func() {
+			waitStart := time.Now()
+			if !i.reindexLimiter.acquire(i.runCtx, space.Id()) {
+				return
+			}
+			defer i.reindexLimiter.release()
 			start := time.Now()
 			total, success, err := i.reindexOutdatedObjects(ctx, space)
 			if err != nil {
 				log.Errorf("reindex outdated failed: %s", err)
 			}
-			l := log.With(zap.String("space", space.Id()), zap.Int("total", total), zap.Int("succeed", success), zap.Int("spentMs", int(time.Since(start).Milliseconds())))
+			l := log.With(zap.String("space", space.Id()), zap.Int("total", total), zap.Int("succeed", success), zap.Int("spentMs", int(time.Since(start).Milliseconds())), zap.Int("waitedMs", int(start.Sub(waitStart).Milliseconds())))
 			if success != total {
 				l.Errorf("reindex outdated partially failed")
 			} else if total != 0 {

--- a/core/indexer/reindex_test.go
+++ b/core/indexer/reindex_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"testing"
+	"time"
 
 	anystore "github.com/anyproto/any-store"
 	"github.com/anyproto/any-sync/commonspace/headsync/headstorage"
@@ -738,6 +739,142 @@ func TestReindexOutdatedObjects(t *testing.T) {
 		require.NoError(t, err)
 		assert.Zero(t, total)
 		assert.Zero(t, success)
+	})
+}
+
+func TestReindexOutdatedConcurrencyLimit(t *testing.T) {
+	// each mock space has one never-indexed object whose space.Do blocks on
+	// proceed, so a space's outdated pass stays "running" until released
+	newBlockedSpace := func(t *testing.T, spaceId string, started chan<- string, proceed <-chan struct{}) *mock_space.MockSpace {
+		ctrl := gomock.NewController(t)
+		headStorage := mock_headstorage.NewMockHeadStorage(ctrl)
+		headStorage.EXPECT().IterateEntries(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+			func(_ context.Context, _ headstorage.IterOpts, iter headstorage.EntryIterator) error {
+				_, err := iter(headstorage.HeadsEntry{Id: spaceId + "/obj", Heads: []string{"head"}, CommonSnapshot: "cs"})
+				return err
+			})
+		stateStorage := mock_statestorage.NewMockStateStorage(ctrl)
+		stateStorage.EXPECT().SettingsId().AnyTimes().Return("settingsId")
+		storage := mock_anystorage.NewMockClientSpaceStorage(t)
+		storage.EXPECT().HeadStorage().Return(headStorage).Maybe()
+		storage.EXPECT().StateStorage().Return(stateStorage).Maybe()
+
+		spc := mock_space.NewMockSpace(t)
+		spc.EXPECT().Id().Return(spaceId).Maybe()
+		spc.EXPECT().Storage().Return(storage).Maybe()
+		spc.EXPECT().DerivedIDs().Return(threads.DerivedSmartblockIds{}).Maybe()
+		spc.EXPECT().FilterNotExists(mock.Anything).Return(nil).Maybe()
+		spc.EXPECT().Do(mock.Anything, mock.Anything).RunAndReturn(func(string, func(smartblock.SmartBlock) error) error {
+			started <- spaceId
+			<-proceed
+			return nil
+		}).Maybe()
+		return spc
+	}
+
+	t.Run("at most width spaces run the outdated pass concurrently", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.reindexLimiter = newReindexLimiter(2, nil)
+		started := make(chan string, 9)
+		proceed := make(chan struct{})
+		defer close(proceed)
+
+		for _, spaceId := range []string{"space1", "space2", "space3"} {
+			checksums := fx.getLatestChecksums(false)
+			require.NoError(t, fx.store.SaveChecksums(spaceId, &checksums))
+
+			// when
+			require.NoError(t, fx.ReindexSpace(newBlockedSpace(t, spaceId, started, proceed)))
+		}
+
+		// then
+		for i := 0; i < 2; i++ {
+			select {
+			case <-started:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("only %d outdated passes started, expected 2", i)
+			}
+		}
+		select {
+		case spaceId := <-started:
+			t.Fatalf("%s started an outdated pass beyond the concurrency limit", spaceId)
+		case <-time.After(150 * time.Millisecond):
+		}
+	})
+
+	t.Run("queued space starts once a slot frees", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.reindexLimiter = newReindexLimiter(2, nil)
+		started := make(chan string, 9)
+		proceed := make(chan struct{})
+
+		for _, spaceId := range []string{"space1", "space2", "space3"} {
+			checksums := fx.getLatestChecksums(false)
+			require.NoError(t, fx.store.SaveChecksums(spaceId, &checksums))
+			require.NoError(t, fx.ReindexSpace(newBlockedSpace(t, spaceId, started, proceed)))
+		}
+		for i := 0; i < 2; i++ {
+			select {
+			case <-started:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("only %d outdated passes started, expected 2", i)
+			}
+		}
+
+		// when
+		close(proceed)
+
+		// then
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("queued space never started after a slot freed")
+		}
+	})
+
+	t.Run("freed slot goes to the space the user has opened, not the earlier waiter", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.reindexLimiter = newReindexLimiter(1, func() map[string]struct{} {
+			return map[string]struct{}{"spaceOpened": {}}
+		})
+		started := make(chan string, 9)
+		proceedRunning := make(chan struct{})
+		proceedRest := make(chan struct{})
+		defer close(proceedRest)
+
+		for _, spaceId := range []string{"spaceRunning", "spaceBackground", "spaceOpened"} {
+			checksums := fx.getLatestChecksums(false)
+			require.NoError(t, fx.store.SaveChecksums(spaceId, &checksums))
+		}
+
+		// spaceRunning takes the only slot
+		require.NoError(t, fx.ReindexSpace(newBlockedSpace(t, "spaceRunning", started, proceedRunning)))
+		select {
+		case spaceId := <-started:
+			require.Equal(t, "spaceRunning", spaceId)
+		case <-time.After(2 * time.Second):
+			t.Fatal("first space never started")
+		}
+
+		// the background space queues before the opened one
+		require.NoError(t, fx.ReindexSpace(newBlockedSpace(t, "spaceBackground", started, proceedRest)))
+		require.Eventually(t, func() bool { return fx.reindexLimiter.waitingCount() == 1 }, 2*time.Second, 5*time.Millisecond)
+		require.NoError(t, fx.ReindexSpace(newBlockedSpace(t, "spaceOpened", started, proceedRest)))
+		require.Eventually(t, func() bool { return fx.reindexLimiter.waitingCount() == 2 }, 2*time.Second, 5*time.Millisecond)
+
+		// when the running pass finishes
+		close(proceedRunning)
+
+		// then
+		select {
+		case spaceId := <-started:
+			assert.Equal(t, "spaceOpened", spaceId)
+		case <-time.After(2 * time.Second):
+			t.Fatal("no queued space started after the slot freed")
+		}
 	})
 }
 

--- a/core/indexer/reindexlimiter.go
+++ b/core/indexer/reindexlimiter.go
@@ -1,0 +1,120 @@
+package indexer
+
+import (
+	"context"
+	"sync"
+)
+
+// maxConcurrentSpaceReindexFor returns how many spaces may run the
+// outdated-objects reindex pass at once on the given platform. Each pass
+// cold-builds every outdated object into the space's object cache and relies on
+// the cache TTL to release it, so with all spaces starting the pass on load the
+// resident set peaks at hundreds of MB (see docs/reindex-peak-heap-handoff.md).
+// Builds are storage-read-bound, so a small overlap keeps throughput while
+// capping the peak; mobile gets half the slots of desktop.
+func maxConcurrentSpaceReindexFor(goos string) int {
+	if goos == "ios" || goos == "android" {
+		return 2
+	}
+	return 4
+}
+
+// reindexLimiter bounds cross-space concurrency of the outdated-objects
+// reindex pass. Waiters queue FIFO, except that a freed slot is granted first
+// to a waiting space the user currently has objects open in (openedSpaceIds,
+// evaluated at grant time), so the visible space's index freshness is not stuck
+// behind big background spaces.
+type reindexLimiter struct {
+	mu             sync.Mutex
+	width          int
+	active         int
+	waiters        []*reindexWaiter
+	openedSpaceIds func() map[string]struct{}
+}
+
+type reindexWaiter struct {
+	spaceId string
+	ready   chan struct{}
+	granted bool
+}
+
+func newReindexLimiter(width int, openedSpaceIds func() map[string]struct{}) *reindexLimiter {
+	return &reindexLimiter{
+		width:          width,
+		openedSpaceIds: openedSpaceIds,
+	}
+}
+
+// acquire blocks until a slot is granted or ctx is done; it reports whether the
+// caller holds a slot and must release it.
+func (l *reindexLimiter) acquire(ctx context.Context, spaceId string) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	l.mu.Lock()
+	if l.active < l.width {
+		l.active++
+		l.mu.Unlock()
+		return true
+	}
+	w := &reindexWaiter{spaceId: spaceId, ready: make(chan struct{})}
+	l.waiters = append(l.waiters, w)
+	l.mu.Unlock()
+
+	select {
+	case <-w.ready:
+		return true
+	case <-ctx.Done():
+		l.mu.Lock()
+		defer l.mu.Unlock()
+		if w.granted {
+			// the slot was handed over concurrently with cancellation: pass it on
+			l.releaseLocked()
+			return false
+		}
+		for i, waiter := range l.waiters {
+			if waiter == w {
+				l.waiters = append(l.waiters[:i], l.waiters[i+1:]...)
+				break
+			}
+		}
+		return false
+	}
+}
+
+func (l *reindexLimiter) release() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.releaseLocked()
+}
+
+// releaseLocked hands the slot to the preferred waiter (opened space first,
+// then FIFO) without decrementing active, or frees the slot when nobody waits.
+func (l *reindexLimiter) releaseLocked() {
+	if len(l.waiters) == 0 {
+		l.active--
+		return
+	}
+	next := 0
+	if l.openedSpaceIds != nil {
+		opened := l.openedSpaceIds()
+		for i, w := range l.waiters {
+			if _, ok := opened[w.spaceId]; ok {
+				next = i
+				break
+			}
+		}
+	}
+	w := l.waiters[next]
+	l.waiters = append(l.waiters[:next], l.waiters[next+1:]...)
+	w.granted = true
+	close(w.ready)
+}
+
+// waitingCount reports how many acquirers are queued; used by tests to
+// synchronize on the queue state.
+func (l *reindexLimiter) waitingCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.waiters)
+}

--- a/core/indexer/reindexlimiter_test.go
+++ b/core/indexer/reindexlimiter_test.go
@@ -1,0 +1,184 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxConcurrentSpaceReindexFor(t *testing.T) {
+	t.Run("mobile platforms are capped at 2", func(t *testing.T) {
+		assert.Equal(t, 2, maxConcurrentSpaceReindexFor("ios"))
+		assert.Equal(t, 2, maxConcurrentSpaceReindexFor("android"))
+	})
+
+	t.Run("other platforms are capped at 4", func(t *testing.T) {
+		assert.Equal(t, 4, maxConcurrentSpaceReindexFor("darwin"))
+		assert.Equal(t, 4, maxConcurrentSpaceReindexFor("linux"))
+		assert.Equal(t, 4, maxConcurrentSpaceReindexFor("windows"))
+	})
+}
+
+// acquireAsync runs acquire in a goroutine and reports its result on the
+// returned channel, so tests can assert both blocking and completion.
+func acquireAsync(l *reindexLimiter, ctx context.Context, spaceId string) <-chan bool {
+	res := make(chan bool, 1)
+	go func() {
+		res <- l.acquire(ctx, spaceId)
+	}()
+	return res
+}
+
+func TestReindexLimiter(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("acquires immediately while slots are free, then blocks", func(t *testing.T) {
+		// given
+		l := newReindexLimiter(2, nil)
+
+		// when
+		require.True(t, l.acquire(ctx, "space1"))
+		require.True(t, l.acquire(ctx, "space2"))
+		blocked := acquireAsync(l, ctx, "space3")
+
+		// then
+		select {
+		case <-blocked:
+			t.Fatal("third acquire succeeded beyond the limit")
+		case <-time.After(100 * time.Millisecond):
+		}
+		require.Eventually(t, func() bool { return l.waitingCount() == 1 }, time.Second, 5*time.Millisecond)
+
+		// when a slot frees
+		l.release()
+
+		// then the waiter gets it
+		select {
+		case ok := <-blocked:
+			assert.True(t, ok)
+		case <-time.After(time.Second):
+			t.Fatal("waiter never got the freed slot")
+		}
+	})
+
+	t.Run("without opened spaces waiters are granted in FIFO order", func(t *testing.T) {
+		// given
+		l := newReindexLimiter(1, nil)
+		require.True(t, l.acquire(ctx, "space1"))
+
+		first := acquireAsync(l, ctx, "spaceFirst")
+		require.Eventually(t, func() bool { return l.waitingCount() == 1 }, time.Second, 5*time.Millisecond)
+		second := acquireAsync(l, ctx, "spaceSecond")
+		require.Eventually(t, func() bool { return l.waitingCount() == 2 }, time.Second, 5*time.Millisecond)
+
+		// when
+		l.release()
+
+		// then
+		select {
+		case <-first:
+		case <-time.After(time.Second):
+			t.Fatal("first waiter never granted")
+		}
+		select {
+		case <-second:
+			t.Fatal("second waiter granted before the first released")
+		case <-time.After(100 * time.Millisecond):
+		}
+		l.release()
+		select {
+		case <-second:
+		case <-time.After(time.Second):
+			t.Fatal("second waiter never granted")
+		}
+	})
+
+	t.Run("freed slot goes to a waiting opened space before earlier waiters", func(t *testing.T) {
+		// given
+		l := newReindexLimiter(1, func() map[string]struct{} {
+			return map[string]struct{}{"spaceOpened": {}}
+		})
+		require.True(t, l.acquire(ctx, "space1"))
+
+		background := acquireAsync(l, ctx, "spaceBackground")
+		require.Eventually(t, func() bool { return l.waitingCount() == 1 }, time.Second, 5*time.Millisecond)
+		opened := acquireAsync(l, ctx, "spaceOpened")
+		require.Eventually(t, func() bool { return l.waitingCount() == 2 }, time.Second, 5*time.Millisecond)
+
+		// when
+		l.release()
+
+		// then the opened space overtakes the earlier background waiter
+		select {
+		case <-opened:
+		case <-time.After(time.Second):
+			t.Fatal("opened space never granted")
+		}
+		select {
+		case <-background:
+			t.Fatal("background space granted while opened space held the slot")
+		case <-time.After(100 * time.Millisecond):
+		}
+		l.release()
+		select {
+		case <-background:
+		case <-time.After(time.Second):
+			t.Fatal("background space never granted")
+		}
+	})
+
+	t.Run("already-cancelled ctx is not granted even when slots are free", func(t *testing.T) {
+		// given
+		l := newReindexLimiter(2, nil)
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		// when
+		granted := l.acquire(cancelledCtx, "space1")
+
+		// then
+		assert.False(t, granted)
+		// both slots stayed free for live callers; bounded ctx so a wrongly
+		// held slot fails the test instead of hanging it
+		liveCtx, liveCancel := context.WithTimeout(ctx, time.Second)
+		defer liveCancel()
+		require.True(t, l.acquire(liveCtx, "space2"))
+		require.True(t, l.acquire(liveCtx, "space3"))
+	})
+
+	t.Run("cancelled waiter leaves the queue and is not granted", func(t *testing.T) {
+		// given
+		l := newReindexLimiter(1, nil)
+		require.True(t, l.acquire(ctx, "space1"))
+
+		waitCtx, cancel := context.WithCancel(ctx)
+		cancelled := acquireAsync(l, waitCtx, "spaceCancelled")
+		require.Eventually(t, func() bool { return l.waitingCount() == 1 }, time.Second, 5*time.Millisecond)
+		remaining := acquireAsync(l, ctx, "spaceRemaining")
+		require.Eventually(t, func() bool { return l.waitingCount() == 2 }, time.Second, 5*time.Millisecond)
+
+		// when
+		cancel()
+
+		// then
+		select {
+		case ok := <-cancelled:
+			assert.False(t, ok)
+		case <-time.After(time.Second):
+			t.Fatal("cancelled waiter never returned")
+		}
+		require.Eventually(t, func() bool { return l.waitingCount() == 1 }, time.Second, 5*time.Millisecond)
+
+		// and the slot still hands over to the remaining waiter
+		l.release()
+		select {
+		case ok := <-remaining:
+			assert.True(t, ok)
+		case <-time.After(time.Second):
+			t.Fatal("remaining waiter never granted")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

A `ForceInvalidateObjectsIndexCounter` bump makes every space run the outdated-objects reindex pass concurrently on load. Each pass cold-builds every outdated object into the space's object cache and relies on the 60s TTL to release it, so with many spaces the resident set peaked at ~834 MB heap in profiling (~89% of it smartblocks pinned in ocache).

## Fix

Gate the async outdated pass behind a cross-space limiter (`core/indexer/reindexlimiter.go`):

- **Width**: 2 concurrent spaces on iOS/Android, 4 on other platforms (`maxConcurrentSpaceReindexFor`), so peak heap scales with the slot count instead of the space count.
- **Priority**: waiters queue FIFO, but a freed slot is granted first to a space the user currently has objects open in — priority source is the block service's `GetOpenedObjects()`, resolved by component name (`space.BlockServiceCName`) exactly like the head-sync sweep, so a giant background space can't starve the space the user is looking at.
- **Scope**: only the background outdated pass is gated — never the synchronous part of `ReindexSpace`, which blocks space load.
- **Shutdown**: `acquire` selects on the indexer's run ctx and refuses an already-cancelled ctx, so queued passes exit on close instead of running against a closing store.

## Tests

- `TestReindexLimiter`: slot bound, FIFO grant, opened-space waiter overtakes an earlier background waiter, cancelled waiter leaves the queue, already-cancelled ctx refused.
- `TestReindexOutdatedConcurrencyLimit`: the same guarantees end-to-end through `ReindexSpace` with mock spaces.
- `TestMaxConcurrentSpaceReindexFor`: per-platform widths.
- Full `core/indexer` suite green under `-race`.

Linear: GO-7382