### PR TITLE
Identify link preview requests as WhatsApp- rather than Mozilla-"compatible"

### DIFF
--- a/util/linkpreview/linkpreview.go
+++ b/util/linkpreview/linkpreview.go
@@ -247,7 +247,7 @@ type proxyRoundTripper struct {
 }
 
 func (p *proxyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; AnytypeBot/1.0; +https://anytype.io/bot)")
+	req.Header.Set("User-Agent", "WhatsApp/2 (compatible; AnytypeBot/1.0; +https://anytype.io/bot)")
 	resp, err := p.RoundTripper.RoundTrip(req)
 	if err == nil {
 		p.lastResponse = resp


### PR DESCRIPTION
<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Without the magic word "WhatsApp," automated retrieval of a link preview – even on the user's behalf – appears too-often impossible. 

The existing Anytype user agent for link previews makes sense in that it is a "bot" and it follows the convention established by search engine crawlers. However, Anytype is not acting as a search engine crawler here; following this convention does not serve it in accessing pages to preview; and regardless it is not a "Mozilla-compatible" agent. 

As what Anytype is here doing is closest to WhatsApp (and Signal) link "unfurling," it should follow this convention, instead – invoking the name `WhatsApp` rather than `Mozilla` – and thereby bypass the relevant bot-smashing restrictions:

```
WhatsApp/2 (compatible; AnytypeBot/1.0; +https://anytype.io/bot)
```

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

* [Cannot load bookmark source due to bot-smashing](https://community.anytype.io/t/cannot-load-bookmark-source-due-to-bot-smashing/31209)

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

None

### Added tests?

- [x] 😎 Happy to do so should this approach be found acceptable. 

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?

None 

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
