### PR TITLE
GO-7400 Fix Windows log sink path resolution

### DIFF
--- a/pkg/lib/logging/logging.go
+++ b/pkg/lib/logging/logging.go
@@ -107,22 +107,40 @@ func (s *bufferedLumberjackSink) Close() error {
 // the package-level zap registration which only happens once.
 var activeSink *bufferedLumberjackSink
 
+// sinkFilename extracts the log file path from a sink URL.
+//
+// zap resolves output paths through url.Parse. A Windows path carries a drive
+// letter, so "lumberjack:C:\dir\anytype.log" has no "/" after the scheme and is
+// parsed as an *opaque* URL: the whole path lands in u.Opaque and u.Path is
+// empty. Using u.Path alone therefore yielded an empty Filename on Windows,
+// and lumberjack silently fell back to os.TempDir()/<argv0>-lumberjack.log —
+// so no logs ever appeared in the expected directory and debug reports shipped
+// with zero log files. This is not a path-separator issue: "C:/dir/x.log"
+// parses as opaque too.
+func sinkFilename(u *url.URL) string {
+	if u.Path != "" {
+		return u.Path
+	}
+	return u.Opaque
+}
+
 func newLumberjackSink(u *url.URL) (zap.Sink, error) {
 	var lj *lumberjack.Logger
 	const bufSize = 256 * 1024
 	const flushInterval = 30 * time.Second
+	filename := sinkFilename(u)
 	// Mobile keeps smaller rotated files to save disk; buffering behaviour
 	// matches desktop.
 	if runtime.GOOS == "android" || runtime.GOOS == "ios" {
 		lj = &lumberjack.Logger{
-			Filename:   u.Path,
+			Filename:   filename,
 			MaxSize:    10,
 			MaxBackups: 2,
 			Compress:   false,
 		}
 	} else {
 		lj = &lumberjack.Logger{
-			Filename:   u.Path,
+			Filename:   filename,
 			MaxSize:    100,
 			MaxBackups: 10,
 			Compress:   true,

--- a/pkg/lib/logging/logging_test.go
+++ b/pkg/lib/logging/logging_test.go
@@ -1,12 +1,62 @@
 package logging
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 
 	"github.com/anyproto/any-sync/app/logger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSinkFilename(t *testing.T) {
+	// zap resolves sink output paths via url.Parse. Windows paths start with a
+	// drive letter, so there is no "/" after the scheme and the URL parses as
+	// opaque, leaving u.Path empty. Regression guard: every platform's path
+	// must resolve to a non-empty filename, otherwise lumberjack silently
+	// falls back to os.TempDir() and no logs reach the expected directory.
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "unix absolute path",
+			path: `/Users/user/Library/Application Support/anytype/common/logs/anytype.log`,
+			want: `/Users/user/Library/Application Support/anytype/common/logs/anytype.log`,
+		},
+		{
+			name: "windows path with backslashes",
+			path: `C:\Users\user\AppData\Roaming\anytype\common\logs\anytype.log`,
+			want: `C:\Users\user\AppData\Roaming\anytype\common\logs\anytype.log`,
+		},
+		{
+			name: "windows path with forward slashes",
+			path: `C:/Users/user/AppData/Roaming/anytype/common/logs/anytype.log`,
+			want: `C:/Users/user/AppData/Roaming/anytype/common/logs/anytype.log`,
+		},
+		{
+			name: "windows UNC path",
+			path: `\\server\share\anytype\logs\anytype.log`,
+			want: `\\server\share\anytype\logs\anytype.log`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given: the output path zap is handed by registerLumberjackSink
+			u, err := url.Parse(lumberjackScheme + ":" + tt.path)
+			require.NoError(t, err)
+
+			// when
+			got := sinkFilename(u)
+
+			// then
+			assert.Equal(t, tt.want, got)
+			assert.NotEmpty(t, got, "empty filename makes lumberjack fall back to os.TempDir()")
+		})
+	}
+}
 
 func TestLevelsFromStr(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
On Windows the middleware wrote **no log files** into the expected logs directory. Debug reports from Windows users therefore always shipped with `"logs": 0`, and support was blind for the entire platform. macOS and Linux were unaffected.

Found while diagnosing a sync failure (GO-7399) where the user had to launch the app from PowerShell and pipe stderr just so we could obtain any middleware logs.

## Root cause

`registerLumberjackSink` hands the log path to zap as a scheme-prefixed output path, and the sink factory read `u.Path`:

```go
config.AddOutputPaths = append(config.AddOutputPaths, lumberjackScheme+":"+logFile)
// ...
lj = &lumberjack.Logger{ Filename: u.Path, ... }
```

zap resolves output paths through `url.Parse`. A Windows path begins with a drive letter, so there is no `/` after the scheme and the URL parses as **opaque**: the whole path goes to `u.Opaque` and `u.Path` is empty.

Measured with `url.Parse`:

| output path | `u.Path` |
|---|---|
| `lumberjack:/Users/x/logs/anytype.log` | `/Users/x/logs/anytype.log` ✅ |
| `lumberjack:C:\Users\x\logs\anytype.log` | `""` ❌ |
| `lumberjack:C:/Users/x/logs/anytype.log` | `""` ❌ |

**Not a path-separator problem** — forward slashes fail identically. The drive letter is what makes the URL opaque.

An empty `Filename` then hits lumberjack fallback:

```go
if l.Filename != "" { return l.Filename }
name := filepath.Base(os.Args[0]) + "-lumberjack.log"
return filepath.Join(os.TempDir(), name)
```

So Windows logs *were* being written — to `%TEMP%\anytypeHelper.exe-lumberjack.log`. Meanwhile `registerLumberjackSink` had already created `<workdir>\common\logs`, so the expected directory existed and was empty and the report builder correctly counted zero log files.

zap guards against exactly this for un-schemed paths (`newSink` notes "URL parsing does not work well for Windows paths such as `c:\log.txt`"), but prefixing `lumberjack:` bypasses that guard.

## Not caused by `doNotSaveLogs`

Verified in anytype-ts: one `InitialSetParameters` call site (`src/ts/lib/analytics.ts:233`) hard-codes `doNotSaveLogs: false` on every platform and channel. `SaveLogs` is true and the file sink *is* requested — the defect is entirely heart-side.

## Change

`sinkFilename()` falls back to `u.Opaque` when `u.Path` is empty, used for both the mobile and desktop lumberjack branches. `TestSinkFilename` covers unix, Windows backslash, Windows forward-slash and UNC paths, parsing through the same `lumberjackScheme + ":" + path` the production code builds.

## Verification

- `go build ./pkg/lib/logging/` — clean
- `go test ./pkg/lib/logging/` — pass (4 new subtests; existing tests unaffected)
- `go vet`, `gofmt -l` — clean
- The Windows cases fail without the fix (`u.Path` is empty for them)

## Follow-ups (not in this PR)

- `registerLumberjackSink` uses `os.Mkdir` rather than `os.MkdirAll`, so it returns early and silently installs no file sink if the parent directory is missing.
- The desktop sets `GOLOG_FILE` (`electron/ts/server.ts:57`), but heart never reads it — it belongs to `ipfs/go-log`. Dead config that implies logs exist where they do not.
- Surface log presence in the report summary so an empty bundle is obvious at triage.
- Existing affected Windows users may still have recoverable history at `%TEMP%\anytypeHelper.exe-lumberjack.log`.

See `docs/NetworkDiagnosticsSpec.md` §2.1.