### PR TITLE
GO-7494 Wait for the caller's event stream before broadcasting accountShow

### DIFF
--- a/core/account.go
+++ b/core/account.go
@@ -39,7 +39,8 @@ func (mw *Middleware) AccountCreate(cctx context.Context, req *pb.RpcAccountCrea
 }
 
 func (mw *Middleware) AccountRecover(cctx context.Context, _ *pb.RpcAccountRecoverRequest) *pb.RpcAccountRecoverResponse {
-	err := mw.applicationService.AccountRecover()
+	token, _ := getSessionToken(cctx)
+	err := mw.applicationService.AccountRecover(cctx, token)
 	code := mapErrorCode(err,
 		errToCode(application.ErrNoMnemonicProvided, pb.RpcAccountRecoverResponseError_NEED_TO_RECOVER_WALLET_FIRST),
 		errToCode(application.ErrBadInput, pb.RpcAccountRecoverResponseError_BAD_INPUT),

--- a/core/application/account_recover.go
+++ b/core/application/account_recover.go
@@ -1,20 +1,63 @@
 package application
 
 import (
+	"context"
+	"time"
+
 	"github.com/anyproto/anytype-heart/core/event"
 	"github.com/anyproto/anytype-heart/pb"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
-func (s *Service) AccountRecover() error {
-	if s.derivedKeys == nil {
+// sessionAttachTimeout bounds how long AccountRecover waits for the caller's
+// event stream. Bracketed on both sides: the client's stream reconnect backoff
+// is 3s (dispatcher.ts), so this covers one full retry, and metrics' LONG_RPC
+// threshold is 10s, past which every slow login would dump a goroutine profile
+// to Sentry. On expiry we broadcast anyway, which is the pre-fix behaviour.
+const sessionAttachTimeout = 5 * time.Second
+
+// AccountRecover answers with nothing but an AccountShow event, and the client's
+// login screen has no other trigger. token is the caller's session token (empty
+// when the transport carries none, e.g. the mobile in-process library).
+func (s *Service) AccountRecover(ctx context.Context, token string) error {
+	// Snapshot rather than read through: WalletRecover writes derivedKeys under
+	// this lock and is unauthenticated, so a second recovery landing during the
+	// wait below would otherwise have us answer this request with that account.
+	s.lock.RLock()
+	derivedKeys := s.derivedKeys
+	s.lock.RUnlock()
+
+	if derivedKeys == nil {
 		return ErrWalletNotInitialized
+	}
+	accountId := derivedKeys.Identity.GetPublic().Account()
+
+	if token != "" {
+		// The client opens ListenSessionEvents and calls AccountRecover as two
+		// independent requests, in that order but with no ordering guarantee, and
+		// the stream loses often enough to be the top login-hang report — plausibly
+		// because the RPC reuses a warm connection while a new stream does not.
+		// Broadcasting into an empty session map drops the event ("no servers to
+		// broadcast event") with nothing to redeliver it, so wait for the caller's
+		// own stream to attach first. Nothing here is slow enough to mask the race
+		// any more: the key derivation that used to sit in front of this broadcast
+		// moved to WalletRecover in GO-6131.
+		if waiter, ok := s.eventSender.(event.SessionWaiter); ok {
+			waiter.WaitForSession(ctx, token, sessionAttachTimeout)
+		}
+		// Checked here rather than on the wait's result: the stream can also attach
+		// and then be torn down before we broadcast, and that drop is invisible in
+		// the log otherwise — Broadcast only reports the case where no session at
+		// all is listening.
+		if !s.eventSender.IsActive(token) {
+			log.Warnf("accountRecover: no event stream for the calling session, accountShow for %s may be lost", accountId)
+		}
 	}
 
 	s.eventSender.Broadcast(event.NewEventSingleMessage("", &pb.EventMessageValueOfAccountShow{
 		AccountShow: &pb.EventAccountShow{
 			Account: &model.Account{
-				Id: s.derivedKeys.Identity.GetPublic().Account(),
+				Id: accountId,
 			},
 		},
 	}))

--- a/core/application/account_recover_test.go
+++ b/core/application/account_recover_test.go
@@ -1,0 +1,254 @@
+package application
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anyproto/any-sync/app"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anyproto/anytype-heart/core/event"
+	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/core"
+)
+
+// streamSender stands in for the gRPC sender: events only reach a client once
+// its ListenSessionEvents stream has attached, and anything broadcast while no
+// session is listening is dropped — that drop is what "no servers to broadcast
+// event" means in the log. Every token-keyed answer is token-accurate, so a
+// regression that waited on the wrong session would fail these tests.
+type streamSender struct {
+	mu        sync.Mutex
+	attached  map[string]bool
+	waiters   map[string][]chan struct{}
+	received  []*pb.Event
+	dropped   int
+	waitCalls int
+}
+
+func newStreamSender() *streamSender {
+	return &streamSender{attached: map[string]bool{}, waiters: map[string][]chan struct{}{}}
+}
+
+// attach registers one client's event stream, releasing only the waiters parked
+// on that same token.
+func (f *streamSender) attach(token string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attached[token] = true
+	for _, ch := range f.waiters[token] {
+		close(ch)
+	}
+	delete(f.waiters, token)
+}
+
+func (f *streamSender) WaitForSession(ctx context.Context, token string, timeout time.Duration) bool {
+	f.mu.Lock()
+	f.waitCalls++
+	if f.attached[token] {
+		f.mu.Unlock()
+		return true
+	}
+	ch := make(chan struct{})
+	f.waiters[token] = append(f.waiters[token], ch)
+	f.mu.Unlock()
+
+	select {
+	case <-ch:
+		return true
+	case <-ctx.Done():
+		return false
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func (f *streamSender) Broadcast(e *pb.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.attached) == 0 {
+		f.dropped++
+		return
+	}
+	f.received = append(f.received, e)
+}
+
+func (f *streamSender) events() []*pb.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.received
+}
+
+func (f *streamSender) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.waitCalls
+}
+
+func (f *streamSender) Init(*app.App) error { return nil }
+func (f *streamSender) Name() string        { return event.CName }
+func (f *streamSender) IsActive(token string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.attached[token]
+}
+func (f *streamSender) SendToSession(string, *pb.Event)             {}
+func (f *streamSender) BroadcastToOtherSessions(string, *pb.Event)  {}
+func (f *streamSender) BroadcastExceptSessions(*pb.Event, []string) {}
+
+var (
+	_ event.Sender        = (*streamSender)(nil)
+	_ event.SessionWaiter = (*streamSender)(nil)
+)
+
+func newRecoverFixture(t *testing.T) (*Service, *streamSender, string) {
+	t.Helper()
+	s := New()
+	mnemonic, err := core.WalletGenerateMnemonic(wordCount)
+	require.NoError(t, err)
+	account, err := core.WalletAccountAt(mnemonic, 0)
+	require.NoError(t, err)
+	s.derivedKeys = &account
+	sender := newStreamSender()
+	s.eventSender = sender
+	return s, sender, account.Identity.GetPublic().Account()
+}
+
+func accountShow(t *testing.T, ev *pb.Event) *pb.EventAccountShow {
+	t.Helper()
+	require.Len(t, ev.Messages, 1)
+	value, ok := ev.Messages[0].Value.(*pb.EventMessageValueOfAccountShow)
+	require.True(t, ok)
+	return value.AccountShow
+}
+
+// blocked reports whether the call is still in flight after a grace period.
+func blocked(t *testing.T, done <-chan error) bool {
+	t.Helper()
+	select {
+	case <-done:
+		return false
+	case <-time.After(100 * time.Millisecond):
+		return true
+	}
+}
+
+func TestService_AccountRecover(t *testing.T) {
+	t.Run("waits for the caller's event stream before broadcasting", func(t *testing.T) {
+		// given a client that issued AccountRecover before its stream attached —
+		// the two are independent requests and this is the order that loses
+		s, sender, accountId := newRecoverFixture(t)
+
+		// when
+		done := make(chan error, 1)
+		go func() { done <- s.AccountRecover(context.Background(), "tok") }()
+		require.True(t, blocked(t, done), "broadcast into an empty session map: the event is lost")
+		sender.attach("tok")
+
+		// then the client gets the one event its login screen waits for
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("AccountRecover did not return after the stream attached")
+		}
+		require.Len(t, sender.events(), 1)
+		assert.Equal(t, accountId, accountShow(t, sender.events()[0]).Account.Id)
+		assert.Zero(t, sender.dropped)
+	})
+
+	t.Run("another session's stream does not release the wait", func(t *testing.T) {
+		// given a second window already listening on its own session
+		s, sender, _ := newRecoverFixture(t)
+
+		// when
+		done := make(chan error, 1)
+		go func() { done <- s.AccountRecover(context.Background(), "tok") }()
+		sender.attach("other")
+
+		// then we are still waiting for the session that actually asked
+		require.True(t, blocked(t, done), "waited on the wrong session")
+		sender.attach("tok")
+		require.NoError(t, <-done)
+	})
+
+	t.Run("answers about the account it was asked for, not one recovered mid-wait", func(t *testing.T) {
+		// given a request parked on its stream
+		s, sender, accountId := newRecoverFixture(t)
+		done := make(chan error, 1)
+		go func() { done <- s.AccountRecover(context.Background(), "tok") }()
+		require.True(t, blocked(t, done))
+
+		// when a second wallet recovery lands during the wait — WalletRecover needs
+		// no session token, so any local process can do this
+		other, err := core.WalletGenerateMnemonic(wordCount)
+		require.NoError(t, err)
+		require.NoError(t, s.WalletRecover(&pb.RpcWalletRecoverRequest{RootPath: t.TempDir(), Mnemonic: other}))
+		sender.attach("tok")
+
+		// then the login screen is offered the account this call was made for
+		require.NoError(t, <-done)
+		require.Len(t, sender.events(), 1)
+		assert.Equal(t, accountId, accountShow(t, sender.events()[0]).Account.Id)
+	})
+
+	t.Run("broadcasts immediately when the stream is already attached", func(t *testing.T) {
+		// given
+		s, sender, accountId := newRecoverFixture(t)
+		sender.attach("tok")
+
+		// when
+		err := s.AccountRecover(context.Background(), "tok")
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, sender.events(), 1)
+		assert.Equal(t, accountId, accountShow(t, sender.events()[0]).Account.Id)
+	})
+
+	t.Run("no session token skips the wait", func(t *testing.T) {
+		// given a caller whose transport carries no token (the mobile library)
+		s, sender, accountId := newRecoverFixture(t)
+		sender.attach("other")
+
+		// when
+		err := s.AccountRecover(context.Background(), "")
+
+		// then it must not park on a session it cannot name
+		require.NoError(t, err)
+		assert.Zero(t, sender.calls())
+		require.Len(t, sender.events(), 1)
+		assert.Equal(t, accountId, accountShow(t, sender.events()[0]).Account.Id)
+	})
+
+	t.Run("gives up and broadcasts anyway when the stream never attaches", func(t *testing.T) {
+		// given a caller that went away before its stream ever arrived
+		s, sender, _ := newRecoverFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// when
+		err := s.AccountRecover(ctx, "tok")
+
+		// then the broadcast still happens — never worse than the pre-fix behaviour
+		require.NoError(t, err)
+		assert.Equal(t, 1, sender.calls())
+		assert.Empty(t, sender.events())
+		assert.Equal(t, 1, sender.dropped)
+	})
+
+	t.Run("no wallet", func(t *testing.T) {
+		// given
+		s := New()
+		s.eventSender = newStreamSender()
+
+		// when
+		err := s.AccountRecover(context.Background(), "tok")
+
+		// then
+		assert.ErrorIs(t, err, ErrWalletNotInitialized)
+	})
+}

--- a/core/event/event.go
+++ b/core/event/event.go
@@ -15,6 +15,9 @@ Scope: global
 */
 
 import (
+	"context"
+	"time"
+
 	"github.com/anyproto/any-sync/app"
 
 	"github.com/anyproto/anytype-heart/pb"
@@ -30,6 +33,15 @@ type Sender interface {
 	BroadcastExceptSessions(event *pb.Event, exceptTokens []string)
 
 	app.Component
+}
+
+// SessionWaiter is the optional half of Sender implemented by senders that route
+// to client-owned streams (GrpcSender). Deliberately not part of Sender:
+// CallbackSender hands events straight to the mobile library's callback, with no
+// stream that could be late, so it must keep working untouched. Callers
+// type-assert and skip the wait when it is not implemented.
+type SessionWaiter interface {
+	WaitForSession(ctx context.Context, token string, timeout time.Duration) bool
 }
 
 type CallbackSender struct {

--- a/core/event/event_grpc.go
+++ b/core/event/event_grpc.go
@@ -4,9 +4,11 @@
 package event
 
 import (
+	"context"
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/anyproto/any-sync/app"
 
@@ -140,6 +142,38 @@ func (es *GrpcSender) SetSessionServer(token string, server service.ClientComman
 		old.sender.close()
 	}
 	return srv
+}
+
+// waitForSessionPollInterval bounds how stale WaitForSession's answer can be.
+// WaitForSession runs at most once per login, so polling costs nothing measurable
+// and buys the absence of a waiter registry: no channels to close exactly once,
+// no lifecycle coupling to session teardown/supersede, and SetSessionServer — the
+// hot path — stays untouched.
+const waitForSessionPollInterval = 50 * time.Millisecond
+
+// WaitForSession blocks until token's event stream is registered and reports
+// whether it is. A client opens ListenSessionEvents and issues the RPC it
+// expects an event from as two independent requests, so the stream is routinely
+// not registered yet when the handler runs — and an event broadcast in that
+// window is dropped, with nothing to redeliver it. Handlers whose only output is
+// a fire-and-forget event call this first. Bounded by timeout and by ctx, so a
+// client that never opens a stream just falls through.
+func (es *GrpcSender) WaitForSession(ctx context.Context, token string, timeout time.Duration) bool {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ticker := time.NewTicker(waitForSessionPollInterval)
+	defer ticker.Stop()
+	for {
+		if es.IsActive(token) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return es.IsActive(token) // it may have attached as we gave up
+		case <-ticker.C:
+		}
+	}
 }
 
 // scheduleClose tears a session down exactly once. It must not block the caller:

--- a/core/event/event_grpc_test.go
+++ b/core/event/event_grpc_test.go
@@ -127,3 +127,66 @@ func TestSendVariants_routing(t *testing.T) {
 	require.Eventually(t, func() bool { return countFor(a) == 2 && countFor(b) == 1 },
 		2*time.Second, time.Millisecond, "SendToSession+except hit a; BroadcastToOthers hit b")
 }
+
+// A handler that must not lose an event needs to wait for the caller's stream:
+// the client opens ListenSessionEvents and calls the RPC as two independent
+// requests, so the stream is often not registered yet when the handler runs.
+// WaitForSession runs on this goroutine and the attach is delayed, so it must
+// observe the absent session first — no scheduling hole that could let this pass
+// via the already-attached fast path.
+func TestWaitForSession_returnsWhenStreamAttachesLater(t *testing.T) {
+	es := NewGrpcSender()
+	const attachAfter = 150 * time.Millisecond
+	go func() {
+		time.Sleep(attachAfter)
+		es.SetSessionServer("tok", &fakeStream{})
+	}()
+
+	start := time.Now()
+	require.True(t, es.WaitForSession(context.Background(), "tok", 10*time.Second))
+	require.GreaterOrEqual(t, time.Since(start), attachAfter, "must have waited for the attach, not fast-pathed")
+}
+
+// An already-attached session returns at once.
+func TestWaitForSession_alreadyAttached(t *testing.T) {
+	es := NewGrpcSender()
+	es.SetSessionServer("tok", &fakeStream{})
+
+	start := time.Now()
+	require.True(t, es.WaitForSession(context.Background(), "tok", time.Minute))
+	require.Less(t, time.Since(start), waitForSessionPollInterval, "must not sleep on the fast path")
+}
+
+// A client that never opens a stream falls through, bounded by the timeout.
+func TestWaitForSession_timesOut(t *testing.T) {
+	es := NewGrpcSender()
+	const timeout = 150 * time.Millisecond
+
+	start := time.Now()
+	require.False(t, es.WaitForSession(context.Background(), "tok", timeout))
+	elapsed := time.Since(start)
+	require.GreaterOrEqual(t, elapsed, timeout)
+	require.Less(t, elapsed, 5*time.Second, "must not outlive its own timeout")
+}
+
+// A caller that goes away (client disconnect) unblocks immediately.
+func TestWaitForSession_canceledCaller(t *testing.T) {
+	es := NewGrpcSender()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	require.False(t, es.WaitForSession(ctx, "tok", time.Minute))
+	require.Less(t, time.Since(start), 5*time.Second, "a canceled caller must not wait out the timeout")
+}
+
+// Another session attaching is not this session's stream.
+func TestWaitForSession_perToken(t *testing.T) {
+	es := NewGrpcSender()
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		es.SetSessionServer("other", &fakeStream{})
+	}()
+	require.False(t, es.WaitForSession(context.Background(), "tok", 150*time.Millisecond),
+		"attaching another token must not satisfy this one")
+}


### PR DESCRIPTION
Fixes [GO-7494](https://linear.app/anytype/issue/GO-7494/accountshow-is-lost-when-accountrecover-races-session-stream). Hotfix — the real fix is GO-7495.

## The bug

Login wedges permanently: the phrase input spins forever, no error, only an app restart recovers it. Heart logs `no servers to broadcast event` — the confirmation GO-7494 listed as still missing.

`AccountRecover`'s only output is a fire-and-forget `accountShow` broadcast. Its response carries no account, and `login.tsx select()` guards on `!accounts.length`, so one lost event wedges login for good.

The client opens `ListenSessionEvents` and calls `AccountRecover` as two independent requests with no ordering between them. When the broadcast wins, `es.Servers` is empty (the previous session was removed synchronously by `WalletCloseSession`) and the event is dropped with nothing to redeliver it.

Latent since 2023, but `AccountRecover` used to derive keys from the mnemonic before broadcasting, and those few hundred ms hid the race. GO-6131 moved the derivation to `WalletRecover`, leaving a pure in-memory broadcast and a window of roughly zero — which is why this got frequent.

## The fix

Wait for the caller's own session stream to attach before broadcasting, bounded by 5s and by the caller's context. On expiry we broadcast anyway, so the outcome is never worse than today.

The 5s bound is bracketed on both sides: the client's stream reconnect backoff is 3s (`dispatcher.ts`), so it covers one full retry; metrics' `LONG_RPC` threshold is 10s (`metrics/interceptors.go:32`), past which every slow login would dump a goroutine profile to Sentry.

`WaitForSession` polls `IsActive` rather than keeping a waiter registry. It runs once per login, so the cost is unmeasurable, and it leaves `SetSessionServer` — the concurrency-sensitive hot path — completely untouched.

Also fixes a data race found in review and independently named in GO-7495: `derivedKeys` is now snapshotted under `s.lock` instead of read through. It is written under that lock by `WalletRecover`, which needs no session token, so a second recovery landing during the wait would otherwise have us answer this request with the other account's id.

## Why not the approach in the ticket

GO-7494 proposed delivering `accountShow` on session attach via the hook runner. That needs an unconditional branch around the `mw.GetApp() != nil` gate (false before `AccountSelect`) and would push `accountShow` on *every* stream attach, risking duplicate accounts in the client's list. Waiting touches one handler and changes what no other session sees.

## Client impact

None required — this fixes already-shipped desktop builds. Mobile is unaffected: `clientlibrary` passes `context.Background()` (no token, wait skipped) and its `CallbackSender` deliberately does not implement `SessionWaiter`.

## Tests

- `TestService_AccountRecover` — 7 cases: waits for the caller's stream; another session's stream does not release the wait; already-attached fast path; `token == ""` skips the wait; gives up and broadcasts anyway; answers about the account it was asked for, not one recovered mid-wait; no wallet.
- `TestWaitForSession_*` — 5 cases covering attach-later, already-attached, timeout, canceled caller, per-token isolation.

Mutation-checked rather than assumed: hardcoding the wrong token fails the token-fidelity case, and restoring the read-through of `derivedKeys` fails the mid-wait case. Both green when restored. `go build ./...`, `-tags nogrpcserver`, `go vet`, and both packages under `-race` are clean.

## Follow-ups (not in this PR)

- **GO-7495** — return `accountId` in the `WalletCreateSession` response and drop `accountShow`. The field already exists in the proto; the mnemonic branch returns `""` with the standing GO-1854 todo. That removes the ordering assumption entirely, and this wait with it.
- **GO-7495 item 6** — `ListenSessionEvents` takes `s.lock.RLock` twice on the attach path while `AccountSelect` write-holds it for an entire cold sync, so opening a stream can block for minutes. It widens this exact window, and the event sender is set once at boot so it needs no lock at all. Worth doing before the refactor.
