### PR TITLE
GO-7430 Restore tag and status as subscription dependency formats

### DIFF
--- a/core/subscription/deps.go
+++ b/core/subscription/deps.go
@@ -12,13 +12,13 @@ import (
 )
 
 // depTracker maintains a parent subscription's render dependencies: the
-// objects referenced by object/file-format values among the requested keys
-// of visible members, plus objects referenced by filter values. They are
-// delivered through a hidden child sub under "{subId}/dep" — a scoped,
-// detail-events-only sibling registered in the same space, so dep detail
-// changes flow through the regular pipeline. The dep id set is recomputed
-// after batches that touched the parent's membership, window or dep-key
-// values (parent.depDirty).
+// objects referenced by dep-format values (see isDepFormat) among the
+// requested keys of visible members, plus objects referenced by filter
+// values. They are delivered through a hidden child sub under "{subId}/dep"
+// — a scoped, detail-events-only sibling registered in the same space, so
+// dep detail changes flow through the regular pipeline. The dep id set is
+// recomputed after batches that touched the parent's membership, window or
+// dep-key values (parent.depDirty).
 //
 // Order dependencies (sorting by an object/tag/status relation) are handled
 // separately and cheaper: every feed item is offered to the parent's
@@ -31,6 +31,19 @@ type depTracker struct {
 	depKeys      []domain.RelationKey
 	depKeySet    map[string]struct{}
 	filterDepIds []string
+}
+
+// isDepFormat reports whether values of this format are ids of objects the
+// client must resolve to render. tag and status belong here as much as
+// object and file do: their values are relationOption ids, and clients build
+// the chip from the option's name and colour.
+func isDepFormat(format model.RelationFormat) bool {
+	switch format {
+	case model.RelationFormat_object, model.RelationFormat_file, model.RelationFormat_tag, model.RelationFormat_status:
+		return true
+	default:
+		return false
+	}
 }
 
 // newDepTracker resolves which requested keys carry object references and
@@ -46,7 +59,7 @@ func newDepTracker(parent *coreSub, spec subSpec, idx spaceindex.Store) *depTrac
 		if err != nil {
 			continue
 		}
-		if format == model.RelationFormat_object || format == model.RelationFormat_file {
+		if isDepFormat(format) {
 			depKeys = append(depKeys, k)
 		}
 	}
@@ -64,7 +77,7 @@ func newDepTracker(parent *coreSub, spec subSpec, idx spaceindex.Store) *depTrac
 		// dependent objects are rendered as name/icon chips; never stream the
 		// high-churn strip-by-default keys (sync/usage) for them, even if the
 		// parent lists those keys for its own rows. depKeys above are derived
-		// from spec.keys and are unaffected (stripped keys are never object/file
+		// from spec.keys and are unaffected (stripped keys never carry a dep
 		// format).
 		keys:             slices.DeleteFunc(slices.Clone(spec.keys), bundle.IsDefaultStrippedKey),
 		members:          make(map[string]struct{}),
@@ -112,7 +125,7 @@ func collectFilterDepIds(filters []database.FilterRequest, idx spaceindex.Store)
 				continue
 			}
 			format, err := idx.GetRelationFormatByKey(f.RelationKey)
-			if err != nil || (format != model.RelationFormat_object && format != model.RelationFormat_file) {
+			if err != nil || !isDepFormat(format) {
 				continue
 			}
 			for _, id := range f.Value.WrapToStringList() {

--- a/core/subscription/deps_test.go
+++ b/core/subscription/deps_test.go
@@ -248,6 +248,90 @@ func TestDependencies(t *testing.T) {
 		require.NoError(t, fx.Unsubscribe("dep-parent"))
 	})
 
+	t.Run("status options referenced by members are delivered as deps", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenStatusRelation(),
+			givenStatusOption("opt-a", "Alpha"),
+			givenStatusOption("opt-b", "Beta"),
+			{
+				bundle.RelationKeyId:             domain.String("t1"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_todo)),
+				statusKey:                        domain.String("opt-a"),
+			},
+		})
+
+		req := givenDepRequest()
+		req.SubId = "status-dep-parent"
+		// name is what the chip renders; clients list it alongside the column
+		req.Keys = []string{bundle.RelationKeyId.String(), bundle.RelationKeyName.String(), statusKey}
+		resp, err := fx.Search(req)
+		require.NoError(t, err)
+
+		// the client renders the chip from the option's name/color, so the
+		// referenced option must arrive as a dependency
+		require.Len(t, resp.Records, 1)
+		require.Len(t, resp.Dependencies, 1)
+		assert.Equal(t, "opt-a", resp.Dependencies[0].GetString(bundle.RelationKeyId))
+
+		// renaming the option must reach the client under the dep subId
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenStatusOption("opt-a", "Alpha Renamed"),
+		})
+		msgs := waitMessages(t, resp.Output, 1)
+		require.Len(t, msgs, 1)
+		amend := msgs[0].GetObjectDetailsAmend()
+		require.NotNil(t, amend)
+		assert.Equal(t, "opt-a", amend.Id)
+		assert.Equal(t, []string{"status-dep-parent/dep"}, amend.SubIds)
+	})
+
+	t.Run("tag options referenced by members are delivered as deps", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenTagRelation(),
+			givenTagOption("urgent"),
+			givenTagOption("later"),
+			givenTagOption("unused"),
+			givenTaggedTask("t1", "urgent", "later"),
+		})
+
+		req := givenDepRequest()
+		req.SubId = "tag-dep-parent"
+		req.Keys = []string{bundle.RelationKeyId.String(), tagKey}
+		resp, err := fx.Search(req)
+		require.NoError(t, err)
+
+		// every option in the multi-select value, and nothing else
+		require.Len(t, resp.Records, 1)
+		require.Len(t, resp.Dependencies, 2)
+		assert.ElementsMatch(t, []string{"urgent", "later"}, recordIds(resp.Dependencies))
+	})
+
+	t.Run("tag options used as filter values are tracked as deps", func(t *testing.T) {
+		fx := newEngineFixture(t)
+		fx.objectStore.AddObjects(t, testSpaceId, []objectstore.TestObject{
+			givenTagRelation(),
+			givenTagOption("urgent"),
+		})
+
+		req := givenDepRequest()
+		req.SubId = "tag-filter-parent"
+		req.Keys = []string{bundle.RelationKeyId.String()}
+		req.Filters = append(req.Filters, database.FilterRequest{
+			RelationKey: tagKey,
+			Condition:   model.BlockContentDataviewFilter_In,
+			Value:       domain.StringList([]string{"urgent"}),
+		})
+		resp, err := fx.Search(req)
+		require.NoError(t, err)
+
+		// the client renders the filter chip's name, so the option must arrive
+		// even though no member references it
+		require.Len(t, resp.Dependencies, 1)
+		assert.Equal(t, "urgent", resp.Dependencies[0].GetString(bundle.RelationKeyId))
+	})
+
 	t.Run("renaming the status option you sort by reorders the parent", func(t *testing.T) {
 		fx := newEngineFixture(t)
 		statusTask := func(id, option string) objectstore.TestObject {


### PR DESCRIPTION
## Summary

- The GO-7320 engine rewrite narrowed the dependency-key rule from `object || file || tag || status` (old `dep.go` `isRelationObject`) to `object || file`, so the `{subId}/dep` child sub stopped delivering the `relationOption` objects that tag/status values point at. Clients that render select/multi-select chips from dependency details show empty cells — see IOS-6605 and https://community.anytype.io/t/ios-select-and-multi-select-properties-not-showing-up-syncing-in-object-type-view/31112. Regression is live from v0.50.10 onward.
- Extracted `isDepFormat` covering object/file/tag/status and routed both `newDepTracker` and `collectFilterDepIds` through it, restoring the old semantics for member-referenced and filter-value options alike.
- Added three `deps_test.go` cases, each red before the fix: status option delivered plus its rename amending under `{subId}/dep`; every option of a multi-select value delivered and unreferenced ones not; a tag option used only as a filter value tracked.

Sort dependencies on tag/status were never broken (order map / `checkOrderDep`), which is why the existing tag/status coverage there was sort-only and missed this.

iOS resolves chips solely from the details storage fed by `Dependencies`, so it renders blank; anytype-ts keeps its own space-wide relation-option subscription and is unaffected.