### PR TITLE
GO-0000 Allow extending bundled relations from JSON files

### DIFF
--- a/pkg/lib/bundle/extra.go
+++ b/pkg/lib/bundle/extra.go
@@ -1,0 +1,127 @@
+package bundle
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
+	"github.com/anyproto/anytype-heart/pkg/lib/logging"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+// envExtraRelations holds an os.PathListSeparator-separated list of JSON files with additional
+// bundled relations. Internal escape hatch: it lets a build learn about a relation without
+// regenerating relation.gen.go. Files use the same schema as relations.json, and a key that
+// already exists in the generated bundle is never replaced.
+const envExtraRelations = "ANYTYPE_EXTRA_RELATIONS"
+
+var log = logging.Logger("bundle")
+
+var relationKeyRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// relationJSON mirrors the schema of relations.json consumed by ./generator, so an entry can be
+// moved between the two unchanged.
+type relationJSON struct {
+	Key         string   `json:"key"`
+	Name        string   `json:"name"`
+	Format      string   `json:"format"`
+	Source      string   `json:"source"`
+	Description string   `json:"description"`
+	MaxCount    int      `json:"maxCount"`
+	Hidden      bool     `json:"hidden"`
+	Readonly    bool     `json:"readonly"`
+	ObjectTypes []string `json:"objectTypes"`
+	Revision    int      `json:"revision"`
+	IncludeTime bool     `json:"includeTime"` // nolint: tagliatelle
+}
+
+func extraRelationsPaths() []string {
+	return filepath.SplitList(os.Getenv(envExtraRelations))
+}
+
+// loadExtraRelations merges relations declared in the given JSON files into dst. Keys already
+// present in dst are skipped with a warning: the generated bundle always wins. Any other problem
+// is an error — a misconfigured env var must not produce a half-populated bundle.
+func loadExtraRelations(paths []string, dst map[domain.RelationKey]*model.Relation) error {
+	declaredIn := make(map[domain.RelationKey]string)
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read extra relations file %s: %w", path, err)
+		}
+		var parsed []relationJSON
+		if err = json.Unmarshal(raw, &parsed); err != nil {
+			return fmt.Errorf("parse extra relations file %s: %w", path, err)
+		}
+		for i, entry := range parsed {
+			relation, err := entry.toModel()
+			if err != nil {
+				return fmt.Errorf("extra relation #%d in %s: %w", i, path, err)
+			}
+			key := domain.RelationKey(relation.Key)
+			if prevPath, ok := declaredIn[key]; ok {
+				return fmt.Errorf("extra relation %q in %s is already declared in %s", key, path, prevPath)
+			}
+			declaredIn[key] = path
+			if _, ok := dst[key]; ok {
+				log.Warnf("extra relation %q from %s is skipped: it is already a bundled relation", key, path)
+				continue
+			}
+			dst[key] = relation
+		}
+	}
+	return nil
+}
+
+// toModel validates an entry and converts it the way ./generator converts relations.json.
+func (r relationJSON) toModel() (*model.Relation, error) {
+	if !relationKeyRegexp.MatchString(r.Key) {
+		return nil, fmt.Errorf("invalid key %q: expected to match %s", r.Key, relationKeyRegexp)
+	}
+	if r.Name == "" {
+		return nil, fmt.Errorf("relation %q has no name", r.Key)
+	}
+	format, ok := model.RelationFormat_value[r.Format]
+	if !ok {
+		return nil, fmt.Errorf("relation %q has unknown format %q", r.Key, r.Format)
+	}
+	dataSource, ok := model.RelationDataSource_value[r.Source]
+	if !ok {
+		return nil, fmt.Errorf("relation %q has unknown source %q", r.Key, r.Source)
+	}
+	if r.MaxCount < 0 || r.MaxCount > math.MaxInt32 {
+		return nil, fmt.Errorf("relation %q has maxCount %d out of range", r.Key, r.MaxCount)
+	}
+	var objectTypes []string
+	for _, objectType := range r.ObjectTypes {
+		if objectType == "" {
+			return nil, fmt.Errorf("relation %q has an empty object type", r.Key)
+		}
+		if strings.HasPrefix(objectType, TypePrefix) {
+			return nil, fmt.Errorf("relation %q object type %q must be a bare type key, without the %s prefix", r.Key, objectType, TypePrefix)
+		}
+		objectTypes = append(objectTypes, TypePrefix+objectType)
+	}
+	return &model.Relation{
+		Id:               addr.BundledRelationURLPrefix + r.Key,
+		Key:              r.Key,
+		Name:             r.Name,
+		Format:           model.RelationFormat(format),
+		DataSource:       model.RelationDataSource(dataSource),
+		Description:      r.Description,
+		MaxCount:         int32(r.MaxCount),
+		Hidden:           r.Hidden,
+		ReadOnly:         r.Readonly,
+		ReadOnlyRelation: true,
+		Scope:            model.Relation_type,
+		ObjectTypes:      objectTypes,
+		Revision:         int64(r.Revision),
+		IncludeTime:      r.IncludeTime,
+	}, nil
+}

--- a/pkg/lib/bundle/extra_test.go
+++ b/pkg/lib/bundle/extra_test.go
@@ -1,0 +1,336 @@
+package bundle
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/domain"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func writeExtraRelationsFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestLoadExtraRelations(t *testing.T) {
+	t.Run("adds relation with all fields", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{
+				"key": "internalTraceId",
+				"name": "Internal trace ID",
+				"format": "shorttext",
+				"source": "details",
+				"description": "Correlates an object with an internal trace",
+				"maxCount": 1,
+				"hidden": true,
+				"readonly": true,
+				"revision": 2,
+				"includeTime": true
+			}
+		]`)
+		dst := map[domain.RelationKey]*model.Relation{}
+		want := map[domain.RelationKey]*model.Relation{
+			"internalTraceId": {
+				Id:               "_brinternalTraceId",
+				Key:              "internalTraceId",
+				Name:             "Internal trace ID",
+				Format:           model.RelationFormat_shorttext,
+				DataSource:       model.Relation_details,
+				Description:      "Correlates an object with an internal trace",
+				MaxCount:         1,
+				Hidden:           true,
+				ReadOnly:         true,
+				ReadOnlyRelation: true,
+				Scope:            model.Relation_type,
+				Revision:         2,
+				IncludeTime:      true,
+			},
+		}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, dst)
+	})
+
+	t.Run("prefixes object types with type prefix", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{"key": "owner", "name": "Owner", "format": "object", "source": "details", "objectTypes": ["profile", "participant"]}
+		]`)
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, dst["owner"])
+		assert.Equal(t, []string{"_otprofile", "_otparticipant"}, dst["owner"].ObjectTypes)
+	})
+
+	t.Run("omitted optional fields stay zero", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{"key": "minimal", "name": "Minimal", "format": "longtext", "source": "local"}
+		]`)
+		dst := map[domain.RelationKey]*model.Relation{}
+		want := &model.Relation{
+			Id:               "_brminimal",
+			Key:              "minimal",
+			Name:             "Minimal",
+			Format:           model.RelationFormat_longtext,
+			DataSource:       model.Relation_local,
+			ReadOnlyRelation: true,
+			Scope:            model.Relation_type,
+		}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, want, dst["minimal"])
+	})
+
+	t.Run("accepts key with leading underscore", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{"key": "_custom_score", "name": "Custom score", "format": "number", "source": "derived"}
+		]`)
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, dst["_custom_score"])
+		assert.Equal(t, "_br_custom_score", dst["_custom_score"].Id)
+	})
+
+	t.Run("existing relation is never overridden", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{"key": "name", "name": "Hijacked", "format": "number", "source": "local"}
+		]`)
+		existing := &model.Relation{Id: "_brname", Key: "name", Name: "Name", Format: model.RelationFormat_shorttext}
+		dst := map[domain.RelationKey]*model.Relation{"name": existing}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, dst, 1)
+		assert.Same(t, existing, dst["name"])
+	})
+
+	t.Run("merges relations from several files", func(t *testing.T) {
+		// given
+		dir := t.TempDir()
+		first := writeExtraRelationsFile(t, dir, "a.json", `[
+			{"key": "alpha", "name": "Alpha", "format": "longtext", "source": "details"}
+		]`)
+		second := writeExtraRelationsFile(t, dir, "b.json", `[
+			{"key": "beta", "name": "Beta", "format": "number", "source": "details"}
+		]`)
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations([]string{first, second}, dst)
+
+		// then
+		require.NoError(t, err)
+		assert.Len(t, dst, 2)
+		assert.Contains(t, dst, domain.RelationKey("alpha"))
+		assert.Contains(t, dst, domain.RelationKey("beta"))
+	})
+
+	t.Run("empty path list is a no-op", func(t *testing.T) {
+		// given
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations(nil, dst)
+
+		// then
+		require.NoError(t, err)
+		assert.Empty(t, dst)
+	})
+
+	t.Run("same key in two files is an error naming both", func(t *testing.T) {
+		// given
+		dir := t.TempDir()
+		first := writeExtraRelationsFile(t, dir, "a.json", `[
+			{"key": "dup", "name": "Dup", "format": "longtext", "source": "details"}
+		]`)
+		second := writeExtraRelationsFile(t, dir, "b.json", `[
+			{"key": "dup", "name": "Dup again", "format": "number", "source": "details"}
+		]`)
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations([]string{first, second}, dst)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), first)
+		assert.Contains(t, err.Error(), second)
+		assert.Contains(t, err.Error(), "dup")
+	})
+
+	t.Run("missing file is an error naming the path", func(t *testing.T) {
+		// given
+		path := filepath.Join(t.TempDir(), "absent.json")
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), path)
+	})
+
+	t.Run("malformed json is an error naming the path", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `{"key": "notAnArray"}`)
+		dst := map[domain.RelationKey]*model.Relation{}
+
+		// when
+		err := loadExtraRelations([]string{path}, dst)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), path)
+	})
+
+	t.Run("invalid entries are errors", func(t *testing.T) {
+		for name, entry := range map[string]string{
+			"unknown format":      `{"key": "x", "name": "X", "format": "hypertext", "source": "details"}`,
+			"unknown source":      `{"key": "x", "name": "X", "format": "longtext", "source": "cloud"}`,
+			"missing format":      `{"key": "x", "name": "X", "source": "details"}`,
+			"missing source":      `{"key": "x", "name": "X", "format": "longtext"}`,
+			"empty key":           `{"key": "", "name": "X", "format": "longtext", "source": "details"}`,
+			"key with dash":       `{"key": "my-key", "name": "X", "format": "longtext", "source": "details"}`,
+			"key with space":      `{"key": "my key", "name": "X", "format": "longtext", "source": "details"}`,
+			"key starting digit":  `{"key": "1key", "name": "X", "format": "longtext", "source": "details"}`,
+			"empty name":          `{"key": "x", "name": "", "format": "longtext", "source": "details"}`,
+			"negative maxCount":   `{"key": "x", "name": "X", "format": "longtext", "source": "details", "maxCount": -1}`,
+			"huge maxCount":       `{"key": "x", "name": "X", "format": "longtext", "source": "details", "maxCount": 3000000000}`,
+			"empty object type":   `{"key": "x", "name": "X", "format": "object", "source": "details", "objectTypes": [""]}`,
+			"prefixed objectType": `{"key": "x", "name": "X", "format": "object", "source": "details", "objectTypes": ["_otpage"]}`,
+		} {
+			t.Run(name, func(t *testing.T) {
+				// given
+				path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", "["+entry+"]")
+				dst := map[domain.RelationKey]*model.Relation{}
+
+				// when
+				err := loadExtraRelations([]string{path}, dst)
+
+				// then
+				require.Error(t, err)
+				assert.Empty(t, dst)
+			})
+		}
+	})
+}
+
+// envInitChildMarker tells a subprocess that it is the child of TestExtraRelationsInit, so package
+// init has already run with ANYTYPE_EXTRA_RELATIONS set.
+const envInitChildMarker = "ANYTYPE_EXTRA_RELATIONS_INIT_CHILD"
+
+const extraInitTestRelation = domain.RelationKey("extraInitTestRelation")
+
+func TestExtraRelationsInitChild(t *testing.T) {
+	if os.Getenv(envInitChildMarker) == "" {
+		t.Skip("runs only as a subprocess of TestExtraRelationsInit")
+	}
+
+	// then
+	relation, err := GetRelation(extraInitTestRelation)
+	require.NoError(t, err)
+	assert.Equal(t, "_brextraInitTestRelation", relation.Id)
+	assert.True(t, HasRelation(extraInitTestRelation))
+	// the merge must happen before init derives the key lists, otherwise a local relation would
+	// be missing from LocalRelationsKeys
+	assert.Contains(t, LocalRelationsKeys, extraInitTestRelation)
+}
+
+func runInitChild(t *testing.T, extraPath string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestExtraRelationsInitChild$", "-test.v")
+	cmd.Env = append(os.Environ(), envInitChildMarker+"=1", envExtraRelations+"="+extraPath)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func TestExtraRelationsInit(t *testing.T) {
+	t.Run("relations from the env file join the bundle before key lists are derived", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{"key": "extraInitTestRelation", "name": "Extra init test", "format": "longtext", "source": "local"}
+		]`)
+
+		// when
+		out, err := runInitChild(t, path)
+
+		// then
+		require.NoError(t, err, out)
+	})
+
+	t.Run("invalid file aborts startup naming the env var", func(t *testing.T) {
+		// given
+		path := writeExtraRelationsFile(t, t.TempDir(), "extra.json", `[
+			{"key": "extraInitTestRelation", "name": "Extra init test", "format": "hypertext", "source": "local"}
+		]`)
+
+		// when
+		out, err := runInitChild(t, path)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, out, envExtraRelations)
+		assert.Contains(t, out, "hypertext")
+	})
+}
+
+func TestExtraRelationsPathsFromEnv(t *testing.T) {
+	t.Run("unset env yields no paths", func(t *testing.T) {
+		// given
+		t.Setenv(envExtraRelations, "")
+
+		// when
+		got := extraRelationsPaths()
+
+		// then
+		assert.Empty(t, got)
+	})
+
+	t.Run("splits env by the os path list separator", func(t *testing.T) {
+		// given
+		joined := strings.Join([]string{"/tmp/a.json", "/tmp/b.json"}, string(os.PathListSeparator))
+		t.Setenv(envExtraRelations, joined)
+		want := []string{"/tmp/a.json", "/tmp/b.json"}
+
+		// when
+		got := extraRelationsPaths()
+
+		// then
+		assert.Equal(t, want, got)
+	})
+}

--- a/pkg/lib/bundle/init.go
+++ b/pkg/lib/bundle/init.go
@@ -69,6 +69,14 @@ var LocalAndDerivedRelationKeys []domain.RelationKey
 var ErrNotFound = fmt.Errorf("not found")
 
 func init() {
+	// extras must join the bundle before the key lists below are derived from it. This is the only
+	// init in the package, so ordering against the generated relations map is guaranteed: package
+	// level vars are initialized before any init runs.
+	if paths := extraRelationsPaths(); len(paths) > 0 {
+		if err := loadExtraRelations(paths, relations); err != nil {
+			panic(fmt.Errorf("%s: %w", envExtraRelations, err))
+		}
+	}
 	for _, r := range relations {
 		if r.DataSource == model.Relation_account || r.DataSource == model.Relation_local {
 			LocalRelationsKeys = append(LocalRelationsKeys, domain.RelationKey(r.Key))


### PR DESCRIPTION
## What

Adds `ANYTYPE_EXTRA_RELATIONS` — an `os.PathListSeparator`-separated list of JSON files with additional bundled relations, read once at package init. It lets an internal build learn about a relation without regenerating `relation.gen.go` and shipping a new binary.

Undocumented on purpose: internal escape hatch, not a user-facing extension point.

## How

`relations` is a single unexported package map (`pkg/lib/bundle/relation.gen.go`) that every accessor reads — `GetRelation`, `PickRelation`, `MustGetRelation`, `GetRelationFormat`, `HasRelation`, `ListRelationsUrls`. Merging into that one map is enough for every consumer to see the extras, including format resolution, the "is this key bundled?" branches in import/objectcreator/smartblock, and the `_br…` bundled-relation source.

Files use the same array-of-objects schema as `relations.json`, and entries are converted exactly as the generator converts it (`Id = _br…`, `Scope = Relation_type`, `ReadOnlyRelation = true`, `_ot`-prefixed object types). An entry graduates into the real bundle by copy-paste plus `go generate`.

The merge runs at the top of the package's **only** `init()`, before the local/derived key lists are derived from the map — so an extra with `source: local` lands in `LocalRelationsKeys` like any other relation.

## Failure behavior

| Situation | Behavior |
|---|---|
| Env var unset | Zero work, zero behavior change — the loader is never called |
| Key collides with a generated relation | Generated relation wins, extra skipped, warning logged |
| Anything else invalid | `panic` at init, naming the env var, the file, and the offending entry |

Collision is the one deliberate exception to fail-fast: erroring would turn a future release that adds a relation with an already-configured key into a startup crash on that deployment.

## Scope

Extras stay in memory. `RelationChecksum` remains a generated constant, so `core/indexer/reindex.go` never observes a change, no reindex is triggered, and no relation objects are created in spaces. Bundled types, layouts, and the system/internal relation lists are untouched, as is the generator. Consequences are spelled out in the design doc: extras get no generated Go constant (string-key access only), and a device without the env var answers `HasRelation` differently.


## Test plan

- `go test ./pkg/lib/bundle/` → ok; 30 subtests pass, 1 skip (`TestExtraRelationsInitChild`, which by design only runs inside the subprocess its parent spawns).
- Loader tests are table-driven against `t.TempDir()`: field mapping, object-type prefixing, omitted optionals, collision leaves the original pointer untouched, same key in two files, missing file, malformed JSON, and 13 invalid-entry cases.
- The `init()` wiring is verified by re-executing the test binary with the env var set — the only way to observe package init. The valid case asserts `GetRelation`/`HasRelation` against real package state plus membership in `LocalRelationsKeys`, which is what proves the merge lands *before* the key lists are derived. The invalid case asserts the child exits non-zero with the env var name and the offending value in its output.
- `go build ./...` clean; `golangci-lint run pkg/lib/bundle/...` reports no new findings (10 pre-existing remain).
- `./core/relationutils/...` green as a consumer spot-check.
