### PR TITLE
GO-7383 Fix type default-view visibility regression (GO-5969)

### DIFF
--- a/core/block/editor/template/collection.go
+++ b/core/block/editor/template/collection.go
@@ -47,13 +47,20 @@ var (
 )
 
 func MakeDataviewContent(isCollection bool, ot *model.ObjectType, relLinks []*model.RelationLink, oldContent *model.BlockContentOfDataview) *model.BlockContentOfDataview {
+	// Explicitly passed relLinks are the caller's visible set — even when ot
+	// is also given (an object type's own dataview passes its recommended
+	// relations here so its default "All" view shows them as columns,
+	// core/block/editor/objecttype.go). ot.RelationLinks is only the fallback
+	// column source when the caller names no relations itself; those columns
+	// stay hidden. GO-5969 inverted this precedence, which left every custom
+	// column of a freshly generated type view hidden (GO-7383).
 	commonVisibleRelations := make([]domain.RelationKey, 0, len(relLinks))
-	if ot != nil {
-		relLinks = ot.RelationLinks
-	} else {
+	if len(relLinks) > 0 {
 		for _, relLink := range relLinks {
 			commonVisibleRelations = append(commonVisibleRelations, domain.RelationKey(relLink.Key))
 		}
+	} else if ot != nil {
+		relLinks = ot.RelationLinks
 	}
 
 	if oldContent == nil {

--- a/core/block/editor/template/collection_test.go
+++ b/core/block/editor/template/collection_test.go
@@ -141,6 +141,43 @@ func TestMakeDataviewContentNew(t *testing.T) {
 			},
 		},
 		{
+			// the objecttype.go calling convention (a type's own default "All"
+			// view): the type AND its relation links are both passed, and the
+			// explicitly passed links must come out VISIBLE. GO-5969 regressed
+			// this to name-only visibility, which left every custom column of a
+			// freshly created type's default view hidden (GO-7383).
+			name: "type's own view: explicitly passed relation links become visible columns",
+			ot: &model.ObjectType{
+				Url:  "typeObjectId",
+				Name: "Plant",
+				Key:  "plant",
+				RelationLinks: makeRelationLinks([]domain.RelationKey{
+					bundle.RelationKeyMentions, bundle.RelationKeyLinkedProjects, bundle.RelationKeyAssignee}),
+			},
+			relLinks: makeRelationLinks([]domain.RelationKey{
+				bundle.RelationKeyMentions, bundle.RelationKeyLinkedProjects, bundle.RelationKeyAssignee}),
+			want: &model.BlockContentDataview{
+				Views: []*model.BlockContentDataviewView{
+					{
+						Type: DefaultViewLayout,
+						Name: defaultViewName,
+						Sorts: []*model.BlockContentDataviewSort{
+							{
+								RelationKey: bundle.RelationKeyLastModifiedDate.String(),
+								Type:        model.BlockContentDataviewSort_Desc,
+							},
+						},
+						Relations: makeDataviewRelations(
+							append(defaultDataviewRelations, bundle.RelationKeyMentions, bundle.RelationKeyLinkedProjects, bundle.RelationKeyAssignee),
+							append(defaultVisibleRelations, bundle.RelationKeyMentions, bundle.RelationKeyLinkedProjects, bundle.RelationKeyAssignee),
+						),
+					},
+				},
+				RelationLinks: makeRelationLinks(
+					append(defaultDataviewRelations, bundle.RelationKeyMentions, bundle.RelationKeyLinkedProjects, bundle.RelationKeyAssignee)),
+			},
+		},
+		{
 			name: "query by relations",
 			relLinks: []*model.RelationLink{
 				{Key: bundle.RelationKeyAddedDate.String()},


### PR DESCRIPTION
## What

Every object type created since Nov 2025 gets an "All" view with **only the Name column visible** — every custom property is present but `hidden: true`.

## Root cause

`d99f04eee` (GO-5969, "Preserve relations in views on source change") rewrote `MakeDataviewContent` and inverted an argument precedence:

- **Before:** explicitly passed `relLinks` were marked visible; `ot.RelationLinks` was only a fallback.
- **After:** `ot != nil` won, and the visible-set loop ran only in the `ot == nil` branch.

`ObjectType.dataviewTemplates` (`core/block/editor/objecttype.go:253`) passes the type's featured + recommended relations in **both** slots, so it took the `ot` path and no column was ever marked visible.

This also silently defeated GO-6087 ("Automatically add props to dataview and All view").

## Fix

Restore the precedence: caller-passed `relLinks` are the visible set even when `ot` is present; `ot.RelationLinks` remains the hidden-column fallback when no relations are passed.

GO-5969's actual subject — source-change semantics (`oldContent != nil`) — is untouched: those callers pass `ot` XOR relations, never both.

## Test

New case in `collection_test.go` using `objecttype.go`'s exact calling convention (both slots populated), asserting the passed relations come out visible. Verified to fail without the fix.

## Notes

- Found while investigating an API v2 gap report; the fix is core editor code with no API involvement, so it is cherry-picked out of the v2 branch to ship on its own.
- Bundled types whose views look correct almost certainly had them generated *before* the regression — the asymmetry is view age, not type provenance. That part is code-derived, not reproduced against a live account.
- Existing types keep their stored views; this fixes generation, not repair of already-generated views.