### PR TITLE
GO-7393 Bound mobile background flush, fsync instead of checkpoint, Apple fullfsync; non-retryable space load on collection-not-found

### DIFF
--- a/core/durability/durability.go
+++ b/core/durability/durability.go
@@ -20,6 +20,7 @@ Flush order: space stores first (critical data), then objectstore (can be reinde
 import (
 	"time"
 
+	anystore "github.com/anyproto/any-store"
 	"github.com/anyproto/any-sync/app"
 	"go.uber.org/zap"
 
@@ -34,7 +35,7 @@ const CName = "durability"
 var log = logging.LoggerNotSugared(CName)
 
 type Flusher interface {
-	Flush(timeout time.Duration, waitPending bool)
+	Flush(timeout time.Duration, waitPending bool, mode anystore.FlushMode)
 }
 
 type durability struct {
@@ -62,16 +63,20 @@ func (s *durability) StateChange(state int) {
 		// waitPending=false because we need to do best effort without locking the app closing
 		// db component will perform final flush on closing after all writes are done
 		// flush space stores first, because others we can reindex without data loss
-		s.spaceCore.Flush(time.Second*3, false)
-		s.anystoreProvider.Flush(time.Second*3, false)
+		s.spaceCore.Flush(time.Second*3, false, anystore.FlushModeCheckpointPassive)
+		s.anystoreProvider.Flush(time.Second*3, false, anystore.FlushModeCheckpointPassive)
 	case domain.CompStateAppWentBackground:
-		// we need to wait here because on mobile when app goes to background
-		// when app goes to background(or hibernat on desktop) we need to be fast, but make sure we wait and have extended timeout in case of slow device and a huge WAL
+		// Blocking: iOS may suspend us right after this RPC returns, so committed data must be
+		// power-safe before we let the call finish.
+		// Fsync mode syncs the WAL only (sufficient at synchronous=normal) instead of a passive
+		// checkpoint: background filesystem I/O is throttled on iOS and a checkpoint of every open
+		// DB can grind for minutes without honoring the context (see GO-7393). WAL space
+		// reclamation stays on the idle auto-flush and wal_autocheckpoint paths.
 		start := time.Now()
-		s.spaceCore.Flush(time.Second*10, true)
+		s.spaceCore.Flush(time.Second*10, true, anystore.FlushModeFsync)
 		spaceCoreSpent := time.Since(start)
 		start = time.Now()
-		s.anystoreProvider.Flush(time.Second*10, true)
+		s.anystoreProvider.Flush(time.Second*10, true, anystore.FlushModeFsync)
 		anystoreSpent := time.Since(start)
 		if spaceCoreSpent+anystoreSpent > time.Second {
 			log.With(zap.Int64("spaceCoreSpentMs", spaceCoreSpent.Milliseconds()), zap.Int64("anystoreSpentMs", anystoreSpent.Milliseconds())).Warn("flushing took too long")

--- a/core/durability/durability_test.go
+++ b/core/durability/durability_test.go
@@ -1,0 +1,72 @@
+package durability
+
+import (
+	"testing"
+	"time"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+)
+
+type flushCall struct {
+	timeout     time.Duration
+	waitPending bool
+	mode        anystore.FlushMode
+}
+
+type flusherMock struct {
+	calls []flushCall
+}
+
+func (f *flusherMock) Flush(timeout time.Duration, waitPending bool, mode anystore.FlushMode) {
+	f.calls = append(f.calls, flushCall{timeout: timeout, waitPending: waitPending, mode: mode})
+}
+
+func TestStateChange(t *testing.T) {
+	t.Run("background uses blocking fsync, not checkpoint", func(t *testing.T) {
+		// given
+		spaceCore := &flusherMock{}
+		provider := &flusherMock{}
+		d := &durability{spaceCore: spaceCore, anystoreProvider: provider}
+		want := []flushCall{{timeout: time.Second * 10, waitPending: true, mode: anystore.FlushModeFsync}}
+
+		// when
+		d.StateChange(int(domain.CompStateAppWentBackground))
+
+		// then
+		assert.Equal(t, want, spaceCore.calls)
+		assert.Equal(t, want, provider.calls)
+	})
+
+	t.Run("closing uses best-effort passive checkpoint", func(t *testing.T) {
+		// given
+		spaceCore := &flusherMock{}
+		provider := &flusherMock{}
+		d := &durability{spaceCore: spaceCore, anystoreProvider: provider}
+		want := []flushCall{{timeout: time.Second * 3, waitPending: false, mode: anystore.FlushModeCheckpointPassive}}
+
+		// when
+		d.StateChange(int(domain.CompStateAppClosingInitiated))
+
+		// then
+		assert.Equal(t, want, spaceCore.calls)
+		assert.Equal(t, want, provider.calls)
+	})
+
+	t.Run("other states do not flush", func(t *testing.T) {
+		// given
+		spaceCore := &flusherMock{}
+		provider := &flusherMock{}
+		d := &durability{spaceCore: spaceCore, anystoreProvider: provider}
+
+		// when
+		d.StateChange(int(domain.CompStateAppWentForeground))
+
+		// then
+		require.Empty(t, spaceCore.calls)
+		require.Empty(t, provider.calls)
+	})
+}

--- a/pkg/lib/datastore/anystoreprovider/provider.go
+++ b/pkg/lib/datastore/anystoreprovider/provider.go
@@ -270,7 +270,7 @@ func (s *provider) setDefaultConfig() {
 	s.anyStoreConfig.SQLiteConnectionOptions = maps.Clone(s.anyStoreConfig.SQLiteConnectionOptions)
 	s.anyStoreConfig.SQLiteConnectionOptions["synchronous"] = "normal"
 	s.anyStoreConfig.SQLiteConnectionOptions["wal_autocheckpoint"] = "10000"
-
+	anystorehelper.ApplyPlatformPragmas(s.anyStoreConfig.SQLiteConnectionOptions)
 }
 
 func (s *provider) GetCommonDb() anystore.DB {
@@ -523,7 +523,13 @@ func (s *provider) DeleteSpaceData(spaceId string) error {
 	return errs
 }
 
-func (s *provider) Flush(timeout time.Duration, waitPending bool) {
+// flushWaitSlack bounds how long Flush may wait past the per-DB timeout. SQLite does not
+// promptly honor context cancellation inside a checkpoint (a goroutine blocked in a read
+// syscall ignores sqlite3_interrupt until it returns), so a plain wg.Wait() can overrun by
+// minutes on throttled mobile background I/O (GO-7393).
+const flushWaitSlack = time.Second * 2
+
+func (s *provider) Flush(timeout time.Duration, waitPending bool, mode anystore.FlushMode) {
 	if !s.dbsAreFlushing.CompareAndSwap(false, true) {
 		return
 	}
@@ -531,7 +537,6 @@ func (s *provider) Flush(timeout time.Duration, waitPending bool) {
 	if waitPending {
 		idleDuration = time.Millisecond * 30
 	}
-	defer s.dbsAreFlushing.Store(false)
 	s.spaceIndexDbsLock.Lock()
 	s.crtdStoreLock.Lock()
 	var dbs = make([]anystore.DB, 0, len(s.spaceIndexDbs)+len(s.crdtDbs)+1)
@@ -546,7 +551,7 @@ func (s *provider) Flush(timeout time.Duration, waitPending bool) {
 	}
 	s.spaceIndexDbsLock.Unlock()
 	s.crtdStoreLock.Unlock()
-	wg := sync.WaitGroup{}
+	wg := &sync.WaitGroup{}
 
 	dbs = append(dbs, s.commonDb)
 	for _, db := range dbs {
@@ -555,13 +560,24 @@ func (s *provider) Flush(timeout time.Duration, waitPending bool) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(s.componentCtx, timeout)
 			defer cancel()
-			err := db.Flush(ctx, idleDuration, anystore.FlushModeCheckpointPassive)
+			err := db.Flush(ctx, idleDuration, mode)
 			if err != nil {
 				log.With(zap.Error(err)).Error("failed to flush db")
 			}
 		}(db)
 	}
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		// unlock the next flush only after the goroutines actually finished
+		s.dbsAreFlushing.Store(false)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout + flushWaitSlack):
+		log.With(zap.Int("dbs", len(dbs)), zap.Duration("timeout", timeout)).Warn("flush overran its budget, returning early")
+	}
 }
 
 func ensureDirExists(dir string) error {

--- a/pkg/lib/datastore/anystoreprovider/provider_test.go
+++ b/pkg/lib/datastore/anystoreprovider/provider_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
+	anystore "github.com/anyproto/any-store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -178,4 +180,59 @@ func TestDeleteSpaceData_ConcurrentReopen(t *testing.T) {
 	require.NoError(t, p.DeleteSpaceData(spaceId))
 	close(stop)
 	wg.Wait()
+}
+
+// slowDB wraps a real anystore.DB but makes Flush ignore the context and grind for a fixed
+// time, emulating an SQLite checkpoint that does not honor sqlite3_interrupt (GO-7393).
+type slowDB struct {
+	anystore.DB
+	flushDuration time.Duration
+}
+
+func (s *slowDB) Flush(ctx context.Context, idle time.Duration, mode anystore.FlushMode) error {
+	time.Sleep(s.flushDuration)
+	return nil
+}
+
+func TestFlushBoundedWait(t *testing.T) {
+	t.Run("returns within timeout plus slack even if a db flush stalls", func(t *testing.T) {
+		// given
+		p := newTestProvider(t)
+		db, err := p.GetSpaceIndexDb("space1")
+		require.NoError(t, err)
+		stallFor := 10 * time.Second
+		p.spaceIndexDbsLock.Lock()
+		p.spaceIndexDbs["space1"] = &slowDB{DB: db, flushDuration: stallFor}
+		p.spaceIndexDbsLock.Unlock()
+		timeout := 100 * time.Millisecond
+
+		// when
+		start := time.Now()
+		p.Flush(timeout, true, anystore.FlushModeCheckpointPassive)
+		elapsed := time.Since(start)
+
+		// then
+		assert.Less(t, elapsed, stallFor, "Flush must not wait for the stalled db")
+		assert.Less(t, elapsed, timeout+flushWaitSlack+time.Second, "Flush must return within timeout+slack")
+		// the stalled flush is still running, so a new flush must be refused until it finishes
+		assert.True(t, p.dbsAreFlushing.Load())
+
+		// restore the real db so provider.Close does not race the sleeping goroutine
+		p.spaceIndexDbsLock.Lock()
+		p.spaceIndexDbs["space1"] = db
+		p.spaceIndexDbsLock.Unlock()
+	})
+
+	t.Run("fast flush returns promptly and resets the flushing flag", func(t *testing.T) {
+		// given
+		p := newTestProvider(t)
+		_, err := p.GetSpaceIndexDb("space1")
+		require.NoError(t, err)
+
+		// when
+		p.Flush(time.Second*10, true, anystore.FlushModeFsync)
+
+		// then
+		assert.Eventually(t, func() bool { return !p.dbsAreFlushing.Load() }, time.Second, 10*time.Millisecond)
+	})
 }

--- a/pkg/lib/localstore/objectstore/anystorehelper/helper.go
+++ b/pkg/lib/localstore/objectstore/anystorehelper/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -15,6 +16,18 @@ import (
 )
 
 var log = logging.Logger("objectstore.spaceindex")
+
+// ApplyPlatformPragmas adds platform-specific SQLite connection pragmas.
+// On Apple platforms plain fsync() does not flush the drive cache, so a WAL
+// checkpoint whose DB sync silently didn't reach stable storage can corrupt the
+// main DB file on power loss ("the only time that a failed sync operation can
+// cause database corruption is during a checkpoint operation", sqlite.org/wal.html).
+// fullfsync=1 makes SQLite use F_FULLFSYNC for all syncs there.
+func ApplyPlatformPragmas(opts map[string]string) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "ios" {
+		opts["fullfsync"] = "1"
+	}
+}
 
 func IsCorruptedError(err error) (code sqlite.ResultCode, isCorrupted bool) {
 	code = sqlite.ErrCode(err)

--- a/space/internal/components/spaceloader/loadingspace.go
+++ b/space/internal/components/spaceloader/loadingspace.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	anystore "github.com/anyproto/any-store"
 	"github.com/anyproto/any-sync/app/logger"
 	"github.com/anyproto/any-sync/commonspace/object/tree/objecttree"
 	"go.uber.org/zap"
@@ -115,7 +116,12 @@ func (ls *loadingSpace) logErrors(ctx context.Context, err error, mandatoryObjec
 }
 
 func (ls *loadingSpace) isNotRetryable(err error) bool {
-	return errors.Is(err, objecttree.ErrHasInvalidChanges) || errors.Is(err, spacedomain.ErrUnexpectedSpaceType) || ls.disableRemoteLoad
+	// ErrCollectionNotFound means the local space store is corrupt or incomplete; retrying
+	// the build can never succeed and would wedge every WaitLoad caller forever (GO-7393)
+	return errors.Is(err, objecttree.ErrHasInvalidChanges) ||
+		errors.Is(err, spacedomain.ErrUnexpectedSpaceType) ||
+		errors.Is(err, anystore.ErrCollectionNotFound) ||
+		ls.disableRemoteLoad
 }
 
 func (ls *loadingSpace) load(ctx context.Context) (ok bool, err error) {

--- a/space/internal/components/spaceloader/loadingspace_test.go
+++ b/space/internal/components/spaceloader/loadingspace_test.go
@@ -1,0 +1,78 @@
+package spaceloader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/space/clientspace"
+)
+
+type fakeSpaceServiceProvider struct {
+	openErr error
+	opens   atomic.Int32
+}
+
+func (f *fakeSpaceServiceProvider) open(ctx context.Context) (clientspace.Space, error) {
+	f.opens.Add(1)
+	return nil, f.openErr
+}
+
+func (f *fakeSpaceServiceProvider) onLoad(sp clientspace.Space, loadErr error) error {
+	return nil
+}
+
+func TestLoadRetry(t *testing.T) {
+	t.Run("collection not found terminates the load instead of retrying forever", func(t *testing.T) {
+		// given
+		provider := &fakeSpaceServiceProvider{openErr: fmt.Errorf("build space: %w", anystore.ErrCollectionNotFound)}
+		ls := &loadingSpace{
+			retryTimeout:         time.Millisecond * 10,
+			spaceServiceProvider: provider,
+			loadCh:               make(chan struct{}),
+		}
+
+		// when
+		go ls.loadRetry(context.Background())
+
+		// then
+		select {
+		case <-ls.loadCh:
+		case <-time.After(time.Second * 2):
+			t.Fatal("load did not terminate on collection not found")
+		}
+		require.ErrorIs(t, ls.getLoadErr(), anystore.ErrCollectionNotFound)
+		assert.Equal(t, int32(1), provider.opens.Load(), "must not retry a corrupt local store")
+	})
+
+	t.Run("generic build error keeps retrying", func(t *testing.T) {
+		// given
+		provider := &fakeSpaceServiceProvider{openErr: errors.New("transient network error")}
+		ls := &loadingSpace{
+			retryTimeout:         time.Millisecond * 10,
+			spaceServiceProvider: provider,
+			loadCh:               make(chan struct{}),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// when
+		go ls.loadRetry(ctx)
+
+		// then
+		assert.Eventually(t, func() bool { return provider.opens.Load() > 1 }, time.Second*5, time.Millisecond*20)
+		cancel()
+		select {
+		case <-ls.loadCh:
+		case <-time.After(time.Second * 2):
+			t.Fatal("load did not terminate on context cancel")
+		}
+	})
+}

--- a/space/spacecore/service.go
+++ b/space/spacecore/service.go
@@ -301,11 +301,15 @@ func (s *service) Close(ctx context.Context) (err error) {
 	return s.spaceCache.Close()
 }
 
-func (s *service) Flush(timeout time.Duration, waitPending bool) {
+// flushWaitSlack bounds how long Flush may wait past the per-DB timeout. SQLite does not
+// promptly honor context cancellation inside a checkpoint, so a plain wg.Wait() can overrun
+// by minutes on throttled mobile background I/O (GO-7393).
+const flushWaitSlack = time.Second * 2
+
+func (s *service) Flush(timeout time.Duration, waitPending bool, mode anystore.FlushMode) {
 	if !s.dbsAreFlushing.CompareAndSwap(false, true) {
 		return
 	}
-	defer s.dbsAreFlushing.Store(false)
 
 	var dbs []anystore.DB
 	s.spaceCache.ForEach(func(v ocache.Object) (isContinue bool) {
@@ -319,18 +323,29 @@ func (s *service) Flush(timeout time.Duration, waitPending bool) {
 		idleDuration = time.Millisecond * 50
 	}
 
-	wg := sync.WaitGroup{}
+	wg := &sync.WaitGroup{}
 	for _, db := range dbs {
 		wg.Add(1)
 		go func(db anystore.DB) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(s.componentCtx, timeout)
 			defer cancel()
-			err := db.Flush(ctx, idleDuration, anystore.FlushModeCheckpointPassive)
+			err := db.Flush(ctx, idleDuration, mode)
 			if err != nil {
 				log.With(zap.Error(err)).Error("failed to flush db")
 			}
 		}(db)
 	}
-	wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		// unlock the next flush only after the goroutines actually finished
+		s.dbsAreFlushing.Store(false)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout + flushWaitSlack):
+		log.With(zap.Int("dbs", len(dbs)), zap.Duration("timeout", timeout)).Warn("flush overran its budget, returning early")
+	}
 }

--- a/space/spacecore/storage/anystorage/storageservice.go
+++ b/space/spacecore/storage/anystorage/storageservice.go
@@ -195,9 +195,39 @@ func (s *storageService) WaitSpaceStorage(ctx context.Context, id string) (space
 	}
 	st, err := spacestorage.New(ctx, id, db)
 	if err != nil {
-		return nil, err
+		return nil, s.handleStorageBuildError(id, db, err)
 	}
-	return NewClientStorage(ctx, st)
+	cs, err := NewClientStorage(ctx, st)
+	if err != nil {
+		return nil, s.handleStorageBuildError(id, db, err)
+	}
+	return cs, nil
+}
+
+// handleStorageBuildError converts a build failure on an openable store.db into
+// ErrSpaceStorageMissing when the db is valid but uninitialized (its mandatory
+// collections were never durably created, e.g. a create interrupted by process
+// kill or power loss). The db passes every corruption check, so without this the
+// space can never load and never self-heal (GO-7393). The db dir is backed up
+// and the caller re-downloads the space from peers.
+func (s *storageService) handleStorageBuildError(id string, db anystore.DB, err error) error {
+	if !errors.Is(err, anystore.ErrCollectionNotFound) {
+		_ = db.Close()
+		return err
+	}
+	log.With(zap.String("spaceId", id), zap.Error(err)).Error("space store is uninitialized, backing up for re-download")
+	if s.reporter != nil {
+		s.reporter.Report("DB_UNINITIALIZED", map[string]any{
+			"db":      filepath.Join(id, "store.db"),
+			"spaceId": id,
+			"error":   err.Error(),
+		}, debugreporter.Capture{Kind: debugreporter.KindNone})
+	}
+	_ = db.Close()
+	if _, backupErr := s.backupCorruptedSpace(id); backupErr != nil {
+		log.With(zap.String("spaceId", id), zap.Error(backupErr)).Error("failed to backup uninitialized space")
+	}
+	return spacestorage.ErrSpaceStorageMissing
 }
 
 func (s *storageService) SpaceExists(id string) bool {

--- a/space/spacecore/storage/anystorage/storageservice.go
+++ b/space/spacecore/storage/anystorage/storageservice.go
@@ -242,6 +242,7 @@ func (s *storageService) anyStoreConfig() *anystore.Config {
 	}
 	opts["synchronous"] = "normal"
 	opts["wal_autocheckpoint"] = "10000"
+	anystorehelper.ApplyPlatformPragmas(opts)
 
 	return &anystore.Config{
 		ReadConnections:                           4,

--- a/space/spacecore/storage/anystorage/storageservice_test.go
+++ b/space/spacecore/storage/anystorage/storageservice_test.go
@@ -1,0 +1,84 @@
+package anystorage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	anystore "github.com/anyproto/any-store"
+	"github.com/anyproto/any-sync/commonspace/spacestorage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestService(t *testing.T) *storageService {
+	return New(t.TempDir(), &anystore.Config{})
+}
+
+// makeUninitializedStore creates the state observed in GO-7393: a valid,
+// openable store.db whose mandatory collections were never created (a space
+// storage create interrupted by process kill or power loss before the WAL
+// was durably synced).
+func makeUninitializedStore(t *testing.T, s *storageService, spaceId string) string {
+	dirPath := filepath.Join(s.rootPath, spaceId)
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	db, err := anystore.Open(context.Background(), filepath.Join(dirPath, "store.db"), s.anyStoreConfig())
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+	return dirPath
+}
+
+func TestWaitSpaceStorage_Uninitialized(t *testing.T) {
+	t.Run("valid but uninitialized store is treated as missing and backed up", func(t *testing.T) {
+		// given
+		s := newTestService(t)
+		const spaceId = "space1"
+		dirPath := makeUninitializedStore(t, s, spaceId)
+
+		// when
+		st, err := s.WaitSpaceStorage(context.Background(), spaceId)
+
+		// then
+		require.ErrorIs(t, err, spacestorage.ErrSpaceStorageMissing)
+		require.Nil(t, st)
+		// the broken dir is moved aside so a re-download can recreate the space cleanly
+		_, statErr := os.Stat(dirPath)
+		assert.True(t, os.IsNotExist(statErr), "uninitialized space dir must be moved to backup")
+		backups := s.ListCorruptedBackups()
+		require.Len(t, backups, 1)
+		assert.Equal(t, spaceId, backups[0].SpaceId)
+		_, statErr = os.Stat(backups[0].BackupPath)
+		assert.NoError(t, statErr, "backup dir must exist")
+		// the space now reads as absent, so the caller takes the remote-download path
+		assert.False(t, s.SpaceExists(spaceId))
+	})
+
+	t.Run("second load attempt returns missing without another backup", func(t *testing.T) {
+		// given
+		s := newTestService(t)
+		const spaceId = "space1"
+		makeUninitializedStore(t, s, spaceId)
+		_, err := s.WaitSpaceStorage(context.Background(), spaceId)
+		require.ErrorIs(t, err, spacestorage.ErrSpaceStorageMissing)
+
+		// when
+		_, err = s.WaitSpaceStorage(context.Background(), spaceId)
+
+		// then
+		require.ErrorIs(t, err, spacestorage.ErrSpaceStorageMissing)
+		assert.Len(t, s.ListCorruptedBackups(), 1)
+	})
+
+	t.Run("missing dir still returns missing without backup", func(t *testing.T) {
+		// given
+		s := newTestService(t)
+
+		// when
+		_, err := s.WaitSpaceStorage(context.Background(), "neverExisted")
+
+		// then
+		require.ErrorIs(t, err, spacestorage.ErrSpaceStorageMissing)
+		assert.Empty(t, s.ListCorruptedBackups())
+	})
+}


### PR DESCRIPTION
Fixes two independent bugs from an iOS LONG_RPC report (`AppSetDeviceState` took 76s).

## 1. Background flush hang

On `AppSetDeviceState(BACKGROUND)`, durability checkpointed every open any-store DB in parallel and blocked on an unbounded `wg.Wait()`. SQLite doesn't promptly honor context cancellation inside a checkpoint, so on iOS throttled background I/O the RPC hung 76s+ (~95 DBs).

- Background flush uses `FlushModeFsync`: one WAL fsync per DB is durability-sufficient at `synchronous=normal`. WAL draining stays on the idle auto-flush (20s) and `wal_autocheckpoint=10000` paths.
- `provider.Flush` / `spacecore.Flush` wait at most `timeout+2s`; a stalled flush finishes in background and blocks re-entry until done.
- `PRAGMA fullfsync=1` on darwin/ios: plain `fsync()` doesn't flush the drive cache on Darwin; a checkpoint whose DB sync wasn't durable can corrupt the main DB on power loss.

Desktop unaffected (only the non-blocking `AppClosingInitiated` path).

## 2. Space stuck Loading forever

One space failed `BuildSpace` with `any-store: collection not found` every retry for the whole session, blocking all `WaitLoad`/`space.Get` callers on it. Diagnosis: a valid, openable `store.db` missing its `changes` collection — a space storage create interrupted by process kill or power loss before the WAL was synced. It passes every corruption check (file exists, quick-check ok), so neither existing self-heal guard fires, and the error was classified retryable → infinite retry.

- `WaitSpaceStorage`: `ErrCollectionNotFound` on build now takes the same path as corruption — back up the space dir, report `DB_UNINITIALIZED`, return `ErrSpaceStorageMissing` → space is re-downloaded from peers. Nothing is lost: the store has no tree data by definition.
- `spaceloader`: `ErrCollectionNotFound` classified non-retryable (defense in depth if it leaks from another source).