### PR TITLE
GO-7423 Stop imported objects losing their name to a guessed note layout

### DIFF
--- a/core/block/editor/page_note_layout_test.go
+++ b/core/block/editor/page_note_layout_test.go
@@ -1,0 +1,56 @@
+package editor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/smartblock"
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// The note layout is the one layout whose creation migration deletes the name detail and
+// turns it into a plain text block. That is intended for real notes, and is why resolveLayout
+// must never hand a merely guessed note layout to this migration.
+func TestCreationStateMigrationNoteLayoutMovesNameIntoBlock(t *testing.T) {
+	newState := func(layout model.ObjectTypeLayout) *state.State {
+		st := state.NewDoc("root", map[string]simple.Block{
+			"root": simple.New(&model.Block{Id: "root"}),
+		}).NewState()
+		st.SetDetail(bundle.RelationKeyName, domain.String("Ship import fix to prod"))
+		st.SetLocalDetail(bundle.RelationKeyResolvedLayout, domain.Int64(int64(layout)))
+		return st
+	}
+
+	t.Run("resolvedLayout=note -> name detail is stripped into a text block", func(t *testing.T) {
+		// given
+		p := &Page{}
+		st := newState(model.ObjectType_note)
+		ctx := &smartblock.InitContext{State: st, IsNewObject: true}
+
+		// when
+		p.CreationStateMigration(ctx).Proc(st)
+
+		// then
+		assert.Equal(t, "", st.Details().GetString(bundle.RelationKeyName), "name survived")
+		assert.Equal(t, "Ship import fix to prod", st.Snippet(), "name leaked into snippet")
+	})
+
+	t.Run("resolvedLayout=basic -> name detail is kept", func(t *testing.T) {
+		// given
+		p := &Page{}
+		st := newState(model.ObjectType_basic)
+		ctx := &smartblock.InitContext{State: st, IsNewObject: true}
+
+		// when
+		p.CreationStateMigration(ctx).Proc(st)
+
+		// then
+		assert.Equal(t, "Ship import fix to prod", st.Details().GetString(bundle.RelationKeyName))
+		assert.Equal(t, "", st.Snippet())
+	})
+}

--- a/core/block/editor/smartblock/detailsinject.go
+++ b/core/block/editor/smartblock/detailsinject.go
@@ -249,7 +249,8 @@ func (sb *smartBlock) deriveChatId(s *state.State) error {
 
 // resolveLayout adds resolvedLayout to local details of object. Priority:
 // layout restricted by sbType > layout > recommendedLayout from type > current resolvedLayout > basic (fallback)
-// resolveLayout also converts object from Note, i.e. adds Name and Title to state
+// resolveLayout also converts object from Note, i.e. adds Name and Title to state,
+// but only when the layout is actually known - never off the fallback guess.
 func (sb *smartBlock) resolveLayout(s *state.State) {
 	if s.Details() == nil && s.LocalDetails() == nil {
 		return
@@ -274,6 +275,7 @@ func (sb *smartBlock) resolveLayout(s *state.State) {
 
 	typeDetails, err := sb.getTypeDetails(s)
 	valueInType := typeDetails.Get(bundle.RelationKeyRecommendedLayout)
+	layoutIsKnown := true
 	if layoutValue.Ok() {
 		newValue = layoutValue
 	} else if valueInType.Ok() {
@@ -281,34 +283,47 @@ func (sb *smartBlock) resolveLayout(s *state.State) {
 	} else if currentValue.Ok() {
 		newValue = currentValue
 	} else {
-		log.Warnf("failed to get recommended layout from details of type: %v. Fallback to basic layout", err)
-		newValue = sb.getFallbackLayoutValue(s)
+		log.Warnf("failed to get recommended layout from details of type: %v. Guessing the layout", err)
+		newValue, layoutIsKnown = sb.getFallbackLayoutValue(s)
 	}
 
 	if newValue.Ok() {
 		s.SetDetailAndBundledRelation(bundle.RelationKeyResolvedLayout, newValue)
 	}
 
+	if !layoutIsKnown {
+		// We don't know the real layout: the type object is most likely just not indexed
+		// yet, e.g. an object imported before its own type. Record a sane resolvedLayout
+		// so the object is not left without one, but never rewrite blocks or move the
+		// name in or out of details based on a guess - resolveLayout runs again once the
+		// type is available, and that is when converting is safe.
+		return
+	}
+
 	convertLayoutBlocks(s, currentValue, newValue)
 }
 
-func (sb *smartBlock) getFallbackLayoutValue(s *state.State) domain.Value {
+// getFallbackLayoutValue is the last resort when neither the object nor its type tells us
+// the layout. layoutIsKnown reports whether the value is actually derived from something
+// authoritative (a bundled type, the smartblock type) rather than merely guessed.
+func (sb *smartBlock) getFallbackLayoutValue(s *state.State) (value domain.Value, layoutIsKnown bool) {
 	if len(s.ObjectTypeKeys()) > 0 {
 		typeKey := s.ObjectTypeKeys()[len(s.ObjectTypeKeys())-1]
 		if bt, err := bundle.GetType(typeKey); err == nil && typeKey != bundle.TypeKeyTemplate {
-			return domain.Int64(int64(bt.Layout))
+			return domain.Int64(int64(bt.Layout)), true
 		}
 	}
 
 	if sb.Type() == smartblock.SmartBlockTypeFileObject {
 		// for file object we use file layout
-		return domain.Int64(int64(model.ObjectType_file))
+		return domain.Int64(int64(model.ObjectType_file)), true
 	}
 
-	if s.Exists(state.TitleBlockID) {
-		return domain.Int64(int64(model.ObjectType_basic))
-	}
-	return domain.Int64(int64(model.ObjectType_note))
+	// Basic is the layout new types get by default. Guessing note here used to be based on
+	// the absence of a title block, which is wrong for objects whose title lives in the name
+	// detail (every imported one), and note is the single layout whose conversion deletes
+	// the name detail - so a wrong guess silently lost the object's name.
+	return domain.Int64(int64(model.ObjectType_basic)), false
 }
 
 func convertLayoutBlocks(st *state.State, oldLayout, newLayout domain.Value) {

--- a/core/block/editor/smartblock/detailsinject_test.go
+++ b/core/block/editor/smartblock/detailsinject_test.go
@@ -551,10 +551,11 @@ func TestGetFallbackLayout(t *testing.T) {
 		st.SetObjectTypeKey(bundle.TypeKeyTask)
 
 		// when
-		v := fx.getFallbackLayoutValue(st)
+		v, layoutIsKnown := fx.getFallbackLayoutValue(st)
 
 		// then
 		assert.Equal(t, domain.Int64(int64(model.ObjectType_todo)), v)
+		assert.True(t, layoutIsKnown)
 	})
 	t.Run("fallback to file if sbType=file", func(t *testing.T) {
 		// given
@@ -564,10 +565,11 @@ func TestGetFallbackLayout(t *testing.T) {
 		st := state.NewDoc(id, nil).NewState()
 
 		// when
-		v := fx.getFallbackLayoutValue(st)
+		v, layoutIsKnown := fx.getFallbackLayoutValue(st)
 
 		// then
 		assert.Equal(t, domain.Int64(int64(model.ObjectType_file)), v)
+		assert.True(t, layoutIsKnown)
 	})
 	t.Run("fallback to basic if title exists", func(t *testing.T) {
 		// given
@@ -580,21 +582,23 @@ func TestGetFallbackLayout(t *testing.T) {
 		}).NewState()
 
 		// when
-		v := fx.getFallbackLayoutValue(st)
+		v, layoutIsKnown := fx.getFallbackLayoutValue(st)
 
 		// then
 		assert.Equal(t, domain.Int64(int64(model.ObjectType_basic)), v)
+		assert.False(t, layoutIsKnown, "layout of an unknown type is only a guess")
 	})
-	t.Run("fallback to note if no title presented", func(t *testing.T) {
+	t.Run("fallback to basic, not note, if no title presented", func(t *testing.T) {
 		// given
 		fx := newFixture(id, t)
 
 		st := state.NewDoc(id, nil).NewState()
 
 		// when
-		v := fx.getFallbackLayoutValue(st)
+		v, layoutIsKnown := fx.getFallbackLayoutValue(st)
 
 		// then
-		assert.Equal(t, domain.Int64(int64(model.ObjectType_note)), v)
+		assert.Equal(t, domain.Int64(int64(model.ObjectType_basic)), v)
+		assert.False(t, layoutIsKnown, "layout of an unknown type is only a guess")
 	})
 }

--- a/core/block/editor/smartblock/repro_import_name_test.go
+++ b/core/block/editor/smartblock/repro_import_name_test.go
@@ -1,0 +1,110 @@
+package smartblock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/block/editor/state"
+	"github.com/anyproto/anytype-heart/core/block/simple"
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/bundle"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// newStateWithTextBlock builds a note-shaped doc: a root holding a single text block,
+// with the title living in that block rather than in the name detail.
+func newStateWithTextBlock(rootId, blockId, text string) *state.State {
+	return state.NewDoc(rootId, map[string]simple.Block{
+		rootId: simple.New(&model.Block{Id: rootId, ChildrenIds: []string{blockId}}),
+		blockId: simple.New(&model.Block{
+			Id:      blockId,
+			Content: &model.BlockContentOfText{Text: &model.BlockContentText{Text: text}},
+		}),
+	}).NewState()
+}
+
+// An object imported before its custom type is indexed used to resolve to the note layout,
+// because it carries its title in the name detail and so has no title block. The creation
+// migration then moved that name into a plain text block and deleted the detail, leaving the
+// object as "Untitled" in sets until it was opened.
+func TestResolveLayoutOfObjectWithNotIndexedType(t *testing.T) {
+	const id = "id"
+
+	newImportedState := func() *state.State {
+		st := state.NewDoc(id, nil).NewState()
+		st.SetDetail(bundle.RelationKeyName, domain.String("Ship import fix to prod"))
+		st.SetObjectTypeKey(domain.TypeKey("teamTask"))
+		st.SetLocalDetail(bundle.RelationKeyType, domain.String("typeObjectId"))
+		return st
+	}
+
+	t.Run("type is not indexed yet -> basic layout is guessed and the name is kept", func(t *testing.T) {
+		// given
+		fx := newFixture(id, t)
+		st := newImportedState()
+
+		// when
+		fx.resolveLayout(st)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_basic), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
+		assert.Equal(t, "Ship import fix to prod", st.Details().GetString(bundle.RelationKeyName))
+		assert.Equal(t, "", st.Snippet(), "name must not leak into the snippet as a text block")
+	})
+
+	t.Run("type is indexed -> layout comes from the type and the name is kept", func(t *testing.T) {
+		// given
+		fx := newFixture(id, t)
+		st := newImportedState()
+		fx.lastDepDetails = map[string]*domain.Details{
+			"typeObjectId": domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyRecommendedLayout: domain.Int64(model.ObjectType_basic),
+			}),
+		}
+
+		// when
+		fx.resolveLayout(st)
+
+		// then
+		require.Equal(t, int64(model.ObjectType_basic), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
+		assert.Equal(t, "Ship import fix to prod", st.Details().GetString(bundle.RelationKeyName))
+	})
+
+	t.Run("guessed layout does not convert blocks", func(t *testing.T) {
+		// given: a note-shaped object - no name, title lives in the first text block -
+		// whose type is unknown. Guessing basic must not pull that block into the name.
+		fx := newFixture(id, t)
+		st := newStateWithTextBlock(id, "textBlock", "First line doubles as the title")
+		st.SetObjectTypeKey(domain.TypeKey("teamNote"))
+		st.SetLocalDetail(bundle.RelationKeyType, domain.String("typeObjectId"))
+
+		// when
+		fx.resolveLayout(st)
+
+		// then
+		assert.Equal(t, int64(model.ObjectType_basic), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
+		assert.Equal(t, "", st.Details().GetString(bundle.RelationKeyName))
+		assert.True(t, st.Exists("textBlock"), "text block was consumed on a guessed layout")
+	})
+
+	t.Run("known layout still converts blocks", func(t *testing.T) {
+		// given: same object, but now the type is indexed and says basic
+		fx := newFixture(id, t)
+		st := newStateWithTextBlock(id, "textBlock", "First line doubles as the title")
+		st.SetObjectTypeKey(domain.TypeKey("teamNote"))
+		st.SetLocalDetail(bundle.RelationKeyType, domain.String("typeObjectId"))
+		fx.lastDepDetails = map[string]*domain.Details{
+			"typeObjectId": domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
+				bundle.RelationKeyRecommendedLayout: domain.Int64(model.ObjectType_basic),
+			}),
+		}
+
+		// when
+		fx.resolveLayout(st)
+
+		// then
+		assert.Equal(t, "First line doubles as the title", st.Details().GetString(bundle.RelationKeyName))
+	})
+}

--- a/core/block/editor/smartblock/repro_import_name_test.go
+++ b/core/block/editor/smartblock/repro_import_name_test.go
@@ -55,12 +55,12 @@ func TestResolveLayoutOfObjectWithNotIndexedType(t *testing.T) {
 	})
 
 	t.Run("type is indexed -> layout comes from the type and the name is kept", func(t *testing.T) {
-		// given
+		// given: a layout distinct from the guessed one, so this cannot pass on the fallback
 		fx := newFixture(id, t)
 		st := newImportedState()
 		fx.lastDepDetails = map[string]*domain.Details{
 			"typeObjectId": domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{
-				bundle.RelationKeyRecommendedLayout: domain.Int64(model.ObjectType_basic),
+				bundle.RelationKeyRecommendedLayout: domain.Int64(model.ObjectType_todo),
 			}),
 		}
 
@@ -68,7 +68,9 @@ func TestResolveLayoutOfObjectWithNotIndexedType(t *testing.T) {
 		fx.resolveLayout(st)
 
 		// then
-		require.Equal(t, int64(model.ObjectType_basic), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
+		resolved, ok := st.LocalDetails().TryInt64(bundle.RelationKeyResolvedLayout)
+		require.True(t, ok, "resolvedLayout must be written")
+		assert.Equal(t, int64(model.ObjectType_todo), resolved)
 		assert.Equal(t, "Ship import fix to prod", st.Details().GetString(bundle.RelationKeyName))
 	})
 
@@ -86,7 +88,10 @@ func TestResolveLayoutOfObjectWithNotIndexedType(t *testing.T) {
 		// then
 		assert.Equal(t, int64(model.ObjectType_basic), st.LocalDetails().GetInt64(bundle.RelationKeyResolvedLayout))
 		assert.Equal(t, "", st.Details().GetString(bundle.RelationKeyName))
-		assert.True(t, st.Exists("textBlock"), "text block was consumed on a guessed layout")
+		// Exists() would stay true either way - WithNameFromFirstBlock only unlinks the
+		// block - so assert it is still in the tree.
+		assert.Contains(t, st.Pick(id).Model().ChildrenIds, "textBlock",
+			"text block was consumed on a guessed layout")
 	})
 
 	t.Run("known layout still converts blocks", func(t *testing.T) {

--- a/core/block/import/processor.go
+++ b/core/block/import/processor.go
@@ -232,7 +232,8 @@ func (p *importProcessor) createObjects(ctx context.Context) (map[string]*domain
 		}
 		batchDetails := p.createObjectsBatch(dataObject, batch)
 		if batchDetails == nil {
-			// import was cancelled mid-batch
+			// batch was cancelled, or failed under ALL_OR_NOTHING - either way the
+			// remaining batches must not run, matching the old single-pool behaviour
 			return nil, ""
 		}
 		for id, d := range batchDetails {
@@ -259,12 +260,14 @@ func splitSchemaSnapshots(snapshots []*common.Snapshot) (schema, rest []*common.
 	return schema, rest
 }
 
-// createObjectsBatch runs a batch to completion, returning nil if the import was cancelled.
+// createObjectsBatch runs a batch to completion, returning nil if it was cancelled or, under
+// ALL_OR_NOTHING, aborted by a failed object. Draining it is what makes the objects it created
+// observable to the next batch: Apply indexes synchronously, so a result here means committed.
 func (p *importProcessor) createObjectsBatch(dataObject *creator.DataObject, snapshots []*common.Snapshot) map[string]*domain.Details {
-	workerCount := workerPoolSize
-	if len(snapshots) < workerCount {
-		workerCount = 1
-	}
+	// Scale to the batch, not down to a single worker: batches are smaller than the whole
+	// import, and dropping to one worker would serialize every archive with fewer snapshots
+	// than the pool size.
+	workerCount := min(workerPoolSize, len(snapshots))
 	pool := workerpool.NewPool(workerCount)
 
 	go p.addWork(snapshots, pool)

--- a/core/block/import/processor.go
+++ b/core/block/import/processor.go
@@ -208,10 +208,6 @@ func (p *importProcessor) createObjects(ctx context.Context) (map[string]*domain
 		return nil, ""
 	}
 
-	workerCount := workerPoolSize
-	if len(p.converterResponse.Snapshots) < workerCount {
-		workerCount = 1
-	}
 	dataObject := creator.NewDataObject(
 		ctx,
 		p.oldIDToNew,
@@ -220,17 +216,61 @@ func (p *importProcessor) createObjects(ctx context.Context) (map[string]*domain
 		p.request.Origin,
 		p.request.SpaceId,
 	)
-	pool := workerpool.NewPool(workerCount)
 
 	p.request.Progress.SetProgressMessage("Create objects")
 
-	go p.addWork(pool)
-	go pool.Start(dataObject)
+	// Schema objects go first, as a separate batch: an object created before its own type
+	// is in the object store cannot resolve its layout from that type, and would fall back
+	// to a guessed one. Draining the batch before starting the next is what makes the type
+	// observable, so these cannot be merely enqueued first.
+	schema, rest := splitSchemaSnapshots(p.converterResponse.Snapshots)
 
-	details := p.readResults(pool)
+	details := make(map[string]*domain.Details, len(p.converterResponse.Snapshots))
+	for _, batch := range [][]*common.Snapshot{schema, rest} {
+		if len(batch) == 0 {
+			continue
+		}
+		batchDetails := p.createObjectsBatch(dataObject, batch)
+		if batchDetails == nil {
+			// import was cancelled mid-batch
+			return nil, ""
+		}
+		for id, d := range batchDetails {
+			details[id] = d
+		}
+	}
+
 	rootCollectionID := p.oldIDToNew[p.converterResponse.RootObjectID]
 
 	return details, rootCollectionID
+}
+
+// splitSchemaSnapshots separates the snapshots that other objects derive their own
+// details from - object types and relations - from the rest, preserving relative order.
+func splitSchemaSnapshots(snapshots []*common.Snapshot) (schema, rest []*common.Snapshot) {
+	for _, snapshot := range snapshots {
+		switch snapshot.Snapshot.SbType {
+		case smartblock.SmartBlockTypeObjectType, smartblock.SmartBlockTypeRelation, smartblock.SmartBlockTypeRelationOption:
+			schema = append(schema, snapshot)
+		default:
+			rest = append(rest, snapshot)
+		}
+	}
+	return schema, rest
+}
+
+// createObjectsBatch runs a batch to completion, returning nil if the import was cancelled.
+func (p *importProcessor) createObjectsBatch(dataObject *creator.DataObject, snapshots []*common.Snapshot) map[string]*domain.Details {
+	workerCount := workerPoolSize
+	if len(snapshots) < workerCount {
+		workerCount = 1
+	}
+	pool := workerpool.NewPool(workerCount)
+
+	go p.addWork(snapshots, pool)
+	go pool.Start(dataObject)
+
+	return p.readResults(pool)
 }
 
 func (p *importProcessor) assignIdsToAllObjects(ctx context.Context) error {
@@ -358,8 +398,8 @@ func (p *importProcessor) preloadFileKeys(snapshot *common.Snapshot) error {
 	return nil
 }
 
-func (p *importProcessor) addWork(pool *workerpool.WorkerPool) {
-	for _, snapshot := range p.converterResponse.Snapshots {
+func (p *importProcessor) addWork(snapshots []*common.Snapshot, pool *workerpool.WorkerPool) {
+	for _, snapshot := range snapshots {
 		t := creator.NewTask(snapshot, p.deps.objectCreator)
 		stop := pool.AddWork(t)
 		if stop {

--- a/core/block/import/processor_schema_order_test.go
+++ b/core/block/import/processor_schema_order_test.go
@@ -1,0 +1,66 @@
+package importer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anyproto/anytype-heart/core/block/import/common"
+	"github.com/anyproto/anytype-heart/pkg/lib/core/smartblock"
+)
+
+func TestSplitSchemaSnapshots(t *testing.T) {
+	snapshot := func(id string, sbType smartblock.SmartBlockType) *common.Snapshot {
+		return &common.Snapshot{
+			Id:       id,
+			Snapshot: &common.SnapshotModel{SbType: sbType},
+		}
+	}
+	ids := func(snapshots []*common.Snapshot) []string {
+		res := make([]string, 0, len(snapshots))
+		for _, s := range snapshots {
+			res = append(res, s.Id)
+		}
+		return res
+	}
+
+	t.Run("types and relations are separated from the objects that depend on them", func(t *testing.T) {
+		// given: an archive that interleaves objects with their schema, as exports do
+		snapshots := []*common.Snapshot{
+			snapshot("task", smartblock.SmartBlockTypePage),
+			snapshot("taskType", smartblock.SmartBlockTypeObjectType),
+			snapshot("project", smartblock.SmartBlockTypePage),
+			snapshot("statusRelation", smartblock.SmartBlockTypeRelation),
+			snapshot("doneOption", smartblock.SmartBlockTypeRelationOption),
+			snapshot("template", smartblock.SmartBlockTypeTemplate),
+		}
+		want := struct {
+			schema []string
+			rest   []string
+		}{
+			schema: []string{"taskType", "statusRelation", "doneOption"},
+			rest:   []string{"task", "project", "template"},
+		}
+
+		// when
+		schema, rest := splitSchemaSnapshots(snapshots)
+
+		// then
+		assert.Equal(t, want.schema, ids(schema))
+		assert.Equal(t, want.rest, ids(rest))
+	})
+
+	t.Run("archive without schema objects", func(t *testing.T) {
+		// given
+		snapshots := []*common.Snapshot{
+			snapshot("task", smartblock.SmartBlockTypePage),
+		}
+
+		// when
+		schema, rest := splitSchemaSnapshots(snapshots)
+
+		// then
+		assert.Empty(t, schema)
+		assert.Equal(t, []string{"task"}, ids(rest))
+	})
+}


### PR DESCRIPTION
Fixes GO-7423.

Some imported objects show as "Untitled" in sets until you open them, at which point they get their name back. They are missing only the `name` detail, and their snippet starts with exactly the title they lost.

## Root cause

An object created before its own type is indexed cannot read `recommendedLayout` from that type, so `resolveLayout` falls back to a guess. `getFallbackLayoutValue` returned `note` whenever the state had no title block.

`note` is the one layout whose creation migration is destructive: `Page.CreationStateMigration` applies `template.WithNameToFirstBlock`, which deletes the `name` detail and re-inserts it as a plain paragraph. That is the only code path producing "no name, and snippet == the title".

The order in `core/block/editor/factory.go` is what connects them:

1. `sb.Init()` → `resolveLayout()` writes the guessed `resolvedLayout`
2. `migration.RunMigrations()` → `CreationStateMigration` reads it back and strips the name
3. `sb.Apply()` indexes details without `name`

Opening repairs it because `resolvedLayout` is deliberately deleted from store-injected local details (`detailsinject.go:57`), so it is recomputed once the type is available and `convertLayoutBlocks` runs `WithNameFromFirstBlock`.

**Two preconditions, not one.** Besides the timing, the snapshot must have no title block at all — `State.Exists` checks the block map rather than tree reachability, so any state that ever materialised a title block took the `basic` branch. Ordinary exported pages carry a title block and were never at risk; the objects that broke were the ones that were *both* title-block-less *and* created before their type was observable. Note the corollary: an object with no title block whose type is **absent from the archive entirely** would break 100% of the time, with no race involved. That case is fixed by the first commit and untouched by the second.

Verified against a real space: 28 imported objects with no `name`, each snippet beginning with its missing title, and the healthy ones had never been opened.

## Changes

**Layout fallback no longer destroys content.** Default is `basic` (what new types get) instead of `note`, and the title-block heuristic is gone. `getFallbackLayoutValue` now also reports whether the layout is actually known; `resolveLayout` records a guessed `resolvedLayout` but no longer runs `convertLayoutBlocks` on it. The guard is not just safe but required: on the old fallback path `convertLayoutBlocks` was always a no-op (it re-tested the same `Exists(TitleBlockID)` predicate the fallback had just used), whereas the new unconditional `basic` default would otherwise let `WithNameFromFirstBlock` eat the first paragraph of a note-shaped state. Bundled-type and file-object fallbacks still count as known, so real Notes are untouched.

**Import creates schema first.** Object types, relations and relation options run as a separate batch drained before the rest, so the archive's type layout is authoritative at creation time. Enqueuing them first would not be enough: workers pull continuously, so an object could still start before its type landed. The barrier is real because indexing is synchronous — `Apply` → `runIndexer` → `spaceIndexer.Index` blocks until both write transactions commit (`core/indexer/spaceindexer.go:142`), so a result from batch 1 means committed and queryable.

This also gives imported objects their title block back, via `CreationStateMigration`'s default branch — without teaching each importer about layouts.

## Known trade-off

An imported object with no `name`, no title block, and its title in the first text block (a genuine note) whose type is unavailable will now keep no name permanently, rather than acquiring one later: the guessed `basic` leads `CreationStateMigration` to add a title block, after which `convertLayoutBlocks` always returns early. Previously such an object was eventually promoted by `WithNameFromFirstBlock`. No existing name is ever lost, and the second commit makes same-archive types observable, so this is bounded to archives that omit the type. Accepted deliberately, and pinned by the `guessed layout does not convert blocks` test.

## Tests

- `smartblock/repro_import_name_test.go` — type unindexed → `basic`, name kept, nothing leaks into the snippet; type indexed → layout from the type; plus both directions of the guess-does-not-convert rule.
- `editor/page_note_layout_test.go` — pins that `note` genuinely does move the name into a block, documenting why a guessed note is dangerous.
- `import/processor_schema_order_test.go` — the batch split.
- `detailsinject_test.go` — `"fallback to note if no title presented"` becomes `"fallback to basic, not note"`.

Mutation-checked: reverting the `note` default, disabling the `layoutIsKnown` guard, or forcing the type lookup to fail each produce failures.

`./core/block/...` and `./core/indexer/...` pass.

## Not included

Existing damaged objects are not repaired — they still need to be opened once, or re-imported. Worth noting that bumping `ForceInvalidateObjectsIndexCounter` (`core/indexer/reindex.go:81`) would deterministically heal every affected user through the existing async reindex path, since reindexing opens each object; that is a heavier, separate decision.
