### PR TITLE
GO-7409 Revert the node-lookup dial budget that stopped self-hosted sync

### DIFF
--- a/space/spacecore/peermanager/manager.go
+++ b/space/spacecore/peermanager/manager.go
@@ -46,16 +46,6 @@ const (
 	// parks a worker per broadcast indefinitely and freezes the send path.
 	// Dropped broadcasts are recovered by the periodic head-sync.
 	broadcastPeerFindDeadline = time.Second * 30
-	// responsibleNodeDialTimeout bounds the node lookup in
-	// fetchResponsiblePeers. pool.GetOneOf parks single-flight behind an
-	// in-flight dial of whichever node id the shuffle picked; on a fresh
-	// cellular path one unreachable node's address chain (schemes x addrs
-	// dialed sequentially, 10s each) can hold that park for tens of seconds
-	// while another responsible node is already connected (observed in the
-	// field: iOS Wi-Fi->cellular, 71 spaces parked behind one dial). Giving up
-	// early lets the fast retry below re-enter GetOneOf, whose active-conn
-	// check then returns any node that connected meanwhile.
-	responsibleNodeDialTimeout = time.Second * 10
 	// responsiblePeersRetryInterval is the re-fetch cadence right after a
 	// failed node lookup while the device believes it is online: quick enough
 	// to pick up a connection established by another space's dial in the
@@ -68,12 +58,21 @@ const (
 	// captive portal — local-only P2P keeps syncing meanwhile), decaying back
 	// to the normal cadence avoids permanent doomed-dial pressure every 5s.
 	fastRetryMaxAttempts = 3
-	// localPeerDialTimeout is the shared budget for refreshing all local (mDNS)
-	// peers in one fetch cycle. After a network switch the peer store still
-	// lists peers from the previous network whose addresses are unroutable;
-	// unbounded dials to them parked every manager single-flight for the whole
-	// scheme x addr chain (~20-40s) while a healthy node connection sat idle.
-	// A bounded failure also actually triggers the stale peer's removal.
+	// localPeerDialTimeout bounds ONE local (mDNS) peer dial. After a network
+	// switch the peer store still lists peers from the previous network whose
+	// addresses are unroutable; unbounded dials to them parked every manager
+	// single-flight for the whole scheme x addr chain (~20-40s) while a healthy
+	// node connection sat idle. A bounded failure also actually triggers the
+	// stale peer's removal.
+	//
+	// Per dial, not one budget shared across the whole loop. A shared budget is
+	// the same defect as GO-7409: the first stale entry consumes it, every peer
+	// behind it then gets an already-expired context, and because the loop
+	// reads any error as "stale" those peers are evicted from the peer store
+	// without ever being tried. Worse, an already-connected peer hits a select
+	// in ocache with both ctx.Done() and the loaded entry ready, so it is
+	// dropped on a coin flip. In LocalOnly mode there are no nodes at all and
+	// these peers are the only sync path, so that eviction costs sync outright.
 	localPeerDialTimeout = time.Second * 5
 )
 
@@ -338,13 +337,16 @@ func (n *clientPeerManager) nextCheckInterval() time.Duration {
 func (n *clientPeerManager) fetchResponsiblePeers() {
 	var peers []peer.Peer
 	prevStatus := n.nodeStatus.GetNodeStatus(n.spaceId)
-	// Bound the lookup: GetOneOf may park single-flight behind another
-	// space's in-flight dial to an unreachable node; waitLoad honors ctx, so
-	// the retry loop stays in control instead of inheriting the slowest
-	// dial's schedule.
-	dialCtx, cancel := context.WithTimeout(n.ctx, responsibleNodeDialTimeout)
-	p, err := n.p.pool.GetOneOf(dialCtx, n.getNodeIds())
-	cancel()
+	// Deliberately unbounded, as it was before GO-7379. GetOneOf walks every
+	// responsible node x every scheme x every address, and each attempt is
+	// already capped by the transports (yamux net.Dialer.Timeout, quic
+	// HandshakeIdleTimeout), so the walk terminates on its own. A bound here
+	// has to be larger than that whole product or it truncates the walk: a
+	// single address that accepts UDP and never replies then consumes it all
+	// and the yamux fallback is never attempted, which cost self-hosted users
+	// sync entirely. See GO-7410 for the layered fix that lets a bound be
+	// reintroduced safely.
+	p, err := n.p.pool.GetOneOf(n.ctx, n.getNodeIds())
 	if err == nil {
 		n.consecutiveFetchFailures.Store(0)
 		peers = []peer.Peer{p}
@@ -377,12 +379,14 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 	}
 	peerIds := n.peerStore.LocalPeerIds(n.spaceId)
 	if len(peerIds) > 0 {
-		// Bound the local dials as one budget: on failure the stale peer is
-		// removed, so a Wi-Fi-era entry costs at most one bounded pass after
-		// the switch instead of an unbounded dial chain per cycle.
-		localCtx, cancelLocal := context.WithTimeout(n.ctx, localPeerDialTimeout)
+		// Bound each dial separately, so one stale entry costs only its own
+		// budget: on failure the stale peer is removed, so a Wi-Fi-era entry
+		// costs at most one bounded attempt after the switch instead of an
+		// unbounded dial chain per cycle.
 		for _, peerId := range peerIds {
+			localCtx, cancelLocal := context.WithTimeout(n.ctx, localPeerDialTimeout)
 			p, err := n.p.pool.Get(localCtx, peerId)
+			cancelLocal()
 			if err != nil {
 				n.peerStore.RemoveLocalPeer(peerId)
 				log.Warn("failed to get local from net pool", zap.String("peerId", peerId), zap.Error(err))
@@ -390,7 +394,6 @@ func (n *clientPeerManager) fetchResponsiblePeers() {
 			}
 			peers = append(peers, p)
 		}
-		cancelLocal()
 	}
 	n.publishResponsiblePeers(peers)
 }

--- a/space/spacecore/peermanager/manager_test.go
+++ b/space/spacecore/peermanager/manager_test.go
@@ -555,15 +555,20 @@ func Test_nextCheckInterval_fastRetryAfterFailure(t *testing.T) {
 	assert.Equal(t, responsiblePeersRetryInterval, f.cm.nextCheckInterval(), "rebuild signal: fast window reopened")
 }
 
-func Test_fetchResponsiblePeers_boundsNodeLookup(t *testing.T) {
+// Regression guard for the GO-7379 dial-budget starvation: the node lookup must
+// NOT carry a deadline. GetOneOf walks every responsible node x scheme x
+// address, and any bound smaller than that whole product truncates the walk --
+// one address that accepts UDP and never replies then consumes the budget and
+// the yamux fallback is never attempted. Per-attempt transport caps already
+// guarantee the walk terminates. A bound may only return once GO-7410 lands.
+func Test_fetchResponsiblePeers_nodeLookupIsNotTruncated(t *testing.T) {
 	spaceId := "spaceId"
 	f := newFixtureManager(t, spaceId)
 	f.updater.EXPECT().Refresh(spaceId)
 	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, ids []string) (peer.Peer, error) {
-			deadline, ok := ctx.Deadline()
-			assert.True(t, ok, "node lookup must carry a deadline so it can't park behind a slow dial")
-			assert.LessOrEqual(t, time.Until(deadline), responsibleNodeDialTimeout)
+			_, ok := ctx.Deadline()
+			assert.False(t, ok, "node lookup must not carry a deadline: it truncates the address walk before the yamux fallback")
 			return newTestPeer("id"), nil
 		})
 	f.cm.fetchResponsiblePeers()
@@ -615,22 +620,39 @@ func Test_fetchResponsiblePeers_nodePublishedBeforeLocalDials(t *testing.T) {
 	assert.Empty(t, f.store.LocalPeerIds(spaceId), "stale local peer must be removed after a failed bounded dial")
 }
 
-func Test_fetchResponsiblePeers_boundsLocalDials(t *testing.T) {
+// Local (mDNS) dials are bounded PER DIAL, not by one budget shared across the
+// loop. A shared budget is the GO-7409 defect in miniature: the first stale
+// entry consumes it and every peer behind it is evicted without being tried --
+// and in LocalOnly mode, where there are no nodes, that costs sync outright.
+func Test_fetchResponsiblePeers_boundsEachLocalDialSeparately(t *testing.T) {
 	spaceId := "spaceId"
 	f := newFixtureManager(t, spaceId)
-	f.store.UpdateLocalPeer("localPeer", []string{spaceId})
+	f.store.UpdateLocalPeer("stalePeer", []string{spaceId})
+	f.store.UpdateLocalPeer("healthyPeer", []string{spaceId})
 	f.updater.EXPECT().Refresh(spaceId)
 	f.pool.EXPECT().GetOneOf(gomock.Any(), gomock.Any()).Return(newTestPeer("node"), nil)
-	f.pool.EXPECT().Get(gomock.Any(), "localPeer").DoAndReturn(
+
+	// the stale peer burns its whole budget, as an unroutable Wi-Fi-era entry does
+	f.pool.EXPECT().Get(gomock.Any(), "stalePeer").DoAndReturn(
+		func(ctx context.Context, id string) (peer.Peer, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+	// the healthy peer behind it must still get a full budget of its own
+	f.pool.EXPECT().Get(gomock.Any(), "healthyPeer").DoAndReturn(
 		func(ctx context.Context, id string) (peer.Peer, error) {
 			deadline, ok := ctx.Deadline()
-			assert.True(t, ok, "local dials must carry a deadline: stale mDNS peers must not park the fetch")
-			assert.LessOrEqual(t, time.Until(deadline), localPeerDialTimeout)
-			return newTestPeer("localPeer"), nil
+			require.True(t, ok, "local dials must carry a deadline")
+			assert.Greater(t, time.Until(deadline), localPeerDialTimeout/2,
+				"each local dial needs its own budget: a stale peer must not starve the ones behind it")
+			return newTestPeer("healthyPeer"), nil
 		})
+
 	f.cm.fetchResponsiblePeers()
 
 	peers, err := f.cm.GetResponsiblePeers(context.Background())
 	require.NoError(t, err)
-	require.Len(t, peers, 2, "node and local peer must both be served after the full fetch")
+	require.Len(t, peers, 2, "node and healthy local peer must both be served")
+	assert.Equal(t, []string{"healthyPeer"}, f.store.LocalPeerIds(spaceId),
+		"only the stale peer may be evicted")
 }


### PR DESCRIPTION
Fixes GO-7409. Follow-up work in GO-7410.

Self-hosted users lost sync entirely after updating 0.50.8 → 0.50.18.

Two shared budgets that stood in for per-attempt caps.

## 1. Node lookup

`fetchResponsiblePeers` bounded the node lookup with `responsibleNodeDialTimeout` (10s, added in GO-7379 `cf6701922`). That single budget has to cover `pool.GetOneOf` walking **every responsible node × every scheme × every address** — and `peerService.Dial` tries all of a peer's QUIC addresses before any yamux address.

QUIC's `HandshakeIdleTimeout` is also 10s. So one address that accepts UDP and never replies consumes the entire budget; every later address plus the whole TCP fallback then fails instantly with `context deadline exceeded`, and no space obtains a responsible peer.

Such an address is normal in self-hosted setups. quic-go dials on an *unconnected* UDP socket, so ICMP port-unreachable is never surfaced and a dead UDP port black-holes for the full timeout — and any-sync-dockercompose writes `quic://127.0.0.1:101x` into every generated `client.yml`, which is only valid on the node host.

v0.50.8 passed `n.ctx` unbounded: it spent ~20–30s on the dead QUIC addresses, then reached yamux and connected.

Reverted to the pre-GO-7379 unbounded call. Each attempt is already capped by the transports (yamux `net.Dialer.Timeout`, quic `HandshakeIdleTimeout`), so the walk terminates without this bound — it was never what made it terminate. The rest of GO-7379 (connectivity signals, fast retry, rebuild-on-reconnect, closed-peer filtering, debugstat) is untouched.

## 2. Local peer dials

`localPeerDialTimeout` was created once before the loop and reused for every `pool.Get`, so 5s was shared across all mDNS peers despite the name. Since the loop reads any error as "stale", the first stale entry caused every peer behind it to be evicted from the peer store without being dialled; already-connected peers were dropped on a coin flip, because `ocache.waitLoad` selects on both `ctx.Done()` and the loaded entry.

In LocalOnly mode nodeconf is empty and these peers are the only sync path, so that eviction costs sync outright. Now bounded per dial, so the name and behaviour agree.

## Trade accepted

The recovery latency GO-7379 addressed returns: after a network switch, spaces can queue behind one doomed dial. That is slow recovery versus today's total sync loss plus a hung `AccountSelect`, and it is a return to previously-shipped behaviour rather than new risk.

GO-7410 removes the trade permanently with a non-blocking `ocache` peek so `pool.getIfActive` stops waiting on an in-flight dial — after which a bound can be reintroduced safely.

## Test plan

- [x] `go test ./space/spacecore/peermanager/` — regression guards for both shapes; the local-dial guard was verified to fail against the shared-budget version and pass against per-dial
- [x] `go build ./...`
- [x] e2e against a self-hosted network with a black-holed QUIC path

This rests on the code analysis plus the reporter's goroutine snapshot; the e2e run needs a reliably black-holed environment. Details in GO-7409.
