### PR TITLE
GO-0000 Stop grpc server when desktop parent exits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,10 @@ jobs:
           COVERAGE=$(go tool cover -func coverage.out | grep total | awk '{print substr($3, 1, length($3)-1)}')
           echo "coverage_middleware $COVERAGE" | curl --data-binary @- --user "$prometheus_username:$prometheus_password" https://pushgateway.anytype.io/metrics/job/tech_quality
 
+      - name: Go test gRPC server
+        run: |
+          CGO_CFLAGS="-Wno-deprecated-non-prototype -Wno-unknown-warning-option -Wno-deprecated-declarations -Wno-xor-used-as-pow -Wno-single-bit-bitfield-constant-conversion" go test ./cmd/grpcserver
+
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN go mod download
 COPY . .
 
 # Install the binary
-RUN go build -o server ./cmd/grpcserver/grpc.go
+RUN go build -o server ./cmd/grpcserver
 
 FROM ubuntu
 

--- a/cmd/grpcserver/grpc.go
+++ b/cmd/grpcserver/grpc.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -14,7 +13,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -50,6 +48,26 @@ const grpcWebStartedMessagePrefix = "gRPC Web proxy started at: "
 var commonOSSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGINT}
 
 func main() {
+	// Establish parent ownership before any middleware initialization. If the
+	// owner is already gone, the monitor starts the hard-exit deadline even if
+	// startup later blocks before reaching the shutdown event loop.
+	lifelineEnabled := parentLifelineEnabled()
+	if lifelineEnabled {
+		ignoreBrokenPipeSignal()
+	}
+
+	var parentLifeline *parentLifelineMonitor
+	var parentLifelineChan <-chan parentLifelineEvent
+	if lifelineEnabled || shouldMonitorParentStdin() {
+		parentLifeline = startParentLifelineMonitor(
+			os.Stdin,
+			lifelineEnabled,
+			gracefulShutdownTimeout,
+			os.Exit,
+		)
+		parentLifelineChan = parentLifeline.events
+	}
+
 	var addr string
 	var webaddr string
 	app.StartWarningAfter = time.Second * 5
@@ -225,30 +243,29 @@ func main() {
 	}
 	// do not change this, js client relies on this msg to ensure that server is up and parse address
 	fmt.Println(grpcWebStartedMessagePrefix + webaddr)
-	if runtime.GOOS == "windows" {
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-			message := scanner.Text()
-			if message == "shutdown" {
-				fmt.Println("[anytype-heart] Shutdown: received shutdown msg, closing components...")
-				// Perform cleanup or exit
-				shutdown()
-				return
-			}
-		}
-	}
 
 	for {
-		sig := <-signalChan
-		if shouldSaveStack(sig) {
-			if err = mw.SaveGoroutinesStack(""); err != nil {
-				log.Errorf("failed to save stack of goroutines: %s", err)
+		select {
+		case <-parentLifelineChan:
+			// Do not write to stdout/stderr here. The event may be EOF because the
+			// owner disappeared and closed those pipes. The monitor independently
+			// enforces the hard deadline while cleanup runs.
+			shutdown()
+			parentLifeline.markShutdownComplete()
+			return
+		case sig := <-signalChan:
+			if shouldSaveStack(sig) {
+				if err = mw.SaveGoroutinesStack(""); err != nil {
+					log.Errorf("failed to save stack of goroutines: %s", err)
+				}
+				continue
 			}
-			continue
+			fmt.Printf("[anytype-heart] Shutdown: received OS signal (%s), closing components...\n", sig.String())
+			// Preserve the historical standalone-server contract: OS-signal
+			// shutdown is not subject to the desktop parent's lifeline deadline.
+			shutdown()
+			return
 		}
-		fmt.Printf("[anytype-heart] Shutdown: received OS signal (%s), closing components...\n", sig.String())
-		shutdown()
-		return
 	}
 }
 

--- a/cmd/grpcserver/lifeline.go
+++ b/cmd/grpcserver/lifeline.go
@@ -1,0 +1,148 @@
+//go:build !nogrpcserver && !_test
+// +build !nogrpcserver,!_test
+
+package main
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	parentLifelineEnv       = "ANYTYPE_PARENT_LIFELINE"
+	parentLifelineStdin     = "stdin"
+	gracefulShutdownTimeout = 10 * time.Second
+)
+
+type parentLifelineEvent string
+
+const (
+	parentLifelineShutdown parentLifelineEvent = "received shutdown message"
+	parentLifelineClosed   parentLifelineEvent = "parent lifeline closed"
+)
+
+type parentLifelineMonitor struct {
+	events   chan parentLifelineEvent
+	done     chan struct{}
+	stopped  chan struct{}
+	doneOnce sync.Once
+}
+
+type parentLifelineDeadline struct {
+	elapsed <-chan time.Time
+	stop    func()
+}
+
+type parentLifelineDeadlineFactory func(time.Duration) parentLifelineDeadline
+
+func parentLifelineEnabled() bool {
+	return os.Getenv(parentLifelineEnv) == parentLifelineStdin
+}
+
+func shouldMonitorParentStdin() bool {
+	// Older Windows clients already use the stdin shutdown command but do not
+	// set the lifeline environment variable. Preserve that protocol there.
+	return parentLifelineEnabled() || runtime.GOOS == "windows"
+}
+
+func startParentLifelineMonitor(
+	reader io.Reader,
+	closeOnEOF bool,
+	timeout time.Duration,
+	forceExit func(int),
+) *parentLifelineMonitor {
+	return startParentLifelineMonitorWithDeadline(reader, closeOnEOF, timeout, newParentLifelineDeadline, forceExit)
+}
+
+func startParentLifelineMonitorWithDeadline(
+	reader io.Reader,
+	closeOnEOF bool,
+	timeout time.Duration,
+	deadlineFactory parentLifelineDeadlineFactory,
+	forceExit func(int),
+) *parentLifelineMonitor {
+	monitor := &parentLifelineMonitor{
+		events:  make(chan parentLifelineEvent, 1),
+		done:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	go monitor.run(reader, closeOnEOF, timeout, deadlineFactory, forceExit)
+	return monitor
+}
+
+func newParentLifelineDeadline(timeout time.Duration) parentLifelineDeadline {
+	timer := time.NewTimer(timeout)
+	return parentLifelineDeadline{
+		elapsed: timer.C,
+		stop: func() {
+			timer.Stop()
+		},
+	}
+}
+
+func (m *parentLifelineMonitor) run(
+	reader io.Reader,
+	closeOnEOF bool,
+	timeout time.Duration,
+	deadlineFactory parentLifelineDeadlineFactory,
+	forceExit func(int),
+) {
+	defer close(m.stopped)
+
+	event, shouldShutdown := readParentLifeline(reader, closeOnEOF)
+	if !shouldShutdown {
+		return
+	}
+	if !closeOnEOF {
+		// Legacy Windows clients send the shutdown command without opting into
+		// parent ownership. Preserve their historical unbounded graceful stop.
+		notifyParentLifeline(m.events, event)
+		return
+	}
+
+	// Start the hard deadline here rather than in main so a dead owner cannot
+	// leave the helper alive when startup has not reached its event loop yet.
+	deadline := deadlineFactory(timeout)
+	defer deadline.stop()
+
+	notifyParentLifeline(m.events, event)
+	select {
+	case <-m.done:
+		return
+	case <-deadline.elapsed:
+		// This callback must not perform logging or any other blocking I/O.
+		// Parent-owned output pipes may be full or already closed.
+		forceExit(1)
+	}
+}
+
+func (m *parentLifelineMonitor) markShutdownComplete() {
+	m.doneOnce.Do(func() {
+		close(m.done)
+	})
+}
+
+func readParentLifeline(reader io.Reader, closeOnEOF bool) (parentLifelineEvent, bool) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == "shutdown" {
+			return parentLifelineShutdown, true
+		}
+	}
+
+	// Read errors fail closed for an opted-in owner, just like EOF. Do not log
+	// here: the parent-owned output pipes may be the source of the failure.
+	return parentLifelineClosed, closeOnEOF
+}
+
+func notifyParentLifeline(events chan<- parentLifelineEvent, event parentLifelineEvent) {
+	select {
+	case events <- event:
+	default:
+	}
+}

--- a/cmd/grpcserver/lifeline_posix.go
+++ b/cmd/grpcserver/lifeline_posix.go
@@ -1,0 +1,15 @@
+//go:build !nogrpcserver && !_test && !windows
+// +build !nogrpcserver,!_test,!windows
+
+package main
+
+import (
+	"os/signal"
+	"syscall"
+)
+
+func ignoreBrokenPipeSignal() {
+	// Electron owns stdout and stderr pipes. If it disappears, writes during
+	// cleanup must return EPIPE rather than terminating cleanup with SIGPIPE.
+	signal.Ignore(syscall.SIGPIPE)
+}

--- a/cmd/grpcserver/lifeline_posix_test.go
+++ b/cmd/grpcserver/lifeline_posix_test.go
@@ -1,0 +1,44 @@
+//go:build !nogrpcserver && !_test && !windows
+// +build !nogrpcserver,!_test,!windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+const lifelineSIGPIPEChildEnv = "ANYTYPE_LIFELINE_SIGPIPE_TEST_CHILD"
+
+func TestIgnoreBrokenPipeSignal(t *testing.T) {
+	if os.Getenv(lifelineSIGPIPEChildEnv) == "1" {
+		runBrokenPipeTestChild()
+		return
+	}
+
+	child := exec.Command(os.Args[0], "-test.run=^TestIgnoreBrokenPipeSignal$")
+	child.Env = append(os.Environ(), lifelineSIGPIPEChildEnv+"=1")
+	if err := child.Run(); err != nil {
+		t.Fatalf("process terminated while writing to closed stdout: %v", err)
+	}
+}
+
+func runBrokenPipeTestChild() {
+	ignoreBrokenPipeSignal()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		os.Exit(2)
+	}
+	_ = reader.Close()
+	if err = syscall.Dup2(int(writer.Fd()), int(os.Stdout.Fd())); err != nil {
+		os.Exit(2)
+	}
+	_ = writer.Close()
+
+	if _, err = os.Stdout.Write([]byte("closed pipe")); err == nil {
+		os.Exit(3)
+	}
+	os.Exit(0)
+}

--- a/cmd/grpcserver/lifeline_test.go
+++ b/cmd/grpcserver/lifeline_test.go
@@ -1,0 +1,299 @@
+//go:build !nogrpcserver && !_test
+// +build !nogrpcserver,!_test
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	lifelineTestRoleEnv = "ANYTYPE_LIFELINE_TEST_ROLE"
+	lifelineTestPIDLine = "LIFELINE_CHILD_PID="
+	lifelineTestTimeout = 5 * time.Second
+)
+
+func TestParentLifelineEnabled(t *testing.T) {
+	t.Setenv(parentLifelineEnv, parentLifelineStdin)
+	if !parentLifelineEnabled() {
+		t.Fatal("expected stdin parent lifeline to be enabled")
+	}
+
+	t.Setenv(parentLifelineEnv, "unknown")
+	if parentLifelineEnabled() {
+		t.Fatal("expected unknown parent lifeline mode to be disabled")
+	}
+}
+
+func TestMonitorParentLifelineShutdownMessage(t *testing.T) {
+	monitor := startParentLifelineMonitor(strings.NewReader("ignored\nshutdown\n"), true, time.Second, func(int) {})
+	defer monitor.markShutdownComplete()
+
+	assertLifelineEvent(t, monitor.events, parentLifelineShutdown)
+}
+
+func TestMonitorParentLifelineEOF(t *testing.T) {
+	monitor := startParentLifelineMonitor(strings.NewReader(""), true, time.Second, func(int) {})
+	defer monitor.markShutdownComplete()
+
+	assertLifelineEvent(t, monitor.events, parentLifelineClosed)
+}
+
+func TestMonitorParentLifelineReadErrorFailsClosed(t *testing.T) {
+	monitor := startParentLifelineMonitor(errorReader{}, true, time.Second, func(int) {})
+	defer monitor.markShutdownComplete()
+
+	assertLifelineEvent(t, monitor.events, parentLifelineClosed)
+}
+
+func TestMonitorParentLifelineForcesExitWithoutMainLoop(t *testing.T) {
+	deadline := make(chan time.Time, 1)
+	exitCode := make(chan int, 1)
+	monitor := startParentLifelineMonitorWithDeadline(
+		strings.NewReader(""),
+		true,
+		time.Hour,
+		deadlineFactory(deadline),
+		func(code int) { exitCode <- code },
+	)
+	defer monitor.markShutdownComplete()
+
+	assertLifelineEvent(t, monitor.events, parentLifelineClosed)
+	deadline <- time.Now()
+	assertExitCode(t, exitCode, 1)
+}
+
+func TestMonitorParentLifelineCompletionCancelsDeadline(t *testing.T) {
+	deadline := make(chan time.Time, 1)
+	exitCode := make(chan int, 1)
+	monitor := startParentLifelineMonitorWithDeadline(
+		strings.NewReader(""),
+		true,
+		time.Hour,
+		deadlineFactory(deadline),
+		func(code int) { exitCode <- code },
+	)
+
+	assertLifelineEvent(t, monitor.events, parentLifelineClosed)
+	monitor.markShutdownComplete()
+	assertMonitorStopped(t, monitor)
+
+	select {
+	case code := <-exitCode:
+		t.Fatalf("unexpected forced exit after completed shutdown: %d", code)
+	default:
+	}
+}
+
+func TestLegacyStdinShutdownMessageStillWorks(t *testing.T) {
+	event, shouldShutdown := readParentLifeline(strings.NewReader("shutdown\n"), false)
+
+	if !shouldShutdown || event != parentLifelineShutdown {
+		t.Fatalf("expected legacy shutdown message, got event %q, shutdown %t", event, shouldShutdown)
+	}
+}
+
+func TestLegacyStdinShutdownDoesNotArmDeadline(t *testing.T) {
+	deadlineCreated := make(chan struct{}, 1)
+	monitor := startParentLifelineMonitorWithDeadline(
+		strings.NewReader("shutdown\n"),
+		false,
+		time.Hour,
+		func(time.Duration) parentLifelineDeadline {
+			deadlineCreated <- struct{}{}
+			return deadlineFactory(make(chan time.Time))(time.Hour)
+		},
+		func(int) {},
+	)
+
+	assertLifelineEvent(t, monitor.events, parentLifelineShutdown)
+	assertMonitorStopped(t, monitor)
+	select {
+	case <-deadlineCreated:
+		t.Fatal("legacy stdin shutdown unexpectedly armed the parent deadline")
+	default:
+	}
+}
+
+func TestLegacyStdinEOFDoesNotShutdown(t *testing.T) {
+	event, shouldShutdown := readParentLifeline(strings.NewReader(""), false)
+
+	if shouldShutdown {
+		t.Fatalf("expected legacy stdin EOF to be ignored, got %q", event)
+	}
+}
+
+func TestParentDeathClosesLifelinePipe(t *testing.T) {
+	switch os.Getenv(lifelineTestRoleEnv) {
+	case "parent":
+		runLifelineTestParent()
+		return
+	case "child":
+		runLifelineTestChild()
+		return
+	}
+
+	parent := exec.Command(os.Args[0], "-test.run=^TestParentDeathClosesLifelinePipe$")
+	parent.Env = lifelineTestEnv("parent")
+	parent.Stderr = os.Stderr
+	stdout, err := parent.StdoutPipe()
+	if err != nil {
+		t.Fatalf("create parent stdout pipe: %v", err)
+	}
+	if err = parent.Start(); err != nil {
+		t.Fatalf("start parent fixture: %v", err)
+	}
+
+	var child *os.Process
+	defer func() {
+		if child != nil {
+			_ = child.Kill()
+		}
+		_ = parent.Process.Kill()
+		_ = parent.Wait()
+	}()
+
+	pidResult := make(chan int, 1)
+	outputClosed := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		if !scanner.Scan() {
+			scanErr := scanner.Err()
+			if scanErr == nil {
+				scanErr = io.ErrUnexpectedEOF
+			}
+			outputClosed <- fmt.Errorf("read child pid: %w", scanErr)
+			return
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		pid, parseErr := strconv.Atoi(strings.TrimPrefix(line, lifelineTestPIDLine))
+		if parseErr != nil || !strings.HasPrefix(line, lifelineTestPIDLine) {
+			outputClosed <- fmt.Errorf("invalid child pid line %q", line)
+			return
+		}
+		pidResult <- pid
+
+		for scanner.Scan() {
+		}
+		outputClosed <- scanner.Err()
+	}()
+
+	select {
+	case pid := <-pidResult:
+		child, err = os.FindProcess(pid)
+		if err != nil {
+			t.Fatalf("find child fixture: %v", err)
+		}
+	case outputErr := <-outputClosed:
+		t.Fatalf("parent fixture exited before reporting child: %v", outputErr)
+	case <-time.After(lifelineTestTimeout):
+		t.Fatal("parent fixture did not report its child")
+	}
+
+	if err = parent.Process.Kill(); err != nil {
+		t.Fatalf("kill parent fixture: %v", err)
+	}
+
+	select {
+	case outputErr := <-outputClosed:
+		if outputErr != nil {
+			t.Fatalf("read fixture output: %v", outputErr)
+		}
+	case <-time.After(lifelineTestTimeout):
+		t.Fatal("lifeline child remained alive after its parent was killed")
+	}
+}
+
+func runLifelineTestParent() {
+	child := exec.Command(os.Args[0], "-test.run=^TestParentDeathClosesLifelinePipe$")
+	child.Env = lifelineTestEnv("child")
+	stdin, err := child.StdinPipe()
+	if err != nil {
+		os.Exit(2)
+	}
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	if err = child.Start(); err != nil {
+		os.Exit(2)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s%d\n", lifelineTestPIDLine, child.Process.Pid)
+	_ = child.Wait()
+	runtime.KeepAlive(stdin)
+	os.Exit(3)
+}
+
+func runLifelineTestChild() {
+	startParentLifelineMonitor(os.Stdin, true, 100*time.Millisecond, os.Exit)
+	select {}
+}
+
+func lifelineTestEnv(role string) []string {
+	prefix := lifelineTestRoleEnv + "="
+	env := make([]string, 0, len(os.Environ())+1)
+	for _, value := range os.Environ() {
+		if !strings.HasPrefix(value, prefix) {
+			env = append(env, value)
+		}
+	}
+	return append(env, prefix+role)
+}
+
+func assertLifelineEvent(t *testing.T, events <-chan parentLifelineEvent, expected parentLifelineEvent) {
+	t.Helper()
+	select {
+	case event := <-events:
+		if event != expected {
+			t.Fatalf("expected %q, got %q", expected, event)
+		}
+	case <-time.After(lifelineTestTimeout):
+		t.Fatalf("timed out waiting for %q", expected)
+	}
+}
+
+func assertExitCode(t *testing.T, exitCode <-chan int, expected int) {
+	t.Helper()
+	select {
+	case code := <-exitCode:
+		if code != expected {
+			t.Fatalf("expected forced exit code %d, got %d", expected, code)
+		}
+	case <-time.After(lifelineTestTimeout):
+		t.Fatal("timed out waiting for forced exit")
+	}
+}
+
+func assertMonitorStopped(t *testing.T, monitor *parentLifelineMonitor) {
+	t.Helper()
+	select {
+	case <-monitor.stopped:
+	case <-time.After(lifelineTestTimeout):
+		t.Fatal("timed out waiting for parent lifeline monitor to stop")
+	}
+}
+
+func deadlineFactory(elapsed <-chan time.Time) parentLifelineDeadlineFactory {
+	return func(time.Duration) parentLifelineDeadline {
+		return parentLifelineDeadline{
+			elapsed: elapsed,
+			stop:    func() {},
+		}
+	}
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}

--- a/cmd/grpcserver/lifeline_windows.go
+++ b/cmd/grpcserver/lifeline_windows.go
@@ -1,0 +1,6 @@
+//go:build !nogrpcserver && !_test && windows
+// +build !nogrpcserver,!_test,windows
+
+package main
+
+func ignoreBrokenPipeSignal() {}

--- a/cmd/grpcserver/lifeline_windows_test.go
+++ b/cmd/grpcserver/lifeline_windows_test.go
@@ -1,0 +1,10 @@
+//go:build !nogrpcserver && !_test && windows
+// +build !nogrpcserver,!_test,windows
+
+package main
+
+import "testing"
+
+func TestIgnoreBrokenPipeSignal(t *testing.T) {
+	t.Skip("SIGPIPE is a POSIX signal")
+}


### PR DESCRIPTION
## Summary
- add an opt-in stdin lifeline so the gRPC server detects desktop parent death on macOS, Linux, and Windows
- start the ownership monitor before middleware initialization and force exit after a bounded deadline if cleanup cannot complete
- avoid SIGPIPE and blocking parent-owned output during parent-loss shutdown
- preserve standalone Unix signal behavior and legacy Windows stdin shutdown behavior
- build the complete grpcserver package and run its tests in CI

## Tests
- go test ./cmd/grpcserver
- focused lifeline tests with the race detector
- black-box parent-death subprocess test
- POSIX broken-pipe subprocess test
- local Windows and Linux cross-compilation
- real built helper: opted-in EOF exited gracefully; standalone EOF remained running

## Rollout
The desktop launcher must set ANYTYPE_PARENT_LIFELINE=stdin. Standalone servers should leave it unset.