### PR TITLE
GO-7492 Let a cold device find its account on the LAN

### DIFF
--- a/space/service_test.go
+++ b/space/service_test.go
@@ -718,3 +718,7 @@ func TestOrderSpacesOpenedFirst(t *testing.T) {
 		assert.Equal(t, ids, orderSpacesOpenedFirst(ids, nil))
 	})
 }
+
+func TestSpaceCoreCNameDrift(t *testing.T) {
+	assert.Equal(t, CName, spacecore.SpaceServiceCName)
+}

--- a/space/spacecore/accountpeers.go
+++ b/space/spacecore/accountpeers.go
@@ -33,28 +33,54 @@ type knownSpaceIdsProvider interface {
 	AllSpaceIds() []string
 }
 
+// exchangeDirection says which side asked. The two answers mean different
+// things and neither may replace the other: an OUTBOUND answer is what the
+// peer holds of the list we asked about (disk plus the derived tech space); an
+// INBOUND answer is what WE hold of the list the peer asked about — bounded by
+// our own disk, so on a cold device it is empty even when the peer holds the
+// whole account. The published list is the union of the latest answer per
+// direction: a fresh outbound answer can still drop a space the peer no
+// longer holds, which a grow-only merge could not.
+type exchangeDirection int
+
+const (
+	directionOutbound exchangeDirection = iota
+	directionInbound
+)
+
 // accountPeers is what the exchange established per LAN peer, kept apart from
 // the peer store's published list so candidacy can be recomputed without
 // clobbering genuine exchange results.
 type accountPeers struct {
-	mu        sync.Mutex
-	proven    map[string]struct{}
-	exchanged map[string][]string
+	mu       sync.Mutex
+	proven   map[string]struct{}
+	outbound map[string][]string
+	inbound  map[string][]string
 }
 
 func newAccountPeers() *accountPeers {
-	return &accountPeers{proven: map[string]struct{}{}, exchanged: map[string][]string{}}
+	return &accountPeers{
+		proven:   map[string]struct{}{},
+		outbound: map[string][]string{},
+		inbound:  map[string][]string{},
+	}
 }
 
 // publishLocalPeer records an exchange result for peerId and publishes its
-// space list: the confirmed shared spaces, plus — when the result proves the
-// account and proof is meaningful (a v2 token exchange; v1 is plaintext) —
-// every pending space. UpdateLocalPeer replaces the list, so the full set is
-// computed here every time.
-func (s *service) publishLocalPeer(peerId string, shared []string, proof bool) {
+// space list: the union of what either direction confirmed, plus — for a
+// peer that proved the account through a v2 token exchange (v1 is plaintext
+// and proves nothing) — the tech space itself, always, and every pending
+// space. UpdateLocalPeer replaces the list, so the full set is computed here
+// every time.
+func (s *service) publishLocalPeer(peerId string, shared []string, proof bool, direction exchangeDirection) {
 	tech := s.techSpaceExchangeInfo()
 	s.accountPeers.mu.Lock()
-	s.accountPeers.exchanged[peerId] = slices.Clone(shared)
+	switch direction {
+	case directionInbound:
+		s.accountPeers.inbound[peerId] = slices.Clone(shared)
+	default:
+		s.accountPeers.outbound[peerId] = slices.Clone(shared)
+	}
 	if proof && tech.id != "" && slices.Contains(shared, tech.id) {
 		if _, known := s.accountPeers.proven[peerId]; !known {
 			log.Info("local peer proved the account", zap.String("peerId", peerId))
@@ -62,25 +88,38 @@ func (s *service) publishLocalPeer(peerId string, shared []string, proof bool) {
 		s.accountPeers.proven[peerId] = struct{}{}
 	}
 	_, proven := s.accountPeers.proven[peerId]
+	confirmed := union(s.accountPeers.outbound[peerId], s.accountPeers.inbound[peerId])
 	s.accountPeers.mu.Unlock()
 	if !proven {
-		s.peerStore.UpdateLocalPeer(peerId, shared)
+		s.peerStore.UpdateLocalPeer(peerId, confirmed)
 		return
 	}
-	s.peerStore.UpdateLocalPeer(peerId, union(shared, s.pendingSpaceIds()))
+	s.peerStore.UpdateLocalPeer(peerId, s.provenListLocked(confirmed, tech.id, s.pendingSpaceIds()))
+}
+
+// provenListLocked is a proven peer's published list: what was confirmed, the
+// tech space it proved — independent of the latest answer, since on a cold
+// device nothing else can supply it — and every space we know of but lack.
+func (s *service) provenListLocked(confirmed []string, techId string, pending []string) []string {
+	list := union(confirmed, pending)
+	if techId != "" && !slices.Contains(list, techId) {
+		list = append(list, techId)
+	}
+	return list
 }
 
 // refreshProvenPeers republishes every proven peer's list. loading names a
 // space about to be pulled that the space service may not list yet.
 func (s *service) refreshProvenPeers(loading ...string) {
+	tech := s.techSpaceExchangeInfo()
 	s.accountPeers.mu.Lock()
 	type entry struct {
-		peerId string
-		shared []string
+		peerId    string
+		confirmed []string
 	}
 	entries := make([]entry, 0, len(s.accountPeers.proven))
 	for peerId := range s.accountPeers.proven {
-		entries = append(entries, entry{peerId, s.accountPeers.exchanged[peerId]})
+		entries = append(entries, entry{peerId, union(s.accountPeers.outbound[peerId], s.accountPeers.inbound[peerId])})
 	}
 	s.accountPeers.mu.Unlock()
 	if len(entries) == 0 {
@@ -89,18 +128,19 @@ func (s *service) refreshProvenPeers(loading ...string) {
 	pending := s.pendingSpaceIds(loading...)
 	for _, e := range entries {
 		// the store notifies only on a real change
-		s.peerStore.UpdateLocalPeer(e.peerId, union(e.shared, pending))
+		s.peerStore.UpdateLocalPeer(e.peerId, s.provenListLocked(e.confirmed, tech.id, pending))
 	}
 }
 
 // forgetLocalPeer drops a peer the peer manager removed (its dial failed), so
-// a later refresh cannot resurrect it. Re-discovery goes through
-// publishLocalPeer again.
+// a later refresh cannot resurrect it: removal is authoritative over both
+// directions and the proof. Re-discovery goes through publishLocalPeer again.
 func (s *service) forgetLocalPeer(peerId string) {
 	s.accountPeers.mu.Lock()
 	defer s.accountPeers.mu.Unlock()
 	delete(s.accountPeers.proven, peerId)
-	delete(s.accountPeers.exchanged, peerId)
+	delete(s.accountPeers.outbound, peerId)
+	delete(s.accountPeers.inbound, peerId)
 }
 
 // pendingSpaceIds is every space we know of but do not hold on disk: the

--- a/space/spacecore/accountpeers.go
+++ b/space/spacecore/accountpeers.go
@@ -77,11 +77,21 @@ func (s *service) publishLocalPeer(peerId string, shared []string, proof bool, d
 	s.accountPeers.mu.Lock()
 	switch direction {
 	case directionInbound:
-		s.accountPeers.inbound[peerId] = slices.Clone(shared)
+		// An inbound answer is what WE hold of the list the peer asked
+		// about, so the tech space in it is our own holding, not the
+		// peer's: a cold device asks about the tech space id it derived
+		// but does not have, and we answer it precisely because we do.
+		// Recording that would make a device with no data a pull
+		// candidate for the one space every cold start needs first.
+		s.accountPeers.inbound[peerId] = withoutSpace(shared, tech.id)
 	default:
 		s.accountPeers.outbound[peerId] = slices.Clone(shared)
 	}
-	if proof && tech.id != "" && slices.Contains(shared, tech.id) {
+	// Only an outbound answer can prove the peer holds the tech space: there
+	// the peer reports its own holdings against the list we asked about. The
+	// inbound intersection is bounded by our disk, so on a warm device it
+	// contains the tech space no matter how empty the peer is.
+	if proof && direction == directionOutbound && tech.id != "" && slices.Contains(shared, tech.id) {
 		if _, known := s.accountPeers.proven[peerId]; !known {
 			log.Info("local peer proved the account", zap.String("peerId", peerId))
 		}
@@ -191,4 +201,13 @@ func lookupKnownSpaces(a *app.App) knownSpaceIdsProvider {
 	}
 	provider, _ := c.(knownSpaceIdsProvider)
 	return provider
+}
+
+// withoutSpace is shared minus spaceId, leaving the input untouched.
+func withoutSpace(shared []string, spaceId string) []string {
+	out := slices.Clone(shared)
+	if spaceId == "" {
+		return out
+	}
+	return slices.DeleteFunc(out, func(id string) bool { return id == spaceId })
 }

--- a/space/spacecore/accountpeers.go
+++ b/space/spacecore/accountpeers.go
@@ -1,0 +1,154 @@
+package spacecore
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/anyproto/any-sync/app"
+	"go.uber.org/zap"
+
+	"github.com/anyproto/anytype-heart/pkg/lib/localstore/addr"
+)
+
+// GO-7492 part 3: a LAN peer whose v2 exchange proves it holds our tech space
+// is one of this account's own devices — the tech token is HKDF over the tech
+// space's first ACL read key, which only the account keys yield. Such a peer
+// may be asked for ANY space: SpacePull serves by id and authorization is
+// inherent in the encrypted payload, so the discovery-key exchange is about
+// which peers are worth asking, not about permission. A cold device therefore
+// registers every proven account peer as a pull candidate for each space it
+// knows of but does not hold yet; once a space is on disk the exchange
+// decides again, so head-sync never runs against a peer for a space it was
+// never confirmed to have.
+
+// SpaceServiceCName mirrors space.CName: space imports this package, so the
+// view-based space list is looked up by name. A drift test in space keeps the
+// two equal.
+const SpaceServiceCName = "client.space"
+
+// knownSpaceIdsProvider is the part of the space service this needs: the
+// space ids known from SpaceViews — NOT the storage list, which on a cold
+// device is exactly the empty one.
+type knownSpaceIdsProvider interface {
+	AllSpaceIds() []string
+}
+
+// accountPeers is what the exchange established per LAN peer, kept apart from
+// the peer store's published list so candidacy can be recomputed without
+// clobbering genuine exchange results.
+type accountPeers struct {
+	mu        sync.Mutex
+	proven    map[string]struct{}
+	exchanged map[string][]string
+}
+
+func newAccountPeers() *accountPeers {
+	return &accountPeers{proven: map[string]struct{}{}, exchanged: map[string][]string{}}
+}
+
+// publishLocalPeer records an exchange result for peerId and publishes its
+// space list: the confirmed shared spaces, plus — when the result proves the
+// account and proof is meaningful (a v2 token exchange; v1 is plaintext) —
+// every pending space. UpdateLocalPeer replaces the list, so the full set is
+// computed here every time.
+func (s *service) publishLocalPeer(peerId string, shared []string, proof bool) {
+	tech := s.techSpaceExchangeInfo()
+	s.accountPeers.mu.Lock()
+	s.accountPeers.exchanged[peerId] = slices.Clone(shared)
+	if proof && tech.id != "" && slices.Contains(shared, tech.id) {
+		if _, known := s.accountPeers.proven[peerId]; !known {
+			log.Info("local peer proved the account", zap.String("peerId", peerId))
+		}
+		s.accountPeers.proven[peerId] = struct{}{}
+	}
+	_, proven := s.accountPeers.proven[peerId]
+	s.accountPeers.mu.Unlock()
+	if !proven {
+		s.peerStore.UpdateLocalPeer(peerId, shared)
+		return
+	}
+	s.peerStore.UpdateLocalPeer(peerId, union(shared, s.pendingSpaceIds()))
+}
+
+// refreshProvenPeers republishes every proven peer's list. loading names a
+// space about to be pulled that the space service may not list yet.
+func (s *service) refreshProvenPeers(loading ...string) {
+	s.accountPeers.mu.Lock()
+	type entry struct {
+		peerId string
+		shared []string
+	}
+	entries := make([]entry, 0, len(s.accountPeers.proven))
+	for peerId := range s.accountPeers.proven {
+		entries = append(entries, entry{peerId, s.accountPeers.exchanged[peerId]})
+	}
+	s.accountPeers.mu.Unlock()
+	if len(entries) == 0 {
+		return
+	}
+	pending := s.pendingSpaceIds(loading...)
+	for _, e := range entries {
+		// the store notifies only on a real change
+		s.peerStore.UpdateLocalPeer(e.peerId, union(e.shared, pending))
+	}
+}
+
+// forgetLocalPeer drops a peer the peer manager removed (its dial failed), so
+// a later refresh cannot resurrect it. Re-discovery goes through
+// publishLocalPeer again.
+func (s *service) forgetLocalPeer(peerId string) {
+	s.accountPeers.mu.Lock()
+	defer s.accountPeers.mu.Unlock()
+	delete(s.accountPeers.proven, peerId)
+	delete(s.accountPeers.exchanged, peerId)
+}
+
+// pendingSpaceIds is every space we know of but do not hold on disk: the
+// view-based list from the space service (plus the ids being loaded right
+// now), minus the storage list.
+func (s *service) pendingSpaceIds(loading ...string) []string {
+	known := map[string]struct{}{}
+	for _, id := range loading {
+		known[id] = struct{}{}
+	}
+	if s.knownSpaces != nil {
+		for _, id := range s.knownSpaces.AllSpaceIds() {
+			known[id] = struct{}{}
+		}
+	}
+	delete(known, "")
+	delete(known, addr.AnytypeMarketplaceWorkspace)
+	onDisk, err := s.spaceStorageProvider.AllSpaceIds()
+	if err != nil {
+		log.Warn("pending space ids: all space ids", zap.Error(err))
+		return nil
+	}
+	for _, id := range onDisk {
+		delete(known, id)
+	}
+	pending := make([]string, 0, len(known))
+	for id := range known {
+		pending = append(pending, id)
+	}
+	slices.Sort(pending)
+	return pending
+}
+
+func union(a, b []string) []string {
+	out := slices.Clone(a)
+	for _, id := range b {
+		if !slices.Contains(out, id) {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func lookupKnownSpaces(a *app.App) knownSpaceIdsProvider {
+	c := a.Component(SpaceServiceCName)
+	if c == nil {
+		return nil
+	}
+	provider, _ := c.(knownSpaceIdsProvider)
+	return provider
+}

--- a/space/spacecore/accountpeers_test.go
+++ b/space/spacecore/accountpeers_test.go
@@ -279,3 +279,74 @@ func TestSpacePullAnswersMissingFromDisk(t *testing.T) {
 	assert.Nil(t, resp)
 	assert.ErrorIs(t, err, spacesyncproto.ErrSpaceMissing)
 }
+
+// TestPublishLocalPeerDirection pins the asymmetry between the two answers.
+// An inbound intersection is bounded by OUR disk, so on a warm device it
+// names the tech space no matter how empty the asking peer is; treating it
+// as the peer's holding makes a cold device a pull candidate for the one
+// space every cold start needs first.
+func TestPublishLocalPeerDirection(t *testing.T) {
+	t.Run("an inbound answer never proves the peer", func(t *testing.T) {
+		// given: a warm device that holds the tech space and s1
+		s, _, lists := newAccountPeersService(t, []string{"s1"}, []string{"s1"})
+		tech := s.techSpaceExchangeInfo().id
+		require.NotEmpty(t, tech)
+
+		// when: a cold peer asks about the tech space id it derived, and we
+		// answer it because WE hold it
+		s.publishLocalPeer("cold", []string{tech}, true, directionInbound)
+
+		// then: the peer is not proven and claims no space at all
+		s.accountPeers.mu.Lock()
+		_, proven := s.accountPeers.proven["cold"]
+		s.accountPeers.mu.Unlock()
+		assert.False(t, proven, "an inbound answer reports our holdings, not the peer's")
+		assert.NotContains(t, lists.of("cold"), tech)
+		assert.Empty(t, lists.of("cold"))
+	})
+
+	t.Run("an inbound answer still records genuinely shared spaces", func(t *testing.T) {
+		// given: a warm device
+		s, _, lists := newAccountPeersService(t, []string{"s1"}, []string{"s1"})
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: a warm peer asks about its own disk list and we hold s1 too
+		s.publishLocalPeer("warm", []string{tech, "s1"}, true, directionInbound)
+
+		// then: s1 survives, the speculative tech space does not
+		assert.Equal(t, []string{"s1"}, lists.of("warm"))
+	})
+
+	t.Run("an outbound answer proves the peer", func(t *testing.T) {
+		// given: the same warm device
+		s, _, lists := newAccountPeersService(t, []string{"s1"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: we asked, and the peer reported it holds the tech space
+		s.publishLocalPeer("warm", []string{tech}, true, directionOutbound)
+
+		// then: proven, and a candidate for every space we lack
+		s.accountPeers.mu.Lock()
+		_, proven := s.accountPeers.proven["warm"]
+		s.accountPeers.mu.Unlock()
+		assert.True(t, proven)
+		assert.Contains(t, lists.of("warm"), tech)
+		assert.Contains(t, lists.of("warm"), "s1")
+	})
+
+	t.Run("a v1 exchange proves nothing in either direction", func(t *testing.T) {
+		// given: a warm device
+		s, _, lists := newAccountPeersService(t, []string{"s1"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: the peer names the tech space over plaintext v1
+		s.publishLocalPeer("v1peer", []string{tech}, false, directionOutbound)
+
+		// then: named spaces are recorded, but nothing is inferred from them
+		s.accountPeers.mu.Lock()
+		_, proven := s.accountPeers.proven["v1peer"]
+		s.accountPeers.mu.Unlock()
+		assert.False(t, proven, "v1 is plaintext and proves no account membership")
+		assert.NotContains(t, lists.of("v1peer"), "s1", "an unproven peer is no candidate for spaces we lack")
+	})
+}

--- a/space/spacecore/accountpeers_test.go
+++ b/space/spacecore/accountpeers_test.go
@@ -1,0 +1,186 @@
+package spacecore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anyproto/any-sync/commonspace/spacesyncproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/space/spacecore/peerstore"
+	"github.com/anyproto/anytype-heart/space/spacecore/storage/mock_storage"
+)
+
+type fakeKnownSpaces struct {
+	ids []string
+}
+
+func (f *fakeKnownSpaces) AllSpaceIds() []string { return f.ids }
+
+// peerLists records the latest list the peer store published per peer: the
+// store exposes peers per space, and the tests need spaces per peer.
+type peerLists struct {
+	last map[string][]string
+}
+
+func (p *peerLists) of(peerId string) []string { return p.last[peerId] }
+
+// newAccountPeersService is a keyed service over a real peer store, with the
+// view-based space list and the on-disk list both under test control.
+func newAccountPeersService(t *testing.T, known []string, onDisk []string) (*service, *fakeKnownSpaces, *peerLists) {
+	t.Helper()
+	store := mock_storage.NewMockClientStorage(t)
+	store.EXPECT().AllSpaceIds().RunAndReturn(func() ([]string, error) { return onDisk, nil }).Maybe()
+	s := newKeyedService(t, 1, store)
+	views := &fakeKnownSpaces{ids: known}
+	lists := &peerLists{last: map[string][]string{}}
+	s.peerStore = peerstore.New()
+	s.accountPeers = newAccountPeers()
+	s.knownSpaces = views
+	s.peerStore.AddObserver(func(peerId string, _, after []string, removed bool) {
+		if removed {
+			s.forgetLocalPeer(peerId)
+			delete(lists.last, peerId)
+			return
+		}
+		lists.last[peerId] = after
+	})
+	return s, views, lists
+}
+
+func TestPublishLocalPeer(t *testing.T) {
+	t.Run("a peer that proves the account becomes a candidate for every space we lack", func(t *testing.T) {
+		// given: views know s1 and s2, nothing is on disk yet
+		s, _, lists := newAccountPeersService(t, []string{"s1", "s2"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: the exchange confirmed only the tech space
+		s.publishLocalPeer("dev", []string{tech}, true)
+
+		// then
+		assert.ElementsMatch(t, []string{tech, "s1", "s2"}, lists.of("dev"))
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s2"), "never exchanged about, still a candidate")
+	})
+
+	t.Run("an unproven peer stays on its confirmed spaces only", func(t *testing.T) {
+		// given
+		s, _, lists := newAccountPeersService(t, []string{"s1", "s2"}, nil)
+
+		// when: it shares an unrelated space
+		s.publishLocalPeer("stranger", []string{"s1"}, true)
+
+		// then
+		assert.Equal(t, []string{"s1"}, lists.of("stranger"))
+		assert.Empty(t, s.peerStore.LocalPeerIds("s2"))
+	})
+
+	t.Run("a v1 result never proves anything", func(t *testing.T) {
+		// given
+		s, _, lists := newAccountPeersService(t, []string{"s1"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: a plaintext list claims the tech space
+		s.publishLocalPeer("legacy", []string{tech}, false)
+
+		// then
+		assert.Equal(t, []string{tech}, lists.of("legacy"))
+		assert.Empty(t, s.peerStore.LocalPeerIds("s1"))
+	})
+
+	t.Run("a space we already hold is decided by the exchange, not by proof", func(t *testing.T) {
+		// given: s1 is on disk, s2 is not
+		s, _, _ := newAccountPeersService(t, []string{"s1", "s2"}, []string{"s1"})
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: the proven peer did not confirm s1
+		s.publishLocalPeer("dev", []string{tech}, true)
+
+		// then
+		assert.Empty(t, s.peerStore.LocalPeerIds("s1"), "held here, not confirmed there: no head-sync against it")
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s2"))
+
+		// and a later exchange that confirms s1 keeps it
+		s.publishLocalPeer("dev", []string{tech, "s1"}, true)
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s1"))
+	})
+}
+
+func TestRefreshProvenPeers(t *testing.T) {
+	t.Run("peer proves first, then a space appears and is loaded", func(t *testing.T) {
+		// given
+		s, views, lists := newAccountPeersService(t, nil, nil)
+		tech := s.techSpaceExchangeInfo().id
+		s.publishLocalPeer("dev", []string{tech}, true)
+		require.Empty(t, s.peerStore.LocalPeerIds("s9"))
+
+		// when: loadSpace is about to pull s9 (the view list may not have it yet)
+		s.refreshProvenPeers("s9")
+
+		// then
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s9"))
+
+		// and once s9 is on disk candidacy ends until the exchange confirms it
+		views.ids = []string{"s9"}
+		s.spaceStorageProvider = func() *mock_storage.MockClientStorage {
+			st := mock_storage.NewMockClientStorage(t)
+			st.EXPECT().AllSpaceIds().Return([]string{"s9"}, nil).Maybe()
+			return st
+		}()
+		s.refreshProvenPeers()
+		assert.Empty(t, s.peerStore.LocalPeerIds("s9"))
+		assert.Equal(t, []string{tech}, lists.of("dev"), "the confirmed result is intact")
+	})
+
+	t.Run("space appears first, then the peer proves", func(t *testing.T) {
+		// given
+		s, _, _ := newAccountPeersService(t, []string{"s9"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+		s.publishLocalPeer("dev", []string{}, true) // first, cold answer: nothing shared
+		require.Empty(t, s.peerStore.LocalPeerIds("s9"))
+
+		// when: the re-exchange proves the account
+		s.publishLocalPeer("dev", []string{tech}, true)
+
+		// then
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s9"))
+	})
+
+	t.Run("a removed peer is forgotten and not resurrected", func(t *testing.T) {
+		// given
+		s, _, _ := newAccountPeersService(t, []string{"s9"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+		s.publishLocalPeer("dev", []string{tech}, true)
+		require.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s9"))
+
+		// when: the peer manager drops it after a failed dial
+		s.peerStore.RemoveLocalPeer("dev")
+		s.refreshProvenPeers("s10")
+
+		// then
+		assert.Empty(t, s.peerStore.AllLocalPeers())
+		assert.Empty(t, s.peerStore.LocalPeerIds("s10"))
+	})
+
+	t.Run("no proven peers is a no-op that never touches disk", func(t *testing.T) {
+		s, _, _ := newAccountPeersService(t, []string{"s9"}, nil)
+		s.spaceStorageProvider = mock_storage.NewMockClientStorage(t) // AllSpaceIds would fail the test
+		s.refreshProvenPeers("s9")
+		assert.Empty(t, s.peerStore.AllLocalPeers())
+	})
+}
+
+func TestSpacePullAnswersMissingFromDisk(t *testing.T) {
+	// given: the space is not on disk; Get would load (and pull on the
+	// caller's behalf), so the handler must not reach it
+	store := mock_storage.NewMockClientStorage(t)
+	store.EXPECT().SpaceExists("absent").Return(false)
+	handler := &rpcHandler{s: &service{spaceStorageProvider: store}}
+
+	// when
+	resp, err := handler.SpacePull(context.Background(), &spacesyncproto.SpacePullRequest{Id: "absent"})
+
+	// then
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, spacesyncproto.ErrSpaceMissing)
+}

--- a/space/spacecore/accountpeers_test.go
+++ b/space/spacecore/accountpeers_test.go
@@ -56,7 +56,7 @@ func TestPublishLocalPeer(t *testing.T) {
 		tech := s.techSpaceExchangeInfo().id
 
 		// when: the exchange confirmed only the tech space
-		s.publishLocalPeer("dev", []string{tech}, true)
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
 
 		// then
 		assert.ElementsMatch(t, []string{tech, "s1", "s2"}, lists.of("dev"))
@@ -68,7 +68,7 @@ func TestPublishLocalPeer(t *testing.T) {
 		s, _, lists := newAccountPeersService(t, []string{"s1", "s2"}, nil)
 
 		// when: it shares an unrelated space
-		s.publishLocalPeer("stranger", []string{"s1"}, true)
+		s.publishLocalPeer("stranger", []string{"s1"}, true, directionOutbound)
 
 		// then
 		assert.Equal(t, []string{"s1"}, lists.of("stranger"))
@@ -81,7 +81,7 @@ func TestPublishLocalPeer(t *testing.T) {
 		tech := s.techSpaceExchangeInfo().id
 
 		// when: a plaintext list claims the tech space
-		s.publishLocalPeer("legacy", []string{tech}, false)
+		s.publishLocalPeer("legacy", []string{tech}, false, directionOutbound)
 
 		// then
 		assert.Equal(t, []string{tech}, lists.of("legacy"))
@@ -94,14 +94,14 @@ func TestPublishLocalPeer(t *testing.T) {
 		tech := s.techSpaceExchangeInfo().id
 
 		// when: the proven peer did not confirm s1
-		s.publishLocalPeer("dev", []string{tech}, true)
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
 
 		// then
 		assert.Empty(t, s.peerStore.LocalPeerIds("s1"), "held here, not confirmed there: no head-sync against it")
 		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s2"))
 
 		// and a later exchange that confirms s1 keeps it
-		s.publishLocalPeer("dev", []string{tech, "s1"}, true)
+		s.publishLocalPeer("dev", []string{tech, "s1"}, true, directionOutbound)
 		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s1"))
 	})
 }
@@ -111,7 +111,7 @@ func TestRefreshProvenPeers(t *testing.T) {
 		// given
 		s, views, lists := newAccountPeersService(t, nil, nil)
 		tech := s.techSpaceExchangeInfo().id
-		s.publishLocalPeer("dev", []string{tech}, true)
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
 		require.Empty(t, s.peerStore.LocalPeerIds("s9"))
 
 		// when: loadSpace is about to pull s9 (the view list may not have it yet)
@@ -136,11 +136,11 @@ func TestRefreshProvenPeers(t *testing.T) {
 		// given
 		s, _, _ := newAccountPeersService(t, []string{"s9"}, nil)
 		tech := s.techSpaceExchangeInfo().id
-		s.publishLocalPeer("dev", []string{}, true) // first, cold answer: nothing shared
+		s.publishLocalPeer("dev", []string{}, true, directionOutbound) // first, cold answer: nothing shared
 		require.Empty(t, s.peerStore.LocalPeerIds("s9"))
 
 		// when: the re-exchange proves the account
-		s.publishLocalPeer("dev", []string{tech}, true)
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
 
 		// then
 		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s9"))
@@ -150,7 +150,7 @@ func TestRefreshProvenPeers(t *testing.T) {
 		// given
 		s, _, _ := newAccountPeersService(t, []string{"s9"}, nil)
 		tech := s.techSpaceExchangeInfo().id
-		s.publishLocalPeer("dev", []string{tech}, true)
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
 		require.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s9"))
 
 		// when: the peer manager drops it after a failed dial
@@ -166,6 +166,101 @@ func TestRefreshProvenPeers(t *testing.T) {
 		s, _, _ := newAccountPeersService(t, []string{"s9"}, nil)
 		s.spaceStorageProvider = mock_storage.NewMockClientStorage(t) // AllSpaceIds would fail the test
 		s.refreshProvenPeers("s9")
+		assert.Empty(t, s.peerStore.AllLocalPeers())
+	})
+}
+
+func TestColdDevicePath(t *testing.T) {
+	t.Run("offline cold device: the peer proves, dials back with nothing, and the tech space stays pullable", func(t *testing.T) {
+		// given: empty spacestore, no views yet, no node — the user's run
+		s, views, lists := newAccountPeersService(t, nil, nil)
+		tech := s.techSpaceExchangeInfo().id
+
+		// when: our outbound exchange proves the peer holds the account
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
+		require.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds(tech))
+
+		// and 122 ms later the peer dials us back; the responder-side answer
+		// is bounded by OUR empty disk
+		s.publishLocalPeer("dev", []string{}, true, directionInbound)
+
+		// then: the outbound proof is intact and the tech space has a source
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds(tech), "the inbound answer must not reduce the outbound one")
+		assert.Equal(t, []string{tech}, lists.of("dev"))
+
+		// the pull begins: loadSpace names the tech space, it is still a candidate
+		s.refreshProvenPeers(tech)
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds(tech))
+
+		// the tech space lands on disk; the peer proved it, so it stays
+		disk := []string{tech}
+		s.spaceStorageProvider = func() *mock_storage.MockClientStorage {
+			st := mock_storage.NewMockClientStorage(t)
+			st.EXPECT().AllSpaceIds().RunAndReturn(func() ([]string, error) { return disk, nil }).Maybe()
+			return st
+		}()
+		s.refreshProvenPeers()
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds(tech))
+
+		// views arrive from the tech space and s1 starts loading: a candidate
+		views.ids = []string{"s1"}
+		s.refreshProvenPeers("s1")
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s1"))
+		assert.ElementsMatch(t, []string{tech, "s1"}, lists.of("dev"))
+
+		// s1 lands; candidacy ends until the re-exchange confirms it
+		disk = []string{tech, "s1"}
+		s.refreshProvenPeers()
+		assert.Empty(t, s.peerStore.LocalPeerIds("s1"))
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds(tech))
+
+		// the re-exchange asks about disk + tech and the peer confirms both
+		s.publishLocalPeer("dev", []string{tech, "s1"}, true, directionOutbound)
+		assert.Equal(t, []string{"dev"}, s.peerStore.LocalPeerIds("s1"))
+	})
+
+	t.Run("an inbound answer never reduces an outbound one, proven or not", func(t *testing.T) {
+		// given
+		s, _, lists := newAccountPeersService(t, nil, nil)
+		s.publishLocalPeer("friend", []string{"s1"}, true, directionOutbound)
+
+		// when
+		s.publishLocalPeer("friend", []string{}, true, directionInbound)
+		require.Equal(t, []string{"s1"}, lists.of("friend"))
+		s.publishLocalPeer("friend", []string{"s2"}, true, directionInbound)
+		require.ElementsMatch(t, []string{"s1", "s2"}, lists.of("friend"))
+
+		// then: a fresh outbound answer replaces only the outbound half
+		s.publishLocalPeer("friend", []string{"s2"}, true, directionOutbound)
+		assert.Equal(t, []string{"s2"}, lists.of("friend"), "s1 is gone: the peer no longer holds it")
+	})
+
+	t.Run("a proven peer's list always carries the tech space", func(t *testing.T) {
+		// given
+		s, _, lists := newAccountPeersService(t, nil, nil)
+		tech := s.techSpaceExchangeInfo().id
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
+
+		// when: a later outbound answer somehow lacks it
+		s.publishLocalPeer("dev", []string{"s1"}, true, directionOutbound)
+
+		// then
+		assert.ElementsMatch(t, []string{"s1", tech}, lists.of("dev"))
+	})
+
+	t.Run("forgetting a peer drops both directions and the proof", func(t *testing.T) {
+		// given
+		s, _, lists := newAccountPeersService(t, []string{"s9"}, nil)
+		tech := s.techSpaceExchangeInfo().id
+		s.publishLocalPeer("dev", []string{tech}, true, directionOutbound)
+		s.publishLocalPeer("dev", []string{"s2"}, true, directionInbound)
+
+		// when
+		s.peerStore.RemoveLocalPeer("dev")
+		s.refreshProvenPeers("s9")
+
+		// then
+		assert.Nil(t, lists.of("dev"))
 		assert.Empty(t, s.peerStore.AllLocalPeers())
 	})
 }

--- a/space/spacecore/discoverykeys.go
+++ b/space/spacecore/discoverykeys.go
@@ -44,6 +44,16 @@ func newDiscoveryKeySource(store storage.ClientStorage, keys *accountdata.Accoun
 	}
 }
 
+// seed records a key derived without storage (the derived tech space, whose
+// ACL root follows from the account keys). It wins over any later read from
+// disk, which yields the identical key.
+func (d *discoveryKeySource) seed(spaceId string, key []byte) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.derived[spaceId] = key
+	delete(d.failedAt, spaceId)
+}
+
 // DiscoveryKeys returns the discovery keys for the given spaces, keyed by
 // spaceId. Spaces without a derivable key are absent from the result.
 func (d *discoveryKeySource) DiscoveryKeys(ctx context.Context, spaceIds []string) map[string][]byte {

--- a/space/spacecore/peer.go
+++ b/space/spacecore/peer.go
@@ -17,11 +17,11 @@ import (
 func (s *service) PeerDiscovered(ctx context.Context, discovered localdiscovery.DiscoveredPeer, own localdiscovery.OwnAddresses) {
 	s.peerService.SetPeerAddrs(discovered.PeerId, s.addSchema(discovered.Addrs))
 	s.rememberOwn(own)
-	shared, err := s.exchangeOutbound(ctx, discovered.PeerId, &own)
+	shared, proof, err := s.exchangeOutbound(ctx, discovered.PeerId, &own)
 	if err != nil {
 		return
 	}
-	s.peerStore.UpdateLocalPeer(discovered.PeerId, shared)
+	s.publishLocalPeer(discovered.PeerId, shared, proof)
 }
 
 // exchangeOutbound is the outbound handshake with one LAN peer: the v2 token
@@ -29,30 +29,32 @@ func (s *service) PeerDiscovered(ctx context.Context, discovered localdiscovery.
 // v1 fallback for peers that predate v2. own may be nil (re-exchange before
 // local discovery reported our addresses): the peer then answers without
 // recording us. The same function serves discovery and re-exchange, so the
-// two cannot drift.
-func (s *service) exchangeOutbound(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error) {
+// two cannot drift. proof is true for a v2 result: its tokens are keyed
+// proofs, while v1 is a plaintext list that proves nothing.
+func (s *service) exchangeOutbound(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) (shared []string, proof bool, err error) {
 	unaryPeer, err := s.poolManager.UnaryPeerPool().Get(ctx, peerId)
 	if err != nil {
-		return nil, fmt.Errorf("get peer: %w", err)
+		return nil, false, fmt.Errorf("get peer: %w", err)
 	}
 	allIds, err := s.exchangeRequestIds()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	var localServer *clientspaceproto.LocalServer
 	if own != nil {
 		localServer = localServerOf(*own)
 	}
-	shared, err := s.spaceExchangeV2(ctx, unaryPeer, peerId, allIds, localServer)
+	shared, err = s.spaceExchangeV2(ctx, unaryPeer, peerId, allIds, localServer)
 	if err != nil {
 		// a peer that predates v2 fails the call; fall back so LAN discovery
 		// keeps working across a mixed-version rollout
 		log.Debug("space exchange v2, falling back to v1", zap.String("peerId", peerId), zap.Error(err))
 		if shared, err = s.spaceExchangeV1(ctx, unaryPeer, allIds, localServer); err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		return shared, false, nil
 	}
-	return shared, nil
+	return shared, true, nil
 }
 
 // spaceExchangeV2 runs the token handshake: send one membership token per

--- a/space/spacecore/peer.go
+++ b/space/spacecore/peer.go
@@ -21,7 +21,7 @@ func (s *service) PeerDiscovered(ctx context.Context, discovered localdiscovery.
 	if err != nil {
 		return
 	}
-	s.publishLocalPeer(discovered.PeerId, shared, proof)
+	s.publishLocalPeer(discovered.PeerId, shared, proof, directionOutbound)
 }
 
 // exchangeOutbound is the outbound handshake with one LAN peer: the v2 token

--- a/space/spacecore/peer.go
+++ b/space/spacecore/peer.go
@@ -16,31 +16,50 @@ import (
 
 func (s *service) PeerDiscovered(ctx context.Context, discovered localdiscovery.DiscoveredPeer, own localdiscovery.OwnAddresses) {
 	s.peerService.SetPeerAddrs(discovered.PeerId, s.addSchema(discovered.Addrs))
-	unaryPeer, err := s.poolManager.UnaryPeerPool().Get(ctx, discovered.PeerId)
+	s.rememberOwn(own)
+	shared, err := s.exchangeOutbound(ctx, discovered.PeerId, &own)
 	if err != nil {
 		return
 	}
-	allIds, err := s.spaceStorageProvider.AllSpaceIds()
+	s.peerStore.UpdateLocalPeer(discovered.PeerId, shared)
+}
+
+// exchangeOutbound is the outbound handshake with one LAN peer: the v2 token
+// exchange over the request list (disk plus the derived tech space), with the
+// v1 fallback for peers that predate v2. own may be nil (re-exchange before
+// local discovery reported our addresses): the peer then answers without
+// recording us. The same function serves discovery and re-exchange, so the
+// two cannot drift.
+func (s *service) exchangeOutbound(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error) {
+	unaryPeer, err := s.poolManager.UnaryPeerPool().Get(ctx, peerId)
 	if err != nil {
-		return
+		return nil, fmt.Errorf("get peer: %w", err)
 	}
-	shared, err := s.spaceExchangeV2(ctx, unaryPeer, discovered.PeerId, allIds, own)
+	allIds, err := s.exchangeRequestIds()
+	if err != nil {
+		return nil, err
+	}
+	var localServer *clientspaceproto.LocalServer
+	if own != nil {
+		localServer = localServerOf(*own)
+	}
+	shared, err := s.spaceExchangeV2(ctx, unaryPeer, peerId, allIds, localServer)
 	if err != nil {
 		// a peer that predates v2 fails the call; fall back so LAN discovery
 		// keeps working across a mixed-version rollout
-		log.Debug("space exchange v2, falling back to v1", zap.String("peerId", discovered.PeerId), zap.Error(err))
-		if shared, err = s.spaceExchangeV1(ctx, unaryPeer, allIds, own); err != nil {
-			return
+		log.Debug("space exchange v2, falling back to v1", zap.String("peerId", peerId), zap.Error(err))
+		if shared, err = s.spaceExchangeV1(ctx, unaryPeer, allIds, localServer); err != nil {
+			return nil, err
 		}
 	}
-	s.peerStore.UpdateLocalPeer(discovered.PeerId, shared)
+	return shared, nil
 }
 
 // spaceExchangeV2 runs the token handshake: send one membership token per
 // space we can derive a discovery key for, padded and sorted so the true space
 // count stays hidden, then match the peer's proof tokens back to our own
 // spaces. Neither side ever transmits a space id.
-func (s *service) spaceExchangeV2(ctx context.Context, unaryPeer peer.Peer, peerId string, allIds []string, own localdiscovery.OwnAddresses) ([]string, error) {
+func (s *service) spaceExchangeV2(ctx context.Context, unaryPeer peer.Peer, peerId string, allIds []string, localServer *clientspaceproto.LocalServer) ([]string, error) {
 	nonce, err := clientspaceproto.NewNonceV2()
 	if err != nil {
 		return nil, fmt.Errorf("nonce: %w", err)
@@ -58,7 +77,7 @@ func (s *service) spaceExchangeV2(ctx context.Context, unaryPeer peer.Peer, peer
 		resp, dErr = clientspaceproto.NewDRPCClientSpaceClient(conn).SpaceExchangeV2(ctx, &clientspaceproto.SpaceExchangeV2Request{
 			Nonce:       nonce,
 			SpaceTokens: tokens,
-			LocalServer: localServerOf(own),
+			LocalServer: localServer,
 		})
 		return dErr
 	})
@@ -71,13 +90,13 @@ func (s *service) spaceExchangeV2(ctx context.Context, unaryPeer peer.Peer, peer
 // spaceExchangeV1 is the legacy plaintext handshake, kept only to reach peers
 // that predate SpaceExchangeV2. It hands our full space id list to whoever
 // asks, so it is never attempted before v2.
-func (s *service) spaceExchangeV1(ctx context.Context, unaryPeer peer.Peer, allIds []string, own localdiscovery.OwnAddresses) ([]string, error) {
+func (s *service) spaceExchangeV1(ctx context.Context, unaryPeer peer.Peer, allIds []string, localServer *clientspaceproto.LocalServer) ([]string, error) {
 	var resp *clientspaceproto.SpaceExchangeResponse
 	err := unaryPeer.DoDrpc(ctx, func(conn drpc.Conn) error {
 		var dErr error
 		resp, dErr = clientspaceproto.NewDRPCClientSpaceClient(conn).SpaceExchange(ctx, &clientspaceproto.SpaceExchangeRequest{
 			SpaceIds:    allIds,
-			LocalServer: localServerOf(own),
+			LocalServer: localServer,
 		})
 		return dErr
 	})

--- a/space/spacecore/peerstore/peerstore.go
+++ b/space/spacecore/peerstore/peerstore.go
@@ -133,7 +133,9 @@ func (p *peerStore) updatePeer(peerId string, oldIds, newIds []string) {
 func (p *peerStore) AllLocalPeers() []string {
 	p.Lock()
 	defer p.Unlock()
-	return p.localPeerIds
+	// Clone under the lock: the caller reads the result after we return, and
+	// a concurrent UpdateLocalPeer/RemoveLocalPeer appends to the same slice.
+	return slices.Clone(p.localPeerIds)
 }
 
 func (p *peerStore) LocalPeerIds(spaceId string) []string {

--- a/space/spacecore/peerstore/peerstore_race_test.go
+++ b/space/spacecore/peerstore/peerstore_race_test.go
@@ -1,0 +1,43 @@
+package peerstore
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestAllLocalPeersNoAlias pins that AllLocalPeers hands back a copy. It
+// returned the live slice, so the one production caller — the re-exchange
+// round, which clones after the lock is already released — raced every
+// concurrent local peer update. Run with -race.
+func TestAllLocalPeersNoAlias(t *testing.T) {
+	p := New().(*peerStore)
+	p.UpdateLocalPeer("a", []string{"s1"})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			_ = p.AllLocalPeers()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			p.UpdateLocalPeer("b", []string{"s2"})
+			p.RemoveLocalPeer("b")
+		}
+	}()
+	wg.Wait()
+
+	// mutating the result must not reach the store
+	got := p.AllLocalPeers()
+	if len(got) > 0 {
+		got[0] = "mutated"
+	}
+	for _, id := range p.AllLocalPeers() {
+		if id == "mutated" {
+			t.Fatal("AllLocalPeers returned the live slice")
+		}
+	}
+}

--- a/space/spacecore/reexchange.go
+++ b/space/spacecore/reexchange.go
@@ -114,13 +114,13 @@ func (s *service) exchangeWithKnownPeers() {
 			return
 		}
 		ctx, cancel := context.WithTimeout(s.componentCtx, reexchangePeerTimeout)
-		shared, err := s.exchangeFn(ctx, peerId, own)
+		shared, proof, err := s.exchangeFn(ctx, peerId, own)
 		cancel()
 		if err != nil {
 			log.Debug("re-exchange with local peer failed", zap.String("peerId", peerId), zap.Error(err))
 			continue
 		}
-		s.peerStore.UpdateLocalPeer(peerId, shared)
+		s.publishLocalPeer(peerId, shared, proof)
 	}
 }
 

--- a/space/spacecore/reexchange.go
+++ b/space/spacecore/reexchange.go
@@ -120,7 +120,7 @@ func (s *service) exchangeWithKnownPeers() {
 			log.Debug("re-exchange with local peer failed", zap.String("peerId", peerId), zap.Error(err))
 			continue
 		}
-		s.publishLocalPeer(peerId, shared, proof)
+		s.publishLocalPeer(peerId, shared, proof, directionOutbound)
 	}
 }
 

--- a/space/spacecore/reexchange.go
+++ b/space/spacecore/reexchange.go
@@ -1,0 +1,146 @@
+package spacecore
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/anyproto/anytype-heart/space/spacecore/localdiscovery"
+)
+
+// GO-7492: a LAN peer that shares nothing at discovery time may share
+// everything seconds later — on a cold device the first exchange happens
+// before the tech space and the SpaceViews arrive. Rather than a blacklist,
+// the space list simply has to be re-sent once it has changed.
+//
+// The trigger is loadSpace: it is the one place every path that makes a space
+// usable in this process converges (derive, create, pull, LAN push), and it
+// is exactly the moment AllSpaceIds grows. Spaces land one after another
+// during a cold sync, so the signals are coalesced: a round runs only after
+// reexchangeWindow of quiet, one round at a time, and a signal that lands
+// mid-round schedules exactly one more. mDNS is not a substitute: the browse
+// client suppresses re-delivery of a known peer until its advertised TTL
+// (3600 s) expires, so PeerDiscovered re-fires for a known peer about hourly.
+var (
+	reexchangeWindow      = 2 * time.Second
+	reexchangePeerTimeout = 10 * time.Second
+)
+
+// reexchanger coalesces "our space list changed" into rounds of run.
+type reexchanger struct {
+	mu      sync.Mutex
+	window  time.Duration
+	run     func()
+	timer   *time.Timer
+	running bool
+	pending bool
+	closed  bool
+	wg      sync.WaitGroup
+}
+
+func newReexchanger(window time.Duration, run func()) *reexchanger {
+	return &reexchanger{window: window, run: run}
+}
+
+// trigger records that the space list changed. It never blocks and never
+// runs anything inline: loadSpace calls it from inside the space cache load.
+func (r *reexchanger) trigger() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
+	if r.running {
+		r.pending = true
+		return
+	}
+	if r.timer == nil {
+		r.timer = time.AfterFunc(r.window, r.fire)
+	}
+}
+
+func (r *reexchanger) fire() {
+	r.mu.Lock()
+	r.timer = nil
+	if r.closed || r.running {
+		r.mu.Unlock()
+		return
+	}
+	r.running = true
+	r.wg.Add(1)
+	r.mu.Unlock()
+	go r.round()
+}
+
+func (r *reexchanger) round() {
+	defer r.wg.Done()
+	r.run()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.running = false
+	if r.pending && !r.closed {
+		// every round is preceded by a quiet window, the rerun included
+		r.pending = false
+		r.timer = time.AfterFunc(r.window, r.fire)
+	}
+}
+
+func (r *reexchanger) close() {
+	r.mu.Lock()
+	r.closed = true
+	if r.timer != nil {
+		r.timer.Stop()
+		r.timer = nil
+	}
+	r.mu.Unlock()
+	r.wg.Wait()
+}
+
+// exchangeWithKnownPeers is one re-exchange round: the outbound handshake with
+// every LAN peer the peer store already knows, with the current space list.
+// A failed exchange changes nothing — this is not a blacklist; the peer
+// manager drops unreachable peers on its own dial failures.
+func (s *service) exchangeWithKnownPeers() {
+	peers := slices.Clone(s.peerStore.AllLocalPeers())
+	if len(peers) == 0 {
+		return
+	}
+	own := s.currentOwn()
+	for _, peerId := range peers {
+		if s.componentCtx.Err() != nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(s.componentCtx, reexchangePeerTimeout)
+		shared, err := s.exchangeFn(ctx, peerId, own)
+		cancel()
+		if err != nil {
+			log.Debug("re-exchange with local peer failed", zap.String("peerId", peerId), zap.Error(err))
+			continue
+		}
+		s.peerStore.UpdateLocalPeer(peerId, shared)
+	}
+}
+
+// rememberOwn keeps the last addresses local discovery reported for this
+// device, so a re-exchange can still tell the peer where to reach us.
+func (s *service) rememberOwn(own localdiscovery.OwnAddresses) {
+	s.ownMu.Lock()
+	defer s.ownMu.Unlock()
+	s.lastOwn = &own
+}
+
+// currentOwn is nil until local discovery has reported our addresses; the
+// exchange then goes without a LocalServer (a probe the peer answers but does
+// not record), which is still enough for us to learn what it shares.
+func (s *service) currentOwn() *localdiscovery.OwnAddresses {
+	s.ownMu.Lock()
+	defer s.ownMu.Unlock()
+	if s.lastOwn == nil {
+		return nil
+	}
+	own := *s.lastOwn
+	return &own
+}

--- a/space/spacecore/reexchange_test.go
+++ b/space/spacecore/reexchange_test.go
@@ -1,0 +1,173 @@
+package spacecore
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/space/spacecore/localdiscovery"
+	"github.com/anyproto/anytype-heart/space/spacecore/peerstore"
+)
+
+func TestReexchanger(t *testing.T) {
+	const window = 20 * time.Millisecond
+	waitRounds := func(t *testing.T, runs *atomic.Int32, want int32) {
+		t.Helper()
+		require.Eventually(t, func() bool { return runs.Load() == want }, time.Second, time.Millisecond)
+	}
+
+	t.Run("a burst of triggers inside the window is one round", func(t *testing.T) {
+		// given
+		var runs atomic.Int32
+		r := newReexchanger(window, func() { runs.Add(1) })
+		defer r.close()
+
+		// when
+		for i := 0; i < 5; i++ {
+			r.trigger()
+		}
+
+		// then
+		waitRounds(t, &runs, 1)
+		time.Sleep(3 * window)
+		assert.Equal(t, int32(1), runs.Load())
+	})
+
+	t.Run("a trigger during a round schedules exactly one more, after a quiet window", func(t *testing.T) {
+		// given
+		var runs atomic.Int32
+		inRound := make(chan struct{})
+		release := make(chan struct{})
+		var once sync.Once
+		r := newReexchanger(window, func() {
+			if runs.Add(1) == 1 {
+				once.Do(func() { close(inRound) })
+				<-release
+			}
+		})
+		defer r.close()
+		r.trigger()
+		<-inRound
+
+		// when
+		r.trigger()
+		r.trigger()
+		r.trigger()
+		close(release)
+
+		// then
+		waitRounds(t, &runs, 2)
+		time.Sleep(3 * window)
+		assert.Equal(t, int32(2), runs.Load())
+	})
+
+	t.Run("closed: no round runs, and close waits for a running one", func(t *testing.T) {
+		// given
+		var runs atomic.Int32
+		r := newReexchanger(window, func() { runs.Add(1) })
+		r.trigger()
+
+		// when
+		r.close()
+		time.Sleep(3 * window)
+
+		// then
+		assert.Equal(t, int32(0), runs.Load())
+		r.trigger()
+		time.Sleep(3 * window)
+		assert.Equal(t, int32(0), runs.Load())
+	})
+}
+
+type exchangeCall struct {
+	peerId string
+	own    *localdiscovery.OwnAddresses
+}
+
+func TestExchangeWithKnownPeers(t *testing.T) {
+	type change struct {
+		peerId        string
+		before, after []string
+		removed       bool
+	}
+	newService := func(t *testing.T, fn func(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error)) (*service, *[]change) {
+		t.Helper()
+		var (
+			mu      sync.Mutex
+			changes []change
+		)
+		store := peerstore.New()
+		store.AddObserver(func(peerId string, before, after []string, removed bool) {
+			mu.Lock()
+			defer mu.Unlock()
+			changes = append(changes, change{peerId, before, after, removed})
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		return &service{peerStore: store, componentCtx: ctx, exchangeFn: fn}, &changes
+	}
+
+	t.Run("a peer that shared nothing flips to sharing on the re-exchange; a failing one is left alone", func(t *testing.T) {
+		// given: two peers registered from the cold exchange with nothing shared
+		var calls []exchangeCall
+		s, changes := newService(t, func(_ context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error) {
+			calls = append(calls, exchangeCall{peerId, own})
+			if peerId == "p2" {
+				return nil, errors.New("unreachable")
+			}
+			return []string{"tech.space", "spaceA"}, nil
+		})
+		s.peerStore.UpdateLocalPeer("p1", []string{})
+		s.peerStore.UpdateLocalPeer("p2", []string{})
+		s.rememberOwn(localdiscovery.OwnAddresses{Addrs: []string{"192.168.1.5"}, Port: 4242})
+
+		// when
+		s.exchangeWithKnownPeers()
+
+		// then
+		want := []change{
+			{"p1", nil, []string{}, false},
+			{"p2", nil, []string{}, false},
+			// the store sorts the list before notifying
+			{"p1", []string{}, []string{"spaceA", "tech.space"}, false},
+		}
+		assert.Equal(t, want, *changes)
+		assert.ElementsMatch(t, []string{"p1"}, s.peerStore.LocalPeerIds("tech.space"))
+		assert.ElementsMatch(t, []string{"p1", "p2"}, s.peerStore.AllLocalPeers(), "a failed exchange is not a blacklist")
+		require.Len(t, calls, 2)
+		assert.Equal(t, 4242, calls[0].own.Port)
+	})
+
+	t.Run("without known addresses the exchange goes as a probe", func(t *testing.T) {
+		// given
+		var calls []exchangeCall
+		s, _ := newService(t, func(_ context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error) {
+			calls = append(calls, exchangeCall{peerId, own})
+			return nil, nil
+		})
+		s.peerStore.UpdateLocalPeer("p1", nil)
+
+		// when
+		s.exchangeWithKnownPeers()
+
+		// then
+		require.Len(t, calls, 1)
+		assert.Nil(t, calls[0].own)
+	})
+
+	t.Run("no known peers is a no-op", func(t *testing.T) {
+		called := false
+		s, _ := newService(t, func(context.Context, string, *localdiscovery.OwnAddresses) ([]string, error) {
+			called = true
+			return nil, nil
+		})
+		s.exchangeWithKnownPeers()
+		assert.False(t, called)
+	})
+}

--- a/space/spacecore/reexchange_test.go
+++ b/space/spacecore/reexchange_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/anyproto/anytype-heart/space/spacecore/localdiscovery"
 	"github.com/anyproto/anytype-heart/space/spacecore/peerstore"
+	"github.com/anyproto/anytype-heart/space/spacecore/storage/mock_storage"
 )
 
 func TestReexchanger(t *testing.T) {
@@ -96,7 +97,7 @@ func TestExchangeWithKnownPeers(t *testing.T) {
 		before, after []string
 		removed       bool
 	}
-	newService := func(t *testing.T, fn func(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error)) (*service, *[]change) {
+	newService := func(t *testing.T, fn func(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, bool, error)) (*service, *[]change) {
 		t.Helper()
 		var (
 			mu      sync.Mutex
@@ -110,18 +111,22 @@ func TestExchangeWithKnownPeers(t *testing.T) {
 		})
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		return &service{peerStore: store, componentCtx: ctx, exchangeFn: fn}, &changes
+		disk := mock_storage.NewMockClientStorage(t)
+		disk.EXPECT().AllSpaceIds().Return(nil, nil).Maybe()
+		s := newKeyedService(t, 1, disk) // publishLocalPeer needs the keys for the proof check
+		s.peerStore, s.componentCtx, s.exchangeFn, s.accountPeers = store, ctx, fn, newAccountPeers()
+		return s, &changes
 	}
 
 	t.Run("a peer that shared nothing flips to sharing on the re-exchange; a failing one is left alone", func(t *testing.T) {
 		// given: two peers registered from the cold exchange with nothing shared
 		var calls []exchangeCall
-		s, changes := newService(t, func(_ context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error) {
+		s, changes := newService(t, func(_ context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, bool, error) {
 			calls = append(calls, exchangeCall{peerId, own})
 			if peerId == "p2" {
-				return nil, errors.New("unreachable")
+				return nil, false, errors.New("unreachable")
 			}
-			return []string{"tech.space", "spaceA"}, nil
+			return []string{"tech.space", "spaceA"}, false, nil // v1-shaped: no proof, so no candidacy expansion
 		})
 		s.peerStore.UpdateLocalPeer("p1", []string{})
 		s.peerStore.UpdateLocalPeer("p2", []string{})
@@ -147,9 +152,9 @@ func TestExchangeWithKnownPeers(t *testing.T) {
 	t.Run("without known addresses the exchange goes as a probe", func(t *testing.T) {
 		// given
 		var calls []exchangeCall
-		s, _ := newService(t, func(_ context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error) {
+		s, _ := newService(t, func(_ context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, bool, error) {
 			calls = append(calls, exchangeCall{peerId, own})
-			return nil, nil
+			return nil, false, nil
 		})
 		s.peerStore.UpdateLocalPeer("p1", nil)
 
@@ -163,9 +168,9 @@ func TestExchangeWithKnownPeers(t *testing.T) {
 
 	t.Run("no known peers is a no-op", func(t *testing.T) {
 		called := false
-		s, _ := newService(t, func(context.Context, string, *localdiscovery.OwnAddresses) ([]string, error) {
+		s, _ := newService(t, func(context.Context, string, *localdiscovery.OwnAddresses) ([]string, bool, error) {
 			called = true
-			return nil, nil
+			return nil, false, nil
 		})
 		s.exchangeWithKnownPeers()
 		assert.False(t, called)

--- a/space/spacecore/rpchandler.go
+++ b/space/spacecore/rpchandler.go
@@ -51,7 +51,7 @@ func (r *rpcHandler) SpaceExchange(ctx context.Context, request *clientspaceprot
 		if err != nil {
 			return nil, err
 		}
-		r.s.recordLocalPeer(ctx, peerId, request.LocalServer, request.SpaceIds)
+		r.s.recordLocalPeer(ctx, peerId, request.LocalServer, request.SpaceIds, false)
 	}
 	log.Debug("returning list with ids", zap.Strings("spaceIds", allIds))
 	resp = &clientspaceproto.SpaceExchangeResponse{SpaceIds: allIds}
@@ -59,8 +59,9 @@ func (r *rpcHandler) SpaceExchange(ctx context.Context, request *clientspaceprot
 }
 
 // recordLocalPeer registers the addresses a LAN peer advertised and the spaces
-// it shares with us, so subsequent syncing dials it directly.
-func (s *service) recordLocalPeer(ctx context.Context, peerId string, localServer *clientspaceproto.LocalServer, spaceIds []string) {
+// it shares with us, so subsequent syncing dials it directly. proof says
+// whether spaceIds came out of a v2 token exchange (a v1 list is plaintext).
+func (s *service) recordLocalPeer(ctx context.Context, peerId string, localServer *clientspaceproto.LocalServer, spaceIds []string, proof bool) {
 	var portAddrs []string
 	peerAddr := peer.CtxPeerAddr(ctx)
 
@@ -83,7 +84,7 @@ func (s *service) recordLocalPeer(ctx context.Context, peerId string, localServe
 	// addSchema pins the transport for local peers (yamux); see its comment
 	addrsWithSchema := s.addSchema(portAddrs)
 	s.peerService.SetPeerAddrs(peerId, addrsWithSchema)
-	s.peerStore.UpdateLocalPeer(peerId, spaceIds)
+	s.publishLocalPeer(peerId, spaceIds, proof)
 	log.Info("updated local peer", zap.Strings("ips", addrsWithSchema), zap.String("peerId", peerId), zap.Strings("spaceIds", spaceIds))
 }
 
@@ -114,13 +115,20 @@ func (r *rpcHandler) SpaceExchangeV2(ctx context.Context, request *clientspacepr
 	// a request without LocalServer is a plain probe: answer the proofs but
 	// record nothing
 	if request.LocalServer != nil {
-		r.s.recordLocalPeer(ctx, callerPeerId, request.LocalServer, shared)
+		r.s.recordLocalPeer(ctx, callerPeerId, request.LocalServer, shared, true)
 	}
 	log.Debug("space exchange v2 received", zap.String("peerId", callerPeerId), zap.Int("shared", len(shared)))
 	return &clientspaceproto.SpaceExchangeV2Response{SpaceTokens: respTokens}, nil
 }
 
 func (r *rpcHandler) SpacePull(ctx context.Context, request *spacesyncproto.SpacePullRequest) (resp *spacesyncproto.SpacePullResponse, err error) {
+	// GO-7492: an account peer may ask for any space we might hold. Answer
+	// from disk: Get would load the space and, if absent, pull it on the
+	// caller's behalf — which recurses back to a caller whose own load of
+	// that space is what is waiting on us.
+	if !r.s.spaceStorageProvider.SpaceExists(request.Id) {
+		return nil, spacesyncproto.ErrSpaceMissing
+	}
 	sp, err := r.s.Get(ctx, request.Id)
 	if err != nil {
 		if err != spacesyncproto.ErrSpaceMissing {

--- a/space/spacecore/rpchandler.go
+++ b/space/spacecore/rpchandler.go
@@ -84,7 +84,7 @@ func (s *service) recordLocalPeer(ctx context.Context, peerId string, localServe
 	// addSchema pins the transport for local peers (yamux); see its comment
 	addrsWithSchema := s.addSchema(portAddrs)
 	s.peerService.SetPeerAddrs(peerId, addrsWithSchema)
-	s.publishLocalPeer(peerId, spaceIds, proof)
+	s.publishLocalPeer(peerId, spaceIds, proof, directionInbound)
 	log.Info("updated local peer", zap.Strings("ips", addrsWithSchema), zap.String("peerId", peerId), zap.Strings("spaceIds", spaceIds))
 }
 

--- a/space/spacecore/service.go
+++ b/space/spacecore/service.go
@@ -95,6 +95,16 @@ type service struct {
 	poolManager          PoolManager
 	discoveryKeys        *discoveryKeySource
 
+	// GO-7492: the derived tech space in every outbound exchange request, and
+	// a re-exchange with known LAN peers once our own space list changes
+	techSpaceOnce sync.Once
+	techSpace     techSpaceExchange
+	reexchange    *reexchanger
+	ownMu         sync.Mutex
+	lastOwn       *localdiscovery.OwnAddresses
+	// exchangeFn is the outbound handshake with one peer; a seam for tests
+	exchangeFn func(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error)
+
 	dbsAreFlushing     atomic.Bool
 	componentCtx       context.Context
 	componentCtxCancel context.CancelFunc
@@ -117,6 +127,8 @@ func (s *service) Init(a *app.App) (err error) {
 	s.peerService = a.MustComponent(peerservice.CName).(peerservice.PeerService)
 	localDiscovery := a.MustComponent(localdiscovery.CName).(localdiscovery.LocalDiscovery)
 	localDiscovery.SetNotifier(s)
+	s.exchangeFn = s.exchangeOutbound
+	s.reexchange = newReexchanger(reexchangeWindow, s.exchangeWithKnownPeers)
 	s.spaceCache = ocache.New(
 		s.loadSpace,
 		ocache.WithLogger(log.Sugar()),
@@ -299,6 +311,11 @@ func (s *service) loadSpace(ctx context.Context, id string) (value ocache.Object
 	if err != nil {
 		return
 	}
+	// the space is on disk now: AllSpaceIds grew, so known LAN peers get a
+	// re-exchange (coalesced; never inline, we are inside the cache load)
+	if s.reexchange != nil {
+		s.reexchange.trigger()
+	}
 	ns, err := newAnySpace(cc, kvObserver)
 	if err != nil {
 		return
@@ -319,6 +336,9 @@ func (s *service) getOpenedSpaceIds() (ids []string) {
 
 func (s *service) Close(ctx context.Context) (err error) {
 	s.componentCtxCancel()
+	if s.reexchange != nil {
+		s.reexchange.close()
+	}
 	return s.spaceCache.Close()
 }
 

--- a/space/spacecore/service.go
+++ b/space/spacecore/service.go
@@ -102,8 +102,13 @@ type service struct {
 	reexchange    *reexchanger
 	ownMu         sync.Mutex
 	lastOwn       *localdiscovery.OwnAddresses
-	// exchangeFn is the outbound handshake with one peer; a seam for tests
-	exchangeFn func(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) ([]string, error)
+	// exchangeFn is the outbound handshake with one peer (shared spaces, and
+	// whether the result is a v2 proof); a seam for tests
+	exchangeFn func(ctx context.Context, peerId string, own *localdiscovery.OwnAddresses) (shared []string, proof bool, err error)
+	// accountPeers and knownSpaces make a proven account peer a pull
+	// candidate for every space we know of but do not hold yet
+	accountPeers *accountPeers
+	knownSpaces  knownSpaceIdsProvider
 
 	dbsAreFlushing     atomic.Bool
 	componentCtx       context.Context
@@ -129,6 +134,13 @@ func (s *service) Init(a *app.App) (err error) {
 	localDiscovery.SetNotifier(s)
 	s.exchangeFn = s.exchangeOutbound
 	s.reexchange = newReexchanger(reexchangeWindow, s.exchangeWithKnownPeers)
+	s.accountPeers = newAccountPeers()
+	s.knownSpaces = lookupKnownSpaces(a)
+	s.peerStore.AddObserver(func(peerId string, _, _ []string, removed bool) {
+		if removed {
+			s.forgetLocalPeer(peerId)
+		}
+	})
 	s.spaceCache = ocache.New(
 		s.loadSpace,
 		ocache.WithLogger(log.Sugar()),
@@ -286,6 +298,10 @@ func (s *service) Delete(ctx context.Context, spaceId string) (err error) {
 }
 
 func (s *service) loadSpace(ctx context.Context, id string) (value ocache.Object, err error) {
+	// about to pull: every proven account peer is a candidate for this space
+	if s.accountPeers != nil {
+		s.refreshProvenPeers(id)
+	}
 	kvObserver := keyvalueobserver.New()
 	statusService := objectsyncstatus.NewSyncStatusService()
 	deps := commonspace.Deps{
@@ -311,8 +327,12 @@ func (s *service) loadSpace(ctx context.Context, id string) (value ocache.Object
 	if err != nil {
 		return
 	}
-	// the space is on disk now: AllSpaceIds grew, so known LAN peers get a
-	// re-exchange (coalesced; never inline, we are inside the cache load)
+	// the space is on disk now: candidacy for it ends until the exchange
+	// confirms it, and AllSpaceIds grew, so known LAN peers get a re-exchange
+	// (coalesced; never inline, we are inside the cache load)
+	if s.accountPeers != nil {
+		s.refreshProvenPeers()
+	}
 	if s.reexchange != nil {
 		s.reexchange.trigger()
 	}

--- a/space/spacecore/techspacekey.go
+++ b/space/spacecore/techspacekey.go
@@ -1,0 +1,91 @@
+package spacecore
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/anyproto/any-sync/commonspace/clientspaceproto"
+	"github.com/anyproto/any-sync/commonspace/object/acl/list"
+	"github.com/anyproto/any-sync/commonspace/object/acl/recordverifier"
+	"github.com/anyproto/any-sync/consensus/consensusproto"
+	"go.uber.org/zap"
+
+	"github.com/anyproto/anytype-heart/space/spacedomain"
+)
+
+// GO-7492: a cold device has no space storage, so AllSpaceIds is empty and
+// the LAN exchange asks about nothing — a peer holding the whole account sits
+// idle while everything is pulled from a network node. The tech space is the
+// one space that can be asked about before it exists locally: it is DERIVED,
+// so both its id and its first ACL read key follow from the account keys.
+// The exchange token needs the discovery key, HKDF over that read key, which
+// discoveryKeySource normally reads from the space's ACL on disk; here the
+// same ACL is built in memory from the derive payload instead.
+
+type consensusRecord = consensusproto.RawRecordWithId
+
+// techSpaceExchange is the derived tech space's id and discovery key,
+// computed once per process.
+type techSpaceExchange struct {
+	id  string
+	key []byte
+}
+
+// techSpaceExchangeInfo returns the tech space's id and discovery key, seeding
+// the discovery key source on first use. Empty on failure: the exchange then
+// behaves exactly as before.
+func (s *service) techSpaceExchangeInfo() techSpaceExchange {
+	s.techSpaceOnce.Do(func() {
+		info, err := s.deriveTechSpaceExchange()
+		if err != nil {
+			log.Warn("derive tech space discovery key", zap.Error(err))
+			return
+		}
+		s.discoveryKeys.seed(info.id, info.key)
+		s.techSpace = info
+	})
+	return s.techSpace
+}
+
+func (s *service) deriveTechSpaceExchange() (techSpaceExchange, error) {
+	payload, err := s.deriveStoragePayload(spacedomain.SpaceTypeTech)
+	if err != nil {
+		return techSpaceExchange{}, fmt.Errorf("derive storage payload: %w", err)
+	}
+	id := payload.SpaceHeaderWithId.Id
+	// the same reading discoveryKeySource.derive performs on disk, over the
+	// deterministic derived root
+	aclStorage, err := list.NewInMemoryStorage(payload.AclWithId.Id, []*consensusRecord{payload.AclWithId})
+	if err != nil {
+		return techSpaceExchange{}, fmt.Errorf("in-memory acl storage: %w", err)
+	}
+	aclList, err := list.BuildAclListWithIdentity(s.accountKeys, aclStorage, recordverifier.NewValidateFull())
+	if err != nil {
+		return techSpaceExchange{}, fmt.Errorf("build acl list: %w", err)
+	}
+	firstKeys, ok := aclList.AclState().Keys()[aclList.Id()]
+	if !ok || firstKeys.ReadKey == nil {
+		return techSpaceExchange{}, list.ErrNoReadKey
+	}
+	key, err := clientspaceproto.DeriveDiscoveryKey(firstKeys.ReadKey, id)
+	if err != nil {
+		return techSpaceExchange{}, fmt.Errorf("derive discovery key: %w", err)
+	}
+	return techSpaceExchange{id: id, key: key}, nil
+}
+
+// exchangeRequestIds is the space list an OUTBOUND exchange asks about:
+// everything on disk plus the derived tech space. Only the request adds it —
+// a responder that does not hold the tech space must not claim to share it,
+// or two cold devices of one account would "share" a space neither has.
+func (s *service) exchangeRequestIds() ([]string, error) {
+	ids, err := s.spaceStorageProvider.AllSpaceIds()
+	if err != nil {
+		return nil, fmt.Errorf("all space ids: %w", err)
+	}
+	tech := s.techSpaceExchangeInfo()
+	if tech.id == "" || slices.Contains(ids, tech.id) {
+		return ids, nil
+	}
+	return append(ids, tech.id), nil
+}

--- a/space/spacecore/techspacekey_test.go
+++ b/space/spacecore/techspacekey_test.go
@@ -1,0 +1,163 @@
+package spacecore
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/anyproto/any-sync/commonspace/clientspaceproto"
+	"github.com/anyproto/any-sync/commonspace/object/accountdata"
+	"github.com/anyproto/any-sync/util/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/wallet/mock_wallet"
+	"github.com/anyproto/anytype-heart/space/spacecore/storage/mock_storage"
+)
+
+// newKeyedService builds the slice of service the exchange needs, for an
+// account whose keys derive from seed, over a storage mock.
+func newKeyedService(t *testing.T, seed byte, store *mock_storage.MockClientStorage) *service {
+	t.Helper()
+	raw := make([]byte, 32)
+	for i := range raw {
+		raw[i] = seed + byte(i)
+	}
+	accountKey, _, err := crypto.GenerateEd25519Key(bytes.NewReader(raw))
+	require.NoError(t, err)
+	masterKey, _, err := crypto.GenerateEd25519Key(bytes.NewReader(raw))
+	require.NoError(t, err)
+	peerKey, _, err := crypto.GenerateRandomEd25519KeyPair()
+	require.NoError(t, err)
+	w := mock_wallet.NewMockWallet(t)
+	w.EXPECT().GetAccountPrivkey().Return(accountKey).Maybe()
+	w.EXPECT().GetMasterKey().Return(masterKey).Maybe()
+	keys := accountdata.New(peerKey, accountKey)
+	return &service{
+		wallet:               w,
+		accountKeys:          keys,
+		spaceStorageProvider: store,
+		discoveryKeys:        newDiscoveryKeySource(store, keys),
+	}
+}
+
+func TestTechSpaceExchangeInfo(t *testing.T) {
+	t.Run("the tech space id and discovery key follow from the account keys alone", func(t *testing.T) {
+		// given
+		a := newKeyedService(t, 1, mock_storage.NewMockClientStorage(t))
+		b := newKeyedService(t, 1, mock_storage.NewMockClientStorage(t))
+		other := newKeyedService(t, 9, mock_storage.NewMockClientStorage(t))
+
+		// when
+		infoA, infoB, infoOther := a.techSpaceExchangeInfo(), b.techSpaceExchangeInfo(), other.techSpaceExchangeInfo()
+
+		// then
+		require.NotEmpty(t, infoA.id)
+		require.Len(t, infoA.key, 32)
+		assert.Equal(t, infoA, infoB, "deterministic: no storage was consulted")
+		assert.NotEqual(t, infoA.id, infoOther.id)
+		assert.NotEqual(t, infoA.key, infoOther.key)
+		// and the key source is seeded, so token building finds it without disk
+		assert.Equal(t, map[string][]byte{infoA.id: infoA.key}, a.discoveryKeys.DiscoveryKeys(t.Context(), []string{infoA.id}))
+	})
+}
+
+func TestExchangeRequestIds(t *testing.T) {
+	t.Run("a cold device asks about the derived tech space", func(t *testing.T) {
+		// given
+		store := mock_storage.NewMockClientStorage(t)
+		store.EXPECT().AllSpaceIds().Return(nil, nil)
+		s := newKeyedService(t, 1, store)
+
+		// when
+		got, err := s.exchangeRequestIds()
+
+		// then
+		require.NoError(t, err)
+		want := []string{s.techSpaceExchangeInfo().id}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("once the tech space is on disk it is not listed twice", func(t *testing.T) {
+		// given
+		store := mock_storage.NewMockClientStorage(t)
+		s := newKeyedService(t, 1, store)
+		techId := s.techSpaceExchangeInfo().id
+		store.EXPECT().AllSpaceIds().Return([]string{"spaceA", techId}, nil)
+
+		// when
+		got, err := s.exchangeRequestIds()
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, []string{"spaceA", techId}, got)
+	})
+
+	t.Run("a storage error is returned", func(t *testing.T) {
+		// given
+		store := mock_storage.NewMockClientStorage(t)
+		store.EXPECT().AllSpaceIds().Return(nil, errors.New("datadir"))
+		s := newKeyedService(t, 1, store)
+
+		// when
+		_, err := s.exchangeRequestIds()
+
+		// then
+		require.Error(t, err)
+	})
+}
+
+func TestColdDeviceExchangesOnTechSpace(t *testing.T) {
+	const callerId, responderId = "coldPeer", "warmPeer"
+	nonce, err := clientspaceproto.NewNonceV2()
+	require.NoError(t, err)
+
+	t.Run("a cold caller learns that a warm responder holds its account", func(t *testing.T) {
+		// given: the caller has no storage, only the seeded tech key; the
+		// responder holds the tech space and one more
+		cold := newKeyedService(t, 1, func() *mock_storage.MockClientStorage {
+			st := mock_storage.NewMockClientStorage(t)
+			st.EXPECT().AllSpaceIds().Return(nil, nil)
+			return st
+		}())
+		callerIds, err := cold.exchangeRequestIds()
+		require.NoError(t, err)
+		tech := cold.techSpaceExchangeInfo()
+		callerKeys := cold.discoveryKeys.DiscoveryKeys(t.Context(), callerIds)
+		responderIds := []string{tech.id, "spaceB"}
+		responderKeys := map[string][]byte{tech.id: tech.key, "spaceB": discoveryKeyFor(t, "spaceB")}
+
+		// when
+		request, err := requestTokens(callerIds, callerKeys, nonce, callerId, responderId)
+		require.NoError(t, err)
+		sharedByResponder, proofs := respondTokens(responderIds, responderKeys, request, nonce, callerId, responderId)
+		got := matchProofs(callerIds, callerKeys, proofs, nonce, callerId, responderId)
+
+		// then
+		assert.Equal(t, []string{tech.id}, got)
+		assert.Equal(t, []string{tech.id}, sharedByResponder)
+	})
+
+	t.Run("a cold responder does not claim a space it does not hold", func(t *testing.T) {
+		// given: both devices are cold; the responder answers from disk only
+		cold := newKeyedService(t, 1, func() *mock_storage.MockClientStorage {
+			st := mock_storage.NewMockClientStorage(t)
+			st.EXPECT().AllSpaceIds().Return(nil, nil)
+			return st
+		}())
+		callerIds, err := cold.exchangeRequestIds()
+		require.NoError(t, err)
+		callerKeys := cold.discoveryKeys.DiscoveryKeys(t.Context(), callerIds)
+		var responderIds []string // the inbound side stays on AllSpaceIds
+		responderKeys := map[string][]byte{}
+
+		// when
+		request, err := requestTokens(callerIds, callerKeys, nonce, callerId, responderId)
+		require.NoError(t, err)
+		_, proofs := respondTokens(responderIds, responderKeys, request, nonce, callerId, responderId)
+		got := matchProofs(callerIds, callerKeys, proofs, nonce, callerId, responderId)
+
+		// then
+		assert.Empty(t, got)
+	})
+}


### PR DESCRIPTION
Split out of #3259 so a change to peer selection can be reverted on its own. #3259 keeps the recovery event stream, which only observes; this PR changes which peers we ask for data and what we serve, and that is the part a field regression would need rolled back.

## The problem

A cold device has an empty space list on disk. The LAN space exchange intersects the two sides' space ids, so a device with nothing to name asks about nothing, and every LAN peer truthfully answers "we share nothing". A peer that holds the whole account is therefore never made a candidate for it, and the cold start goes to the network even when the data is one hop away on the same subnet.

## What this does

**Ask about the derived tech space.** The tech space is derived, so its id and its first ACL read key follow from the account keys alone — a device can name it before it holds any of it. A cold device now includes that id in the exchange, which is enough for a peer that does hold the account to answer with it.

**Re-exchange as the space list grows.** Space ids arrive over time. Each new space on disk coalesces into a re-exchange round with the peers we already know, so a list that was empty at discovery does not stay empty.

**Make a proven peer a candidate for what we lack.** A peer that answered with the tech space over a v2 token exchange has proven account membership; it becomes a pull candidate for every space we know of from SpaceViews but do not hold, and stops being one per space as that space lands on disk.

**Guard `SpacePull`.** The handler ran the full load path, so serving a space we do not hold would pull it on the caller's behalf — two cold devices asking each other would deadlock. It now answers only from what is already on disk.

## Direction matters, and it did not

The last commit fixes a bug found in review, with regressions that fail against the code before it.

The two exchange answers mean different things: an **outbound** answer is what the peer holds of the list we asked about; an **inbound** answer is what *we* hold of the list the peer asked about, bounded by our own disk. Only the first says anything about the peer.

The proof did not distinguish them. So a warm device receiving an inbound exchange from a *cold* peer intersected the cold peer's derived tech space id against its own disk, found it — because the warm device holds it — and marked the empty peer proven. That made a device with no data a pull candidate for the one space every cold start needs first, which is precisely the case this PR introduces.

The proof is now outbound-only, and an inbound answer no longer records the tech space it cannot vouch for while keeping the genuinely shared spaces it does establish.

Also fixed: `AllLocalPeers` returned the live slice under a lock released on return. Its one production caller — the re-exchange round — clones after the lock is gone, so every round raced concurrent local peer updates. It clones under the lock now; the regression reproduces under `-race`.

## Tests

`TestPublishLocalPeerDirection` pins the asymmetry in all four combinations (inbound never proves, inbound still records genuinely shared spaces, outbound proves, v1 proves nothing in either direction). `TestAllLocalPeersNoAlias` catches the aliasing. Both fail against the previous commit — verified, not assumed. The reexchanger's coalescing and `exchangeWithKnownPeers` were already covered.

**Known gap:** nothing asserts that `loadSpace` actually calls `refreshProvenPeers`/`reexchange.trigger`. All three call sites can be deleted with a green suite, which would silently disable the LAN path. Closing it needs a real `commonspace`, so I left it rather than write a test that only looks like coverage.

## Review

Verified by a review pass that wrote executable tests against the real code rather than reading it — that is how both fixed bugs were found and how the direction bug was confirmed reachable.
