### PR TITLE
GO-7454 Fulltext ranking: tie-break boost for participant objects

### DIFF
--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -430,14 +430,20 @@ type Filters struct {
 
 // participantLayoutBoost is a tie-break signal for participant (space member)
 // objects: deliberately an order of magnitude below the 1.0-weight signals so
-// a person wins over an otherwise-equal regular object (same match, same
-// recency) without ever overcoming a real relevance difference.
+// a person wins over an otherwise-equal regular object without overcoming a
+// real relevance difference like a name match. Combined with the pinned
+// recency below it puts a matching person above ANY equally-matching regular
+// object regardless of how recently that object was edited (1.0 + 0.1 vs the
+// regular maximum of 1.0).
 const participantLayoutBoost = 0.1
 
 // ComputeFinalScore blends a Tantivy BM25 score with additive signals:
-//   - recency: exponential decay on the more-recent of lastOpenedDate / lastModifiedDate (30-day half-life, [0,1])
+//   - recency: exponential decay on the more-recent of lastOpenedDate / lastModifiedDate (30-day half-life, [0,1]).
+//     Participant objects are pinned to 1.0: their lastModifiedDate moves only
+//     on profile changes, so the decayed value is noise, and a person must not
+//     sink below recently edited objects on it.
 //   - nameBoost: 1.0 when the fulltext match landed in the "name" relation field, 0 otherwise
-//   - participantLayoutBoost: 0.1 for participant objects (tie-break only)
+//   - participantLayoutBoost: 0.1 for participant objects (tie-break)
 //
 // Formula: ln(1+bm25) + recency + nameBoost + participantBoost
 // Log-compressing the BM25 score keeps recency and nameBoost as equal-weight additive signals.
@@ -447,24 +453,29 @@ func ComputeFinalScore(bm25Score float64, details *domain.Details, nameMatch boo
 	if details == nil {
 		return math.Log1p(bm25Score)
 	}
-	// hour granularity: the recency signal must be stable between consecutive
-	// page requests, or the re-ranked result order drifts mid-pagination and
-	// pages overlap; with a 30-day half-life the precision loss is negligible
-	now := time.Now().Truncate(time.Hour).Unix()
-	lastOpened := details.GetInt64(bundle.RelationKeyLastOpenedDate)
-	lastModified := details.GetInt64(bundle.RelationKeyLastModifiedDate)
+	isParticipant := details.GetInt64(bundle.RelationKeyResolvedLayout) == int64(model.ObjectType_participant)
 	var recency float64
-	if lastOpened > lastModified {
-		recency = recencyDecay(now, lastOpened)
+	if isParticipant {
+		recency = 1.0
 	} else {
-		recency = recencyDecay(now, lastModified)
+		// hour granularity: the recency signal must be stable between consecutive
+		// page requests, or the re-ranked result order drifts mid-pagination and
+		// pages overlap; with a 30-day half-life the precision loss is negligible
+		now := time.Now().Truncate(time.Hour).Unix()
+		lastOpened := details.GetInt64(bundle.RelationKeyLastOpenedDate)
+		lastModified := details.GetInt64(bundle.RelationKeyLastModifiedDate)
+		if lastOpened > lastModified {
+			recency = recencyDecay(now, lastOpened)
+		} else {
+			recency = recencyDecay(now, lastModified)
+		}
 	}
 	nameBoost := 0.0
 	if nameMatch {
 		nameBoost = 1.0
 	}
 	participantBoost := 0.0
-	if details.GetInt64(bundle.RelationKeyResolvedLayout) == int64(model.ObjectType_participant) {
+	if isParticipant {
 		participantBoost = participantLayoutBoost
 	}
 	return math.Log1p(bm25Score) + recency + nameBoost + participantBoost

--- a/pkg/lib/database/database.go
+++ b/pkg/lib/database/database.go
@@ -428,12 +428,21 @@ type Filters struct {
 	Order     Order
 }
 
-// ComputeFinalScore blends a Tantivy BM25 score with two additive signals:
+// participantLayoutBoost is a tie-break signal for participant (space member)
+// objects: deliberately an order of magnitude below the 1.0-weight signals so
+// a person wins over an otherwise-equal regular object (same match, same
+// recency) without ever overcoming a real relevance difference.
+const participantLayoutBoost = 0.1
+
+// ComputeFinalScore blends a Tantivy BM25 score with additive signals:
 //   - recency: exponential decay on the more-recent of lastOpenedDate / lastModifiedDate (30-day half-life, [0,1])
 //   - nameBoost: 1.0 when the fulltext match landed in the "name" relation field, 0 otherwise
+//   - participantLayoutBoost: 0.1 for participant objects (tie-break only)
 //
-// Formula: ln(1+bm25) + recency + nameBoost
+// Formula: ln(1+bm25) + recency + nameBoost + participantBoost
 // Log-compressing the BM25 score keeps recency and nameBoost as equal-weight additive signals.
+// All signals derive from the doc itself, keeping the score budget-stable
+// (identical across page requests regardless of the candidate set).
 func ComputeFinalScore(bm25Score float64, details *domain.Details, nameMatch bool) float64 {
 	if details == nil {
 		return math.Log1p(bm25Score)
@@ -454,7 +463,11 @@ func ComputeFinalScore(bm25Score float64, details *domain.Details, nameMatch boo
 	if nameMatch {
 		nameBoost = 1.0
 	}
-	return math.Log1p(bm25Score) + recency + nameBoost
+	participantBoost := 0.0
+	if details.GetInt64(bundle.RelationKeyResolvedLayout) == int64(model.ObjectType_participant) {
+		participantBoost = participantLayoutBoost
+	}
+	return math.Log1p(bm25Score) + recency + nameBoost + participantBoost
 }
 
 // recencyDecay returns exp(-ln(2)/30 * age_in_days) clamped to [0,1].

--- a/pkg/lib/database/database_test.go
+++ b/pkg/lib/database/database_test.go
@@ -901,22 +901,26 @@ func TestComputeFinalScore(t *testing.T) {
 		assert.InDelta(t, withoutBoost+1.0, withBoost, 1e-9)
 	})
 
-	t.Run("participant layout adds the tie-break boost", func(t *testing.T) {
-		// given
-		regular := domain.NewDetails()
-		regular.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_basic))
-		participant := domain.NewDetails()
-		participant.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_participant))
+	t.Run("participant outranks any recency, loses only to real relevance", func(t *testing.T) {
+		// given: a stale participant (no dates — its lastModified moves only
+		// on profile edits, so recency is pinned to the maximum) vs a regular
+		// object edited right now
+		freshRegular := domain.NewDetails()
+		freshRegular.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_basic))
+		freshRegular.SetInt64(bundle.RelationKeyLastModifiedDate, time.Now().Unix())
+		staleParticipant := domain.NewDetails()
+		staleParticipant.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_participant))
 		score := 2.77
 
 		// when
-		regularScore := ComputeFinalScore(score, regular, false)
-		participantScore := ComputeFinalScore(score, participant, false)
+		regularScore := ComputeFinalScore(score, freshRegular, false)
+		participantScore := ComputeFinalScore(score, staleParticipant, false)
 
-		// then: participant wins an otherwise-equal tie...
-		assert.InDelta(t, regularScore+participantLayoutBoost, participantScore, 1e-9)
-		// ...but never overcomes a real signal like a name match
-		assert.Greater(t, ComputeFinalScore(score, regular, true), participantScore)
+		// then: pinned recency 1.0 + tie-break 0.1 beats the freshest regular
+		assert.Greater(t, participantScore, regularScore)
+		assert.InDelta(t, math.Log1p(score)+1.0+participantLayoutBoost, participantScore, 1e-9)
+		// ...but a real relevance signal (name match) still dominates
+		assert.Greater(t, ComputeFinalScore(score, freshRegular, true), participantScore)
 	})
 
 	t.Run("fresh open adds recency on top of log-score", func(t *testing.T) {

--- a/pkg/lib/database/database_test.go
+++ b/pkg/lib/database/database_test.go
@@ -901,6 +901,24 @@ func TestComputeFinalScore(t *testing.T) {
 		assert.InDelta(t, withoutBoost+1.0, withBoost, 1e-9)
 	})
 
+	t.Run("participant layout adds the tie-break boost", func(t *testing.T) {
+		// given
+		regular := domain.NewDetails()
+		regular.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_basic))
+		participant := domain.NewDetails()
+		participant.SetInt64(bundle.RelationKeyResolvedLayout, int64(model.ObjectType_participant))
+		score := 2.77
+
+		// when
+		regularScore := ComputeFinalScore(score, regular, false)
+		participantScore := ComputeFinalScore(score, participant, false)
+
+		// then: participant wins an otherwise-equal tie...
+		assert.InDelta(t, regularScore+participantLayoutBoost, participantScore, 1e-9)
+		// ...but never overcomes a real signal like a name match
+		assert.Greater(t, ComputeFinalScore(score, regular, true), participantScore)
+	})
+
 	t.Run("fresh open adds recency on top of log-score", func(t *testing.T) {
 		// given
 		details := domain.NewDetails()

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
@@ -1138,6 +1138,41 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		assert.InDelta(t, math.Log1p(score), records[0].Details.GetFloat64(bundle.RelationKey_final_score), 1e-9)
 	})
 
+	t.Run("participant layout wins an otherwise-equal tie", func(t *testing.T) {
+		// given: two objects with the same match and no other signals
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("teammate"),
+				bundle.RelationKeyName:           domain.String("Sergey Fuksman"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			},
+			{
+				bundle.RelationKeyId:             domain.String("member"),
+				bundle.RelationKeyName:           domain.String("Sergey Fuksman"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_participant)),
+			},
+		})
+
+		score := 2.77
+		results := []database.FulltextResult{
+			{Path: domain.ObjectPath{ObjectId: "teammate", RelationKey: bundle.RelationKeyName.String()}, Score: score, NameMatch: true},
+			{Path: domain.ObjectPath{ObjectId: "member", RelationKey: bundle.RelationKeyName.String()}, Score: score, NameMatch: true},
+		}
+
+		// when: a text query injects the default _final_score desc order that
+		// production search paths re-rank the head with
+		textFilters, err := database.NewFilters(database.Query{TextQuery: "fuksman"}, s, &anyenc.Arena{}, &collate.Buffer{})
+		require.NoError(t, err)
+		records, err := s.QueryFromFulltext(results, *textFilters, 10, 0, "fuksman")
+
+		// then: the space member ranks first on the tie-break boost
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+		assert.Equal(t, "member", records[0].Details.GetString(bundle.RelationKeyId))
+		assert.Equal(t, "teammate", records[1].Details.GetString(bundle.RelationKeyId))
+	})
+
 	t.Run("_final_score gets name_boost when match is in name field", func(t *testing.T) {
 		// given
 		s := NewStoreFixture(t)


### PR DESCRIPTION
Searching a person's name showed space members below equal-scoring regular objects (screenshot in GO-7454).

Two-part fix in `ComputeFinalScore` (applies everywhere `_final_score` is computed — per-space and cross-space search):

1. **Participant recency is pinned to 1.0** — a participant's `lastModifiedDate` moves only on profile changes, so its decayed recency is noise, not signal. People no longer sink below recently edited objects.
2. **+0.1 tie-break boost** for `resolvedLayout == participant` on top.

Net semantics: a matching person outranks **any** equally-matching regular object regardless of edit recency (`1.0 + 0.1` vs the regular maximum of `1.0`), while a real relevance difference — a name match (`+1.0`) or a better BM25 — still dominates. Budget-stable: derived from the doc's own details, identical across page requests.

Tests: unit (stale participant beats a just-edited regular object; a name match still wins) and end-to-end (`QueryFromFulltext` with the production-injected `_final_score` order).