### PR TITLE
GO-7420 Update Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
 
       - name: Setup GO

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25
+          go-version: 1.26
           cache: false
         env:
           GOPRIVATE: "github.com/anyproto"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
 
       - name: Setup GO

--- a/.github/workflows/perftests-grafana.yml
+++ b/.github/workflows/perftests-grafana.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: false
           check-latest: true
 

--- a/.github/workflows/perftests.yml
+++ b/.github/workflows/perftests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: false
           check-latest: true
       - name: Configure Go env vars

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
 
       - name: Clone anytype-heart with specified branch

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
       - name: git config
         run: git config --global url.https://${{ secrets.ANYTYPE_PAT }}@github.com/.insteadOf https://github.com/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anyproto/anytype-heart
 
-go 1.25.7
+go 1.26.5
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.4.0


### PR DESCRIPTION
## Summary
- Bump `go.mod` from Go 1.25.7 to 1.26.5 (latest stable release)
- Bump `go-version` in CI workflows (build, test, golangci-lint, nightly, smoke-tests, perftests, perftests-grafana) from 1.25 to 1.26

## Test plan
- [x] `go build ./...` succeeds locally with Go 1.26.5
- [ ] CI green on build/test/lint workflows

Linear: GO-7420