### PR TITLE
GO-7459 Collect single-value object relations as dependent objects

### DIFF
--- a/core/block/export/export_test.go
+++ b/core/block/export/export_test.go
@@ -703,6 +703,9 @@ func Test_docsForExport(t *testing.T) {
 	t.Run("get relation options - no relation options", func(t *testing.T) {
 		// given
 		fx := newFixture(t)
+		// the state carries a single-value status/tag relation; its value is now collected as a
+		// dependency (it was silently dropped before), so the type lookup has to be stubbed
+		fx.sbtProvider.EXPECT().Type(spaceId, "value").Return(smartblock.SmartBlockTypePage, nil).Maybe()
 
 		fx.store.AddObjects(t, spaceId, []objectstore.TestObject{
 			{
@@ -746,6 +749,9 @@ func Test_docsForExport(t *testing.T) {
 	t.Run("get relation options - 1 relation option", func(t *testing.T) {
 		// given
 		fx := newFixture(t)
+		// the state carries a single-value status/tag relation; its value is now collected as a
+		// dependency (it was silently dropped before), so the type lookup has to be stubbed
+		fx.sbtProvider.EXPECT().Type(spaceId, "value").Return(smartblock.SmartBlockTypePage, nil).Maybe()
 
 		fx.store.AddObjects(t, spaceId, []objectstore.TestObject{
 			{
@@ -795,6 +801,9 @@ func Test_docsForExport(t *testing.T) {
 	t.Run("get derived objects - relation, object type with recommended relations, template with link", func(t *testing.T) {
 		// given
 		fx := newFixture(t)
+		// the state carries a single-value status/tag relation; its value is now collected as a
+		// dependency (it was silently dropped before), so the type lookup has to be stubbed
+		fx.sbtProvider.EXPECT().Type(spaceId, "value").Return(smartblock.SmartBlockTypePage, nil).Maybe()
 		recommendedRelationKey := domain.RelationKey("recommendedRelationKey")
 		templateId := "templateId"
 		templateObjectTypeId := "templateObjectTypeId"

--- a/core/block/object/objectlink/dependent_objects.go
+++ b/core/block/object/objectlink/dependent_objects.go
@@ -3,6 +3,7 @@ package objectlink
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -184,6 +185,34 @@ func collectIdsFromTypes(s *state.State, converter KeyToIDConverter) (ids []stri
 	return ids
 }
 
+// relationsExcludedFromDeps lists object/file-format relations whose value must never be collected
+// as a dependent object. Three kinds live here:
+//   - references outside this space's graph (spaceId, sourceObject pointing at a bundled or
+//     marketplace object, identityProfileLink);
+//   - infrastructure pointers the client never renders as a chip (chatId, discussionId,
+//     spaceDashboardId, targetObjectType, defaultTypeId, defaultTemplateId);
+//   - file ids rendered straight from the id rather than from the file object's record
+//     (iconImage, coverId, picture).
+//
+// The list only guards the generic relation-value walk at the bottom of collectIdsFromDetail. The
+// explicit branches above it (creator/lastModifiedBy behind CreatorModifierWorkspace, and coverId's
+// CID check) keep their own behaviour — coverId is listed here so the generic walk never picks it
+// up, not to disable that branch.
+var relationsExcludedFromDeps = []domain.RelationKey{
+	bundle.RelationKeySpaceId,
+	bundle.RelationKeySourceObject,
+	bundle.RelationKeyIdentityProfileLink,
+	bundle.RelationKeyChatId,
+	bundle.RelationKeyDiscussionId,
+	bundle.RelationKeySpaceDashboardId,
+	bundle.RelationKeyTargetObjectType,
+	bundle.RelationKeyDefaultTypeId,
+	bundle.RelationKeyDefaultTemplateId,
+	bundle.RelationKeyIconImage,
+	bundle.RelationKeyCoverId,
+	bundle.RelationKeyPicture,
+}
+
 func collectIdsFromDetail(rel *model.RelationLink, det *domain.Details, flags Flags) (ids []string) {
 	if flags.NoSystemRelations {
 		if rel.Format != model.RelationFormat_object || bundle.IsSystemRelation(domain.RelationKey(rel.Key)) {
@@ -247,8 +276,14 @@ func collectIdsFromDetail(rel *model.RelationLink, det *domain.Details, flags Fl
 		return
 	}
 
-	// add all object relation values as dependents
-	for _, targetID := range det.GetStringList(domain.RelationKey(rel.Key)) {
+	if slices.Contains(relationsExcludedFromDeps, domain.RelationKey(rel.Key)) {
+		return
+	}
+
+	// add all object relation values as dependents. WrapToStringList, not GetStringList: a
+	// maxCount=1 relation (createdInContext, and every single-value object/tag/status relation)
+	// holds a plain string, which GetStringList silently reports as no value at all.
+	for _, targetID := range det.WrapToStringList(domain.RelationKey(rel.Key)) {
 		if targetID != "" {
 			ids = append(ids, targetID)
 		}

--- a/core/block/object/objectlink/dependent_objects_test.go
+++ b/core/block/object/objectlink/dependent_objects_test.go
@@ -264,7 +264,8 @@ func TestState_DepSmartIdsLinksAndRelations(t *testing.T) {
 			Format: model.RelationFormat_object,
 		})
 		objectIDs := DependentObjectIDs(st, converter, fetcher, Flags{Details: true})
-		assert.Len(t, objectIDs, 1)
+		// the 4 single-value relations above + the backlink
+		assert.Len(t, objectIDs, 5)
 		assert.Contains(t, objectIDs, "link1")
 	})
 	t.Run("skip backlinks", func(t *testing.T) {
@@ -275,7 +276,8 @@ func TestState_DepSmartIdsLinksAndRelations(t *testing.T) {
 			Format: model.RelationFormat_object,
 		})
 		objectIDs := DependentObjectIDs(st, converter, fetcher, Flags{Details: true, NoBackLinks: true})
-		assert.Len(t, objectIDs, 0)
+		assert.Len(t, objectIDs, 4)
+		assert.NotContains(t, objectIDs, "link1")
 	})
 }
 
@@ -468,4 +470,56 @@ func TestDependentObjectIDsPerSpace(t *testing.T) {
 	assert.Len(t, ids[spc1], 9)
 	assert.Len(t, ids[spc2], 3)
 	assert.Len(t, ids[spc3], 2)
+}
+
+func TestState_DepSmartIdsSingleValueRelations(t *testing.T) {
+	// given
+	newState := func() *state.State {
+		s := state.NewDoc("fileObj", nil).(*state.State)
+		s.SetDetail(bundle.RelationKeyCreatedInContext, domain.String("chatObjId"))
+		s.SetDetail(bundle.RelationKeyCreatedInContextRef, domain.String("messageId"))
+		return s
+	}
+	converter := &fakeConverter{}
+	fetcher := setupFetcher(t, pbtypes.RelationLinks{})
+	// the flags smartblock.dependentSmartIds passes
+	depFlags := Flags{Blocks: true, Details: true, Types: true, CreatorModifierWorkspace: true}
+
+	t.Run("createdInContext is a dependency", func(t *testing.T) {
+		// when
+		ids := DependentObjectIDs(newState(), converter, fetcher, depFlags)
+
+		// then: the ref is a shorttext locator, never an object
+		assert.Equal(t, []string{"chatObjId"}, ids)
+	})
+
+	t.Run("excluded relations are not dependencies", func(t *testing.T) {
+		// given
+		s := newState()
+		s.SetDetail(bundle.RelationKeyIconImage, domain.String("iconImageObjId"))
+		s.SetDetail(bundle.RelationKeySourceObject, domain.String("sourceObjId"))
+		s.SetDetail(bundle.RelationKeyChatId, domain.String("chatIdObjId"))
+		s.SetDetail(bundle.RelationKeySpaceId, domain.String("spaceObjId"))
+		want := []string{"chatObjId"}
+
+		// when
+		got := DependentObjectIDs(s, converter, fetcher, depFlags)
+
+		// then
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("createdInContext is skipped for the links detail", func(t *testing.T) {
+		// given: injectLinksDetails skips system relations, and createdInContext is one
+		linkFlags := Flags{
+			Blocks: true, Details: true, DataviewBlockOnlyTarget: true,
+			NoSystemRelations: true, NoHiddenBundledRelations: true, RoundDateIdsToDay: true,
+		}
+
+		// when
+		ids := DependentObjectIDs(newState(), converter, fetcher, linkFlags)
+
+		// then
+		assert.Empty(t, ids)
+	})
 }


### PR DESCRIPTION
Closes [GO-7459](https://linear.app/anytype/issue/GO-7459/single-value-object-relations-are-never-collected-as-dependent-objects)

## Problem

`createdInContext` never comes back as a dependent object, so a client opening a file/object created in a chat cannot resolve the context object's name or icon for the "Created in …" chip.

It is not specific to that relation: **every single-value (`maxCount: 1`) object/file/tag/status relation was silently dropped from deps.**

## Root cause

`collectIdsFromDetail` read relation values with `det.GetStringList(key)`. A `maxCount: 1` relation holds a plain string, and `GetStringList` reports a plain string as *no value at all*.

On a state carrying `createdInContext`, `iconImage`, `sourceObject` (single strings) and `assignee` (list), with the flags `smartblock.dependentSmartIds` passes:

```
deps -> [assigneeObj]   // only the list-valued relation survives
```

## Fix

`GetStringList` → `WrapToStringList`, plus a `relationsExcludedFromDeps` list guarding that walk so the wider fix does not sweep in relations that must never be deps:

| kind | keys |
|---|---|
| outside this space's graph | `spaceId`, `sourceObject` (bundled/marketplace object), `identityProfileLink` |
| infrastructure pointers, never rendered as a chip | `chatId`, `discussionId`, `spaceDashboardId`, `targetObjectType`, `defaultTypeId`, `defaultTemplateId` |
| file ids rendered from the id, not the record | `iconImage`, `coverId`, `picture` |

`coverId` is already a dep via an explicit `cid.Decode`-guarded branch further up. It is listed so the *generic* walk never picks it up; that branch is intact, so cover behaviour is unchanged.

`creator` / `lastModifiedBy` needed nothing — they have their own branch behind `CreatorModifierWorkspace` that returns before the walk.

## Not touched, deliberately

`injectLinksDetails` / `injectMentions` pass `NoSystemRelations: true` and `createdInContext` is a system relation, so `links` and `mentions` are unaffected (covered by a test). `relationsToSkipLinksIndexing` is unchanged, so the links table gains nothing and chat attachments still have no backlink to the chat — by design, see `canOwnOrphans` in `objectgc/orphanlist.go` and `docs/GO-7323-cascade-deletion-client-impl.md`.

## Also promoted by this fix

`company`, `status`, `deletedBy`, and every **custom** single-value object/tag/status relation, which previously produced no dep at all. This applies at all six `DependentObjectIDs` call sites, including export nesting and the graph view — worth a look during review.

## Tests

New `TestState_DepSmartIdsSingleValueRelations`: dep present, exclusions held out, still absent from `links`.

Updated expectations that encoded the dropped values:
- `TestState_DepSmartIdsLinksAndRelations` save/skip backlinks — asserted `Len 1`/`Len 0` on a state with four single-value relations; now `5`/`4`, with `Contains`/`NotContains` carrying the actual backlink intent.
- Three `Test_docsForExport` subtests needed a `Type(spaceId, "value")` mock stub now that the state's single-value status relation gets looked up. Doc counts unchanged, so no export behaviour moved.

Green: `objectlink`, `smartblock`, `export`, `history`, `subscription` (+ `crossspacesub`, `objectsubscription`).