### PR TITLE
GO-7467 Fix the network identity that deletes and launders QUIC verdicts

### DIFF
--- a/core/device/mock_device/mock_NetworkState.go
+++ b/core/device/mock_device/mock_NetworkState.go
@@ -5,6 +5,8 @@ package mock_device
 import (
 	app "github.com/anyproto/any-sync/app"
 
+	networkkey "github.com/anyproto/anytype-heart/core/device/networkkey"
+
 	mock "github.com/stretchr/testify/mock"
 
 	model "github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -238,22 +240,22 @@ func (_c *MockNetworkState_IsOffline_Call) RunAndReturn(run func() bool) *MockNe
 }
 
 // NetworkIdentity provides a mock function with no fields
-func (_m *MockNetworkState) NetworkIdentity() (string, bool) {
+func (_m *MockNetworkState) NetworkIdentity() (networkkey.Key, bool) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for NetworkIdentity")
 	}
 
-	var r0 string
+	var r0 networkkey.Key
 	var r1 bool
-	if rf, ok := ret.Get(0).(func() (string, bool)); ok {
+	if rf, ok := ret.Get(0).(func() (networkkey.Key, bool)); ok {
 		return rf()
 	}
-	if rf, ok := ret.Get(0).(func() string); ok {
+	if rf, ok := ret.Get(0).(func() networkkey.Key); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(string)
+		r0 = ret.Get(0).(networkkey.Key)
 	}
 
 	if rf, ok := ret.Get(1).(func() bool); ok {
@@ -282,12 +284,12 @@ func (_c *MockNetworkState_NetworkIdentity_Call) Run(run func()) *MockNetworkSta
 	return _c
 }
 
-func (_c *MockNetworkState_NetworkIdentity_Call) Return(_a0 string, _a1 bool) *MockNetworkState_NetworkIdentity_Call {
+func (_c *MockNetworkState_NetworkIdentity_Call) Return(_a0 networkkey.Key, _a1 bool) *MockNetworkState_NetworkIdentity_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockNetworkState_NetworkIdentity_Call) RunAndReturn(run func() (string, bool)) *MockNetworkState_NetworkIdentity_Call {
+func (_c *MockNetworkState_NetworkIdentity_Call) RunAndReturn(run func() (networkkey.Key, bool)) *MockNetworkState_NetworkIdentity_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/core/device/networkkey/key.go
+++ b/core/device/networkkey/key.go
@@ -1,0 +1,56 @@
+// Package networkkey holds the network identity type on its own, so the
+// generated device mocks can name it without importing core/device back.
+package networkkey
+
+// Key identifies a network by the parts that were actually observed. It is
+// deliberately not a single string: the client's report (type and path id)
+// and the monitor's interface snapshot land at different times - the snapshot
+// within milliseconds of Run, the report only once the account app is up,
+// since DeviceNetworkStateSet is rejected before login. A concatenated key
+// therefore differs from itself on one network depending on when it was read,
+// which is why comparison goes through SameNetwork.
+//
+// The client's path id is only as stable as the client makes it (Android
+// sends the network handle, which changes on every reconnect - see
+// docs/mobile-network-integration.md), and the snapshot is the whole address
+// set, so a VPN or a DHCP lease moves it. A genuinely stable per-network key
+// from the client is what would make persistence reliable on mobile.
+type Key struct {
+	// Reported: the client has told us Type and PathId. Without it Type is
+	// indistinguishable from WIFI, the enum's zero value.
+	Reported bool   `json:"reported,omitempty"`
+	Type     int32  `json:"type,omitempty"`
+	PathId   string `json:"pathId,omitempty"`
+	Snapshot string `json:"snapshot,omitempty"`
+}
+
+// Known reports whether anything DISCRIMINATING identifies the network. A
+// bare type does not: "some Wi-Fi" matches every Wi-Fi, so a verdict filed
+// under it would apply on every Wi-Fi the device ever joins.
+func (k Key) Known() bool {
+	return k.PathId != "" || k.Snapshot != ""
+}
+
+// SameNetwork reports whether two observations can be of the same network.
+// Every part known on BOTH sides must agree; a part missing on one side is
+// absence of evidence, not evidence of a different network. Comparing whole
+// keys instead read a half-formed observation as a move and threw away state
+// that belonged to the network the device was still on.
+//
+// The direction of the remaining doubt is deliberate: when two observations
+// share no known part, this answers true and the caller keeps what it has.
+// Using the slower transport to a healthy peer for a while is a smaller harm
+// than re-learning the verdict on every launch, which is the failure this
+// exists to prevent.
+func (k Key) SameNetwork(other Key) bool {
+	if k.Reported && other.Reported && k.Type != other.Type {
+		return false
+	}
+	if k.PathId != "" && other.PathId != "" && k.PathId != other.PathId {
+		return false
+	}
+	if k.Snapshot != "" && other.Snapshot != "" && k.Snapshot != other.Snapshot {
+		return false
+	}
+	return true
+}

--- a/core/device/networkkey/key_test.go
+++ b/core/device/networkkey/key_test.go
@@ -1,0 +1,49 @@
+package networkkey
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestKey_SameNetwork pins the rule that a part missing on one side is
+// absence of evidence. The three parts of an identity arrive at different
+// times — the interface snapshot within milliseconds of start, the client's
+// report only once the account app is up — so comparing whole keys read one
+// network as two and threw away the verdict learned on it.
+func TestKey_SameNetwork(t *testing.T) {
+	full := Key{Reported: true, Type: 0, PathId: "en0|192.168.1.1", Snapshot: "192.168.1.218"}
+
+	t.Run("the cold-start half of a key still matches the whole", func(t *testing.T) {
+		// given: what the startup check sees before the client has reported
+		half := Key{Snapshot: "192.168.1.218"}
+
+		// then
+		assert.True(t, full.SameNetwork(half))
+		assert.True(t, half.SameNetwork(full))
+	})
+
+	t.Run("a genuinely different network still differs", func(t *testing.T) {
+		assert.False(t, full.SameNetwork(Key{Snapshot: "10.0.0.5"}))
+		assert.False(t, full.SameNetwork(Key{Reported: true, PathId: "en0|10.0.0.1", Snapshot: "192.168.1.218"}))
+	})
+
+	t.Run("a reported type change is a different network", func(t *testing.T) {
+		wifi := Key{Reported: true, Type: 0, PathId: "p"}
+		cell := Key{Reported: true, Type: 1, PathId: "p"}
+		assert.False(t, wifi.SameNetwork(cell))
+	})
+
+	t.Run("no overlap keeps what we have", func(t *testing.T) {
+		// nothing can be proven either way, and deleting a verdict on no
+		// evidence is the failure this exists to prevent
+		assert.True(t, Key{Snapshot: "a"}.SameNetwork(Key{Reported: true, PathId: "b"}))
+	})
+
+	t.Run("a bare type identifies nothing", func(t *testing.T) {
+		// "some Wi-Fi" matches every Wi-Fi
+		assert.False(t, Key{Reported: true, Type: 0}.Known())
+		assert.True(t, Key{Snapshot: "a"}.Known())
+		assert.True(t, Key{PathId: "p"}.Known())
+	})
+}

--- a/core/device/networkstate.go
+++ b/core/device/networkstate.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/anyproto/anytype-heart/core/device/networkkey"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/net/addrs"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -62,14 +63,15 @@ type NetworkState interface {
 	// interface with no real connectivity); callers must treat this as a hint
 	// for backing off, not as a guarantee.
 	IsOffline() bool
-	// NetworkIdentity is an opaque key identifying the current network:
-	// client-reported type and path id (mobile) combined with the net
-	// monitor's interface snapshot (desktop). Equal keys mean the device is
-	// still on the same network; callers use it to scope per-network state
-	// like transport penalties. ok is false while nothing identifies the
-	// network - no path id reported, no interface snapshot, or the device is
-	// offline - and such a key must be neither compared nor persisted.
-	NetworkIdentity() (identity string, ok bool)
+	// NetworkIdentity identifies the current network as the separately
+	// observed parts it is made of. Callers use it to scope per-network
+	// state like transport penalties, and must compare with
+	// NetworkKey.SameNetwork rather than by equality: the parts arrive at
+	// different times, so two observations of one network routinely differ.
+	// ok is false while nothing identifies the network - nothing reported,
+	// no interface snapshot, or the device is offline - and such a key must
+	// be neither compared nor persisted.
+	NetworkIdentity() (key NetworkKey, ok bool)
 }
 
 type openedObjectRefresher interface {
@@ -423,28 +425,27 @@ func (n *networkState) fingerprint() string {
 	return fmt.Sprintf("%d|%s|%d", state, id, n.monitorGen.Load())
 }
 
-func (n *networkState) NetworkIdentity() (string, bool) {
+// NetworkKey is the network identity; see networkkey.Key.
+type NetworkKey = networkkey.Key
+
+func (n *networkState) NetworkIdentity() (NetworkKey, bool) {
 	n.networkMu.Lock()
-	state, id := n.networkState, n.networkId
+	state, id, reported := n.networkState, n.networkId, n.networkStateReported
 	n.networkMu.Unlock()
-	snapshot := n.monitorSnapshot.Load()
-	// Unknown until something actually identifies the network. Before the
-	// client's first report and the monitor's first snapshot the fields are
-	// zero, and formatting them yields "0||" - a key that looks real, so a
-	// stored verdict compared against it on a mobile cold start was dropped,
-	// and a verdict persisted under it matched on every later network. The
-	// type alone is no better ("some Wi-Fi" matches every Wi-Fi), and
-	// offline says nothing about where the device is. Callers degrade to
-	// not persisting rather than persisting under a key that fits anywhere.
-	// The client's path id is only as stable as the client makes it (Android
-	// sends the network handle, which changes on every reconnect - see
-	// docs/mobile-network-integration.md); without interface enumeration a
-	// genuinely stable per-network key from the client is what would make
-	// persistence reliable there.
-	if state == model.DeviceNetworkType_NOT_CONNECTED || (id == "" && snapshot == "") {
-		return "", false
+	// Offline says nothing about which network the device is on.
+	if state == model.DeviceNetworkType_NOT_CONNECTED {
+		return NetworkKey{}, false
 	}
-	return fmt.Sprintf("%d|%s|%s", state, id, snapshot), true
+	key := NetworkKey{
+		Reported: reported,
+		Type:     int32(state),
+		PathId:   id,
+		Snapshot: n.monitorSnapshot.Load(),
+	}
+	if !key.Known() {
+		return NetworkKey{}, false
+	}
+	return key, true
 }
 
 func (n *networkState) IsOffline() bool {

--- a/core/device/networkstate_test.go
+++ b/core/device/networkstate_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/anyproto/anytype-heart/core/device/mock_device"
+	"github.com/anyproto/anytype-heart/core/device/networkkey"
 	"github.com/anyproto/anytype-heart/core/domain"
 	"github.com/anyproto/anytype-heart/net/addrs"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
@@ -432,7 +433,7 @@ func TestNetworkState_NetworkIdentity(t *testing.T) {
 
 		// then
 		assert.True(t, ok)
-		assert.Equal(t, "0|wifi-1|10.0.0.5", identity)
+		assert.Equal(t, networkkey.Key{Reported: true, Type: int32(model.DeviceNetworkType_WIFI), PathId: "wifi-1", Snapshot: "10.0.0.5"}, identity)
 	})
 	t.Run("identity changes when the network path changes", func(t *testing.T) {
 		// given
@@ -493,7 +494,7 @@ func TestNetworkState_NetworkIdentity(t *testing.T) {
 
 		// then
 		assert.True(t, ok)
-		assert.Equal(t, "1|cell-1|", identity)
+		assert.Equal(t, networkkey.Key{Reported: true, Type: int32(model.DeviceNetworkType_CELLULAR), PathId: "cell-1"}, identity)
 	})
 	t.Run("monitor snapshot alone is an identity", func(t *testing.T) {
 		// given
@@ -505,7 +506,7 @@ func TestNetworkState_NetworkIdentity(t *testing.T) {
 
 		// then
 		assert.True(t, ok)
-		assert.Equal(t, "0||10.0.0.5", identity)
+		assert.Equal(t, networkkey.Key{Snapshot: "10.0.0.5"}, identity)
 	})
 	t.Run("offline is not an identity", func(t *testing.T) {
 		// given: a known network, then the client reports the link gone

--- a/net/transportpenalty/service.go
+++ b/net/transportpenalty/service.go
@@ -39,6 +39,8 @@ import (
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/app/logger"
 	"github.com/anyproto/any-sync/net/quicdemotion"
+
+	"github.com/anyproto/anytype-heart/core/device"
 	"go.uber.org/zap"
 )
 
@@ -94,8 +96,10 @@ type penaltyManager interface {
 // networkIdentity is the device.NetworkState surface this component needs.
 type networkIdentity interface {
 	// NetworkIdentity reports ok=false while nothing identifies the network;
-	// such a key is never compared, persisted or remembered here.
-	NetworkIdentity() (identity string, ok bool)
+	// such a key is never compared, persisted or remembered here. Keys are
+	// compared with SameNetwork, never by equality: the parts arrive at
+	// different times, so one network yields different keys over a session.
+	NetworkIdentity() (key device.NetworkKey, ok bool)
 	RegisterConnectivityHook(hook func(online bool))
 }
 
@@ -105,10 +109,11 @@ type repoPathProvider interface {
 
 // storedState is the on-disk format of <repo>/transport_penalties.json.
 type storedState struct {
-	// NetworkKey is the network identity the penalties were learned on. A
-	// file this version writes always carries one (saves wait for a known
-	// identity); an empty key keeps the verdict (fail open).
-	NetworkKey string                       `json:"networkKey"`
+	// NetworkKey is the network identity the penalties were learned on: the
+	// one this component had already observed and acted on, never merely the
+	// one current at write time. A key with nothing known keeps the verdict
+	// (fail open).
+	NetworkKey device.NetworkKey            `json:"networkKey"`
 	UpdatedAt  time.Time                    `json:"updatedAt"`
 	Penalties  quicdemotion.PenaltySnapshot `json:"penalties"`
 }
@@ -132,14 +137,15 @@ type service struct {
 	saveMu sync.Mutex
 
 	mu           sync.Mutex
-	lastIdentity string // last known network identity; "" until the first known observation
+	lastIdentity device.NetworkKey
+	identitySeen bool // last known network identity; "" until the first known observation
 	// loadedKey is the network key of the state file as it was loaded, i.e.
 	// the network the seeded penalties were learned on. Only load sets it:
 	// if a save could rewrite it with the current identity, a penalty
 	// mutation landing before the first observation would relabel a verdict
 	// from network A as learned on B and the stale-verdict check would
 	// never fire.
-	loadedKey   string
+	loadedKey   device.NetworkKey
 	saveTimer   *time.Timer
 	savePending bool
 	closed      bool
@@ -274,7 +280,7 @@ func (s *service) load() {
 	s.peers.Seed(st.Penalties)
 	log.Info("seeded stored transport penalties",
 		zap.Int("peers", len(st.Penalties.Peers)),
-		zap.String("networkKey", st.NetworkKey),
+		zap.Any("networkKey", st.NetworkKey),
 		zap.Time("updatedAt", st.UpdatedAt))
 }
 
@@ -302,7 +308,7 @@ func (s *service) onConnectivityRecovery(online bool) {
 // one and resets the penalties when the device moved to another network. The
 // first observation is compared against the persisted key instead: penalties
 // learned on a different network must not apply here.
-func (s *service) checkIdentity(identity string) {
+func (s *service) checkIdentity(identity device.NetworkKey) {
 	s.mu.Lock()
 	if s.closed {
 		// a recovery delivered after Close (see wg): acting on it reset the
@@ -312,24 +318,34 @@ func (s *service) checkIdentity(identity string) {
 	}
 	s.wg.Add(1)
 	defer s.wg.Done()
-	prev := s.lastIdentity
-	s.lastIdentity = identity
+	prev, seen := s.lastIdentity, s.identitySeen
+	s.lastIdentity, s.identitySeen = identity, true
 	loadedKey := s.loadedKey
 	s.mu.Unlock()
-	if prev == identity {
-		return
-	}
-	if prev == "" {
-		if loadedKey != "" && loadedKey != identity {
+	if !seen {
+		// First observation. The verdict on disk was learned elsewhere only
+		// if the two keys actively disagree; a part the stored key has and
+		// this one does not is the client's report not having landed yet,
+		// not a different network.
+		if loadedKey.Known() && !loadedKey.SameNetwork(identity) {
 			log.Info("stored transport penalties are from another network, resetting",
-				zap.String("storedKey", loadedKey), zap.String("identity", identity))
+				zap.Any("storedKey", loadedKey), zap.Any("identity", identity))
 			s.peers.Reset()
 			s.removeFile()
+			return
 		}
+		// A verdict learned before any identity was known is still only in
+		// memory: nothing else will prompt it onto disk, because a demoted
+		// peer is dialed yamux-first and stops producing the degraded deaths
+		// that mutate the state.
+		s.scheduleSave()
+		return
+	}
+	if prev.SameNetwork(identity) {
 		return
 	}
 	log.Info("network changed, resetting transport penalties",
-		zap.String("from", prev), zap.String("to", identity))
+		zap.Any("from", prev), zap.Any("to", identity))
 	s.peers.Reset()
 }
 
@@ -363,16 +379,31 @@ func (s *service) save() {
 		s.removeFileLocked()
 		return
 	}
-	identity, ok := s.network.NetworkIdentity()
-	if !ok {
-		// Nothing to attribute the verdict to. Persisted under an unknown
-		// key it would match on the next start wherever the device is, so
-		// it stays in memory; the next mutation on a known network persists.
-		log.Debug("network identity unknown, not persisting transport penalties")
+	// Label the snapshot with the identity this component has already
+	// observed and acted on, not with wherever the device happens to be now.
+	// The two are not the same: NetworkIdentity() switches the instant the
+	// client reports, while the hook that resets the penalties runs seconds
+	// later, behind recovery coalescing and a pool flush. Reading them
+	// independently wrote network A's verdict under network B's key, and
+	// once the file says B the stale-verdict check agrees with it forever.
+	s.mu.Lock()
+	observed, seen := s.lastIdentity, s.identitySeen
+	s.mu.Unlock()
+	if !seen {
+		// Nothing observed yet, so there is nothing to attribute the verdict
+		// to. It stays in memory; the first observation persists it.
+		log.Debug("network identity not yet observed, not persisting transport penalties")
+		return
+	}
+	current, ok := s.network.NetworkIdentity()
+	if !ok || !observed.SameNetwork(current) {
+		// Already elsewhere, but the reset has not run yet. Either key would
+		// be a lie; the reset's own save writes the clean state after it.
+		log.Debug("network moved ahead of the reset, not persisting transport penalties")
 		return
 	}
 	st := storedState{
-		NetworkKey: identity,
+		NetworkKey: observed,
 		UpdatedAt:  time.Now().UTC(),
 		Penalties:  snap,
 	}

--- a/net/transportpenalty/service_test.go
+++ b/net/transportpenalty/service_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/anyproto/any-sync/app"
 	"github.com/anyproto/any-sync/net/quicdemotion"
+
+	"github.com/anyproto/anytype-heart/core/device"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -142,21 +144,30 @@ func (f *fakePenaltyManager) peers() map[string]quicdemotion.PeerPenalty {
 // startup goroutine and the save path while tests reassign it, hence the lock.
 type fakeNetwork struct {
 	mu       sync.Mutex
-	identity string
+	identity device.NetworkKey
 	hooks    []func(online bool)
 }
 
 func (f *fakeNetwork) Init(a *app.App) error { return nil }
 func (f *fakeNetwork) Name() string          { return "fakeNetworkState" }
 
-// NetworkIdentity models the unknown state as an empty identity.
-func (f *fakeNetwork) NetworkIdentity() (string, bool) {
+// NetworkIdentity models the unknown state as a key with nothing known.
+func (f *fakeNetwork) NetworkIdentity() (device.NetworkKey, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.identity, f.identity != ""
+	return f.identity, f.identity.Known()
 }
 
-func (f *fakeNetwork) setIdentity(identity string) {
+// netKey names a network the way the interface monitor observes one, which is
+// what the desktop path supplies and the shape most of these tests care about.
+func netKey(name string) device.NetworkKey {
+	if name == "" {
+		return device.NetworkKey{}
+	}
+	return device.NetworkKey{Snapshot: name}
+}
+
+func (f *fakeNetwork) setIdentity(identity device.NetworkKey) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.identity = identity
@@ -214,7 +225,7 @@ func newStoppedFixture(t *testing.T, identity string) *fixture {
 		service: New().(*service),
 		a:       new(app.App),
 		peers:   &fakePenaltyManager{},
-		network: &fakeNetwork{identity: identity},
+		network: &fakeNetwork{identity: netKey(identity)},
 		repo:    t.TempDir(),
 	}
 	// short intervals so tests don't wait
@@ -270,7 +281,7 @@ func TestService_Seed(t *testing.T) {
 	t.Run("seeds stored penalties on start", func(t *testing.T) {
 		// given
 		repo := t.TempDir()
-		st := storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
+		st := storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
 		data, err := json.Marshal(st)
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(filepath.Join(repo, fileName), data, 0o600))
@@ -279,7 +290,7 @@ func TestService_Seed(t *testing.T) {
 			service: New().(*service),
 			a:       new(app.App),
 			peers:   &fakePenaltyManager{},
-			network: &fakeNetwork{identity: "net-A"},
+			network: &fakeNetwork{identity: netKey("net-A")},
 			repo:    repo,
 		}
 		fx.service.saveDebounce = 10 * time.Millisecond
@@ -305,7 +316,7 @@ func TestService_Seed(t *testing.T) {
 		// given
 		t.Setenv(DisableEnv, "0")
 		fx := newStoppedFixture(t, "net-A")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), Penalties: demotedPeers("p1")})
 
 		// when
 		fx.start(t)
@@ -318,7 +329,7 @@ func TestService_Seed(t *testing.T) {
 		// given: the switch is "0" means off, anything else means on
 		t.Setenv(DisableEnv, "1")
 		fx := newStoppedFixture(t, "net-A")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), Penalties: demotedPeers("p1")})
 
 		// when
 		fx.start(t)
@@ -346,7 +357,7 @@ func TestService_Save(t *testing.T) {
 		require.NoError(t, err)
 		var st storedState
 		require.NoError(t, json.Unmarshal(data, &st))
-		assert.Equal(t, "net-A", st.NetworkKey)
+		assert.Equal(t, netKey("net-A"), st.NetworkKey)
 		assert.Contains(t, st.Penalties.Peers, "p1")
 		// the schema version travels with the data; without it the real
 		// component ignores the file on the next start
@@ -418,7 +429,7 @@ func TestService_ConcurrentSave(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				for i := 0; i < rounds; i++ {
-					errs <- writeFileAtomic(path, storedState{NetworkKey: "net-A", Penalties: demotedPeers("p1")})
+					errs <- writeFileAtomic(path, storedState{NetworkKey: netKey("net-A"), Penalties: demotedPeers("p1")})
 				}
 			}()
 		}
@@ -443,7 +454,7 @@ func TestService_ConcurrentSave(t *testing.T) {
 		fx := newStoppedFixture(t, "net-A")
 		stale := fx.statePath() + ".123456.tmp"
 		require.NoError(t, os.WriteFile(stale, []byte("{"), 0o600))
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), Penalties: demotedPeers("p1")})
 
 		// when
 		fx.start(t)
@@ -463,7 +474,7 @@ func TestService_NetworkChange(t *testing.T) {
 		require.Equal(t, 0, fx.peers.resetCount())
 
 		// when
-		fx.network.setIdentity("net-B")
+		fx.network.setIdentity(netKey("net-B"))
 		fx.network.fireRecovery()
 
 		// then
@@ -483,9 +494,9 @@ func TestService_NetworkChange(t *testing.T) {
 
 		// when: the link drops (identity now reflects the offline state) and
 		// comes back on the same network
-		fx.network.setIdentity("offline")
+		fx.network.setIdentity(netKey("offline"))
 		fx.network.fireOffline()
-		fx.network.setIdentity("net-A")
+		fx.network.setIdentity(netKey("net-A"))
 		fx.network.fireRecovery()
 
 		// then
@@ -496,7 +507,7 @@ func TestService_NetworkChange(t *testing.T) {
 		// given: stored net-A verdict, device starts offline, startup check
 		// kept out of the way
 		fx := newStoppedFixture(t, "offline")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
 		fx.service.startupCheckInterval = time.Hour
 		fx.start(t)
 		require.Len(t, fx.peers.seededSnapshots(), 1)
@@ -510,14 +521,14 @@ func TestService_NetworkChange(t *testing.T) {
 		assert.NoError(t, err)
 
 		// and the reconnect on net-A is the first real observation: a match
-		fx.network.setIdentity("net-A")
+		fx.network.setIdentity(netKey("net-A"))
 		fx.network.fireRecovery()
 		assert.Equal(t, 0, fx.peers.resetCount())
 	})
 	t.Run("stored key mismatch on first observation resets seeded penalties", func(t *testing.T) {
 		// given: verdict learned on net-A, device now on net-B
 		repo := t.TempDir()
-		st := storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
+		st := storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
 		data, err := json.Marshal(st)
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(filepath.Join(repo, fileName), data, 0o600))
@@ -526,7 +537,7 @@ func TestService_NetworkChange(t *testing.T) {
 			service: New().(*service),
 			a:       new(app.App),
 			peers:   &fakePenaltyManager{},
-			network: &fakeNetwork{identity: "net-B"},
+			network: &fakeNetwork{identity: netKey("net-B")},
 			repo:    repo,
 		}
 		fx.service.saveDebounce = 10 * time.Millisecond
@@ -550,17 +561,20 @@ func TestService_NetworkChange(t *testing.T) {
 		// given: verdict learned on net-A, device now on net-B, and the
 		// startup check kept out of the way
 		fx := newStoppedFixture(t, "net-B")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
 		fx.service.startupCheckInterval = time.Hour
 		fx.start(t)
 		require.Len(t, fx.peers.seededSnapshots(), 1)
 
-		// a strike lands and is persisted before any identity observation
+		// a strike lands before any identity observation: there is nothing to
+		// attribute it to, so it stays in memory and the file is untouched.
+		// Persisting it would have to pick a key, and either choice is wrong
+		// — the current one relabels net-A's verdict as net-B's, and the
+		// stored one claims a network we have no evidence we are on.
 		fx.peers.mutate("p2", quicdemotion.PeerPenalty{ConsecutiveDegraded: 1})
-		require.Eventually(t, func() bool {
-			_, ok := fx.readStateFile(t).Penalties.Peers["p2"]
-			return ok
-		}, time.Second, 10*time.Millisecond)
+		time.Sleep(20 * fx.service.saveDebounce)
+		assert.NotContains(t, fx.readStateFile(t).Penalties.Peers, "p2")
+		assert.Equal(t, netKey("net-A"), fx.readStateFile(t).NetworkKey)
 
 		// when: the first observation arrives
 		fx.network.fireRecovery()
@@ -575,7 +589,7 @@ func TestService_NetworkChange(t *testing.T) {
 	t.Run("stored key match keeps seeded penalties", func(t *testing.T) {
 		// given
 		repo := t.TempDir()
-		st := storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
+		st := storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
 		data, err := json.Marshal(st)
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(filepath.Join(repo, fileName), data, 0o600))
@@ -584,7 +598,7 @@ func TestService_NetworkChange(t *testing.T) {
 			service: New().(*service),
 			a:       new(app.App),
 			peers:   &fakePenaltyManager{},
-			network: &fakeNetwork{identity: "net-A"},
+			network: &fakeNetwork{identity: netKey("net-A")},
 			repo:    repo,
 		}
 		fx.service.saveDebounce = 10 * time.Millisecond
@@ -608,7 +622,7 @@ func TestService_UnknownIdentity(t *testing.T) {
 		// given: stored net-A verdict, nothing identifies the network yet
 		// (mobile cold start before the client's first report)
 		fx := newStoppedFixture(t, "")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
 		fx.start(t)
 		require.Len(t, fx.peers.seededSnapshots(), 1)
 
@@ -619,7 +633,7 @@ func TestService_UnknownIdentity(t *testing.T) {
 		assert.NoError(t, err)
 
 		// when: the identity becomes known and differs
-		fx.network.setIdentity("net-B")
+		fx.network.setIdentity(netKey("net-B"))
 
 		// then: the poll picks it up
 		require.Eventually(t, func() bool { return fx.peers.resetCount() == 1 }, time.Second, time.Millisecond)
@@ -631,13 +645,13 @@ func TestService_UnknownIdentity(t *testing.T) {
 	t.Run("startup poll is bounded; a later recovery observes instead", func(t *testing.T) {
 		// given
 		fx := newStoppedFixture(t, "")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
 		fx.service.startupCheckTimeout = 30 * time.Millisecond
 		fx.start(t)
 		time.Sleep(3 * fx.service.startupCheckTimeout)
 
 		// when: the identity becomes known after the poll gave up
-		fx.network.setIdentity("net-B")
+		fx.network.setIdentity(netKey("net-B"))
 		time.Sleep(10 * fx.service.startupCheckInterval)
 
 		// then: no check ran; the next recovery is the first observation
@@ -658,14 +672,14 @@ func TestService_UnknownIdentity(t *testing.T) {
 		assert.True(t, os.IsNotExist(err))
 
 		// and once the network is known the next mutation persists under it
-		fx.network.setIdentity("net-A")
+		fx.network.setIdentity(netKey("net-A"))
 		fx.peers.mutate("p2", quicdemotion.PeerPenalty{ConsecutiveDegraded: 1})
-		require.Eventually(t, func() bool { return fx.readStateFile(t).NetworkKey == "net-A" }, time.Second, time.Millisecond)
+		require.Eventually(t, func() bool { return fx.readStateFile(t).NetworkKey == netKey("net-A") }, time.Second, time.Millisecond)
 	})
 	t.Run("recovery with an unknown identity is not an observation", func(t *testing.T) {
 		// given
 		fx := newStoppedFixture(t, "")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
 		fx.service.startupCheckInterval = time.Hour
 		fx.start(t)
 
@@ -678,7 +692,7 @@ func TestService_UnknownIdentity(t *testing.T) {
 		assert.NoError(t, err)
 
 		// and the first known observation is still compared to the stored key
-		fx.network.setIdentity("net-B")
+		fx.network.setIdentity(netKey("net-B"))
 		fx.network.fireRecovery()
 		assert.Equal(t, 1, fx.peers.resetCount())
 	})
@@ -690,7 +704,7 @@ func TestService_Close(t *testing.T) {
 		// networkState closes after this component (reverse registration
 		// order) so its last recoveries can still call the hook
 		fx := newStoppedFixture(t, "net-B")
-		fx.writeStateFile(t, storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.writeStateFile(t, storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
 		fx.service.startupCheckInterval = time.Hour
 		fx.start(t)
 		require.NoError(t, fx.service.Close(ctx))
@@ -748,7 +762,7 @@ func TestService_SchemaVersion(t *testing.T) {
 		// here the file would stay on disk forever and the stored key would
 		// be recorded for a seed that never happened
 		fx := newStoppedFixture(t, "net-A")
-		st := storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
+		st := storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
 		st.Penalties.Version = 99
 		fx.writeStateFile(t, st)
 
@@ -771,7 +785,7 @@ func TestService_CorruptFile(t *testing.T) {
 			service: New().(*service),
 			a:       new(app.App),
 			peers:   &fakePenaltyManager{},
-			network: &fakeNetwork{identity: "net-A"},
+			network: &fakeNetwork{identity: netKey("net-A")},
 			repo:    repo,
 		}
 		fx.service.saveDebounce = 10 * time.Millisecond
@@ -784,5 +798,72 @@ func TestService_CorruptFile(t *testing.T) {
 		defer func() { require.NoError(t, fx.a.Close(ctx)) }()
 
 		assert.Empty(t, fx.peers.seededSnapshots())
+	})
+}
+
+// TestService_IdentityArrivesInParts covers the two ways a time-varying
+// identity used to be misread. Both were silent, and both are the failure
+// this component exists to prevent: re-learning the demotion on a network the
+// device never left, and applying one network's verdict on another.
+func TestService_IdentityArrivesInParts(t *testing.T) {
+	t.Run("a cold start keeps a verdict the client has not confirmed yet", func(t *testing.T) {
+		// given: last session filed the verdict with the client's report in
+		// the key; this session's startup check runs before the client can
+		// report, so it sees the interface snapshot alone
+		fx := newStoppedFixture(t, "")
+		stored := device.NetworkKey{Reported: true, Type: 0, PathId: "en0", Snapshot: "192.168.1.218"}
+		fx.writeStateFile(t, storedState{NetworkKey: stored, UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.network.setIdentity(device.NetworkKey{Snapshot: "192.168.1.218"})
+
+		// when
+		fx.start(t)
+		fx.network.fireRecovery()
+
+		// then: the verdict survives and the file is still there
+		assert.Equal(t, 0, fx.peers.resetCount(), "the same network must not read as a move")
+		_, err := os.Stat(fx.statePath())
+		assert.NoError(t, err)
+	})
+
+	t.Run("a genuinely different network is still rejected", func(t *testing.T) {
+		// given
+		fx := newStoppedFixture(t, "")
+		stored := device.NetworkKey{Reported: true, PathId: "en0", Snapshot: "192.168.1.218"}
+		fx.writeStateFile(t, storedState{NetworkKey: stored, UpdatedAt: time.Now(), Penalties: demotedPeers("p1")})
+		fx.network.setIdentity(device.NetworkKey{Snapshot: "10.0.0.5"})
+
+		// when
+		fx.start(t)
+		fx.network.fireRecovery()
+
+		// then
+		assert.Equal(t, 1, fx.peers.resetCount())
+		require.Eventually(t, func() bool {
+			_, err := os.Stat(fx.statePath())
+			return os.IsNotExist(err)
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("a verdict is never filed under a network we have only just moved to", func(t *testing.T) {
+		// given: settled on net-A
+		fx := newFixture(t, "net-A")
+		fx.peers.mutate("p1", quicdemotion.PeerPenalty{ConsecutiveDegraded: 1})
+		require.Eventually(t, func() bool {
+			return fx.readStateFile(t).NetworkKey == netKey("net-A")
+		}, time.Second, 10*time.Millisecond)
+
+		// when: the device moves and a strike lands in the window before the
+		// reset hook runs — NetworkIdentity() already says net-B, but nothing
+		// has observed it yet
+		fx.network.setIdentity(netKey("net-B"))
+		fx.peers.mutate("p2", quicdemotion.PeerPenalty{ConsecutiveDegraded: 1})
+		time.Sleep(20 * fx.service.saveDebounce)
+
+		// then: net-A's verdict was not relabelled as net-B's. Had it been,
+		// the stored key would match on the next start and the stale-verdict
+		// check could never fire again on this install.
+		st := fx.readStateFile(t)
+		assert.Equal(t, netKey("net-A"), st.NetworkKey)
+		assert.NotContains(t, st.Penalties.Peers, "p2")
 	})
 }

--- a/net/transportpenalty/wiring_test.go
+++ b/net/transportpenalty/wiring_test.go
@@ -30,7 +30,7 @@ func newNodeConf(t *testing.T) app.Component {
 // the double. The double cannot catch a mismatch between what this component
 // writes and what quicdemotion accepts, nor the Init-order requirement.
 func TestService_RealQuicDemotion(t *testing.T) {
-	stored := storedState{NetworkKey: "net-A", UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
+	stored := storedState{NetworkKey: netKey("net-A"), UpdatedAt: time.Now(), Penalties: demotedPeers("p1")}
 	t.Run("registered after quicdemotion: the stored verdict is seeded", func(t *testing.T) {
 		// given
 		repo := t.TempDir()
@@ -41,7 +41,7 @@ func TestService_RealQuicDemotion(t *testing.T) {
 		a.Register(&fakeWallet{repoPath: repo}).
 			Register(newNodeConf(t)).
 			Register(demotion).
-			Register(&fakeNetwork{identity: "net-A"}).
+			Register(&fakeNetwork{identity: netKey("net-A")}).
 			Register(svc)
 		(&fixture{service: svc, a: a, repo: repo}).writeStateFile(t, stored)
 
@@ -62,7 +62,7 @@ func TestService_RealQuicDemotion(t *testing.T) {
 		a := new(app.App)
 		a.Register(&fakeWallet{repoPath: repo}).
 			Register(newNodeConf(t)).
-			Register(&fakeNetwork{identity: "net-A"}).
+			Register(&fakeNetwork{identity: netKey("net-A")}).
 			Register(svc).
 			Register(quicdemotion.New())
 		(&fixture{service: svc, a: a, repo: repo}).writeStateFile(t, stored)


### PR DESCRIPTION
Follow-up to #3261. A second review round on that PR confirmed two defects that its fix pass did not close; #3261 merged at the round's tip, so both are on `develop` now. Each was reproduced end to end with the real components, and each regression here returns the old wrong answer against the previous commit.

## One root cause

The network identity is three **separately observed parts** — the client's reported type and path id, and the interface monitor's snapshot — that arrive at different times. They were concatenated into one string and compared verbatim, which treats a time-varying observation as a stable fact. It failed in both directions.

## Read too early: a valid verdict is deleted

The startup check samples as soon as anything is known, which on every platform is the monitor's snapshot within milliseconds. The client cannot report until the account app is up, because `DeviceNetworkStateSet` is rejected before login.

```
Session 1 (café with DPI): learned the demotion, stored
          "0|en0|192.168.1.1|192.168.1.218"

Session 2, same café:
  t=0.002s  monitor snapshot lands
  t=1s      startup check sees "0||192.168.1.218"   <- no client path id yet
            != stored key -> "from another network" -> Reset + file removed
  t=2.5s    client reports; identity is now byte-identical to the key
            that was deleted a second and a half earlier
```

The app re-pays a minute or more of dead QUIC on every launch, while the log reports a successful seed followed by a network change. On desktop the same thing happens whenever the interface set is still filling in at boot.

## Read too late: a foreign verdict is adopted

```go
snap := s.peers.Snapshot()                    // what we learned - network A
identity, ok := s.network.NetworkIdentity()   // where we are NOW - network B
```

Nothing bound those two reads. `NetworkIdentity()` switches the instant the client reports, but the hook that resets the penalties runs seconds later, behind recovery coalescing and a pool flush. A strike landing in that window wrote **network A's verdict under network B's key** — and from then on the stored key always matches, so the stale-verdict check can never fire again on that install. Every node peer is dialled yamux-first for up to four hours on a healthy network.

The worst variant needs no network change and no crash: on a cold start, one degraded death inside the startup-check window is enough.

## The fix

`NetworkKey` keeps the parts apart, and `SameNetwork` compares only those **known on both sides** — a part missing on one side is absence of evidence, not evidence of a move. A bare type is not an identity: "some Wi-Fi" matches every Wi-Fi, so `Known()` requires a path id or a snapshot.

`save()` labels the snapshot with the identity this component has already **observed and acted on**, and writes nothing while that and the current identity disagree, because either label would be a lie — the reset's own save persists the clean state just after. The first observation also persists a verdict learned before any identity was known; nothing else would, since a demoted peer is dialled yamux-first and stops producing the degraded deaths that mutate the state.

`NetworkKey` lives in its own leaf package so the generated device mocks can name it without importing `core/device` back.

## Not fixed here

The snapshot is the **whole address set**, so a VPN, Tailscale, Docker, a DHCP lease change or ISP IPv6 `/64` re-delegation still reads as a different network on the same Wi-Fi. No comparison rule fixes that — it needs keying on the default route or gateway instead, which is a change to what "network identity" means. Filed separately.

Mobile also still lacks a genuinely stable per-network key: Android's `networkId` is the network handle, which the client guide documents as changing on every reconnect. That needs a client-side field.

## Tests

`TestKey_SameNetwork` pins the comparison rule including the no-overlap direction. `TestService_IdentityArrivesInParts` drives the two field scenarios end to end. Counterfactually verified: with whole-key comparison the cold start deletes the verdict, and without the save guard the file is written as `net-B` carrying net-A's peer. Green under `-race`.
