### PR TITLE
GO-7393 Scope fullfsync to space stores only

### DIFF
--- a/pkg/lib/datastore/anystoreprovider/provider.go
+++ b/pkg/lib/datastore/anystoreprovider/provider.go
@@ -270,7 +270,9 @@ func (s *provider) setDefaultConfig() {
 	s.anyStoreConfig.SQLiteConnectionOptions = maps.Clone(s.anyStoreConfig.SQLiteConnectionOptions)
 	s.anyStoreConfig.SQLiteConnectionOptions["synchronous"] = "normal"
 	s.anyStoreConfig.SQLiteConnectionOptions["wal_autocheckpoint"] = "10000"
-	anystorehelper.ApplyPlatformPragmas(s.anyStoreConfig.SQLiteConnectionOptions)
+	// No fullfsync here (unlike space stores): these dbs are derived state, rebuilt by
+	// reindex/replay, and openDatabaseWithReinit self-heals corruption. They also checkpoint
+	// far more often, so F_FULLFSYNC per checkpoint would be a real cost on Apple platforms.
 }
 
 func (s *provider) GetCommonDb() anystore.DB {

--- a/pkg/lib/localstore/objectstore/anystorehelper/helper.go
+++ b/pkg/lib/localstore/objectstore/anystorehelper/helper.go
@@ -23,6 +23,11 @@ var log = logging.Logger("objectstore.spaceindex")
 // main DB file on power loss ("the only time that a failed sync operation can
 // cause database corruption is during a checkpoint operation", sqlite.org/wal.html).
 // fullfsync=1 makes SQLite use F_FULLFSYNC for all syncs there.
+//
+// Intended only for source-of-truth dbs (space stores, which may hold the sole
+// copy of not-yet-synced data). Derived dbs (object index, crdt state) skip it:
+// they are rebuilt by reindex/replay on corruption and checkpoint too often to
+// pay F_FULLFSYNC on every one.
 func ApplyPlatformPragmas(opts map[string]string) {
 	if runtime.GOOS == "darwin" || runtime.GOOS == "ios" {
 		opts["fullfsync"] = "1"


### PR DESCRIPTION
Follow-up to #3221, which set `PRAGMA fullfsync=1` on Apple platforms for all any-store DBs.

Restrict it to space stores. Object index (`objects.db`) and crdt (`crdt.db`) DBs are derived state: rebuilt by reindex/replay, with `openDatabaseWithReinit` already self-healing corruption — worst case after power loss is a reindex, not data loss. They also checkpoint far more often than space stores (every object change feeds them, 20s idle checkpoints per DB), so F_FULLFSYNC (tens of ms per call on Mac SSDs) on every checkpoint is a real I/O and energy cost.

Space stores keep `fullfsync=1`: they are the source of truth and may hold the sole copy of not-yet-synced data, where checkpoint corruption on power loss is unrecoverable.