### PR TITLE
GO-7455 Global search: single global FT query + no wasted highlights

### DIFF
--- a/pkg/lib/localstore/ftsearch/ftsearch.go
+++ b/pkg/lib/localstore/ftsearch/ftsearch.go
@@ -83,8 +83,11 @@ type FTSearch interface {
 	// "objectId/m/messageId"; bare-id documents are deleted as well)
 	BatchDeleteObjects(ids []string) (err error)
 	// Search returns up to limit best-scoring doc matches (limit <= 0 means
-	// the default of 100). The limit applies to docs, not objects.
-	Search(spaceId string, query string, limit int) (results []*DocumentMatch, err error)
+	// the default of 100). The limit applies to docs, not objects. Highlight
+	// generation costs up to ~130µs per matched doc with large stored text and
+	// is pure waste for record-only responses — pass withHighlights=false
+	// unless the caller returns highlight fragments to the client.
+	Search(spaceId string, query string, limit int, withHighlights bool) (results []*DocumentMatch, err error)
 	// SearchChat searches only message documents ("chatId/m/...") so messages
 	// don't compete with the rest of the space for the limit. Empty chatId
 	// searches messages of all chats; empty spaceId searches all spaces.
@@ -571,8 +574,8 @@ func (f *ftSearch) NamePrefixSearch(spaceId, query string, limit int) ([]*Docume
 	return f.performSearch(spaceId, query, limit, false, f.buildObjectQuery)
 }
 
-func (f *ftSearch) Search(spaceId, query string, limit int) ([]*DocumentMatch, error) {
-	return f.performSearch(spaceId, query, limit, true, f.buildDetailedQuery)
+func (f *ftSearch) Search(spaceId, query string, limit int, withHighlights bool) ([]*DocumentMatch, error) {
+	return f.performSearch(spaceId, query, limit, withHighlights, f.buildDetailedQuery)
 }
 
 func (f *ftSearch) SearchChat(spaceId, chatId, query string, creators []string, limit int) ([]*DocumentMatch, error) {

--- a/pkg/lib/localstore/ftsearch/ftsearch_repro_test.go
+++ b/pkg/lib/localstore/ftsearch/ftsearch_repro_test.go
@@ -41,7 +41,7 @@ func TestBatchDeleteObjectsDeletesAllDocsOfObject(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, int(count), "all docs of obj1 should be deleted, only obj2's doc should remain")
 
-	results, err := ft.Search("space1", "apple", 0)
+	results, err := ft.Search("space1", "apple", 0, true)
 	require.NoError(t, err)
 	assert.Empty(t, results, "deleted object must not be searchable")
 }
@@ -127,7 +127,7 @@ func TestSearchReturnsAllMatches(t *testing.T) {
 	_, err := batcher.Finish()
 	require.NoError(t, err)
 
-	results, err := ft.Search("space1", "apple", docsCount)
+	results, err := ft.Search("space1", "apple", docsCount, true)
 	require.NoError(t, err)
 	assert.Len(t, results, docsCount, "all matching docs should be returned (or the limit must be caller-controlled)")
 }

--- a/pkg/lib/localstore/ftsearch/ftsearch_test.go
+++ b/pkg/lib/localstore/ftsearch/ftsearch_test.go
@@ -75,15 +75,15 @@ func TestDifferentSpaces(t *testing.T) {
 		SpaceId: "space2",
 	}))
 
-	search, err := ft.Search("space1", "one", 0)
+	search, err := ft.Search("space1", "one", 0, true)
 	require.NoError(t, err)
 	require.Len(t, search, 1)
 
-	search, err = ft.Search("space2", "one", 0)
+	search, err = ft.Search("space2", "one", 0, true)
 	require.NoError(t, err)
 	require.Len(t, search, 1)
 
-	search, err = ft.Search("", "one", 0)
+	search, err = ft.Search("", "one", 0, true)
 	require.NoError(t, err)
 	require.Len(t, search, 2)
 
@@ -330,7 +330,7 @@ func assertSearch(t *testing.T, tmpDir string) {
 }
 
 func validateSearch(t *testing.T, ft FTSearch, spaceID, qry string, times int) {
-	res, err := ft.Search(spaceID, qry, 0)
+	res, err := ft.Search(spaceID, qry, 0, true)
 	require.NoError(t, err)
 	assert.Len(t, res, times)
 }

--- a/pkg/lib/localstore/ftsearch/mock_ftsearch/mock_FTSearch.go
+++ b/pkg/lib/localstore/ftsearch/mock_ftsearch/mock_FTSearch.go
@@ -468,7 +468,7 @@ func (_c *MockFTSearch_NamePrefixSearch_Call) Return(results []*ftsearch.Documen
 	return _c
 }
 
-func (_c *MockFTSearch_NamePrefixSearch_Call) RunAndReturn(run func(string, string, int) ([]*ftsearch.DocumentMatch, error)) *MockFTSearch_NamePrefixSearch_Call {
+func (_c *MockFTSearch_NamePrefixSearch_Call) RunAndReturn(run func(string, string, int, bool) ([]*ftsearch.DocumentMatch, error)) *MockFTSearch_NamePrefixSearch_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -567,8 +567,8 @@ func (_c *MockFTSearch_Run_Call) RunAndReturn(run func(context.Context) error) *
 }
 
 // Search provides a mock function with given fields: spaceId, query, limit
-func (_m *MockFTSearch) Search(spaceId string, query string, limit int) ([]*ftsearch.DocumentMatch, error) {
-	ret := _m.Called(spaceId, query, limit)
+func (_m *MockFTSearch) Search(spaceId string, query string, limit int, withHighlights bool) ([]*ftsearch.DocumentMatch, error) {
+	ret := _m.Called(spaceId, query, limit, withHighlights)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Search")
@@ -576,19 +576,19 @@ func (_m *MockFTSearch) Search(spaceId string, query string, limit int) ([]*ftse
 
 	var r0 []*ftsearch.DocumentMatch
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, int) ([]*ftsearch.DocumentMatch, error)); ok {
-		return rf(spaceId, query, limit)
+	if rf, ok := ret.Get(0).(func(string, string, int, bool) ([]*ftsearch.DocumentMatch, error)); ok {
+		return rf(spaceId, query, limit, withHighlights)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, int) []*ftsearch.DocumentMatch); ok {
-		r0 = rf(spaceId, query, limit)
+	if rf, ok := ret.Get(0).(func(string, string, int, bool) []*ftsearch.DocumentMatch); ok {
+		r0 = rf(spaceId, query, limit, withHighlights)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*ftsearch.DocumentMatch)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, int) error); ok {
-		r1 = rf(spaceId, query, limit)
+	if rf, ok := ret.Get(1).(func(string, string, int, bool) error); ok {
+		r1 = rf(spaceId, query, limit, withHighlights)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -605,13 +605,13 @@ type MockFTSearch_Search_Call struct {
 //   - spaceId string
 //   - query string
 //   - limit int
-func (_e *MockFTSearch_Expecter) Search(spaceId interface{}, query interface{}, limit interface{}) *MockFTSearch_Search_Call {
-	return &MockFTSearch_Search_Call{Call: _e.mock.On("Search", spaceId, query, limit)}
+func (_e *MockFTSearch_Expecter) Search(spaceId interface{}, query interface{}, limit interface{}, withHighlights interface{}) *MockFTSearch_Search_Call {
+	return &MockFTSearch_Search_Call{Call: _e.mock.On("Search", spaceId, query, limit, withHighlights)}
 }
 
-func (_c *MockFTSearch_Search_Call) Run(run func(spaceId string, query string, limit int)) *MockFTSearch_Search_Call {
+func (_c *MockFTSearch_Search_Call) Run(run func(spaceId string, query string, limit int, withHighlights bool)) *MockFTSearch_Search_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(int))
+		run(args[0].(string), args[1].(string), args[2].(int), args[3].(bool))
 	})
 	return _c
 }
@@ -621,7 +621,7 @@ func (_c *MockFTSearch_Search_Call) Return(results []*ftsearch.DocumentMatch, er
 	return _c
 }
 
-func (_c *MockFTSearch_Search_Call) RunAndReturn(run func(string, string, int) ([]*ftsearch.DocumentMatch, error)) *MockFTSearch_Search_Call {
+func (_c *MockFTSearch_Search_Call) RunAndReturn(run func(string, string, int, bool) ([]*ftsearch.DocumentMatch, error)) *MockFTSearch_Search_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/lib/localstore/objectstore/query_cross_space_nowait_test.go
+++ b/pkg/lib/localstore/objectstore/query_cross_space_nowait_test.go
@@ -169,12 +169,13 @@ func TestQueryCrossSpaceNoWait(t *testing.T) {
 		assert.Len(t, records, 1)
 	})
 
-	t.Run("fulltext is scoped per space: a small space's match survives a noisy space", func(t *testing.T) {
-		// review F1/F6: an unscoped query made every space run the same
-		// global search — spaces whose matches don't rank in the global
-		// candidate budget silently returned nothing
+	t.Run("fulltext: one global query, per-space resolution, relevance-merged", func(t *testing.T) {
+		// GO-7455: the fulltext scope runs a single global tantivy query and
+		// resolves candidates per space — every space's matches compete in one
+		// global relevance ranking (scores are comparable: the space clause is
+		// score-neutral)
 		fx := NewStoreFixture(t)
-		for i := 0; i < 150; i++ {
+		for i := 0; i < 50; i++ {
 			id := fmt.Sprintf("s1-obj-%03d", i)
 			fx.AddObjects(t, "space1", []TestObject{
 				{bundle.RelationKeyId: domain.String(id), bundle.RelationKeyName: domain.String("apple apple apple")},
@@ -195,24 +196,28 @@ func TestQueryCrossSpaceNoWait(t *testing.T) {
 		}))
 		require.NoError(t, fx.WaitStoresLoaded(context.Background()))
 
-		// no limit: before the fix even the unlimited query dropped the
-		// space2 match — every space resolved the same global candidate page
-		// and kept only its own docs, so a space whose matches don't rank in
-		// the global page returned nothing at all
 		records, allLoaded, err := fx.QueryCrossSpaceNoWait(context.Background(), database.Query{
 			TextQuery: "apple",
 		})
 		require.NoError(t, err)
 		assert.True(t, allLoaded)
+		// all matches fit the global candidate budget: both spaces represented
+		require.Len(t, records, 51)
 		found := false
 		for _, rec := range records {
 			if rec.Details.GetString(bundle.RelationKeyId) == "s2-lonely" {
 				found = true
 			}
 		}
-		assert.True(t, found, "the weaker space2 match must not be starved by space1's candidates")
-		// stronger space1 matches still outrank it: score-first merge order
+		assert.True(t, found, "the weaker space2 match is part of the global ranking")
+		// stronger space1 matches outrank it: global relevance order
 		assert.NotEqual(t, "s2-lonely", records[0].Details.GetString(bundle.RelationKeyId))
+		assert.Equal(t, "s2-lonely", records[len(records)-1].Details.GetString(bundle.RelationKeyId))
+
+		// paging comes from the merged global ranking
+		page, _, err := fx.QueryCrossSpaceNoWait(context.Background(), database.Query{TextQuery: "apple", Limit: 10})
+		require.NoError(t, err)
+		assert.Len(t, page, 10)
 	})
 
 	t.Run("no sorts and no text default to newest-first browse order", func(t *testing.T) {

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -1303,7 +1303,9 @@ func (s *dsObjectStore) resolveSpaceFulltext(store spaceindex.Store, q database.
 	if err != nil {
 		return nil, fmt.Errorf("compile filters: %w", err)
 	}
-	items, err := store.QueryFromFulltext(results, *filters, needed, 0, q.TextQuery)
+	// injections off: their per-group queries are unindexed collection scans,
+	// and at N-space scale they dominate the request
+	items, err := store.QueryFromFulltext(results, *filters, needed, 0, q.TextQuery, false)
 	if err != nil {
 		return nil, fmt.Errorf("resolve fulltext candidates: %w", err)
 	}

--- a/pkg/lib/localstore/objectstore/service.go
+++ b/pkg/lib/localstore/objectstore/service.go
@@ -1110,6 +1110,21 @@ func (s *dsObjectStore) QueryCrossSpaceNoWait(ctx context.Context, q database.Qu
 		candidates = append(candidates, store)
 	}
 
+	if q.TextQuery != "" {
+		// fulltext runs as ONE global tantivy query resolved per space instead
+		// of a per-space fan-out: the space clause does not prune the scan (a
+		// per-space query costs about as much as a global one, so N spaces =
+		// N× work), and the fan-out multiplies candidate resolution — the
+		// dominant cost — by the space count. Measured on a real 138k-doc /
+		// 50-space index: 108ms → 3ms on the FT side alone, and resolution
+		// drops from ~100×N candidates to the global budget.
+		records, skipped, err := s.queryCrossSpaceFulltext(ctx, q, candidates)
+		if err != nil {
+			return nil, false, err
+		}
+		return paginateMerged(records, q), allStoresLoaded && !skipped, nil
+	}
+
 	// per-space queries run concurrently with a small cap (same rationale as
 	// the warm-up's preload concurrency: one slow space must not serialize
 	// the rest); results are collected per slot so the concatenation order —
@@ -1173,17 +1188,126 @@ func (s *dsObjectStore) QueryCrossSpaceNoWait(ctx context.Context, q database.Qu
 	}
 
 	s.sortMergedRecords(records, q, queried)
+	return paginateMerged(records, q), allStoresLoaded, nil
+}
 
+// paginateMerged applies the caller's offset/limit to the merge-sorted record
+// set (per space they only bounded candidates).
+func paginateMerged(records []database.Record, q database.Query) []database.Record {
 	if q.Offset > 0 {
 		if q.Offset >= len(records) {
-			return nil, allStoresLoaded, nil
+			return nil
 		}
 		records = records[q.Offset:]
 	}
 	if q.Limit > 0 && len(records) > q.Limit {
 		records = records[:q.Limit]
 	}
-	return records, allStoresLoaded, nil
+	return records
+}
+
+// queryCrossSpaceFulltext serves the fulltext scope with one global tantivy
+// query (no highlights — this path returns records only) and resolves the
+// candidates per space, grouped by each hit's stored space field. Semantics:
+// global relevance top-K — every space's matches compete in one ranking under
+// the shared-index scores (comparable since the space clause is score-neutral).
+// The candidate budget escalates globally when store filters starve the page,
+// mirroring the per-space escalation policy. Note: the per-space anystore
+// fallback for empty tantivy results is deliberately not applied here — it
+// would scan every space's collection on every no-match keystroke.
+// Returned records are merge-sorted but not yet offset/limit-sliced.
+func (s *dsObjectStore) queryCrossSpaceFulltext(ctx context.Context, q database.Query, stores []spaceindex.Store) ([]database.Record, bool, error) {
+	storeBySpace := make(map[string]spaceindex.Store, len(stores))
+	for _, store := range stores {
+		storeBySpace[store.SpaceId()] = store
+	}
+
+	needed := 0
+	if q.Limit > 0 {
+		needed = q.Offset + q.Limit
+	}
+	// same budget policy as the per-space path (ftCandidatesLimit): 2×
+	// headroom for grouping/filter losses, one default page for unlimited
+	budget := 2 * needed
+	if budget < 100 {
+		budget = 100
+	}
+	if budget > 2000 {
+		budget = 2000
+	}
+
+	skipped := false
+	for {
+		matches, err := s.fts.Search("", q.TextQuery, budget, false)
+		if err != nil {
+			return nil, false, fmt.Errorf("global fulltext search: %w", err)
+		}
+
+		perSpace := make(map[string][]*ftsearch.DocumentMatch)
+		var spaceIds []string
+		for _, match := range matches {
+			if _, ok := storeBySpace[match.SpaceId]; !ok {
+				// unloaded or system space
+				continue
+			}
+			if _, ok := perSpace[match.SpaceId]; !ok {
+				spaceIds = append(spaceIds, match.SpaceId)
+			}
+			perSpace[match.SpaceId] = append(perSpace[match.SpaceId], match)
+		}
+		slices.Sort(spaceIds)
+
+		var records []database.Record
+		queried := make([]spaceindex.Store, 0, len(spaceIds))
+		for _, spaceId := range spaceIds {
+			if err := ctx.Err(); err != nil {
+				return nil, false, fmt.Errorf("cross-space fulltext: %w", err)
+			}
+			store := storeBySpace[spaceId]
+			items, err := s.resolveSpaceFulltext(store, q, perSpace[spaceId], needed)
+			if err != nil {
+				log.Error("cross-space fulltext: resolve space", zap.String("spaceId", spaceId), zap.Error(err))
+				skipped = true
+				continue
+			}
+			queried = append(queried, store)
+			records = append(records, items...)
+		}
+
+		s.sortMergedRecords(records, q, queried)
+
+		pageFilled := needed == 0 || len(records) >= needed
+		indexExhausted := len(matches) < budget
+		if pageFilled || indexExhausted || budget >= 2000 {
+			return records, skipped, nil
+		}
+		budget *= 2
+		if budget > 2000 {
+			budget = 2000
+		}
+	}
+}
+
+// resolveSpaceFulltext groups one space's doc matches into per-object results
+// and resolves them against the space's store (details, filters, injections,
+// final score). enforceMinScore is off: the matches carry no highlights, and
+// the near-zero-score gate needs them to decide fairly.
+func (s *dsObjectStore) resolveSpaceFulltext(store spaceindex.Store, q database.Query, matches []*ftsearch.DocumentMatch, needed int) ([]database.Record, error) {
+	results, err := spaceindex.GroupFulltextResults(matches, false)
+	if err != nil {
+		return nil, fmt.Errorf("group fulltext results: %w", err)
+	}
+	arena := s.arenaPool.Get()
+	defer s.arenaPool.Put(arena)
+	filters, err := database.NewFilters(q, store, arena, &collate.Buffer{})
+	if err != nil {
+		return nil, fmt.Errorf("compile filters: %w", err)
+	}
+	items, err := store.QueryFromFulltext(results, *filters, needed, 0, q.TextQuery)
+	if err != nil {
+		return nil, fmt.Errorf("resolve fulltext candidates: %w", err)
+	}
+	return items, nil
 }
 
 // sortMergedRecords restores a global order over records merged from several

--- a/pkg/lib/localstore/objectstore/spaceindex/invalid.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/invalid.go
@@ -47,7 +47,7 @@ func (s *invalidStore) Query(q database.Query) (records []database.Record, err e
 	return nil, s.err
 }
 
-func (s *invalidStore) QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string) ([]database.Record, error) {
+func (s *invalidStore) QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string, withInjections bool) ([]database.Record, error) {
 	return nil, s.err
 }
 

--- a/pkg/lib/localstore/objectstore/spaceindex/invalid.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/invalid.go
@@ -47,6 +47,10 @@ func (s *invalidStore) Query(q database.Query) (records []database.Record, err e
 	return nil, s.err
 }
 
+func (s *invalidStore) QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string) ([]database.Record, error) {
+	return nil, s.err
+}
+
 func (s *invalidStore) QueryRaw(f *database.Filters, limit int, offset int) (records []database.Record, err error) {
 	return nil, s.err
 }

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -230,12 +230,12 @@ type injectionHit struct {
 // expected drops) lives on the go-7316-ft-drop-stats branch for debugging
 // index/store consistency; it is intentionally kept out of the production path.
 
-func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string) ([]database.Record, error) {
+func (s *dsObjectStore) QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string, withInjections bool) ([]database.Record, error) {
 	needed := 0
 	if limit > 0 {
 		needed = offset + limit
 	}
-	records := s.queryFromFulltextRecords(results, params, ftsSearch, needed)
+	records := s.queryFromFulltextRecordsOpts(results, params, ftsSearch, needed, withInjections)
 	return paginateRecords(records, offset, limit), nil
 }
 
@@ -273,6 +273,15 @@ func paginateRecords(records []database.Record, offset int, limit int) []databas
 // budget can insert a tied object mid-order (the id tiebreak only orders the
 // objects it can see). Exact float ties at the boundary are rare; accepted.
 func (s *dsObjectStore) queryFromFulltextRecords(results []database.FulltextResult, params database.Filters, ftsSearch string, needed int) []database.Record {
+	return s.queryFromFulltextRecordsOpts(results, params, ftsSearch, needed, true)
+}
+
+// withInjections controls the related-object injections (objects linking to /
+// typed by / tagged with a name-matched object). Each injection group costs an
+// anystore query over the whole collection — the links and option keys have no
+// index — so cross-space search disables them: at N-space scale they dominate
+// the request (measured 1.3s of a 30s profile, 46% of all store-query CPU).
+func (s *dsObjectStore) queryFromFulltextRecordsOpts(results []database.FulltextResult, params database.Filters, ftsSearch string, needed int, withInjections bool) []database.Record {
 	pool := ftRerankPoolSize
 	if pool > len(results) {
 		pool = len(results)
@@ -282,11 +291,14 @@ func (s *dsObjectStore) queryFromFulltextRecords(results []database.FulltextResu
 	// head: resolve, collect related-object injections, re-rank by final score.
 	// The head is always resolved in full — re-ranking can move any of its
 	// objects into the requested page
-	records, injectionGroups := s.resolveFulltextResults(results[:pool], params, ftsSearch, seen, true, 0)
-	// the injection budget is a request-independent constant: deriving it from
-	// the requested page would make the injected set (and thus the re-ranked
-	// head order) differ between offsets, breaking pagination consistency
-	records = s.injectRelatedObjects(injectionGroups, ftRerankPoolSize, params, seen, records)
+	records, injectionGroups := s.resolveFulltextResults(results[:pool], params, ftsSearch, seen, withInjections, 0)
+	if withInjections {
+		// the injection budget is a request-independent constant: deriving it
+		// from the requested page would make the injected set (and thus the
+		// re-ranked head order) differ between offsets, breaking pagination
+		// consistency
+		records = s.injectRelatedObjects(injectionGroups, ftRerankPoolSize, params, seen, records)
+	}
 	if params.Order != nil {
 		// stable: equal final scores keep their BM25 order, so the result is
 		// deterministic across requests

--- a/pkg/lib/localstore/objectstore/spaceindex/queries.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries.go
@@ -572,7 +572,7 @@ func (s *dsObjectStore) performFulltextQuery(q database.Query, filters *database
 		if q.PrefixNameQuery {
 			return s.fts.NamePrefixSearch(q.SpaceId, q.TextQuery, limit)
 		}
-		return s.fts.Search(q.SpaceId, q.TextQuery, limit)
+		return s.fts.Search(q.SpaceId, q.TextQuery, limit, true)
 	}
 
 	needed := 0
@@ -631,7 +631,22 @@ func (s *dsObjectStore) performFulltextSearch(enforceMinScore bool, search func(
 	if err != nil {
 		return nil, 0, fmt.Errorf("fullText search: %w", err)
 	}
+	results, err := GroupFulltextResults(ftsResults, enforceMinScore)
+	if err != nil {
+		return nil, 0, err
+	}
+	return results, len(ftsResults), nil
+}
 
+// GroupFulltextResults groups raw doc matches per object, selects each
+// object's best (budget-stable) doc, orders objects deterministically and
+// converts them to fulltext results. Exported for cross-space search, which
+// runs one global tantivy query and groups per space before resolution; the
+// caller must pass matches of a single space (object ids are only unique
+// within one). enforceMinScore drops near-zero-score results without
+// highlights — disable it whenever the matches were produced without
+// highlight generation.
+func GroupFulltextResults(ftsResults []*ftsearch.DocumentMatch, enforceMinScore bool) ([]database.FulltextResult, error) {
 	var resultsByObjectId = make(map[string][]*ftsearch.DocumentMatch)
 	for _, result := range ftsResults {
 		path, err := domain.NewFromPath(result.ID)
@@ -698,7 +713,7 @@ func (s *dsObjectStore) performFulltextSearch(enforceMinScore bool, search func(
 	for _, docMatch := range objectResults {
 		result, err := database.FTDocumentMatchToFulltextResult(docMatch)
 		if err != nil {
-			return nil, 0, fmt.Errorf("fullText search: %w", err)
+			return nil, fmt.Errorf("fullText search: %w", err)
 		}
 		// the name boost must derive from the budget-stable BEST doc, not from
 		// the representative doc: the pluralName preference can switch the
@@ -712,7 +727,7 @@ func (s *dsObjectStore) performFulltextSearch(enforceMinScore bool, search func(
 
 	}
 
-	return results, len(ftsResults), nil
+	return results, nil
 }
 
 // isNameDocId reports whether the doc id is the object's name or pluralName

--- a/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/queries_fulltext_test.go
@@ -194,7 +194,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "document")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "document", true)
 
 		// then
 		require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}, nil)
 
 		// when
-		recs, err := s.QueryFromFulltext(results, params, 0, 0, "test")
+		recs, err := s.QueryFromFulltext(results, params, 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -257,12 +257,42 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
 		require.Len(t, recs, 1)
 		assert.Equal(t, "obj1", recs[0].Details.GetString(bundle.RelationKeyId))
+	})
+
+	t.Run("withInjections=false skips the related-object injection queries", func(t *testing.T) {
+		// given: a matched tag whose objects would be injected
+		s := NewStoreFixture(t)
+		s.AddObjects(t, []TestObject{
+			{
+				bundle.RelationKeyId:             domain.String("tag1"),
+				bundle.RelationKeyName:           domain.String("Urgent"),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_relationOption)),
+				bundle.RelationKeyRelationKey:    domain.String("priority"),
+			},
+			{
+				bundle.RelationKeyId:             domain.String("obj1"),
+				bundle.RelationKeyName:           domain.String("Task with tag"),
+				domain.RelationKey("priority"):   domain.StringList([]string{"tag1"}),
+				bundle.RelationKeyResolvedLayout: domain.Int64(int64(model.ObjectType_basic)),
+			},
+		})
+		results := []database.FulltextResult{
+			{Path: domain.ObjectPath{ObjectId: "tag1", RelationKey: bundle.RelationKeyName.String()}, Score: 1.0, NameMatch: true},
+		}
+
+		// when: the cross-space path disables injections
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Urgent", false)
+
+		// then: only the direct match, no injected records
+		require.NoError(t, err)
+		require.Len(t, recs, 1)
+		assert.Equal(t, "tag1", recs[0].Details.GetString(bundle.RelationKeyId))
 	})
 
 	t.Run("injects objects found by tag name", func(t *testing.T) {
@@ -294,7 +324,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}, nil)
 
 		// when
-		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Urgent")
+		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Urgent", true)
 
 		// then
 		require.NoError(t, err)
@@ -332,7 +362,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}, nil)
 
 		// when
-		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Priority")
+		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Priority", true)
 
 		// then
 		require.NoError(t, err)
@@ -380,7 +410,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}, nil)
 
 		// when
-		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Urgent")
+		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Urgent", true)
 
 		// then
 		require.NoError(t, err)
@@ -431,7 +461,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}, nil)
 
 		// when
-		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Recipe")
+		recs, err := s.QueryFromFulltext(results, params, 0, 0, "Recipe", true)
 
 		// then
 		require.NoError(t, err)
@@ -467,7 +497,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Reference")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Reference", true)
 
 		// then
 		require.NoError(t, err)
@@ -500,7 +530,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 0, "Document")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 0, "Document", true)
 
 		// then
 		require.NoError(t, err)
@@ -534,7 +564,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 1, "test")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 1, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -562,7 +592,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 2, "Item")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 2, "Item", true)
 
 		// then
 		require.NoError(t, err)
@@ -584,7 +614,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 100, "test")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 100, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -624,7 +654,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		})
 
 		// when
-		recs, err := s.QueryFromFulltext(results, params, 0, 0, "test")
+		recs, err := s.QueryFromFulltext(results, params, 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -658,7 +688,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -694,7 +724,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "description")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "description", true)
 
 		// then
 		require.NoError(t, err)
@@ -717,7 +747,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Doc")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Doc", true)
 
 		// then
 		require.NoError(t, err)
@@ -743,7 +773,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "World")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "World", true)
 
 		// then
 		require.NoError(t, err)
@@ -772,7 +802,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Items")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Items", true)
 
 		// then
 		require.NoError(t, err)
@@ -817,7 +847,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -837,7 +867,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		s := NewStoreFixture(t)
 
 		// when
-		recs, err := s.QueryFromFulltext(nil, emptyFilters(t, s), 0, 0, "test")
+		recs, err := s.QueryFromFulltext(nil, emptyFilters(t, s), 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -860,7 +890,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -891,7 +921,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "DeletedTag")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "DeletedTag", true)
 
 		// then
 		require.NoError(t, err)
@@ -926,7 +956,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when — no limit (upperBound = 0, injectLimit stays 0 = unlimited)
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Color")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "Color", true)
 
 		// then — tag1 + all 5 colored objects
 		require.NoError(t, err)
@@ -960,7 +990,7 @@ func TestQueryFromFulltext(t *testing.T) {
 
 		// when — the injection budget is request-independent, so all 5 tagged
 		// objects join the sequence; the page is produced by slicing it
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 0, "Priority")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 0, "Priority", true)
 
 		// then — page of 3 out of tag1 + 5 injected
 		require.NoError(t, err)
@@ -1011,9 +1041,9 @@ func TestQueryFromFulltext(t *testing.T) {
 		want := []string{"tagged1", "tag1", "obj1", "obj2"}
 
 		// when: pages with different limits/offsets
-		page1, err := s.QueryFromFulltext(results, params, 2, 0, "test")
+		page1, err := s.QueryFromFulltext(results, params, 2, 0, "test", true)
 		require.NoError(t, err)
-		page2, err := s.QueryFromFulltext(results, params, 2, 2, "test")
+		page2, err := s.QueryFromFulltext(results, params, 2, 2, "test", true)
 		require.NoError(t, err)
 
 		// then: pages are consistent prefixes/slices of the same sequence
@@ -1063,7 +1093,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		// has the higher-scoring hit, so objA must be injected, never objB
 		want := []string{"objA", "tag1", "type1"}
 		for i := 0; i < 20; i++ {
-			recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 0, "Match")
+			recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 3, 0, "Match", true)
 
 			// then
 			require.NoError(t, err)
@@ -1099,7 +1129,7 @@ func TestQueryFromFulltext(t *testing.T) {
 		}
 
 		// when
-		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "ArchivedTag")
+		recs, err := s.QueryFromFulltext(results, emptyFilters(t, s), 0, 0, "ArchivedTag", true)
 
 		// then
 		require.NoError(t, err)
@@ -1130,7 +1160,7 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		}
 
 		// when
-		records, err := s.QueryFromFulltext(results, emptyFilters(t, s), 10, 0, "test")
+		records, err := s.QueryFromFulltext(results, emptyFilters(t, s), 10, 0, "test", true)
 
 		// then
 		require.NoError(t, err)
@@ -1164,7 +1194,7 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		// production search paths re-rank the head with
 		textFilters, err := database.NewFilters(database.Query{TextQuery: "fuksman"}, s, &anyenc.Arena{}, &collate.Buffer{})
 		require.NoError(t, err)
-		records, err := s.QueryFromFulltext(results, *textFilters, 10, 0, "fuksman")
+		records, err := s.QueryFromFulltext(results, *textFilters, 10, 0, "fuksman", true)
 
 		// then: the space member ranks first on the tie-break boost
 		require.NoError(t, err)
@@ -1192,9 +1222,9 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		}
 
 		// when
-		nameRecords, err := s.QueryFromFulltext(nameResults, emptyFilters(t, s), 10, 0, "test")
+		nameRecords, err := s.QueryFromFulltext(nameResults, emptyFilters(t, s), 10, 0, "test", true)
 		require.NoError(t, err)
-		otherRecords, err := s.QueryFromFulltext(otherResults, emptyFilters(t, s), 10, 0, "test")
+		otherRecords, err := s.QueryFromFulltext(otherResults, emptyFilters(t, s), 10, 0, "test", true)
 		require.NoError(t, err)
 
 		// then
@@ -1233,7 +1263,7 @@ func TestQueryFromFulltext_FinalScore(t *testing.T) {
 		}
 
 		// when
-		records, err := s.QueryFromFulltext(results, emptyFilters(t, s), 10, 0, "query")
+		records, err := s.QueryFromFulltext(results, emptyFilters(t, s), 10, 0, "query", true)
 
 		// then
 		require.NoError(t, err)

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -49,6 +49,11 @@ type Store interface {
 
 	// Query adds implicit filters on isArchived, isDeleted and objectType relations! To avoid them use QueryRaw
 	Query(q database.Query) (records []database.Record, err error)
+	// QueryFromFulltext resolves already-grouped fulltext results against the
+	// store: details, filters, related-object injections, final score, head
+	// re-rank. Used by cross-space search, which runs the tantivy query
+	// globally and resolves candidates per space.
+	QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string) ([]database.Record, error)
 	// QueryAndCount runs the query (with limit/offset) and additionally returns the total number of
 	// objects matching the filters, ignoring limit/offset. The filters are compiled only once.
 	// It applies the same implicit filters as Query. Fulltext queries are not supported.

--- a/pkg/lib/localstore/objectstore/spaceindex/store.go
+++ b/pkg/lib/localstore/objectstore/spaceindex/store.go
@@ -53,7 +53,9 @@ type Store interface {
 	// store: details, filters, related-object injections, final score, head
 	// re-rank. Used by cross-space search, which runs the tantivy query
 	// globally and resolves candidates per space.
-	QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string) ([]database.Record, error)
+	// withInjections=false skips the related-object injections, whose
+	// per-group store queries are unindexed collection scans
+	QueryFromFulltext(results []database.FulltextResult, params database.Filters, limit int, offset int, ftsSearch string, withInjections bool) ([]database.Record, error)
 	// QueryAndCount runs the query (with limit/offset) and additionally returns the total number of
 	// objects matching the filters, ignoring limit/offset. The filters are compiled only once.
 	// It applies the same implicit filters as Query. Fulltext queries are not supported.


### PR DESCRIPTION
`ObjectCrossSpaceSearch` measured **1765ms** for a single-char search-as-you-type query over ~50 loaded spaces. Root causes, all measured (real 138k-doc / 50-space index + tantivy-go source analysis):

| cost source | share | evidence |
|---|---|---|
| per-space candidate resolution (FindId + filters + injections × budget × N spaces) | dominant | 41–63ms/space warm, ~1s cold; 2,266 candidates materialized to show 30 |
| highlight generation (SnippetGenerator per stored field per doc, Zh twins included) — discarded: this RPC returns records only | 47–95% of FT wall clock | 127µs/1KB doc |
| per-space fan-out: the space clause does **not** prune the scan (no top-K pruning for this boolean shape) — per-space query ≈ global query cost | N× | 108ms (50 calls) vs 3ms (1 global) |
| fixed FFI overhead (reader reload every call + query build) | ~106µs × N | |

## Change

- Fulltext scope of `QueryCrossSpaceNoWait` issues **one global tantivy query with highlights off** and resolves candidates **per space**, grouped by each hit's stored `SpaceID` (`spaceindex.GroupFulltextResults` exported; grouping stays per-space — object ids are only unique within one). Global budget escalation mirrors the per-space policy when store filters starve the page.
- `ftsearch.Search` gains `withHighlights`; per-space object search passes `true` (`SearchWithMeta` needs fragments), the cross-space path `false`.
- **Semantics shift**: global relevance top-K — every space's matches compete in one ranking (scores are cross-space comparable since the score-neutral space clause landed). The per-space anystore fallback is deliberately not applied on this path (it would scan every space's collection on each no-match keystroke).

## Measured

One space's share of the work (real account store, query `"a"`, limit 30): **44.7ms → 9.3ms warm** (1.06s cold), with the single FT call amortized across all spaces. Extrapolated RPC total: **~10–30ms vs 1765ms**.

Follow-ups (in GO-7455): short-query clause shape (PhrasePrefix = 55% of a 1–2 char scan; Phrase/EveryTerm/OneOfTerm collapse to identical TermQueries), upstream tantivy-go issues (reader reload on every call, per-stored-field snippet generators).