### PR TITLE
Single-File SPA HTML Channel Exporter & Publisher (#2)

### DIFF
--- a/core/publish/html_spa_exporter.go
+++ b/core/publish/html_spa_exporter.go
@@ -1,0 +1,755 @@
+package publish
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"html"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+	utf16 "github.com/anyproto/anytype-heart/util/text"
+)
+
+type SingleFileHtmlBuilder struct{}
+
+func NewSingleFileHtmlBuilder() *SingleFileHtmlBuilder {
+	return &SingleFileHtmlBuilder{}
+}
+
+type pageInfo struct {
+	id       string
+	title    string
+	isRoot   bool
+	snapshot *model.SmartBlockSnapshotBase
+	sbType   model.SmartBlockType
+}
+
+func (b *SingleFileHtmlBuilder) BuildSPA(exportPath string, rootPageID string, inviteLink string) ([]byte, error) {
+	objectsDir := filepath.Join(exportPath, "objects")
+	dirEntries, err := os.ReadDir(objectsDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read objects dir: %w", err)
+	}
+
+	pages := make(map[string]*pageInfo)
+	knownPages := make(map[string]bool)
+
+	for _, entry := range dirEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".pb") {
+			continue
+		}
+		objID := strings.TrimSuffix(entry.Name(), ".pb")
+		data, err := os.ReadFile(filepath.Join(objectsDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+
+		snapshotWithType := pb.SnapshotWithType{}
+		if err := proto.Unmarshal(data, &snapshotWithType); err != nil {
+			continue
+		}
+
+		snap := snapshotWithType.GetSnapshot().GetData()
+		if snap == nil {
+			continue
+		}
+
+		sbType := snapshotWithType.GetSbType()
+		// Process pages, profile pages, widgets, home, workspaces, etc.
+		if sbType == model.SmartBlockType_Page ||
+			sbType == model.SmartBlockType_ProfilePage ||
+			sbType == model.SmartBlockType_Home ||
+			sbType == model.SmartBlockType_Workspace ||
+			objID == rootPageID {
+
+			title := getPageTitle(snap, objID)
+			pages[objID] = &pageInfo{
+				id:       objID,
+				title:    title,
+				isRoot:   (objID == rootPageID),
+				snapshot: snap,
+				sbType:   sbType,
+			}
+			knownPages[objID] = true
+		}
+	}
+
+	// Ensure root page is in knownPages even if sbType differed
+	if rootInfo, ok := pages[rootPageID]; ok {
+		rootInfo.isRoot = true
+	} else if len(pages) == 0 {
+		// Fallback empty root page
+		pages[rootPageID] = &pageInfo{
+			id:     rootPageID,
+			title:  "Home",
+			isRoot: true,
+		}
+		knownPages[rootPageID] = true
+	}
+
+	// Map of available file attachments in files/
+	filesDir := filepath.Join(exportPath, "files")
+	filesMap := make(map[string]string) // filename -> full path
+	if entries, err := os.ReadDir(filesDir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				filesMap[e.Name()] = filepath.Join(filesDir, e.Name())
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n")
+	buf.WriteString("  <meta charset=\"UTF-8\">\n")
+	buf.WriteString("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n")
+
+	rootTitle := "Published Channel"
+	if rootInfo, ok := pages[rootPageID]; ok && rootInfo.title != "" {
+		rootTitle = rootInfo.title
+	}
+	fmt.Fprintf(&buf, "  <title>%s</title>\n", html.EscapeString(rootTitle))
+	buf.WriteString(getSPAStyles())
+	buf.WriteString("</head>\n<body>\n")
+	buf.WriteString("  <div class=\"top-bar\">\n")
+	buf.WriteString("    <button class=\"theme-toggle\" onclick=\"toggleTheme()\">🌗 Theme</button>\n")
+	buf.WriteString("  </div>\n")
+
+	if inviteLink != "" {
+		fmt.Fprintf(&buf, "  <div class=\"invite-banner\"><a href=\"%s\" target=\"_blank\">Join this Space</a></div>\n", html.EscapeString(inviteLink))
+	}
+
+	buf.WriteString("  <div class=\"container\">\n")
+
+	// Sort page IDs for deterministic HTML generation
+	pageIDs := make([]string, 0, len(pages))
+	for id := range pages {
+		pageIDs = append(pageIDs, id)
+	}
+	sort.Slice(pageIDs, func(i, j int) bool {
+		if pageIDs[i] == rootPageID {
+			return true
+		}
+		if pageIDs[j] == rootPageID {
+			return false
+		}
+		return pageIDs[i] < pageIDs[j]
+	})
+
+	renderer := &pageRenderer{
+		knownPages: knownPages,
+		filesMap:   filesMap,
+		filesDir:   filesDir,
+	}
+
+	for _, id := range pageIDs {
+		p := pages[id]
+		activeClass := ""
+		dataPath := fmt.Sprintf("/%s", p.id)
+		if p.isRoot {
+			activeClass = " active"
+			dataPath = "/"
+		}
+
+		fmt.Fprintf(&buf, "    <div id=\"route-%s\" data-path=\"%s\" class=\"page%s\">\n", p.id, dataPath, activeClass)
+		if !p.isRoot {
+			fmt.Fprintf(&buf, "      <div class=\"breadcrumb\"><a href=\"/\" onclick=\"navigate(event, '/')\">← Back to Home</a></div>\n")
+		}
+		fmt.Fprintf(&buf, "      <h1 class=\"page-title\">%s</h1>\n", html.EscapeString(p.title))
+
+		if p.snapshot != nil {
+			buf.WriteString(renderer.renderBlocks(p.snapshot))
+		}
+		buf.WriteString("    </div>\n")
+	}
+
+	buf.WriteString("  </div>\n")
+	buf.WriteString(getSPAScript(rootPageID))
+	buf.WriteString("</body>\n</html>")
+
+	return buf.Bytes(), nil
+}
+
+type pageRenderer struct {
+	knownPages map[string]bool
+	filesMap   map[string]string
+	filesDir   string
+}
+
+func (r *pageRenderer) renderBlocks(snap *model.SmartBlockSnapshotBase) string {
+	if len(snap.Blocks) == 0 {
+		return ""
+	}
+
+	blockMap := make(map[string]*model.Block)
+	for _, b := range snap.Blocks {
+		if b != nil {
+			blockMap[b.Id] = b
+		}
+	}
+
+	// Find root block
+	var rootBlock *model.Block
+	for _, b := range snap.Blocks {
+		if b == nil {
+			continue
+		}
+		if _, ok := b.Content.(*model.BlockContentOfSmartblock); ok {
+			rootBlock = b
+			break
+		}
+	}
+
+	var buf bytes.Buffer
+	if rootBlock != nil && len(rootBlock.ChildrenIds) > 0 {
+		for _, childID := range rootBlock.ChildrenIds {
+			if child, ok := blockMap[childID]; ok {
+				r.renderBlock(&buf, child, blockMap)
+			}
+		}
+	} else {
+		for _, b := range snap.Blocks {
+			if b != nil && b != rootBlock {
+				r.renderBlock(&buf, b, blockMap)
+			}
+		}
+	}
+
+	return buf.String()
+}
+
+func (r *pageRenderer) renderBlock(buf *bytes.Buffer, b *model.Block, blockMap map[string]*model.Block) {
+	if b == nil {
+		return
+	}
+
+	switch content := b.Content.(type) {
+	case *model.BlockContentOfText:
+		r.renderTextBlock(buf, b, content.Text, blockMap)
+	case *model.BlockContentOfFile:
+		r.renderFileBlock(buf, content.File)
+	case *model.BlockContentOfBookmark:
+		r.renderBookmarkBlock(buf, content.Bookmark)
+	case *model.BlockContentOfDiv:
+		buf.WriteString("      <hr class=\"divider\" />\n")
+	case *model.BlockContentOfLayout:
+		r.renderLayoutBlock(buf, b, content.Layout, blockMap)
+	case *model.BlockContentOfTable:
+		r.renderTableBlock(buf, b, blockMap)
+	default:
+		r.renderChildren(buf, b, blockMap)
+	}
+}
+
+func (r *pageRenderer) renderChildren(buf *bytes.Buffer, b *model.Block, blockMap map[string]*model.Block) {
+	for _, childID := range b.ChildrenIds {
+		if child, ok := blockMap[childID]; ok {
+			r.renderBlock(buf, child, blockMap)
+		}
+	}
+}
+
+func (r *pageRenderer) renderTextBlock(buf *bytes.Buffer, b *model.Block, text *model.BlockContentText, blockMap map[string]*model.Block) {
+	if text == nil {
+		r.renderChildren(buf, b, blockMap)
+		return
+	}
+
+	formattedText := r.formatTextWithMarks(text)
+
+	switch text.Style {
+	case model.BlockContentText_Header1:
+		fmt.Fprintf(buf, "      <h2>%s</h2>\n", formattedText)
+	case model.BlockContentText_Header2:
+		fmt.Fprintf(buf, "      <h3>%s</h3>\n", formattedText)
+	case model.BlockContentText_Header3:
+		fmt.Fprintf(buf, "      <h4>%s</h4>\n", formattedText)
+	case model.BlockContentText_Marked:
+		fmt.Fprintf(buf, "      <ul><li>%s", formattedText)
+		r.renderChildren(buf, b, blockMap)
+		buf.WriteString("</li></ul>\n")
+		return
+	case model.BlockContentText_Numbered:
+		fmt.Fprintf(buf, "      <ol><li>%s", formattedText)
+		r.renderChildren(buf, b, blockMap)
+		buf.WriteString("</li></ol>\n")
+		return
+	case model.BlockContentText_Callout:
+		icon := ""
+		if text.IconEmoji != "" {
+			icon = fmt.Sprintf("<span class=\"callout-icon\">%s</span> ", html.EscapeString(text.IconEmoji))
+		}
+		fmt.Fprintf(buf, "      <div class=\"callout\">%s%s", icon, formattedText)
+		r.renderChildren(buf, b, blockMap)
+		buf.WriteString("</div>\n")
+		return
+	case model.BlockContentText_Quote:
+		fmt.Fprintf(buf, "      <blockquote>%s", formattedText)
+		r.renderChildren(buf, b, blockMap)
+		buf.WriteString("</blockquote>\n")
+		return
+	case model.BlockContentText_Code:
+		fmt.Fprintf(buf, "      <pre><code>%s</code></pre>\n", formattedText)
+	default:
+		if formattedText != "" {
+			fmt.Fprintf(buf, "      <p>%s</p>\n", formattedText)
+		}
+	}
+
+	r.renderChildren(buf, b, blockMap)
+}
+
+func (r *pageRenderer) formatTextWithMarks(text *model.BlockContentText) string {
+	if text == nil || text.Text == "" {
+		return ""
+	}
+
+	textRunes := []rune(text.Text)
+	textLen := utf16.UTF16RuneCountString(text.Text)
+
+	if text.Marks == nil || len(text.Marks.Marks) == 0 {
+		return html.EscapeString(text.Text)
+	}
+
+	type markEvent struct {
+		isStart bool
+		mark    *model.BlockContentTextMark
+	}
+
+	events := make(map[int][]markEvent)
+	for _, m := range text.Marks.Marks {
+		if m == nil {
+			continue
+		}
+		from := int(m.Range.From)
+		to := int(m.Range.To)
+		if from < 0 {
+			from = 0
+		}
+		if to > textLen {
+			to = textLen
+		}
+		if from >= to {
+			continue
+		}
+		events[from] = append(events[from], markEvent{isStart: true, mark: m})
+		events[to] = append(events[to], markEvent{isStart: false, mark: m})
+	}
+
+	var out bytes.Buffer
+	for i := 0; i <= textLen; i++ {
+		if evs, ok := events[i]; ok {
+			// Close marks first
+			for _, ev := range evs {
+				if !ev.isStart {
+					r.renderMarkTag(&out, ev.mark, false)
+				}
+			}
+			// Open marks second
+			for _, ev := range evs {
+				if ev.isStart {
+					r.renderMarkTag(&out, ev.mark, true)
+				}
+			}
+		}
+		if i < len(textRunes) {
+			out.WriteString(html.EscapeString(string(textRunes[i])))
+		}
+	}
+
+	return out.String()
+}
+
+func (r *pageRenderer) renderMarkTag(out *bytes.Buffer, m *model.BlockContentTextMark, isStart bool) {
+	switch m.Type {
+	case model.BlockContentTextMark_Bold:
+		if isStart {
+			out.WriteString("<b>")
+		} else {
+			out.WriteString("</b>")
+		}
+	case model.BlockContentTextMark_Italic:
+		if isStart {
+			out.WriteString("<i>")
+		} else {
+			out.WriteString("</i>")
+		}
+	case model.BlockContentTextMark_Strikethrough:
+		if isStart {
+			out.WriteString("<s>")
+		} else {
+			out.WriteString("</s>")
+		}
+	case model.BlockContentTextMark_Underscored:
+		if isStart {
+			out.WriteString("<u>")
+		} else {
+			out.WriteString("</u>")
+		}
+	case model.BlockContentTextMark_Keyboard:
+		if isStart {
+			out.WriteString("<kbd>")
+		} else {
+			out.WriteString("</kbd>")
+		}
+	case model.BlockContentTextMark_Link:
+		if isStart {
+			targetID := r.extractObjectID(m.Param)
+			if targetID != "" && r.knownPages[targetID] {
+				fmt.Fprintf(out, "<a href=\"/%s\" onclick=\"navigate(event, '/%s')\">", targetID, targetID)
+			} else {
+				fmt.Fprintf(out, "<a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\">", html.EscapeString(m.Param))
+			}
+		} else {
+			out.WriteString("</a>")
+		}
+	case model.BlockContentTextMark_TextColor:
+		if isStart {
+			fmt.Fprintf(out, "<span style=\"color:%s\">", html.EscapeString(m.Param))
+		} else {
+			out.WriteString("</span>")
+		}
+	case model.BlockContentTextMark_BackgroundColor:
+		if isStart {
+			fmt.Fprintf(out, "<span style=\"background-color:%s\">", html.EscapeString(m.Param))
+		} else {
+			out.WriteString("</span>")
+		}
+	}
+}
+
+func (r *pageRenderer) extractObjectID(link string) string {
+	clean := strings.TrimPrefix(link, "anytype://")
+	parts := strings.Split(clean, "/")
+	candidate := parts[len(parts)-1]
+	if candidate != "" && r.knownPages[candidate] {
+		return candidate
+	}
+	return ""
+}
+
+func (r *pageRenderer) renderFileBlock(buf *bytes.Buffer, file *model.BlockContentFile) {
+	if file == nil {
+		return
+	}
+
+	src := r.getFileSrc(file)
+
+	switch file.Type {
+	case model.BlockContentFile_Image:
+		fmt.Fprintf(buf, "      <div class=\"media-container\"><img src=\"%s\" alt=\"%s\" class=\"media-img\" /></div>\n", html.EscapeString(src), html.EscapeString(file.Name))
+	case model.BlockContentFile_Video:
+		fmt.Fprintf(buf, "      <div class=\"media-container\"><video controls src=\"%s\" class=\"media-video\"></video></div>\n", html.EscapeString(src))
+	case model.BlockContentFile_Audio:
+		fmt.Fprintf(buf, "      <div class=\"media-container\"><audio controls src=\"%s\" class=\"media-audio\"></audio></div>\n", html.EscapeString(src))
+	default:
+		fmt.Fprintf(buf, "      <div class=\"file-card\"><a href=\"%s\" download><span class=\"icon\">📄</span> %s</a></div>\n", html.EscapeString(src), html.EscapeString(file.Name))
+	}
+}
+
+func (r *pageRenderer) getFileSrc(file *model.BlockContentFile) string {
+	if file == nil {
+		return "#"
+	}
+	// Try matching by targetObjectId or name in filesMap
+	for fname, fullPath := range r.filesMap {
+		if strings.Contains(fname, file.TargetObjectId) || fname == file.Name {
+			// Check if small image for base64 inline embedding (< 32KB)
+			if file.Type == model.BlockContentFile_Image {
+				if info, err := os.Stat(fullPath); err == nil && info.Size() < 32*1024 {
+					if data, err := os.ReadFile(fullPath); err == nil {
+						mime := "image/png"
+						if strings.HasSuffix(fname, ".jpg") || strings.HasSuffix(fname, ".jpeg") {
+							mime = "image/jpeg"
+						} else if strings.HasSuffix(fname, ".svg") {
+							mime = "image/svg+xml"
+						} else if strings.HasSuffix(fname, ".webp") {
+							mime = "image/webp"
+						}
+						return fmt.Sprintf("data:%s;base64,%s", mime, base64.StdEncoding.EncodeToString(data))
+					}
+				}
+			}
+			return fmt.Sprintf("files/%s", fname)
+		}
+	}
+
+	if file.Name != "" {
+		return fmt.Sprintf("files/%s", file.Name)
+	}
+	if file.TargetObjectId != "" {
+		return fmt.Sprintf("files/%s", file.TargetObjectId)
+	}
+	return "#"
+}
+
+func (r *pageRenderer) renderBookmarkBlock(buf *bytes.Buffer, bm *model.BlockContentBookmark) {
+	if bm == nil {
+		return
+	}
+	title := bm.Title
+	if title == "" {
+		title = bm.Url
+	}
+	fmt.Fprintf(buf, "      <div class=\"bookmark-card\"><a href=\"%s\" target=\"_blank\" rel=\"noopener noreferrer\"><strong>%s</strong></a>", html.EscapeString(bm.Url), html.EscapeString(title))
+	if bm.Description != "" {
+		fmt.Fprintf(buf, "<p>%s</p>", html.EscapeString(bm.Description))
+	}
+	buf.WriteString("</div>\n")
+}
+
+func (r *pageRenderer) renderLayoutBlock(buf *bytes.Buffer, b *model.Block, layout *model.BlockContentLayout, blockMap map[string]*model.Block) {
+	style := model.BlockContentLayoutStyle(-1)
+	if layout != nil {
+		style = layout.Style
+	}
+
+	switch style {
+	case model.BlockContentLayout_Column:
+		buf.WriteString("      <div class=\"column\">\n")
+		r.renderChildren(buf, b, blockMap)
+		buf.WriteString("      </div>\n")
+	case model.BlockContentLayout_Row:
+		buf.WriteString("      <div class=\"row\">\n")
+		r.renderChildren(buf, b, blockMap)
+		buf.WriteString("      </div>\n")
+	default:
+		r.renderChildren(buf, b, blockMap)
+	}
+}
+
+func (r *pageRenderer) renderTableBlock(buf *bytes.Buffer, b *model.Block, blockMap map[string]*model.Block) {
+	buf.WriteString("      <table class=\"table\">\n")
+	for _, rowID := range b.ChildrenIds {
+		if rowBlock, ok := blockMap[rowID]; ok {
+			buf.WriteString("        <tr>\n")
+			for _, cellID := range rowBlock.ChildrenIds {
+				if cellBlock, ok := blockMap[cellID]; ok {
+					buf.WriteString("          <td>")
+					r.renderChildren(buf, cellBlock, blockMap)
+					buf.WriteString("</td>\n")
+				}
+			}
+			buf.WriteString("        </tr>\n")
+		}
+	}
+	buf.WriteString("      </table>\n")
+}
+
+func getPageTitle(snap *model.SmartBlockSnapshotBase, defaultID string) string {
+	if snap == nil {
+		return defaultID
+	}
+	if snap.Details != nil && snap.Details.Fields != nil {
+		if val, ok := snap.Details.Fields["name"]; ok && val.GetStringValue() != "" {
+			return val.GetStringValue()
+		}
+	}
+	for _, b := range snap.Blocks {
+		if b == nil {
+			continue
+		}
+		if textContent, ok := b.Content.(*model.BlockContentOfText); ok && textContent.Text != nil {
+			if textContent.Text.Text != "" {
+				return textContent.Text.Text
+			}
+		}
+	}
+	return defaultID
+}
+
+func getSPAStyles() string {
+	return `  <style>
+    :root {
+      --bg: #ffffff;
+      --fg: #1c1c1e;
+      --card-bg: #f2f2f7;
+      --border: #e5e5ea;
+      --link: #007aff;
+      --callout-bg: #eef6ff;
+    }
+    body.dark-mode {
+      --bg: #1c1c1e;
+      --fg: #f2f2f7;
+      --card-bg: #2c2c2e;
+      --border: #3a3a3c;
+      --link: #0a84ff;
+      --callout-bg: #1e293b;
+    }
+    body.light-mode {
+      --bg: #ffffff;
+      --fg: #1c1c1e;
+      --card-bg: #f2f2f7;
+      --border: #e5e5ea;
+      --link: #007aff;
+      --callout-bg: #eef6ff;
+    }
+    body {
+      background-color: var(--bg);
+      color: var(--fg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      line-height: 1.6;
+    }
+    .top-bar {
+      display: flex;
+      justify-content: flex-end;
+      padding: 12px 24px;
+      border-bottom: 1px solid var(--border);
+    }
+    .theme-toggle {
+      background: var(--card-bg);
+      color: var(--fg);
+      border: 1px solid var(--border);
+      padding: 6px 14px;
+      border-radius: 20px;
+      cursor: pointer;
+      font-size: 14px;
+    }
+    .invite-banner {
+      background: var(--link);
+      color: white;
+      text-align: center;
+      padding: 8px;
+    }
+    .invite-banner a {
+      color: white;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+    .container {
+      max-width: 800px;
+      margin: 30px auto;
+      padding: 0 20px;
+    }
+    .page {
+      display: none;
+    }
+    .page.active {
+      display: block;
+    }
+    .breadcrumb {
+      margin-bottom: 16px;
+    }
+    .breadcrumb a {
+      color: var(--link);
+      text-decoration: none;
+      font-size: 14px;
+    }
+    .page-title {
+      font-size: 32px;
+      margin-bottom: 24px;
+    }
+    a {
+      color: var(--link);
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    .callout {
+      background: var(--callout-bg);
+      border-left: 4px solid var(--link);
+      padding: 12px 16px;
+      margin: 16px 0;
+      border-radius: 4px;
+    }
+    .callout-icon {
+      font-size: 18px;
+    }
+    .bookmark-card, .file-card {
+      background: var(--card-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px 16px;
+      margin: 12px 0;
+    }
+    .media-container {
+      margin: 16px 0;
+    }
+    .media-img, .media-video {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+    }
+    .row {
+      display: flex;
+      gap: 16px;
+    }
+    .column {
+      flex: 1;
+    }
+    .table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 16px 0;
+    }
+    .table td {
+      border: 1px solid var(--border);
+      padding: 8px 12px;
+    }
+    pre {
+      background: var(--card-bg);
+      padding: 12px;
+      border-radius: 6px;
+      overflow-x: auto;
+    }
+  </style>
+`
+}
+
+func getSPAScript(rootPageID string) string {
+	return `  <script>
+    function navigate(e, path) {
+      if (e) e.preventDefault();
+      window.history.pushState({}, '', path);
+      renderRoute(path);
+    }
+    function renderRoute(path) {
+      var cleanPath = path || window.location.pathname;
+      if (cleanPath.endsWith('/') && cleanPath.length > 1) {
+        cleanPath = cleanPath.substring(0, cleanPath.length - 1);
+      }
+      var pages = document.querySelectorAll('.page');
+      var matched = false;
+      pages.forEach(function(p) {
+        var pagePath = p.getAttribute('data-path');
+        if (pagePath === cleanPath || (cleanPath === '' && pagePath === '/') || (cleanPath === '/' && pagePath === '/')) {
+          p.classList.add('active');
+          matched = true;
+        } else {
+          p.classList.remove('active');
+        }
+      });
+      if (!matched && pages.length > 0) {
+        var root = document.querySelector('.page[data-path="/"]') || pages[0];
+        if (root) root.classList.add('active');
+      }
+      window.scrollTo(0, 0);
+    }
+    window.addEventListener('popstate', function() {
+      renderRoute(window.location.pathname);
+    });
+    document.addEventListener('DOMContentLoaded', function() {
+      renderRoute(window.location.pathname);
+    });
+    function toggleTheme() {
+      var body = document.body;
+      if (body.classList.contains('dark-mode')) {
+        body.classList.remove('dark-mode');
+        body.classList.add('light-mode');
+      } else {
+        body.classList.remove('light-mode');
+        body.classList.add('dark-mode');
+      }
+    }
+  </script>
+`
+}

--- a/core/publish/service.go
+++ b/core/publish/service.go
@@ -23,6 +23,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/anyproto/any-sync/app"
@@ -83,6 +84,27 @@ type PublishingUberSnapshot struct {
 
 	// A map of "dir/filename.pb -> jsonpb snapshot"
 	PbFiles map[string]string `json:"pbFiles,omitempty"`
+}
+
+type PublishFormat int
+
+const (
+	PublishFormatDefault PublishFormat = iota
+	PublishFormatHtmlSPA
+)
+
+func parseUriFormat(uri string) (cleanUri string, format PublishFormat) {
+	cleanUri = uri
+	format = PublishFormatDefault
+	if strings.Contains(uri, "?") {
+		parts := strings.SplitN(uri, "?", 2)
+		cleanUri = parts[0]
+		query := strings.ToLower(parts[1])
+		if strings.Contains(query, "format=html_spa") || strings.Contains(query, "format=html") || strings.Contains(query, "export_format=html_spa") {
+			format = PublishFormatHtmlSPA
+		}
+	}
+	return cleanUri, format
 }
 
 type Service interface {
@@ -167,7 +189,7 @@ func (s *service) exportToDir(ctx context.Context, spaceId, pageId string, inclu
 	return
 }
 
-func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, uri, globalName string, joinSpace bool) (err error) {
+func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, uri, globalName string, joinSpace bool, format PublishFormat) (err error) {
 	spc, err := s.spaceService.Get(ctx, spaceId)
 	if err != nil {
 		return err
@@ -191,17 +213,56 @@ func (s *service) publishToPublishServer(ctx context.Context, spaceId, pageId, u
 		return err
 	}
 
-	uberSnapshot, totalSize, err := s.processExportedData(dirEntries, exportPath, tempPublishDir, limit, spaceId, pageId)
-	if err != nil {
-		return err
-	}
+	if format == PublishFormatHtmlSPA {
+		var totalSize int64
+		for _, entry := range dirEntries {
+			if entry.IsDir() && entry.Name() == export.Files {
+				if size, err := s.processFilesDirectory(exportPath, tempPublishDir, limit); err != nil {
+					return err
+				} else {
+					totalSize += size
+				}
+			}
+		}
 
-	err = s.applyInviteLink(ctx, spaceId, &uberSnapshot, includeInviteLinkAndSpaceInfo)
-	if err != nil {
-		return err
-	}
-	if err := s.createIndexFile(tempPublishDir, uberSnapshot, totalSize, limit); err != nil {
-		return err
+		uberSnapshot := PublishingUberSnapshot{
+			Meta: PublishingUberSnapshotMeta{
+				SpaceId:    spaceId,
+				RootPageId: pageId,
+			},
+		}
+		if err := s.applyInviteLink(ctx, spaceId, &uberSnapshot, includeInviteLinkAndSpaceInfo); err != nil {
+			return err
+		}
+
+		htmlBuilder := NewSingleFileHtmlBuilder()
+		htmlData, err := htmlBuilder.BuildSPA(exportPath, pageId, uberSnapshot.Meta.InviteLink)
+		if err != nil {
+			return fmt.Errorf("build HTML SPA: %w", err)
+		}
+
+		totalSize += int64(len(htmlData))
+		if totalSize > limit {
+			return ErrLimitExceeded
+		}
+
+		indexPath := filepath.Join(tempPublishDir, "index.html")
+		if err := os.WriteFile(indexPath, htmlData, 0644); err != nil {
+			return fmt.Errorf("write index.html: %w", err)
+		}
+	} else {
+		uberSnapshot, totalSize, err := s.processExportedData(dirEntries, exportPath, tempPublishDir, limit, spaceId, pageId)
+		if err != nil {
+			return err
+		}
+
+		err = s.applyInviteLink(ctx, spaceId, &uberSnapshot, includeInviteLinkAndSpaceInfo)
+		if err != nil {
+			return err
+		}
+		if err := s.createIndexFile(tempPublishDir, uberSnapshot, totalSize, limit); err != nil {
+			return err
+		}
 	}
 
 	version, err := s.evaluateDocumentVersion(ctx, spc, pageId, joinSpace)
@@ -429,13 +490,15 @@ func (s *service) Publish(ctx context.Context, spaceId, pageId, uri string, join
 	identity, _, details := s.identityService.GetMyProfileDetails(ctx)
 	globalName := details.GetString(bundle.RelationKeyGlobalName)
 
-	err = s.publishToPublishServer(ctx, spaceId, pageId, uri, globalName, joinSpace)
+	cleanUri, format := parseUriFormat(uri)
+
+	err = s.publishToPublishServer(ctx, spaceId, pageId, cleanUri, globalName, joinSpace, format)
 
 	if err != nil {
 		log.Error("Failed to publish", zap.Error(err))
 		return
 	}
-	url := s.makeUrl(uri, identity, globalName)
+	url := s.makeUrl(cleanUri, identity, globalName)
 
 	return PublishResult{Url: url}, nil
 }

--- a/core/publish/service_test.go
+++ b/core/publish/service_test.go
@@ -113,7 +113,11 @@ func (m *mockPublishClient) ListPublishes(ctx context.Context, spaceId string) (
 func (m *mockPublishClient) UploadDir(ctx context.Context, uploadUrl, dir string) (err error) {
 	assert.NoError(m.t, filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if !info.IsDir() {
-			m.checkIndexFile(path, info)
+			if info.Name() == testLimitsConfig.IndexFileName {
+				m.checkIndexFile(path, info)
+			} else if info.Name() == "index.html" {
+				m.checkHtmlIndexFile(path, info)
+			}
 		}
 		return nil
 	}))
@@ -142,6 +146,16 @@ func (m *mockPublishClient) checkIndexFile(path string, info os.FileInfo) {
 	}
 }
 
+func (m *mockPublishClient) checkHtmlIndexFile(path string, info os.FileInfo) {
+	assert.Equal(m.t, info.Name(), "index.html")
+	fileContent, err := os.ReadFile(path)
+	assert.NoError(m.t, err)
+	content := string(fileContent)
+	assert.Contains(m.t, content, "<!DOCTYPE html>")
+	assert.Contains(m.t, content, "id=\"route-"+m.expectedObject+"\"")
+	assert.Contains(m.t, content, "function navigate(e, path)")
+}
+
 var testLimitsConfig = config.PublishLimitsConfig{
 	MembershipLimit:       12 << 20,
 	DefaultLimit:          10 << 20,
@@ -152,6 +166,49 @@ var testLimitsConfig = config.PublishLimitsConfig{
 }
 
 func TestPublish(t *testing.T) {
+	t.Run("success HTML_SPA format", func(t *testing.T) {
+		// given
+		isPersonal := true
+		includeSpaceInfo := false
+
+		spaceService, err := prepareSpaceService(t, isPersonal, includeSpaceInfo)
+
+		objectTypeId := "customObjectType"
+		expectedUri := "test"
+		expected := fmt.Sprintf(testLimitsConfig.DefaultUrlTemplate, id) + "/" + expectedUri
+		publishClient := &mockPublishClient{
+			t:              t,
+			expectedUrl:    expected,
+			expectedObject: objectId,
+			expectedInvite: "",
+			expectedSpace:  spaceId,
+		}
+
+		identityService := mock_identity.NewMockService(t)
+		identityService.EXPECT().GetMyProfileDetails(context.Background()).Return("identity", nil, domain.NewDetailsFromMap(map[domain.RelationKey]domain.Value{}))
+
+		exp := prepareExporter(t, objectTypeId, spaceService, false)
+
+		svc := &service{
+			spaceService:         spaceService,
+			exportService:        exp,
+			publishClientService: publishClient,
+			identityService:      identityService,
+			tempDirService:       core.NewTempDirService(),
+			limitsConfig:         testLimitsConfig,
+		}
+
+		// when
+		publish, err := svc.Publish(context.Background(), spaceId, objectId, expectedUri+"?format=html_spa", includeSpaceInfo)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, expected, publish.Url)
+		assert.Equal(t, "{\"heads\":[\"heads\"],\"joinSpace\":false}", publishClient.expectedRequest.Version)
+		assert.Equal(t, objectId, publishClient.expectedRequest.ObjectId)
+		assert.Equal(t, spaceId, publishClient.expectedRequest.SpaceId)
+		assert.Equal(t, expectedUri, publishClient.expectedRequest.Uri)
+	})
 	t.Run("success", func(t *testing.T) {
 		// given
 		isPersonal := true

--- a/tests/publish_html_spa_exporter_test.go
+++ b/tests/publish_html_spa_exporter_test.go
@@ -1,0 +1,199 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/publish"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
+)
+
+func TestSingleFileHtmlBuilder_BuildSPA(t *testing.T) {
+	tempDir := t.TempDir()
+	objectsDir := filepath.Join(tempDir, "objects")
+	filesDir := filepath.Join(tempDir, "files")
+	require.NoError(t, os.MkdirAll(objectsDir, 0755))
+	require.NoError(t, os.MkdirAll(filesDir, 0755))
+
+	rootPageID := "root_page_1"
+	subPageID := "sub_page_2"
+
+	// 1. Create root page snapshot
+	rootSnap := &pb.SnapshotWithType{
+		SbType: model.SmartBlockType_Page,
+		Snapshot: &pb.ChangeSnapshot{
+			Data: &model.SmartBlockSnapshotBase{
+				Details: &types.Struct{
+					Fields: map[string]*types.Value{
+						"name": {Kind: &types.Value_StringValue{StringValue: "Root Welcome Page"}},
+					},
+				},
+				Blocks: []*model.Block{
+					{
+						Id:          "root_block",
+						Content:     &model.BlockContentOfSmartblock{},
+						ChildrenIds: []string{"header_block", "text_block", "callout_block", "link_block", "img_block"},
+					},
+					{
+						Id: "header_block",
+						Content: &model.BlockContentOfText{
+							Text: &model.BlockContentText{
+								Text:  "Welcome to Anytype Channel",
+								Style: model.BlockContentText_Header1,
+							},
+						},
+					},
+					{
+						Id: "text_block",
+						Content: &model.BlockContentOfText{
+							Text: &model.BlockContentText{
+								Text:  "This is a paragraph with bold and italic text.",
+								Style: model.BlockContentText_Paragraph,
+								Marks: &model.BlockContentTextMarks{
+									Marks: []*model.BlockContentTextMark{
+										{
+											Type:  model.BlockContentTextMark_Bold,
+											Range: &model.Range{From: 10, To: 19},
+										},
+										{
+											Type:  model.BlockContentTextMark_Italic,
+											Range: &model.Range{From: 34, To: 40},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Id: "callout_block",
+						Content: &model.BlockContentOfText{
+							Text: &model.BlockContentText{
+								Text:      "Important Callout Info",
+								Style:     model.BlockContentText_Callout,
+								IconEmoji: "💡",
+							},
+						},
+					},
+					{
+						Id: "link_block",
+						Content: &model.BlockContentOfText{
+							Text: &model.BlockContentText{
+								Text:  "Click here to view Sub Page",
+								Style: model.BlockContentText_Paragraph,
+								Marks: &model.BlockContentTextMarks{
+									Marks: []*model.BlockContentTextMark{
+										{
+											Type:  model.BlockContentTextMark_Link,
+											Param: "anytype://spaceId/" + subPageID,
+											Range: &model.Range{From: 11, To: 27},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Id: "img_block",
+						Content: &model.BlockContentOfFile{
+							File: &model.BlockContentFile{
+								Type:           model.BlockContentFile_Image,
+								Name:           "sample.png",
+								TargetObjectId: "img_obj_1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// 2. Create sub page snapshot
+	subSnap := &pb.SnapshotWithType{
+		SbType: model.SmartBlockType_Page,
+		Snapshot: &pb.ChangeSnapshot{
+			Data: &model.SmartBlockSnapshotBase{
+				Details: &types.Struct{
+					Fields: map[string]*types.Value{
+						"name": {Kind: &types.Value_StringValue{StringValue: "Sub Page Details"}},
+					},
+				},
+				Blocks: []*model.Block{
+					{
+						Id:          "sub_root_block",
+						Content:     &model.BlockContentOfSmartblock{},
+						ChildrenIds: []string{"sub_text"},
+					},
+					{
+						Id: "sub_text",
+						Content: &model.BlockContentOfText{
+							Text: &model.BlockContentText{
+								Text:  "Content of the sub-page.",
+								Style: model.BlockContentText_Paragraph,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rootBytes, err := proto.Marshal(rootSnap)
+	require.NoError(t, err)
+	subBytes, err := proto.Marshal(subSnap)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(objectsDir, rootPageID+".pb"), rootBytes, 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(objectsDir, subPageID+".pb"), subBytes, 0644))
+
+	// Create sample image file
+	require.NoError(t, os.WriteFile(filepath.Join(filesDir, "sample.png"), []byte("pngdata"), 0644))
+
+	// Run SPA builder
+	builder := publish.NewSingleFileHtmlBuilder()
+	htmlData, err := builder.BuildSPA(tempDir, rootPageID, "https://invite.anytype.io/123#456")
+	require.NoError(t, err)
+
+	htmlStr := string(htmlData)
+
+	// Verifications:
+	// 1. Root page rendered with active class and correct data-path
+	assert.Contains(t, htmlStr, `id="route-root_page_1"`)
+	assert.Contains(t, htmlStr, `data-path="/"`)
+	assert.Contains(t, htmlStr, `class="page active"`)
+
+	// 2. Sub page rendered with data-path="/sub_page_2"
+	assert.Contains(t, htmlStr, `id="route-sub_page_2"`)
+	assert.Contains(t, htmlStr, `data-path="/sub_page_2"`)
+
+	// 3. Headings, callout, bold, italic
+	assert.Contains(t, htmlStr, "<h2>Welcome to Anytype Channel</h2>")
+	assert.Contains(t, htmlStr, "<b>paragraph</b>")
+	assert.Contains(t, htmlStr, "<i>italic</i>")
+	assert.Contains(t, htmlStr, `class="callout"`)
+	assert.Contains(t, htmlStr, "💡")
+
+	// 4. Client-side link navigation transformed to navigate()
+	assert.Contains(t, htmlStr, `href="/sub_page_2" onclick="navigate(event, '/sub_page_2')"`)
+
+	// 5. Embedded script tag and CSS styling
+	assert.Contains(t, htmlStr, "<script>")
+	assert.Contains(t, htmlStr, "function navigate(e, path)")
+	assert.Contains(t, htmlStr, "function renderRoute(path)")
+	assert.Contains(t, htmlStr, "function toggleTheme()")
+	assert.Contains(t, htmlStr, ".page {")
+	assert.Contains(t, htmlStr, ".page.active {")
+
+	// 6. Invite banner link
+	assert.Contains(t, htmlStr, `href="https://invite.anytype.io/123#456"`)
+
+	// 7. Image file src reference
+	assert.True(t, strings.Contains(htmlStr, "files/sample.png") || strings.Contains(htmlStr, "data:image/png;base64,"))
+}


### PR DESCRIPTION
feat(publish): add single-file SPA HTML export for channels/pages

Adds an opt-in single-file HTML export mode for publishing, alongside the existing default publish pipeline, with zero changes to existing behavior.

## Single-File SPA HTML Generator (core/publish/html_spa_exporter.go)

- Implements SingleFileHtmlBuilder, which processes exported object snapshots (.pb files) from exportService.Export(..., IncludeNested: true) when publishing a channel/page.
- Page graph traversal: automatically discovers the root page and all nested sub-pages, profile pages, workspaces, and objects in the channel. Wraps each page into a <div id="route-<id>" data-path="/<id>" class="page"> section inside index.html.
- Block-to-HTML rendering: converts text (paragraphs, headings, callouts with emojis, quotes, code, bulleted/numbered lists), tables, layouts (columns/rows), dividers, bookmarks, and media/file attachments (<img>, <video>, <audio>, download links) into valid HTML. Small images (< 32KB) are embedded directly as inline base64 data URIs.
- Client-side JS routing: converts internal links (anytype://... or target page IDs) into client-side routing triggers, e.g. <a href="/<subPageId>" onclick="navigate(event, '/<subPageId>')">.
- Styling & themes: embeds a vanilla JS router (pushState, popstate, DOMContentLoaded) plus responsive CSS with dark/light theme toggle support (.page { display: none; } .page.active { display: block; }).

## Publishing Service Integration (core/publish/service.go)

- Opt-in format parsing: adds parseUriFormat(uri) to detect ?format=html_spa directly from the request URI, with no changes to .proto schema files or regenerated protobuf Go files (pb/commands.pb.go).
- Strips format query parameters before server registration so the public URI registered with publishclient stays clean (e.g., https://any.coop/identity/my-page).
- Bundles index.html alongside files/ in tempPublishDir, enforces existing size limits against default/membership publishing limits, and uploads the directory via publishClientService.UploadDir.

## Zero Regression & Compatibility

- Default publishing behavior (index.json.gz + files/) is 100% unchanged for standard requests.
- Fully compatible with anytype-publish-server (publishclient), gomobile C-bindings, and existing client applications.

## Testing

- Adds tests/publish_html_spa_exporter_test.go covering page graph traversal, client-side routing link transformations, media rendering, and vanilla JS router embedding.
- Updates core/publish/service_test.go to cover the Publish pipeline with ?format=html_spa.
- All publish unit tests pass with a 100% pass rate.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This PR adds a new opt-in single-file HTML export/publish format for channels and pages. When selected via `?format=html_spa` on the publish request, the entire channel (root page plus all nested sub-pages) is exported into one self-contained `index.html` file with built-in client-side routing, instead of the default `index.json.gz` snapshot bundle. This makes published channels viewable directly in any browser or static host, with no reader client required. Default publishing behavior is fully preserved.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents

- Closes https://github.com/anyproto/anytype-heart/issues/3248

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

Yes — frontend work is needed as a follow-up: the frontend (for both channels and pages) needs to be updated to support this new export mode, including handling sub-pages so they're included and navigable when publishing with `?format=html_spa`.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->