### PR TITLE
Fix Notion inline equation import

### DIFF
--- a/core/block/import/notion/api/block/text_test.go
+++ b/core/block/import/notion/api/block/text_test.go
@@ -215,8 +215,55 @@ func Test_GetTextBlocksEquation(t *testing.T) {
 
 	bl := to.GetTextBlocks(model.BlockContentText_Paragraph, nil, &api.NotionImportContext{})
 	assert.Len(t, bl.Blocks, 1)
-	assert.NotNil(t, bl.Blocks[0].GetLatex())
-	assert.Equal(t, bl.Blocks[0].GetLatex().Text, "Equation")
+	assert.NotNil(t, bl.Blocks[0].GetText())
+	assert.Equal(t, "$Equation$", bl.Blocks[0].GetText().Text)
+	assert.Nil(t, bl.Blocks[0].GetLatex())
+}
+
+func Test_GetTextBlocksInlineEquationPreservesPosition(t *testing.T) {
+	to := &TextObject{
+		RichText: []api.RichText{
+			{
+				Type:      api.Text,
+				PlainText: "The value is ",
+			},
+			{
+				Type: api.Equation,
+				Equation: &api.EquationObject{
+					Expression: "x^2",
+				},
+			},
+			{
+				Type:      api.Text,
+				PlainText: ".",
+			},
+		},
+	}
+
+	got := to.GetTextBlocks(
+		model.BlockContentText_Paragraph,
+		nil,
+		&api.NotionImportContext{},
+	)
+
+	assert.Len(t, got.Blocks, 1)
+	assert.NotNil(t, got.Blocks[0].GetText())
+	assert.Equal(t, "The value is $x^2$.", got.Blocks[0].GetText().Text)
+	assert.Nil(t, got.Blocks[0].GetLatex())
+}
+
+func Test_EquationBlockRemainsBlockLatex(t *testing.T) {
+	equation := &EquationBlock{
+		Equation: api.EquationObject{
+			Expression: `\sum_{i=1}^{n} i`,
+		},
+	}
+
+	got := equation.GetBlocks(&api.NotionImportContext{}, "")
+
+	assert.Len(t, got.Blocks, 1)
+	assert.NotNil(t, got.Blocks[0].GetLatex())
+	assert.Equal(t, `\sum_{i=1}^{n} i`, got.Blocks[0].GetLatex().Text)
 }
 
 func Test_GetCodeBlocksSuccess(t *testing.T) {

--- a/core/block/import/notion/api/block/textobject.go
+++ b/core/block/import/notion/api/block/textobject.go
@@ -42,7 +42,7 @@ func (t *TextObject) GetTextBlocks(style model.BlockContentTextStyle, childIds [
 		if rt.Type == api.Mention {
 			marks = append(marks, t.handleMentionType(rt, &text, req)...)
 		}
-		if rt.Type == api.Equation {
+		if rt.Type == api.Equation && rt.Equation != nil {
 			text.WriteByte('$')
 			text.WriteString(rt.Equation.Expression)
 			text.WriteByte('$')

--- a/core/block/import/notion/api/block/textobject.go
+++ b/core/block/import/notion/api/block/textobject.go
@@ -32,8 +32,6 @@ type TextObject struct {
 func (t *TextObject) GetTextBlocks(style model.BlockContentTextStyle, childIds []string, req *api.NotionImportContext) *MapResponse {
 	var marks []*model.BlockContentTextMark
 	id := bson.NewObjectId().Hex()
-	allBlocks := make([]*model.Block, 0)
-	allIds := make([]string, 0)
 	var (
 		text strings.Builder
 	)
@@ -45,9 +43,9 @@ func (t *TextObject) GetTextBlocks(style model.BlockContentTextStyle, childIds [
 			marks = append(marks, t.handleMentionType(rt, &text, req)...)
 		}
 		if rt.Type == api.Equation {
-			eqBlock := rt.Equation.HandleEquation()
-			allBlocks = append(allBlocks, eqBlock)
-			allIds = append(allIds, eqBlock.Id)
+			text.WriteByte('$')
+			text.WriteString(rt.Equation.Expression)
+			text.WriteByte('$')
 		}
 	}
 	var backgroundColor, textColor string
@@ -57,13 +55,7 @@ func (t *TextObject) GetTextBlocks(style model.BlockContentTextStyle, childIds [
 		textColor = api.NotionColorToAnytype[t.Color]
 	}
 
-	if t.isNotTextBlocks() {
-		return &MapResponse{
-			Blocks:   allBlocks,
-			BlockIDs: allIds,
-		}
-	}
-	allBlocks = append(allBlocks, &model.Block{
+	block := &model.Block{
 		Id:              id,
 		ChildrenIds:     childIds,
 		BackgroundColor: backgroundColor,
@@ -76,13 +68,10 @@ func (t *TextObject) GetTextBlocks(style model.BlockContentTextStyle, childIds [
 				Color:   textColor,
 			},
 		},
-	})
-	for _, b := range allBlocks {
-		allIds = append(allIds, b.Id)
 	}
 	return &MapResponse{
-		Blocks:   allBlocks,
-		BlockIDs: allIds,
+		Blocks:   []*model.Block{block},
+		BlockIDs: []string{id},
 	}
 }
 
@@ -270,10 +259,6 @@ func (t *TextObject) handleLinkPreviewMention(rt api.RichText, text *strings.Bui
 		Type: model.BlockContentTextMark_Link,
 	})
 	return marks
-}
-
-func (t *TextObject) isNotTextBlocks() bool {
-	return len(t.RichText) == 1 && t.RichText[0].Type == api.Equation
 }
 
 type TextObjectWithChildren struct {


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This PR fixes the Notion importer so that equations contained in rich text remain inline and preserve their original position.

Previously, inline equations were converted into standalone LaTeX blocks. This change serializes rich-text equations as `$expression$` inside the surrounding text block.

Standalone Notion equation blocks continue to be imported as standalone LaTeX blocks.

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

- https://github.com/anyproto/anytype-ts/issues/2187

### Mobile & Desktop Screenshots/Recordings

Not tested through the desktop UI.
The importer behavior is covered by unit tests.

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

Added tests covering:

- A rich-text paragraph containing only an inline equation
- Preservation of an inline equation between surrounding text
- Preservation of standalone Notion equation blocks as standalone LaTeX blocks

The following test packages pass locally:

```sh
CGO_LDFLAGS=-Wl,-no_warn_duplicate_libraries go test -count=1 ./core/block/import/notion/api/block
```

```sh
CGO_LDFLAGS=-Wl,-no_warn_duplicate_libraries go test -count=1 ./core/block/import/notion/...
```

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

No post-deployment tasks are required.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
