### PR TITLE
Fix GetListViews dropping grouped Dataview filters

### DIFF
--- a/core/api/service/list.go
+++ b/core/api/service/list.go
@@ -60,17 +60,7 @@ func (s *Service) GetListViews(ctx context.Context, spaceId string, listId strin
 		for _, view := range content.Dataview.Views {
 			var filters []apimodel.Filter
 			for _, f := range view.Filters {
-				if f.Condition == model.BlockContentDataviewFilter_None {
-					continue
-				}
-				apiCond, _ := filter.ToApiCondition(f.Condition)
-				filters = append(filters, apimodel.Filter{
-					Id:          f.Id,
-					PropertyKey: f.RelationKey,
-					Format:      RelationFormatToPropertyFormat[f.Format],
-					Condition:   apiCond,
-					Value:       f.Value.GetStringValue(),
-				})
+				filters = appendListViewFilters(filters, f)
 			}
 			var sorts []apimodel.Sort
 			for _, srt := range view.Sorts {
@@ -97,6 +87,33 @@ func (s *Service) GetListViews(ctx context.Context, spaceId string, listId strin
 	paginatedViews, hasMore := pagination.Paginate(views, offset, limit)
 
 	return paginatedViews, total, hasMore, nil
+}
+
+// appendListViewFilters flattens grouped dataview filters into the API's
+// existing list of leaf filters. Group nodes have no API condition of their
+// own, but their nested conditions must still be returned.
+func appendListViewFilters(filters []apimodel.Filter, f *model.BlockContentDataviewFilter) []apimodel.Filter {
+	if f == nil {
+		return filters
+	}
+	if f.Condition == model.BlockContentDataviewFilter_None {
+		for _, nested := range f.NestedFilters {
+			filters = appendListViewFilters(filters, nested)
+		}
+		return filters
+	}
+
+	apiCond, ok := filter.ToApiCondition(f.Condition)
+	if !ok {
+		return filters
+	}
+	return append(filters, apimodel.Filter{
+		Id:          f.Id,
+		PropertyKey: f.RelationKey,
+		Format:      RelationFormatToPropertyFormat[f.Format],
+		Condition:   apiCond,
+		Value:       f.Value.GetStringValue(),
+	})
 }
 
 // GetObjectsInList retrieves objects in a list

--- a/core/api/service/list_test.go
+++ b/core/api/service/list_test.go
@@ -89,6 +89,57 @@ func TestListService_GetListViews(t *testing.T) {
 		require.Len(t, retView.Sorts, 1)
 	})
 
+	t.Run("returns filters nested in groups", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.populateCache(mockedSpaceId)
+
+		view := &model.BlockContentDataviewView{
+			Id:   "grouped-view",
+			Name: "Grouped View",
+			Filters: []*model.BlockContentDataviewFilter{
+				{
+					Condition: model.BlockContentDataviewFilter_None,
+					NestedFilters: []*model.BlockContentDataviewFilter{
+						{
+							Id:          "nested-filter-1",
+							RelationKey: "status",
+							Condition:   model.BlockContentDataviewFilter_Equal,
+							Value:       pbtypes.String("done"),
+						},
+					},
+				},
+			},
+		}
+		resp := &pb.RpcObjectShowResponse{
+			Error: &pb.RpcObjectShowResponseError{Code: pb.RpcObjectShowResponseError_NULL},
+			ObjectView: &model.ObjectView{
+				Blocks: []*model.Block{{
+					Id: "dataview",
+					Content: &model.BlockContentOfDataview{
+						Dataview: &model.BlockContentDataview{Views: []*model.BlockContentDataviewView{view}},
+					},
+				}},
+			},
+		}
+		fx.mwMock.
+			On("ObjectShow", mock.Anything, &pb.RpcObjectShowRequest{
+				SpaceId:  mockedSpaceId,
+				ObjectId: mockedListId,
+			}).
+			Return(resp, nil).Once()
+
+		views, _, _, err := fx.service.GetListViews(context.Background(), mockedSpaceId, mockedListId, offset, limit)
+		require.NoError(t, err)
+		require.Len(t, views, 1)
+		require.Equal(t, []apimodel.Filter{{
+			Id:          "nested-filter-1",
+			PropertyKey: "status",
+			Format:      apimodel.PropertyFormatText,
+			Condition:   apimodel.FilterConditionEq,
+			Value:       "done",
+		}}, views[0].Filters)
+	})
+
 	t.Run("object show error", func(t *testing.T) {
 		fx := newFixture(t)
 		fx.populateCache(mockedSpaceId)


### PR DESCRIPTION
## What this PR does

Fixes #3228.

`GET /v1/spaces/{space_id}/lists/{list_id}/views` silently dropped grouped Dataview filters. The filter loop skipped any filter with `Condition == None` (`BlockContentDataviewFilter_None`) via `continue`, never looking at `NestedFilters` — so filters configured as groups (AND/OR) disappeared from the response.

## Changes

- Flatten grouped filters into their nested conditions so they are returned in the API's existing list-of-leaf-filters format.
- Added a regression test covering a filter nested inside a group.

## Test plan

- `go test ./core/api/service/ -run TestListService_GetListViews -count=1`
- `go test ./core/api/... -count=1`
- `go vet ./core/api/service/`