### PR TITLE
Remove RelationKeyMentions from excluded property mapping

### DIFF
--- a/core/api/service/property.go
+++ b/core/api/service/property.go
@@ -57,7 +57,6 @@ var excludedSystemProperties = map[string]bool{
 	bundle.RelationKeyCoverScale.String():             true,
 	bundle.RelationKeyCoverX.String():                 true,
 	bundle.RelationKeyCoverY.String():                 true,
-	bundle.RelationKeyMentions.String():               true,
 	bundle.RelationKeyOldAnytypeID.String():           true,
 	bundle.RelationKeySourceFilePath.String():         true,
 	bundle.RelationKeyImportType.String():             true,

--- a/pkg/lib/bundle/relation.gen.go
+++ b/pkg/lib/bundle/relation.gen.go
@@ -9,7 +9,7 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-const RelationChecksum = "cb8c8504438f2846044f86bbc2274d236d682c9f088ac3514d5268dbad219f3b"
+const RelationChecksum = "8600dd60a66928508dfca8bc3d250d341b02e4660811f8b8f725bff6f6ee3248"
 const (
 	RelationKeyTag                                  domain.RelationKey = "tag"
 	RelationKeyCamera                               domain.RelationKey = "camera"
@@ -1535,12 +1535,12 @@ var (
 			DataSource:       model.Relation_local,
 			Description:      "Objects that are mentioned in blocks of this object",
 			Format:           model.RelationFormat_object,
-			Hidden:           true,
 			Id:               "_brmentions",
 			Key:              "mentions",
 			Name:             "Mentions",
 			ReadOnly:         true,
 			ReadOnlyRelation: true,
+			Revision:         1,
 			Scope:            model.Relation_type,
 		},
 		RelationKeyMigrationObjectContext: {

--- a/pkg/lib/bundle/relations.json
+++ b/pkg/lib/bundle/relations.json
@@ -1470,12 +1470,13 @@
   {
     "description": "Objects that are mentioned in blocks of this object",
     "format": "object",
-    "hidden": true,
+    "hidden": false,
     "key": "mentions",
     "maxCount": 0,
     "name": "Mentions",
     "readonly": true,
-    "source": "local"
+    "source": "local",
+    "revision": 1
   },
   {
     "description": "Unix time representation of date object",


### PR DESCRIPTION
The Mentions field is valuable for external renderes togive short context on the linked objects, for example in a PDF report.

The Links field contains absolutely all links, including regular properties. But regular properties might be dealt with in a context specific manner.

Mentions is the only field representing a basic "semantically relevant" designation.

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

---

