### PR TITLE
GO-7495 Return the account id from WalletCreateSession

### DIFF
--- a/core/application/account_recover.go
+++ b/core/application/account_recover.go
@@ -7,13 +7,20 @@ import (
 )
 
 // AccountRecover broadcasts the recovered wallet's account as an accountShow
-// event.
+// event. Desktop no longer needs it -- WalletCreateSession answers with the
+// account -- but it is still how swift and kotlin learn theirs, so it is not
+// going away on its own schedule.
 //
-// Deprecated: the account is returned synchronously by WalletCreateSession, and
-// that is what the client should read. This is kept only until swift and kotlin
-// are off the event (GO-7495); an event broadcast here is dropped outright if the
-// caller's ListenSessionEvents stream has not attached yet, which is what used to
-// wedge desktop login (GO-7494).
+// Mobile reaches this through the gomobile bridge, which calls handlers with
+// context.Background() and no auth interceptor: it holds no session token and
+// never calls WalletCreateSession, so the synchronous answer is not reachable
+// from there. Retiring this needs a mobile-visible replacement first (the
+// account on a response they do call, e.g. WalletRecover) -- see GO-7495.
+//
+// Mobile is not exposed to the delivery race that made this unfit for desktop
+// login (GO-7494): its sender is the in-process CallbackSender, so a broadcast
+// always has a live sink, with no ListenSessionEvents stream to lose a race
+// against.
 func (s *Service) AccountRecover() error {
 	accountId := s.walletAccountId()
 	if accountId == "" {

--- a/core/application/account_recover.go
+++ b/core/application/account_recover.go
@@ -6,15 +6,24 @@ import (
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
+// AccountRecover broadcasts the recovered wallet's account as an accountShow
+// event.
+//
+// Deprecated: the account is returned synchronously by WalletCreateSession, and
+// that is what the client should read. This is kept only until swift and kotlin
+// are off the event (GO-7495); an event broadcast here is dropped outright if the
+// caller's ListenSessionEvents stream has not attached yet, which is what used to
+// wedge desktop login (GO-7494).
 func (s *Service) AccountRecover() error {
-	if s.derivedKeys == nil {
+	accountId := s.walletAccountId()
+	if accountId == "" {
 		return ErrWalletNotInitialized
 	}
 
 	s.eventSender.Broadcast(event.NewEventSingleMessage("", &pb.EventMessageValueOfAccountShow{
 		AccountShow: &pb.EventAccountShow{
 			Account: &model.Account{
-				Id: s.derivedKeys.Identity.GetPublic().Account(),
+				Id: accountId,
 			},
 		},
 	}))

--- a/core/application/sessions.go
+++ b/core/application/sessions.go
@@ -54,7 +54,17 @@ func (s *Service) CreateSession(req *pb.RpcWalletCreateSessionRequest) (token st
 			return "", "", err
 		}
 		token, err = s.sessions.StartSession(s.sessionSigningKey, scope) // nolint:gosec
-		return token, "", err
+		if err != nil {
+			return "", "", err
+		}
+		return token, s.walletAccountId(), nil
+	}
+
+	// Both paths below compare against the recovered wallet; the accountKey one
+	// used to dereference it unchecked.
+	walletAccountId := s.walletAccountId()
+	if walletAccountId == "" {
+		return "", "", ErrWalletNotInitialized
 	}
 
 	var derived crypto.DerivationResult
@@ -65,10 +75,6 @@ func (s *Service) CreateSession(req *pb.RpcWalletCreateSessionRequest) (token st
 			return "", "", errors.Join(ErrBadInput, fmt.Errorf("invalid account key: %w", err))
 		}
 	} else {
-		if s.derivedKeys == nil {
-			return "", "", ErrWalletNotInitialized
-		}
-
 		// Derive keys from provided mnemonic to verify it's correct
 		derived, err = core.WalletAccountAt(mnemonic, 0)
 		if err != nil {
@@ -77,15 +83,32 @@ func (s *Service) CreateSession(req *pb.RpcWalletCreateSessionRequest) (token st
 	}
 
 	// Compare account IDs to verify we are at the same account
-	if derived.Identity.GetPublic().Account() != s.derivedKeys.Identity.GetPublic().Account() {
+	accountId = derived.Identity.GetPublic().Account()
+	if accountId != walletAccountId {
 		return "", "", errors.Join(ErrBadInput, fmt.Errorf("incorrect mnemonic"))
 	}
 	token, err = s.sessions.StartSession(s.sessionSigningKey, model.AccountAuth_Full)
 	if err != nil {
 		return "", "", err
 	}
-	// todo: account is empty, to be implemented with GO-1854
-	return token, "", nil
+	// Answering with the account is what keeps login synchronous: the client
+	// learns its own id from the response it is already awaiting, instead of
+	// having to be subscribed to an accountShow broadcast at the right
+	// microsecond (GO-7494). Retires the GO-1854 todo.
+	return token, accountId, nil
+}
+
+// walletAccountId is the recovered wallet's account id, or "" when no wallet is
+// initialized. derivedKeys is written under s.lock by WalletRecover and
+// WalletCreate, so it must not be read through.
+func (s *Service) walletAccountId() string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if s.derivedKeys == nil {
+		return ""
+	}
+	return s.derivedKeys.Identity.GetPublic().Account()
 }
 
 func (s *Service) CloseSession(req *pb.RpcWalletCloseSessionRequest) error {

--- a/core/application/sessions_test.go
+++ b/core/application/sessions_test.go
@@ -14,6 +14,7 @@ import (
 	walletComp "github.com/anyproto/anytype-heart/core/wallet"
 	"github.com/anyproto/anytype-heart/core/wallet/mock_wallet"
 	"github.com/anyproto/anytype-heart/pb"
+	"github.com/anyproto/anytype-heart/pkg/lib/core"
 	"github.com/anyproto/anytype-heart/pkg/lib/pb/model"
 )
 
@@ -31,6 +32,63 @@ func TestCreateSession(t *testing.T) {
 			require.Error(t, err)
 		})
 	})
+
+	t.Run("with mnemonic", func(t *testing.T) {
+		t.Run("answers with the account id", func(t *testing.T) {
+			// given a recovered wallet — this is what login does, and the account it
+			// gets back here is what spares it waiting on an accountShow broadcast
+			s := New()
+			mnemonic, err := core.WalletGenerateMnemonic(wordCount)
+			require.NoError(t, err)
+			require.NoError(t, s.WalletRecover(&pb.RpcWalletRecoverRequest{RootPath: t.TempDir(), Mnemonic: mnemonic}))
+			want, err := core.WalletAccountAt(mnemonic, 0)
+			require.NoError(t, err)
+
+			// when
+			token, accountId, err := s.CreateSession(&pb.RpcWalletCreateSessionRequest{
+				Auth: &pb.RpcWalletCreateSessionRequestAuthOfMnemonic{Mnemonic: mnemonic},
+			})
+
+			// then
+			require.NoError(t, err)
+			assert.NotEmpty(t, token)
+			assert.Equal(t, want.Identity.GetPublic().Account(), accountId)
+		})
+
+		t.Run("wrong mnemonic is still refused", func(t *testing.T) {
+			// given
+			s := New()
+			mnemonic, err := core.WalletGenerateMnemonic(wordCount)
+			require.NoError(t, err)
+			require.NoError(t, s.WalletRecover(&pb.RpcWalletRecoverRequest{RootPath: t.TempDir(), Mnemonic: mnemonic}))
+			other, err := core.WalletGenerateMnemonic(wordCount)
+			require.NoError(t, err)
+
+			// when
+			_, accountId, err := s.CreateSession(&pb.RpcWalletCreateSessionRequest{
+				Auth: &pb.RpcWalletCreateSessionRequestAuthOfMnemonic{Mnemonic: other},
+			})
+
+			// then
+			require.ErrorIs(t, err, ErrBadInput)
+			assert.Empty(t, accountId)
+		})
+
+		t.Run("no wallet recovered yet", func(t *testing.T) {
+			// given
+			s := New()
+			mnemonic, err := core.WalletGenerateMnemonic(wordCount)
+			require.NoError(t, err)
+
+			// when
+			_, _, err = s.CreateSession(&pb.RpcWalletCreateSessionRequest{
+				Auth: &pb.RpcWalletCreateSessionRequestAuthOfMnemonic{Mnemonic: mnemonic},
+			})
+
+			// then
+			require.ErrorIs(t, err, ErrWalletNotInitialized)
+		})
+	})
 }
 
 // mockApiService is a stub for api.Service used in LinkLocalRevokeApp tests.
@@ -38,12 +96,12 @@ type mockApiService struct {
 	revokedTokens []string
 }
 
-func (m *mockApiService) Name() string                                        { return api.CName }
-func (m *mockApiService) Init(_ *app.App) error                               { return nil }
-func (m *mockApiService) Run(_ context.Context) error                         { return nil }
-func (m *mockApiService) Close(_ context.Context) error                       { return nil }
-func (m *mockApiService) ReassignAddress(_ context.Context, _ string) error   { return nil }
-func (m *mockApiService) RevokeToken(token string)                            { m.revokedTokens = append(m.revokedTokens, token) }
+func (m *mockApiService) Name() string                                      { return api.CName }
+func (m *mockApiService) Init(_ *app.App) error                             { return nil }
+func (m *mockApiService) Run(_ context.Context) error                       { return nil }
+func (m *mockApiService) Close(_ context.Context) error                     { return nil }
+func (m *mockApiService) ReassignAddress(_ context.Context, _ string) error { return nil }
+func (m *mockApiService) RevokeToken(token string)                          { m.revokedTokens = append(m.revokedTokens, token) }
 
 func TestLinkLocalRevokeApp(t *testing.T) {
 	signingKey := []byte("test-signing-key-1234")


### PR DESCRIPTION
Closes [GO-7495](https://linear.app/anytype/issue/GO-7495). Fixes [GO-7494](https://linear.app/anytype/issue/GO-7494) at the root, replacing the hotfix in #3263.

Client side: anyproto/anytype-ts#2368

## Why

Login learned its **own account id** through a fire-and-forget `accountShow` broadcast it had to already be subscribed to. The client opens `ListenSessionEvents` and calls `AccountRecover` as two independent requests with no ordering between them; when the broadcast wins, `es.Servers` is empty, the event is dropped (`no servers to broadcast event`), and since `login.tsx select()` guards on `!accounts.length`, `AccountSelect` is never issued and login wedges until restart.

There is no reason for this to be asynchronous. The client asks a question; the answer belongs in the response.

## What

`Rpc.Wallet.CreateSession.Response.accountId` **already exists** and was populated only in the appKey branch — the mnemonic and accountKey branches returned `""` with the standing `// todo: account is empty, to be implemented with GO-1854`. They now answer with the account. **No proto change.**

The substitution is lossless: `accountShow` carries nothing but `Account.Id`.

## Two bugs that fell out of reading `derivedKeys` properly

- **Data race.** `derivedKeys` is written under `s.lock` by `WalletRecover`/`WalletCreate`, but was read through in both `AccountRecover` and `CreateSession`. `WalletRecover` is in `noAuthMethods`, so it can land at any moment. Both now go through `walletAccountId()`, which takes the lock.
- **Nil dereference.** `CreateSession`'s accountKey branch compared against `s.derivedKeys` without checking it. It now returns `ErrWalletNotInitialized` instead of panicking. Behaviour change worth noting: an *invalid* account key with *no* wallet now reports `ErrWalletNotInitialized` rather than `ErrBadInput`.

## Mobile

`AccountRecover` keeps broadcasting `accountShow`, and mobile keeps depending on it.

swift and kotlin **were never exposed to this race**: the gomobile bridge registers an in-process `CallbackSender` via `SetEventHandlerMobile`, so a broadcast always has a live sink — there is no session map and no `ListenSessionEvents` stream to lose a race against. Nothing to fix there, and nothing urgent to adopt.

They also **cannot** adopt the field in this PR: neither calls `WalletCreateSession` at all. The bridge invokes handlers with `context.Background()` and only the metrics interceptors, so `Authorize` is never in their chain and they hold no session token. Retiring `AccountRecover` therefore needs a mobile-visible replacement first — the account on a response they do call, e.g. `WalletRecover` — rather than just a migration window. Worth amending GO-7495 step 2, which currently reads as if they can move to the synchronous path unaided.

## Why not the hotfix in #3263

That waited up to 5s inside `AccountRecover` for the caller's stream. It works, but review found it only covers **one** client stream-reconnect (backoff is 3s), so it narrows the window rather than closing it — if the stream request fails rather than merely arriving late, login still hangs, 5 seconds later. This removes the ordering assumption instead, and is less code. #3263 will be closed.

Its one advantage — needing no client change — turned out not to apply: `anytype-ts` pins `middleware.version` and bundles `anytypeHelper`, so heart never reaches a desktop user without a new desktop release anyway.

## Tests

`TestCreateSession/with_mnemonic` — answers with the account id; wrong mnemonic still refused; no wallet recovered yet. Mutation-checked: restoring `return token, "", nil` fails the first case. `go build ./...`, `go vet`, and `core/application` + `core/event` under `-race` are clean.

## Follow-up (not here)

GO-7495 item 6: `ListenSessionEvents` takes `s.lock.RLock` twice on the attach path while `AccountSelect` write-holds it for an entire cold sync, so opening an event stream can block for minutes. The event sender is set once at boot and needs no lock at all.
