### PR TITLE
GO-7404 Keep objects with empty property values in relation-sourced queries

### DIFF
--- a/core/subscription/filters_test.go
+++ b/core/subscription/filters_test.go
@@ -83,6 +83,36 @@ func TestSourceResolution(t *testing.T) {
 		assert.ElementsMatch(t, []string{"o1", "o2"}, recordIds(resp.Records))
 	})
 
+	// GO-7404: a relation source means "has this property", not "has a value in
+	// it" — filtering the empty ones out breaks `Property → is empty` views
+	t.Run("relation source keeps objects holding the property with an empty value", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		givenObjects(fx)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("o4"),
+				"assignee":                       domain.StringList([]string{}),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			},
+			{
+				bundle.RelationKeyId:             domain.String("o5"),
+				"assignee":                       domain.String(""),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			},
+		})
+
+		resp, err := fx.Search(SubscribeRequest{
+			SpaceId:           testSpaceId,
+			SubId:             "source-empty",
+			Internal:          true,
+			NoDepSubscription: true,
+			Keys:              []string{bundle.RelationKeyId.String()},
+			Source:            []string{"rel-assignee"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"o2", "o4", "o5"}, recordIds(resp.Records))
+	})
+
 	t.Run("unresolvable source errors instead of widening to the space", func(t *testing.T) {
 		fx := newEngineFixture(t)
 		givenObjects(fx)

--- a/core/subscription/normalize.go
+++ b/core/subscription/normalize.go
@@ -169,7 +169,7 @@ func normalizeKeys(keys []string) []domain.RelationKey {
 
 // resolveSources translates Source entries (setOf semantics) into a filter:
 // object-type sources become `type In [...]`, relation sources become
-// `relationKey NotEmpty`, OR-combined. Each entry is tried as a unique key
+// `relationKey Exists`, OR-combined. Each entry is tried as a unique key
 // first (the JSON API sends `ot-…` unique keys), then as a type object id,
 // then as a relation id — the same resolution order dataview uses.
 func resolveSources(idx spaceindex.Store, source []string) ([]database.FilterRequest, error) {
@@ -223,9 +223,12 @@ func resolveSources(idx spaceindex.Store, source []string) ([]database.FilterReq
 		})
 	}
 	for _, key := range relationKeys {
+		// Exists, not NotEmpty: setOf means "carries this property", so an
+		// object holding it with an empty value still belongs to the set —
+		// NotEmpty here also starved `Property → is empty` views (GO-7404)
 		alternatives = append(alternatives, database.FilterRequest{
 			RelationKey: domain.RelationKey(key),
-			Condition:   model.BlockContentDataviewFilter_NotEmpty,
+			Condition:   model.BlockContentDataviewFilter_Exists,
 		})
 	}
 	switch len(alternatives) {


### PR DESCRIPTION
Fixes [GO-7404](https://linear.app/anytype/issue/GO-7404/query-results-no-longer-return-objects-with-empty-values) — reported against 0.56.0: *"Query by Property doesn't return Objects that have that Property but empty"*.

## Root cause

The subscription-engine rewrite (GO-7320) reimplemented source resolution. A relation entry in `Source` (setOf semantics) became:

```go
FilterRequest{RelationKey: key, Condition: model.BlockContentDataviewFilter_NotEmpty}
```

The pre-rewrite resolver used `database.FilterExists{Key: relKey}` (`v0.49.1:core/subscription/service.go:977`).

`Exists` means *the object carries this property*. `NotEmpty` additionally demands a value, so every object holding the property with an empty value silently dropped out of the query. It also starved `Property → is empty` views, which is the second symptom in the report: the source filter removes exactly the rows the view filter is looking for.

`resolveSources` is the only place that translates setOf into filters, and `compileGroupsFilters` shares it, so kanban groups were affected the same way and are fixed here too.

## Fix

Restore `Exists`, and correct the doc comment above `resolveSources`, which documented the wrong condition.

## Tests

New subtest in `TestSourceResolution` adding objects that carry `assignee` with an empty list and with an empty string, asserting a `rel-assignee` source returns them alongside the populated one. It goes through `fx.Search`, so it covers the real request path rather than the resolver in isolation.

Written test-first. It failed with `extra elements in list A: o4, o5` before the change — which also confirms the store really does persist the key when the value is empty, i.e. the reported case is reachable.

`go test ./core/subscription/... -count=1` passes across all three packages; gofmt and go vet clean.