### PR TITLE
GO-7424 Dial local peers over yamux instead of QUIC

### DIFF
--- a/space/spacecore/clientserver/clientserver.go
+++ b/space/spacecore/clientserver/clientserver.go
@@ -39,10 +39,6 @@ type ClientServer interface {
 	ServerStarted() bool
 }
 
-type DbProvider interface {
-	GetCommonDb() anystore.DB
-}
-
 // udpListener is the part of quic.Quic used here; narrowed for tests.
 type udpListener interface {
 	ListenAddrs(ctx context.Context, addrs ...string) ([]net.Addr, error)
@@ -52,6 +48,13 @@ type udpListener interface {
 type tcpListenerRegistry interface {
 	AddListener(lis net.Listener)
 }
+
+// keep the narrowed interfaces in sync with any-sync at compile time, so an
+// upstream API change fails the build instead of panicking in Init
+var (
+	_ udpListener         = (quic.Quic)(nil)
+	_ tcpListenerRegistry = (yamux.Yamux)(nil)
+)
 
 type clientServer struct {
 	quic          udpListener
@@ -75,7 +78,9 @@ func (s *clientServer) Name() (name string) {
 
 func (s *clientServer) Run(ctx context.Context) error {
 	if err := s.startServer(ctx); err != nil {
-		log.InfoCtx(ctx, "failed to start drpc server", zap.Error(err))
+		// the app stays up without local P2P, but both local listeners are
+		// missing — warn, don't bury it at info
+		log.WarnCtx(ctx, "failed to start local p2p server", zap.Error(err))
 	} else {
 		s.serverStarted = true
 	}
@@ -95,7 +100,7 @@ func (s *clientServer) startServer(ctx context.Context) (err error) {
 	}
 	s.port, err = s.listen(ctx, oldPort)
 	if err != nil {
-		return fmt.Errorf("listen: %w", err)
+		return fmt.Errorf("bind local listeners: %w", err)
 	}
 	if oldPort == s.port {
 		return nil
@@ -158,13 +163,19 @@ func (s *clientServer) listenPort(ctx context.Context, tryPort int) (port int, e
 		_ = list.Close()
 		return 0, fmt.Errorf("listen udp on port %d: %w", port, err)
 	}
+	port, err = s.parsePort(addrs[0].String())
+	if err != nil {
+		_ = list.Close()
+		return 0, fmt.Errorf("parse udp listener port: %w", err)
+	}
 	// Hand the TCP listener to the yamux transport so local peers can dial us
 	// over TCP as well. AddListener starts the accept loop itself, and
 	// yamux.Run starts one per registered listener — so this must run after
 	// yamux.Run. Component registration order guarantees it: yamux is
-	// registered before clientserver, and this is only called from Run.
+	// registered before clientserver, and this is only called from Run. It is
+	// also the last step of an attempt, so a failed attempt never registers.
 	s.yamux.AddListener(list)
-	return s.parsePort(addrs[0].String())
+	return port, nil
 }
 
 func (s *clientServer) Close(_ context.Context) (err error) {

--- a/space/spacecore/clientserver/clientserver.go
+++ b/space/spacecore/clientserver/clientserver.go
@@ -3,6 +3,7 @@ package clientserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -10,22 +11,23 @@ import (
 	anystore "github.com/anyproto/any-store"
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/app/logger"
-	"github.com/anyproto/any-sync/net/transport"
 	"github.com/anyproto/any-sync/net/transport/quic"
+	"github.com/anyproto/any-sync/net/transport/yamux"
 	"go.uber.org/zap"
 
 	"github.com/anyproto/anytype-heart/pkg/lib/datastore/anystoreprovider"
 	"github.com/anyproto/anytype-heart/util/keyvaluestore"
 )
 
-const (
-	CName           = "client.space.clientserver"
-	PreferredSchema = transport.Quic
-)
+const CName = "client.space.clientserver"
 
 var log = logger.NewNamed(CName)
 
 var ErrNoPortAssigned = errors.New("no port assigned to the server")
+
+// listenAttempts bounds retries when the UDP side of a freshly reserved port
+// turns out to be occupied: first try the saved port, then ephemeral ports.
+const listenAttempts = 4
 
 func New() ClientServer {
 	return &clientServer{}
@@ -41,8 +43,19 @@ type DbProvider interface {
 	GetCommonDb() anystore.DB
 }
 
+// udpListener is the part of quic.Quic used here; narrowed for tests.
+type udpListener interface {
+	ListenAddrs(ctx context.Context, addrs ...string) ([]net.Addr, error)
+}
+
+// tcpListenerRegistry is the part of yamux.Yamux used here; narrowed for tests.
+type tcpListenerRegistry interface {
+	AddListener(lis net.Listener)
+}
+
 type clientServer struct {
-	quic          quic.Quic
+	quic          udpListener
+	yamux         tcpListenerRegistry
 	provider      anystoreprovider.Provider
 	port          int
 	storage       keyvaluestore.Store[int]
@@ -51,7 +64,8 @@ type clientServer struct {
 
 func (s *clientServer) Init(a *app.App) (err error) {
 	s.provider = app.MustComponent[anystoreprovider.Provider](a)
-	s.quic = a.MustComponent(quic.CName).(quic.Quic)
+	s.quic = a.MustComponent(quic.CName).(udpListener)
+	s.yamux = a.MustComponent(yamux.CName).(tcpListenerRegistry)
 	return nil
 }
 
@@ -77,11 +91,11 @@ func (s *clientServer) startServer(ctx context.Context) (err error) {
 
 	oldPort, err := s.storage.Get(ctx, anystoreprovider.SystemKeys.PortKey())
 	if err != nil && !errors.Is(err, anystore.ErrDocNotFound) {
-		return
+		return fmt.Errorf("get saved port: %w", err)
 	}
-	s.port, err = s.listenQuic(ctx, oldPort)
+	s.port, err = s.listen(ctx, oldPort)
 	if err != nil {
-		return
+		return fmt.Errorf("listen: %w", err)
 	}
 	if oldPort == s.port {
 		return nil
@@ -113,21 +127,43 @@ func (s *clientServer) prepareListener(port int) (net.Listener, error) {
 	return net.Listen("tcp", ":")
 }
 
-func (s *clientServer) listenQuic(ctx context.Context, savedPort int) (port int, err error) {
-	// trying to listen to old port or get new one
-	list, err := s.prepareListener(savedPort)
+// listen binds both local transports on one shared port: TCP for yamux and
+// UDP for QUIC. The TCP listener doubles as the port reservation. A free TCP
+// port does not guarantee a free UDP port, so on a UDP bind failure the
+// reservation is dropped and another port is tried.
+func (s *clientServer) listen(ctx context.Context, savedPort int) (port int, err error) {
+	tryPort := savedPort
+	for i := 0; i < listenAttempts; i++ {
+		port, err = s.listenPort(ctx, tryPort)
+		if err == nil {
+			return port, nil
+		}
+		tryPort = 0
+	}
+	return 0, err
+}
+
+func (s *clientServer) listenPort(ctx context.Context, tryPort int) (port int, err error) {
+	list, err := s.prepareListener(tryPort)
 	if err != nil {
-		return
+		return 0, fmt.Errorf("listen tcp: %w", err)
 	}
 	port, err = s.parsePort(list.Addr().String())
 	if err != nil {
-		return
+		_ = list.Close()
+		return 0, fmt.Errorf("parse tcp listener port: %w", err)
 	}
-	_ = list.Close()
 	addrs, err := s.quic.ListenAddrs(ctx, "0.0.0.0:"+strconv.Itoa(port))
 	if err != nil {
-		return
+		_ = list.Close()
+		return 0, fmt.Errorf("listen udp on port %d: %w", port, err)
 	}
+	// Hand the TCP listener to the yamux transport so local peers can dial us
+	// over TCP as well. AddListener starts the accept loop itself, and
+	// yamux.Run starts one per registered listener — so this must run after
+	// yamux.Run. Component registration order guarantees it: yamux is
+	// registered before clientserver, and this is only called from Run.
+	s.yamux.AddListener(list)
 	return s.parsePort(addrs[0].String())
 }
 

--- a/space/spacecore/clientserver/clientserver_test.go
+++ b/space/spacecore/clientserver/clientserver_test.go
@@ -127,11 +127,24 @@ func TestListen(t *testing.T) {
 		lisPort, err := fx.parsePort(fx.yamux.listeners[0].Addr().String())
 		require.NoError(t, err)
 		assert.Equal(t, port, lisPort)
+	})
 
-		failedPort, err := fx.parsePort(fx.quic.calls[0])
+	t.Run("saved port busy on tcp falls back to another port", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		occupied, err := net.Listen("tcp", ":")
 		require.NoError(t, err)
-		_, err = net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(failedPort))
-		assert.Error(t, err)
+		defer occupied.Close()
+		savedPort, err := fx.parsePort(occupied.Addr().String())
+		require.NoError(t, err)
+
+		// when
+		port, err := fx.listen(context.Background(), savedPort)
+
+		// then
+		require.NoError(t, err)
+		require.Greater(t, port, 0)
+		assert.NotEqual(t, savedPort, port)
 	})
 
 	t.Run("gives up after all attempts fail", func(t *testing.T) {

--- a/space/spacecore/clientserver/clientserver_test.go
+++ b/space/spacecore/clientserver/clientserver_test.go
@@ -1,0 +1,172 @@
+package clientserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/datastore/anystoreprovider"
+)
+
+type fixture struct {
+	*clientServer
+	yamux *yamuxStub
+	quic  *quicStub
+}
+
+func newFixture(t *testing.T) *fixture {
+	yamuxStub := &yamuxStub{}
+	quicStub := &quicStub{}
+	s := New().(*clientServer)
+	s.yamux = yamuxStub
+	s.quic = quicStub
+	t.Cleanup(yamuxStub.closeAll)
+	return &fixture{
+		clientServer: s,
+		yamux:        yamuxStub,
+		quic:         quicStub,
+	}
+}
+
+type yamuxStub struct {
+	listeners []net.Listener
+}
+
+func (y *yamuxStub) AddListener(lis net.Listener) {
+	y.listeners = append(y.listeners, lis)
+}
+
+func (y *yamuxStub) closeAll() {
+	for _, lis := range y.listeners {
+		_ = lis.Close()
+	}
+}
+
+type quicStub struct {
+	failures int
+	calls    []string
+}
+
+func (q *quicStub) ListenAddrs(_ context.Context, addrs ...string) ([]net.Addr, error) {
+	q.calls = append(q.calls, addrs...)
+	if q.failures > 0 {
+		q.failures--
+		return nil, errors.New("bind: address already in use")
+	}
+	res := make([]net.Addr, 0, len(addrs))
+	for _, addr := range addrs {
+		port, err := strconv.Atoi(addr[strings.LastIndex(addr, ":")+1:])
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, &net.UDPAddr{IP: net.IPv4zero, Port: port})
+	}
+	return res, nil
+}
+
+func TestListen(t *testing.T) {
+	t.Run("tcp listener stays bound and is handed to yamux", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+
+		// when
+		port, err := fx.listen(context.Background(), 0)
+
+		// then
+		require.NoError(t, err)
+		require.Greater(t, port, 0)
+		require.Len(t, fx.yamux.listeners, 1)
+		assert.Equal(t, []string{"0.0.0.0:" + strconv.Itoa(port)}, fx.quic.calls)
+
+		lisPort, err := fx.parsePort(fx.yamux.listeners[0].Addr().String())
+		require.NoError(t, err)
+		assert.Equal(t, port, lisPort)
+
+		conn, err := net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(port))
+		require.NoError(t, err)
+		_ = conn.Close()
+	})
+
+	t.Run("saved port is reused when free", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		probe, err := net.Listen("tcp", ":")
+		require.NoError(t, err)
+		savedPort, err := fx.parsePort(probe.Addr().String())
+		require.NoError(t, err)
+		require.NoError(t, probe.Close())
+
+		// when
+		port, err := fx.listen(context.Background(), savedPort)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, savedPort, port)
+	})
+
+	t.Run("falls back to another port when udp side is occupied", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.quic.failures = 1
+
+		// when
+		port, err := fx.listen(context.Background(), 0)
+
+		// then
+		require.NoError(t, err)
+		require.Greater(t, port, 0)
+		// the failed attempt's tcp listener must be closed and not registered
+		require.Len(t, fx.quic.calls, 2)
+		require.Len(t, fx.yamux.listeners, 1)
+		lisPort, err := fx.parsePort(fx.yamux.listeners[0].Addr().String())
+		require.NoError(t, err)
+		assert.Equal(t, port, lisPort)
+
+		failedPort, err := fx.parsePort(fx.quic.calls[0])
+		require.NoError(t, err)
+		_, err = net.Dial("tcp", "127.0.0.1:"+strconv.Itoa(failedPort))
+		assert.Error(t, err)
+	})
+
+	t.Run("gives up after all attempts fail", func(t *testing.T) {
+		// given
+		fx := newFixture(t)
+		fx.quic.failures = listenAttempts
+
+		// when
+		_, err := fx.listen(context.Background(), 0)
+
+		// then
+		require.Error(t, err)
+		assert.Empty(t, fx.yamux.listeners)
+	})
+}
+
+func TestStartServer(t *testing.T) {
+	t.Run("port is persisted and reused across restarts", func(t *testing.T) {
+		// given
+		provider, err := anystoreprovider.NewInPath(t.TempDir())
+		require.NoError(t, err)
+		fx := newFixture(t)
+		fx.provider = provider
+
+		// when
+		require.NoError(t, fx.startServer(context.Background()))
+		firstPort := fx.Port()
+		fx.yamux.closeAll()
+		fx.yamux.listeners = nil
+
+		fx2 := newFixture(t)
+		fx2.provider = provider
+		require.NoError(t, fx2.startServer(context.Background()))
+
+		// then
+		assert.Equal(t, firstPort, fx2.Port())
+	})
+}

--- a/space/spacecore/peer.go
+++ b/space/spacecore/peer.go
@@ -6,8 +6,8 @@ import (
 	"storj.io/drpc"
 
 	"github.com/anyproto/any-sync/commonspace/clientspaceproto"
+	"github.com/anyproto/any-sync/net/transport"
 
-	"github.com/anyproto/anytype-heart/space/spacecore/clientserver"
 	"github.com/anyproto/anytype-heart/space/spacecore/localdiscovery"
 )
 
@@ -38,10 +38,17 @@ func (s *service) PeerDiscovered(ctx context.Context, peer localdiscovery.Discov
 	s.peerStore.UpdateLocalPeer(peer.PeerId, resp.SpaceIds)
 }
 
+// addSchema expands each discovered ip:port into explicit transport URLs.
+// Local peers are dialed over yamux (TCP) only: a dead peer answers the dial
+// with an RST in one RTT, while a QUIC dial to a dead port has to wait out the
+// whole handshake timeout (quic-go has no ICMP/ECONNREFUSED handling on the
+// unconnected sockets any-sync uses). The QUIC listener stays bound so
+// not-yet-updated clients can still dial us; that inbound connection is
+// bidirectional, so mixed versions keep syncing.
 func (s *service) addSchema(addrs []string) (res []string) {
 	res = make([]string, 0, len(addrs))
 	for _, addr := range addrs {
-		res = append(res, clientserver.PreferredSchema+"://"+addr)
+		res = append(res, transport.Yamux+"://"+addr)
 	}
 	return res
 }

--- a/space/spacecore/peer.go
+++ b/space/spacecore/peer.go
@@ -39,10 +39,12 @@ func (s *service) PeerDiscovered(ctx context.Context, peer localdiscovery.Discov
 }
 
 // addSchema expands each discovered ip:port into explicit transport URLs.
-// Local peers are dialed over yamux (TCP) only: a dead peer answers the dial
-// with an RST in one RTT, while a QUIC dial to a dead port has to wait out the
-// whole handshake timeout (quic-go has no ICMP/ECONNREFUSED handling on the
-// unconnected sockets any-sync uses). The QUIC listener stays bound so
+// Local peers are dialed over yamux (TCP) only: a live host whose app has
+// quit answers the dial with an RST in one RTT, while a QUIC dial to a dead
+// port has to wait out the whole handshake timeout (quic-go has no
+// ICMP/ECONNREFUSED handling on the unconnected sockets any-sync uses). A
+// host that left the network answers neither transport — that case still
+// costs the full dial timeout. The QUIC listener stays bound so
 // not-yet-updated clients can still dial us; that inbound connection is
 // bidirectional, so mixed versions keep syncing.
 func (s *service) addSchema(addrs []string) (res []string) {

--- a/space/spacecore/peer_test.go
+++ b/space/spacecore/peer_test.go
@@ -1,0 +1,33 @@
+package spacecore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddSchema(t *testing.T) {
+	t.Run("local peer addrs get yamux scheme only", func(t *testing.T) {
+		// given
+		s := &service{}
+		addrs := []string{"192.168.1.5:4242", "10.0.0.3:4242"}
+		want := []string{"yamux://192.168.1.5:4242", "yamux://10.0.0.3:4242"}
+
+		// when
+		got := s.addSchema(addrs)
+
+		// then
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		// given
+		s := &service{}
+
+		// when
+		got := s.addSchema(nil)
+
+		// then
+		assert.Empty(t, got)
+	})
+}

--- a/space/spacecore/rpchandler.go
+++ b/space/spacecore/rpchandler.go
@@ -3,7 +3,9 @@ package spacecore
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 
 	"github.com/anyproto/any-sync/commonspace"
 	"github.com/anyproto/any-sync/commonspace/clientspaceproto"
@@ -53,9 +55,11 @@ func (r *rpcHandler) SpaceExchange(ctx context.Context, request *clientspaceprot
 		peerAddr := peer.CtxPeerAddr(ctx)
 
 		if peerAddr != "" {
-			// prioritize address remote peer connected us from
-			if u, errParse := url.Parse(peerAddr); errParse == nil {
-				portAddrs = append(portAddrs, u.Host)
+			// prioritize the address the remote peer connected us from — but
+			// with its advertised listening port: the port in peerAddr is the
+			// dialer's ephemeral source port, nothing listens on it
+			if u, errParse := url.Parse(peerAddr); errParse == nil && u.Hostname() != "" {
+				portAddrs = append(portAddrs, net.JoinHostPort(u.Hostname(), strconv.Itoa(int(request.LocalServer.Port))))
 			}
 		}
 
@@ -67,9 +71,10 @@ func (r *rpcHandler) SpaceExchange(ctx context.Context, request *clientspaceprot
 			portAddrs = append(portAddrs, addr)
 		}
 		// addSchema pins the transport for local peers (yamux); see its comment
-		r.s.peerService.SetPeerAddrs(peerId, r.s.addSchema(portAddrs))
+		addrsWithSchema := r.s.addSchema(portAddrs)
+		r.s.peerService.SetPeerAddrs(peerId, addrsWithSchema)
 		r.s.peerStore.UpdateLocalPeer(peerId, request.SpaceIds)
-		log.Info("updated local peer", zap.Strings("ips", r.s.addSchema(portAddrs)), zap.String("peerId", peerId), zap.Strings("spaceIds", request.SpaceIds))
+		log.Info("updated local peer", zap.Strings("ips", addrsWithSchema), zap.String("peerId", peerId), zap.Strings("spaceIds", request.SpaceIds))
 	}
 	log.Debug("returning list with ids", zap.Strings("spaceIds", allIds))
 	resp = &clientspaceproto.SpaceExchangeResponse{SpaceIds: allIds}

--- a/space/spacecore/rpchandler.go
+++ b/space/spacecore/rpchandler.go
@@ -66,8 +66,7 @@ func (r *rpcHandler) SpaceExchange(ctx context.Context, request *clientspaceprot
 			}
 			portAddrs = append(portAddrs, addr)
 		}
-		// addSchema adds discovered protocol for connection.
-		// Otherwise localdiscovery fallbacks to tcp, but anytype clients are listening on udp
+		// addSchema pins the transport for local peers (yamux); see its comment
 		r.s.peerService.SetPeerAddrs(peerId, r.s.addSchema(portAddrs))
 		r.s.peerStore.UpdateLocalPeer(peerId, request.SpaceIds)
 		log.Info("updated local peer", zap.Strings("ips", r.s.addSchema(portAddrs)), zap.String("peerId", peerId), zap.Strings("spaceIds", request.SpaceIds))


### PR DESCRIPTION
Linear: [GO-7424](https://linear.app/anytype/issue/GO-7424)

### Problems
- A dead local (mDNS) peer costs the full QUIC dial budget every cycle: any-sync dials from an unconnected UDP socket, so the ICMP port-unreachable never reaches quic-go, which retransmits until `HandshakeIdleTimeout`.
- The first candidate for every local peer was always dead: `SpaceExchange` stored the peer's ephemeral source port as its address.
- If the saved port's UDP side is occupied at startup, the app silently came up with no local P2P server.

### Changes
- `clientserver` keeps the TCP listener it already creates to pick the port and registers it with the yamux transport on the same port as QUIC; startup retries with fresh ports when the UDP side is occupied, and a total failure now logs at Warn instead of Info.
- `addSchema` advertises `yamux://` only — a dead port answers with an RST in one RTT. The QUIC listener stays bound so not-yet-updated clients still dial in; mDNS dialing is symmetric and connections are bidirectional, so mixed versions keep syncing.
- `SpaceExchange`'s connected-from candidate now uses the advertised listening port instead of the dialer's ephemeral source port.

### Notes
- Works against the pinned any-sync v0.12.16: the quic pass over a yamux-only address list is a no-op string match, then the yamux pass dials.
- Trade-off: no UDP fallback between two updated clients when inbound TCP is blocked on both sides (falls back to node sync).
- New unit tests: listener binding + handoff, saved-port reuse, UDP/TCP-occupied fallbacks, port persistence, addSchema.